### PR TITLE
Cleanup redundant command

### DIFF
--- a/roles/mds/tasks/main.yml
+++ b/roles/mds/tasks/main.yml
@@ -6,10 +6,6 @@
   copy: src=fetch/{{ hostvars[groups['mons'][0]]['ansible_hostname'] }}/var/lib/ceph/bootstrap-mds/ceph.keyring dest=/var/lib/ceph/bootstrap-mds/ceph.keyring owner=root group=root mode=600
   when: cephx
 
-- name: Set MDS bootstrap key permissions
-  file: path=/var/lib/ceph/bootstrap-mds/ceph.keyring mode=0600 owner=root group=root
-  when: cephx
-
 - name: Create MDS directory
   action: file path=/var/lib/ceph/mds/ceph-{{ ansible_hostname }} state=directory owner=root group=root mode=0644
   when: cephx

--- a/roles/osd/tasks/main.yml
+++ b/roles/osd/tasks/main.yml
@@ -9,10 +9,6 @@
   copy: src=fetch/{{ hostvars[groups['mons'][0]]['ansible_hostname'] }}/var/lib/ceph/bootstrap-osd/ceph.keyring dest=/var/lib/ceph/bootstrap-osd/ceph.keyring owner=root group=root mode=600
   when: cephx
 
-- name: Set OSD bootstrap key permissions
-  file: path=/var/lib/ceph/bootstrap-osd/ceph.keyring mode=0600 owner=root group=root
-  when: cephx
-
 # NOTE (leseb): current behavior of ceph-disk is to fail when the device is mounted "stderr: ceph-disk: Error: Device is mounted: /dev/sdb1"
 # the return code is 1, which makes sense, however ideally if ceph-disk will detect a ceph partition
 # it should exist we rc=0 and don't do anything unless we do something like --force


### PR DESCRIPTION
Since the fetch module takes care of the permissions it is not necessary
to set them with another module. The second command is useless.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
