### PR TITLE
Support diverse setup disks

### DIFF
--- a/group_vars/osds
+++ b/group_vars/osds
@@ -3,6 +3,10 @@
 #
 
 # Devices to be used as OSDs
+# You can pre-provision disks that are not present yet.
+# Ansible will just skip them. Newly added disk will be
+# automatically configured during the next run.
+#
 devices:
   - /dev/sdc
   - /dev/sdd

--- a/roles/osd/tasks/main.yml
+++ b/roles/osd/tasks/main.yml
@@ -21,7 +21,7 @@
 #
 
 - name: If partition named 'ceph' exists
-  shell: parted {{ item }} print | egrep -sq '^ 1.*ceph'
+  shell: parted --script {{ item }} print | egrep -sq '^ 1.*ceph'
   ignore_errors: True
   with_items: devices
   register: parted
@@ -43,6 +43,7 @@
 - name: Prepare OSD disk(s)
   command: ceph-disk prepare {{ item.1 }} {{ journal_device }}
   when: item.0.rc != 0
+  ignore_errors: True
   with_together:
     - parted.results
     - devices
@@ -56,6 +57,7 @@
 
 - name: Activate OSD(s)
   command: ceph-disk activate {{ item }}1
+  ignore_errors: True
   with_items: devices
   changed_when: False
 


### PR DESCRIPTION
This brings the support of heterogeneous hardware. Not all the servers
are identical, some have more or less disks than the others. Prior this
commit, the 'parted' command was hanging, now the command simply exits 1
if the device doesn't exist, same for the 'egrep' piped command after.
Then we skip these errors and continue to run. So now, you can specify
multiple devices in group_vars/osds that don't exist on all the
servers.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
