### PR TITLE
Add multi-journal support and fix collocation scenario

### DIFF
--- a/group_vars/osds
+++ b/group_vars/osds
@@ -7,12 +7,45 @@
 # Ansible will just skip them. Newly added disk will be
 # automatically configured during the next run.
 #
-devices:
-  - /dev/sdc
-  - /dev/sdd
 
-# Use 'None' to undefined the variable.
-# Using 'None' will colocate both journal and data on the same disk
+
+# !! WARNING !!
+#
+# /!\ ENABLE ONLY ONE SCENARIO AT A TIME /!\
+#
+# !! WARNING !!
+
+
+# Declare devices
+# All the scenarii inherit from the following device declaration
+#
+devices: [ 'sdd', 'sde', 'sdf', 'sdg']
+
+
+# I. First scenario: journal and osd_data on the same device
+# Use 'true' to enable this scenario
+# This will collocate both journal and data on the same disk
 # creating a partition at the beginning of the device
 #
-journal_device: /dev/sdb
+journal_collocation: true
+
+
+# II. Second scenario: single journal device for N OSDs
+# Use 'true' to enable this scenario
+#
+raw_journal: false
+raw_journal_device: /dev/sdb
+
+
+# III. Third scenario: N journal devices for N OSDs
+# Use 'true' to enable this scenario
+#
+# In the following example:
+# * sdd and sde will get sdb as a journal
+# * sdf and sdg will get sdc as a journal
+# While starting you have 2 options:
+# 1. Pre-allocate all the devices
+# 2. Progressively add new devices
+
+raw_multi_journal: false
+raw_journal_devices:  [ 'sdb', 'sdb', 'sdc', 'sdc' ]

--- a/roles/osd/tasks/main.yml
+++ b/roles/osd/tasks/main.yml
@@ -36,13 +36,33 @@
 # if you have 64 disks with 4TB each, this will take a while
 # since Ansible will sequential process the loop
 
+# Scenario 1 without dedicated journal
 - name: Prepare OSD disk(s)
-  command: ceph-disk prepare {{ item.1 }} {{ journal_device }}
-  when: item.0.rc != 0
+  command: ceph-disk prepare {{ item.1 }}
+  when: item.0.rc != 0 and journal_collocation
   ignore_errors: True
   with_together:
     - parted.results
     - devices
+
+# Scenario 2 with dedicated journal
+- name: Prepare OSD disk(s)
+  command: ceph-disk prepare {{ item.1 }} {{ journal_device }}
+  when: item.0.rc != 0 and raw_journal
+  ignore_errors: True
+  with_together:
+    - parted.results
+    - devices
+
+# Scenario 3
+- name: Prepare OSD disk(s)
+  command: ceph-disk prepare /dev/{{ item.1 }} /dev/{{ item.2 }}
+  when: item.0.rc != 0 and raw_multi_journal
+  ignore_errors: True
+  with_together:
+    - parted.results
+    - devices
+    - raw_journal_devices
 
 # Activate means:
 # - mount the volume in a temp location


### PR DESCRIPTION
This commits brings the support of multiple journals where each journal
points to a specific OSD and vice-versa. The commit also clarifies the
usage of multi scenarios for both journal and osd_data.
In the meantime, it fixes the collocation scenario.

Closes: #5 
Signed-off-by: Sébastien Han sebastien.han@enovance.com
