### PR TITLE
Multi distro installation support

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -5,6 +5,7 @@
 distro_release: "{{ facter_lsbdistcodename }}"
 apt_key: https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
 ceph_release: emperor
+redhat_distro: el6 # supported distros are el6, rhel6, f18, f19, opensuse12.2, sles11
 
 # Ceph options
 cephx: true

--- a/roles/common/tasks/Debian.yml
+++ b/roles/common/tasks/Debian.yml
@@ -1,0 +1,40 @@
+---
+## Common to all the Ceph Debian nodes
+#
+
+- name: Fail on unsupported system
+  fail: msg="System not supported {{ ansible_system }}"
+  when: ansible_system not in ['Linux']
+
+- name: Fail on unsupported architecture
+  fail: msg="Architeture not supported {{ ansible_architectore }}"
+  when: ansible_architecture not in ['x86_64']
+
+- name: Fail on unsupported distribution
+  fail: msg="Distribution not supported {{ ansible_os_family }}"
+  when: ansible_os_family not in ['Debian', 'RedHat']
+
+- name: Install dependancies
+  apt: pkg={{ item }} state=installed update_cache=yes cache_valid_time=3600 # we update the cache just in case...
+  with_items:
+    - python-pycurl
+    - ntp
+
+- name: Install the Ceph key
+  apt_key: url={{ apt_key }} state=present
+
+- name: Add Ceph repository
+  apt_repository: repo='deb http://ceph.com/debian-{{ ceph_release }}/ {{ ansible_lsb.codename }} main' state=present
+
+- name: Install Ceph
+  apt: pkg={{ item }} state=latest
+  with_items:
+    - ceph
+    - ceph-common    #|
+    - ceph-fs-common #|--> yes, they are already all dependancies from 'ceph'
+    - ceph-fuse      #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
+    - ceph-mds       #|--> they don't get update so we need to force them
+    - libcephfs1     #|
+
+- name: Generate ceph configuration file
+  template: src=roles/common/templates/ceph.conf.j2 dest=/etc/ceph/ceph.conf owner=root group=root mode=0644

--- a/roles/common/tasks/RedHat.yml
+++ b/roles/common/tasks/RedHat.yml
@@ -1,0 +1,33 @@
+---
+## Common to all the Ceph RedHat nodes
+#
+
+- name: Fail on unsupported system
+  fail: msg="System not supported {{ ansible_system }}"
+  when: ansible_system not in ['Linux']
+
+- name: Fail on unsupported architecture
+  fail: msg="Architeture not supported {{ ansible_architectore }}"
+  when: ansible_architecture not in ['x86_64']
+
+- name: Fail on unsupported distribution
+  fail: msg="Distribution not supported {{ ansible_os_family }}"
+  when: ansible_os_family not in ['Debian', 'RedHat']
+
+- name: Install dependancies
+  yum: name={{ item }} state=installed
+  with_items:
+    - python-pycurl
+    - ntp
+
+- name: Install the Ceph key
+  rpm_key: key={{ apt_key }} state=present
+
+- name: Add Ceph repository
+  command: rpm -U http://ceph.com/rpm-{{ ceph_release }}/{{ redhat_distro }}/noarch/ceph-release-1-0.el6.noarch.rpm creates=/etc/yum.repos.d/ceph.repo
+
+- name: Install Ceph
+  yum: name=ceph state=latest
+
+- name: Generate Ceph configuration file
+  template: src=roles/common/templates/ceph.conf.j2 dest=/etc/ceph/ceph.conf owner=root group=root mode=0644

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,36 +1,8 @@
 ---
-## Common to all the ceph nodes
+## Check OS family
 #
 
-- name: Fail on unsupported system
-  fail: msg="System not supported {{ ansible_system }}"
-  when: ansible_system not in ['Linux']
-
-- name: Fail on unsupported architecture
-  fail: msg="Architeture not supported {{ ansible_architectore }}"
-  when: ansible_architecture not in ['x86_64']
-
-- name: Install dependancies
-  apt: pkg={{ item }} state=installed update_cache=yes # we update the cache just in case...
-  with_items:
-    - python-pycurl
-    - ntp
-
-- name: Install the ceph key
-  apt_key: url={{ apt_key }} state=present
-
-- name: Add ceph repository
-  apt_repository: repo='deb http://ceph.com/debian-{{ ceph_release }}/ {{ ansible_lsb.codename }} main' state=present
-
-- name: Install ceph
-  apt: pkg={{ item }} state=latest
-  with_items:
-    - ceph
-    - ceph-common    #|
-    - ceph-fs-common #|--> yes, they are already all dependancies from 'ceph'
-    - ceph-fuse      #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
-    - ceph-mds       #|--> they don't get update so we need to force them
-    - libcephfs1     #|
-
-- name: Generate ceph configuration file
-  template: src=roles/common/templates/ceph.conf.j2 dest=/etc/ceph/ceph.conf owner=root group=root mode=0644
+- include: RedHat.yml
+  when: ansible_os_family == 'RedHat'
+- include: Debian.yml
+  when: ansible_os_family == 'Debian'


### PR DESCRIPTION
Now the playbook is able to install Ceph on RedHat systems.
This has been tested on CentOS 6.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
