### PR TITLE
Use full device name

### DIFF
--- a/group_vars/osds
+++ b/group_vars/osds
@@ -19,7 +19,7 @@
 # Declare devices
 # All the scenarii inherit from the following device declaration
 #
-devices: [ 'sdd', 'sde', 'sdf', 'sdg']
+devices: [ '/dev/sdd', '/dev/sde', '/dev/sdf', '/dev/sdg']
 
 
 # I. First scenario: journal and osd_data on the same device
@@ -48,4 +48,4 @@ raw_journal_device: /dev/sdb
 # 2. Progressively add new devices
 
 raw_multi_journal: false
-raw_journal_devices:  [ 'sdb', 'sdb', 'sdc', 'sdc' ]
+raw_journal_devices:  [ '/dev/sdb', '/dev/sdb', '/dev/sdc', '/dev/sdc' ]

--- a/roles/osd/tasks/main.yml
+++ b/roles/osd/tasks/main.yml
@@ -56,7 +56,7 @@
 
 # Scenario 3
 - name: Prepare OSD disk(s)
-  command: ceph-disk prepare /dev/{{ item.1 }} /dev/{{ item.2 }}
+  command: ceph-disk prepare {{ item.1 }} {{ item.2 }}
   when: item.0.rc != 0 and raw_multi_journal
   ignore_errors: True
   with_together:


### PR DESCRIPTION
Use full device name so we can specify custom devices (by-path, links
etc...)

Closes: #17

Signed-off-by: Sébastien Han sebastien.han@enovance.com
