### PR TITLE
Allow to disable MDS

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -9,6 +9,7 @@ redhat_distro: el6 # supported distros are el6, rhel6, f18, f19, opensuse12.2, s
 
 # Ceph options
 cephx: true
+mds: false # disable mds configuration in ceph.conf
 fsid: 4a158d27-f750-41d5-9e7f-26ce4c9d2d45
 
 # OSD options

--- a/roles/common/templates/ceph.conf.j2
+++ b/roles/common/templates/ceph.conf.j2
@@ -51,8 +51,10 @@
   public_network = {{ public_network }}
 {% endif %}
 
+{% if mds %}
 [mds]
 {% for host in groups['mdss'] %}
   [mds.{{ hostvars[host]['ansible_hostname'] }}]
     host = {{ hostvars[host]['ansible_hostname'] }}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
Even if MDS are not configured in site.yml the playbook has a
dependancy on the ceph.conf template.
This disables the mds section from the ceph.conf file.

Closes: #21

Signed-off-by: Sébastien Han sebastien.han@enovance.com
