### PR TITLE
Remove hardcoded interface name

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -11,6 +11,9 @@ redhat_distro: el6 # supported distros are el6, rhel6, f18, f19, opensuse12.2, s
 cephx: true
 fsid: 4a158d27-f750-41d5-9e7f-26ce4c9d2d45
 
+# Monitors options
+monitor_interface: eth1
+
 # OSD options
 journal_size: 100
 pool_default_pg_num: 128

--- a/roles/common/templates/ceph.conf.j2
+++ b/roles/common/templates/ceph.conf.j2
@@ -33,7 +33,7 @@
 {% for host in groups['mons'] %}
   [mon.{{ hostvars[host]['ansible_hostname'] }}]
     host = {{ hostvars[host]['ansible_hostname'] }}
-    mon addr = {{ hostvars[host]['ansible_eth1']['ipv4']['address'] }}
+    mon addr = {{ hostvars[host]['ansible_' + monitor_interface ]['ipv4']['address'] }}
 {% endfor %}
 
 [osd]


### PR DESCRIPTION
Add the ability to select a binding interface for the monitors.

Closes: #20

Signed-off-by: Sébastien Han sebastien.han@enovance.com
