### PR TITLE
Autogenerate initial mon key

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -10,7 +10,7 @@ redhat_distro: el6 # supported distros are el6, rhel6, f18, f19, opensuse12.2, s
 # Ceph options
 cephx: true
 mds: false # disable mds configuration in ceph.conf
-fsid: 4a158d27-f750-41d5-9e7f-26ce4c9d2d45
+fsid: # /!\ GENERATE ONE WITH 'uuidgen -r' /!\
 
 # Monitors options
 monitor_interface: eth1

--- a/group_vars/mons
+++ b/group_vars/mons
@@ -1,5 +1,0 @@
----
-# Variables here are applicable to all host groups NOT roles
-
-# Monitor options
-monitor_secret: AQD7kyJQQGoOBhAAqrPAqSopSwPrrfMMomzVdw==

--- a/roles/mon/tasks/main.yml
+++ b/roles/mon/tasks/main.yml
@@ -2,14 +2,22 @@
 ## Deploy Ceph monitor(s)
 #
 
+- name: Generate monitor initial keyring
+  command: ceph-authtool -C foo --gen-print-key creates=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
+  when: ansible_hostname == hostvars[groups['mons'][0]]['ansible_hostname'] and cephx
+  register: monitor_secret
+
+- set_fact: 'monitor_secret="{{ monitor_secret.stdout }}"'
+  when: ansible_hostname == hostvars[groups['mons'][0]]['ansible_hostname'] and cephx
+
 - name: Create monitor initial keyring
-  command: ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} --create-keyring --name=mon. --add-key={{ monitor_secret }} --cap mon 'allow *' creates=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
+  command: ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} --create-keyring --name=mon. --add-key={{ hostvars[groups['mons'][0]]['monitor_secret'] }} --cap mon 'allow *' creates=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
 
 - name: Set initial monitor key permissions
   file: path=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} mode=0600 owner=root group=root
 
 - name: Create monitor directory
-  action: file path=/var/lib/ceph/mon/ceph-{{ ansible_hostname }} state=directory owner=root group=root mode=0644
+  file: path=/var/lib/ceph/mon/ceph-{{ ansible_hostname }} state=directory owner=root group=root mode=0644
 
 - name: Ceph monitor mkfs
   command: ceph-mon --mkfs -i {{ ansible_hostname }} --keyring /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} creates=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/keyring


### PR DESCRIPTION
As mentionned in the issue 24 it's not really safe to store a default
fsid nor a monitor key. Thus the commit brings the auto-generation of
the initial monitor key. However it is quite complex to do the same for
the fsid, so I leave this to the person in charge of the deployment to
generate one and edit group_vars/all accordingly. The default fsid has
been removed as well.

Close: #24

Signed-off-by: Sébastien Han sebastien.han@enovance.com
