### PR TITLE
Ability to reduce verbosity

### DIFF
--- a/.ansible.cfg
+++ b/.ansible.cfg
@@ -6,3 +6,5 @@ ansible_managed = Ansible managed: modified on %Y-%m-%d %H:%M:%S by {uid}
 private_key_file = ~/.vagrant.d/insecure_private_key
 error_on_undefined_vars = False
 forks = 6
+#If set to False, ansible will not display any status for a task that is skipped. The default behavior is to display skipped tasks:
+display_skipped_hosts=True


### PR DESCRIPTION
If you don't want to see the output of all the skipped host, you can set
this value to 'False'.
This will dramatically reduce the output of the run.
Default now is False, since True is good for testing.

Closes: #32

Signed-off-by: Sébastien Han sebastien.han@enovance.com
