### PR TITLE
Revert 37882255d6ac5d15b7725df6a2c15a2c0c22928f (auto key generation)

### DIFF
--- a/group_vars/mons
+++ b/group_vars/mons
@@ -1,0 +1,5 @@
+----
+# Variables here are applicable to all host groups NOT roles
+
+# Monitor options
+monitor_secret: # /!\ GENERATE ONE WITH 'ceph-authtool -C foo --gen-print-key' /!\

--- a/roles/mon/tasks/main.yml
+++ b/roles/mon/tasks/main.yml
@@ -2,16 +2,8 @@
 ## Deploy Ceph monitor(s)
 #
 
-- name: Generate monitor initial keyring
-  command: ceph-authtool -C foo --gen-print-key creates=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
-  when: ansible_hostname == hostvars[groups['mons'][0]]['ansible_hostname'] and cephx
-  register: monitor_secret
-
-- set_fact: 'monitor_secret="{{ monitor_secret.stdout }}"'
-  when: ansible_hostname == hostvars[groups['mons'][0]]['ansible_hostname'] and cephx
-
 - name: Create monitor initial keyring
-  command: ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} --create-keyring --name=mon. --add-key={{ hostvars[groups['mons'][0]]['monitor_secret'] }} --cap mon 'allow *' creates=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
+  command: ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} --create-keyring --name=mon. --add-key={{ monitor_secret }} --cap mon 'allow *' creates=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
 
 - name: Set initial monitor key permissions
   file: path=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} mode=0600 owner=root group=root


### PR DESCRIPTION
We introduced a key generation mechanism that aimed to ease deployment.
In the end, it brought more complexity to the playbook and doesn't
scale.

Reverting the auto generation commit and instructing users to generate
their own keys.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
