### PR TITLE
Remove mon_initial_members option

### DIFF
--- a/roles/common/templates/ceph.conf.j2
+++ b/roles/common/templates/ceph.conf.j2
@@ -12,7 +12,6 @@
   auth supported = none
 {% endif %}
   fsid = {{ fsid }}
-  mon_initial_members = {{ hostvars[groups['mons'][0]]['ansible_hostname'] }}
 {% if pool_default_pg_num is defined %}
   osd pool default pg num = {{ pool_default_pg_num }}
 {% endif %}


### PR DESCRIPTION
The mon_initial_members is not used since we declare the mon section in
the ceph.conf file. Later, we could reduce the ceph.conf file by only
using the mon_host flag instead of all the mon sections.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
