### PR TITLE
Remove HTTPS from ceph key url

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -3,7 +3,7 @@
 
 # Setup options
 distro_release: "{{ facter_lsbdistcodename }}"
-apt_key: https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+apt_key: http://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
 ceph_release: emperor
 redhat_distro: el6 # supported distros are el6, rhel6, f18, f19, opensuse12.2, sles11
 


### PR DESCRIPTION
It's a public key, no need for HTTPS as it triggers "failed to validate the SSL certificate for ceph.com:443" errors
