### PR TITLE
Fix rgw section name

### DIFF
--- a/roles/common/templates/ceph.conf.j2
+++ b/roles/common/templates/ceph.conf.j2
@@ -64,7 +64,7 @@
 
 {% if radosgw %}
 {% for host in groups['rgws'] %}
-[client.radosgw.gateway.{{ hostvars[host]['ansible_hostname'] }}]
+[client.radosgw.gateway]
   host = {{ hostvars[host]['ansible_fqdn'] }}
   keyring = /etc/ceph/keyring.radosgw.gateway
   rgw socket path = /tmp/radosgw.sock


### PR DESCRIPTION
All the rgw instances should share the same key so the section name
should not be changed.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
