### PR TITLE
Skip missing RGW hosts in ceph.conf

### DIFF
--- a/roles/common/templates/ceph.conf.j2
+++ b/roles/common/templates/ceph.conf.j2
@@ -64,6 +64,7 @@
 
 {% if radosgw %}
 {% for host in groups['rgws'] %}
+{% if hostvars[host]['ansible_hostname'] is defined %}
 [client.radosgw.gateway]
   host = {{ hostvars[host]['ansible_fqdn'] }}
   keyring = /etc/ceph/keyring.radosgw.gateway
@@ -71,5 +72,6 @@
   log file = /var/log/ceph/radosgw.log
   rgw data = /var/lib/ceph/radosgw/{{ hostvars[host]['ansible_hostname'] }}
   rgw print continue = false
+{% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
This PR skip adding missing RGW nodes to ceph.conf
