### PR TITLE
Drop a update-motd.d fragment for monitors so when the user/admin logs i...

### DIFF
--- a/roles/mon/files/precise/92-ceph
+++ b/roles/mon/files/precise/92-ceph
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo -n "Ceph state is: "
+/usr/bin/ceph health
+echo ""

--- a/roles/mon/tasks/main.yml
+++ b/roles/mon/tasks/main.yml
@@ -40,3 +40,7 @@
     - /var/lib/ceph/bootstrap-osd/ceph.keyring # this handles the non-colocation case
     - /var/lib/ceph/bootstrap-mds/ceph.keyring
     - /etc/ceph/keyring.radosgw.gateway
+
+- name: Drop in a motd script to report status when logging in
+  copy: src=precise/92-ceph dest=/etc/update-motd.d/92-ceph owner=root group=root mode=0755
+  when: ansible_distribution_release == 'precise'


### PR DESCRIPTION
...nto a monitor there is a small notice for the user about the state of the ceph cluster. Works only on ubuntu for now

got the original idea from http://www.sebastien-han.fr/blog/sys-vrak/
