### PR TITLE
Use ansible_hostname in RGW config inside ceph.conf

### DIFF
--- a/roles/common/templates/ceph.conf.j2
+++ b/roles/common/templates/ceph.conf.j2
@@ -66,7 +66,7 @@
 {% for host in groups['rgws'] %}
 {% if hostvars[host]['ansible_hostname'] is defined %}
 [client.radosgw.gateway]
-  host = {{ hostvars[host]['ansible_fqdn'] }}
+  host = {{ hostvars[host]['ansible_hostname'] }}
   keyring = /etc/ceph/keyring.radosgw.gateway
   rgw socket path = /tmp/radosgw.sock
   log file = /var/log/ceph/radosgw.log


### PR DESCRIPTION
Use ansible_hostname in RGW config inside ceph.conf
Fix #54
