### PR TITLE
Add maintenance playbook

### DIFF
--- a/hosts
+++ b/hosts
@@ -5,19 +5,19 @@
 ## Common setup example
 #
 [mons]
-ceph-mon0:2222
-ceph-mon1:2200
-ceph-mon2:2201
+ceph-mon0:2200
+ceph-mon1:2201
+ceph-mon2:2202
 [osds]
-ceph-osd0:2202
-ceph-osd1:2203
-ceph-osd2:2204
+ceph-osd0:2203
+ceph-osd1:2204
+ceph-osd2:2205
 [mdss]
-ceph-osd0:2202
-ceph-osd1:2203
-ceph-osd2:2204
-[rgws]
-ceph-rgw:2205
+ceph-osd0:2203
+ceph-osd1:2204
+ceph-osd2:2205
+#[rgws]
+#ceph-rgw:2200
 
 # Colocation setup example
 #[mons]

--- a/maintenance.yml
+++ b/maintenance.yml
@@ -1,0 +1,30 @@
+---
+# This playbook was made to automate Ceph servers maintenance
+# Typical use case: hardware change
+# By running this playbook you will set the 'noout' flag on your
+# cluster, which means that OSD **can't** be marked as out
+# of the CRUSH map, but they will be marked as down.
+# Basically we tell the cluster to don't move any data since
+# the operation won't last for too long.
+
+- hosts: <your_host>
+  gather_facts: False
+
+  tasks:
+
+  - name: Set the noout flag
+    command: ceph osd set noout
+    delegate_to: <your_monitor>
+
+  - name: Turn off the server
+    command: poweroff
+
+  - name: Wait for the server to go down
+    local_action: wait_for host=<your_host> port=22 state=stopped
+
+  - name: Wait for the server to come up
+    local_action: wait_for host=<your_host port=22 delay=10 timeout=3600
+
+  - name: Unset the noout flag
+    command: ceph osd unset noout
+    delegate_to: <your_monitor>


### PR DESCRIPTION
This playbook was made to automate Ceph servers maintenance
Typical use case: hardware change
By running this playbook you will set the 'noout' flag on your
cluster, which means that OSD **can't** be marked as out
of the CRUSH map, but they will be marked as down.
Basically we tell the cluster to don't move any data since
the operation won't last for too long.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
