### PR TITLE
Change the default disk numbering

### DIFF
--- a/group_vars/osds
+++ b/group_vars/osds
@@ -19,7 +19,7 @@
 # Declare devices
 # All the scenarii inherit from the following device declaration
 #
-devices: [ '/dev/sdd', '/dev/sde', '/dev/sdf', '/dev/sdg']
+devices: [ '/dev/sdb', '/dev/sdc', '/dev/sdd', '/dev/sde']
 
 
 # I. First scenario: journal and osd_data on the same device


### PR DESCRIPTION
While trying to auto-provision with vagrant, new disks get /dev/sdb and
so forth. So starting from /dev/sdd doesn't make sense.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
