### PR TITLE
Enable single host mode

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -48,3 +48,8 @@ osd_op_threads: 8
 osd_recovery_max_active: 5
 osd_max_backfills: 2
 osd_recovery_op_priority: 2
+
+
+## Testing mode
+# enable this mode _only_ when you have a single node
+common_single_host_mode: true

--- a/roles/common/templates/ceph.conf.j2
+++ b/roles/common/templates/ceph.conf.j2
@@ -27,6 +27,9 @@
 {% if pool_default_crush_rule is defined %}
   osd pool default crush rule = {{ pool_default_crush_rule }}
 {% endif %}
+{% if common_single_host_mode is defined %}
+  osd crush chooseleaf type = 0
+{% endif %}
 
 [mon]
   mon osd down out interval = {{ mon_osd_down_out_interval }}


### PR DESCRIPTION
This commit introduces a new config option 'osd crush chooseleaf type'.
With the help of this option and by setting it to '0' we tell Ceph to
store all the replicas on a single host. Basically we tell CRUSH to
iterate over disk and not over host.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
