### PR TITLE
Since Emperor, Ceph stores xattr into levelDB thus this option is not

### DIFF
--- a/roles/common/templates/ceph.conf.j2
+++ b/roles/common/templates/ceph.conf.j2
@@ -46,9 +46,6 @@
 {% if osd_mkfs_type is defined %}
   osd mkfs type = {{ osd_mkfs_type }}
 {% endif %}
-{% if osd_mkfs_type == "ext4" %}
-  filestore xattr use omap = true
-{% endif %}
   osd journal size = {{ journal_size }}
 {% if cluster_network is defined %}
   cluster_network = {{ cluster_network }}


### PR DESCRIPTION
needed anymore.

Fixes: #83

Signed-off-by: Sébastien Han sebastien.han@enovance.com
