### PR TITLE
Fix Ansible architecture tasks

### DIFF
--- a/roles/common/tasks/Debian.yml
+++ b/roles/common/tasks/Debian.yml
@@ -7,7 +7,7 @@
   when: ansible_system not in ['Linux']
 
 - name: Fail on unsupported architecture
-  fail: msg="Architeture not supported {{ ansible_architectore }}"
+  fail: msg="Architecture not supported {{ ansible_architecture }}"
   when: ansible_architecture not in ['x86_64']
 
 - name: Fail on unsupported distribution

--- a/roles/common/tasks/RedHat.yml
+++ b/roles/common/tasks/RedHat.yml
@@ -7,7 +7,7 @@
   when: ansible_system not in ['Linux']
 
 - name: Fail on unsupported architecture
-  fail: msg="Architeture not supported {{ ansible_architectore }}"
+  fail: msg="Architecture not supported {{ ansible_architecture }}"
   when: ansible_architecture not in ['x86_64']
 
 - name: Fail on unsupported distribution


### PR DESCRIPTION
Typos in Debian and Redhat ansible tasks prevent this from provisioning properly.
