### PR TITLE
Use firefly as the default release

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -5,7 +5,7 @@
 #
 distro_release: "{{ facter_lsbdistcodename }}"
 apt_key: http://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
-ceph_release: emperor
+ceph_release: firefly
 redhat_distro: el6 # supported distros are el6, rhel6, f18, f19, opensuse12.2, sles11
 
 ## Ceph options


### PR DESCRIPTION
Since Firefly is out, we use it.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
