### PR TITLE
Ipv6 support for networks and monitor address

### DIFF
--- a/filter_plugins/network.py
+++ b/filter_plugins/network.py
@@ -1,0 +1,107 @@
+import ipcalc
+
+
+# Old versions don't have this method.
+if not hasattr(ipcalc.IP, 'to_compressed'):
+    import re
+
+    # Shamelessly copied from
+    # https://github.com/tehmaze/ipcalc/blob/master/ipcalc.py
+    def to_compressed(address):
+        '''
+        Compress an IP address to its shortest possible compressed form.
+
+        >>> print IP('127.0.0.1').to_compressed()
+        127.1
+        >>> print IP('127.1.0.1').to_compressed()
+        127.1.1
+        >>> print IP('127.0.1.1').to_compressed()
+        127.0.1.1
+        >>> print IP('2001:1234:0000:0000:0000:0000:0000:5678').to_compressed()
+        2001:1234::5678
+        >>> print IP('1234:0000:0000:beef:0000:0000:0000:5678').to_compressed()
+        1234:0:0:beef::5678
+        >>> print IP('0000:0000:0000:0000:0000:0000:0000:0001').to_compressed()
+        ::1
+        >>> print IP('fe80:0000:0000:0000:0000:0000:0000:0000').to_compressed()
+        fe80::
+        '''
+
+        if address.v == 4:
+            quads = address.dq.split('.')
+            try:
+                zero = quads.index('0')
+                if zero == 1 and quads.index('0', zero + 1):
+                    quads.pop(zero)
+                    quads.pop(zero)
+                    return '.'.join(quads)
+                elif zero == 2:
+                    quads.pop(zero)
+                    return '.'.join(quads)
+            except ValueError:  # No zeroes
+                pass
+
+            return address.dq
+        else:
+            quads = map(lambda q: '%x' % (int(q, 16)), address.dq.split(':'))
+            quadc = ':%s:' % (':'.join(quads),)
+            zeros = [0, -1]
+
+            # Find the largest group of zeros
+            for match in re.finditer(r'(:[:0]+)', quadc):
+                count = len(match.group(1)) - 1
+                if count > zeros[0]:
+                    zeros = [count, match.start(1)]
+
+            count, where = zeros
+            if count:
+                quadc = quadc[:where] + ':' + quadc[where + count:]
+
+            quadc = re.sub(r'((^:)|(:$))', '', quadc)
+            quadc = re.sub(r'((^:)|(:$))', '::', quadc)
+
+            return quadc
+
+    setattr(ipcalc.IP, 'to_compressed', to_compressed)
+
+
+def in_network(address, network, mask=None):
+    ''' Return true if address is in network. '''
+    return address in ipcalc.Network(network, mask=mask)
+
+
+def is_ipv4(address):
+    ''' Return true if address is an IPv4 one. '''
+    return ipcalc.Network(address).version() == 4
+
+
+def is_ipv6(address):
+    ''' Return true if address is an IPv6 one. '''
+    return ipcalc.Network(address).version() == 6
+
+
+def address(address):
+    ''' Return the address part. '''
+    ip = ipcalc.IP(address)
+    if ip.version() == 4:
+        return ip
+    else:
+        return ip.to_compressed()
+
+
+def mask(address):
+    ''' Return the mask part. '''
+    return ipcalc.Network(address).mask
+
+
+class FilterModule(object):
+    ''' Utility filters for operating on network addresses. '''
+
+    def filters(self):
+        return {
+            'in_network': in_network,
+            'is_ipv4': is_ipv4,
+            'is_ipv6': is_ipv6,
+            'address': address,
+            'mask': mask,
+        }

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -13,7 +13,7 @@ redhat_distro: el6 # supported distros are el6, rhel6, f18, f19, opensuse12.2, s
 cephx: true
 ## Monitor options
 #
-monitor_interface: eth1
+#monitor_interface: eth1
 mon_osd_down_out_interval: 600
 mon_osd_min_down_reporters: 7 # number of OSDs per host + 1
 

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -105,18 +105,10 @@
 {% endif %}
   osd journal size = {{ journal_size }}
 {% if cluster_network is defined %}
-  {% if cluster_network | is_ipv6 %}
-  cluster_network = [{{ cluster_network | address }}]/{{ cluster_network | mask }}
-  {% else %}
   cluster_network = {{ cluster_network }}
-  {% endif %}
 {% endif %}
 {% if public_network is defined %}
-  {% if public_network | is_ipv6 %}
-  public_network = [{{ public_network | address }}]/{{ public_network | mask }}
-  {% else %}
   public_network = {{ public_network }}
-  {% endif %}
 {% endif %}
   osd mon heartbeat interval = {{ osd_mon_heartbeat_interval }}
   # Performance tuning

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -1,3 +1,4 @@
+#jinja2:lstrip_blocks:True
 # {{ ansible_managed }}
 
 [global]
@@ -30,15 +31,71 @@
 {% if common_single_host_mode is defined %}
   osd crush chooseleaf type = 0
 {% endif %}
+{% if public_network is defined and public_network | is_ipv6 %}
+  ms_bind_ipv6 = true
+{% endif %}
 
 [mon]
   mon osd down out interval = {{ mon_osd_down_out_interval }}
   mon osd min down reporters = {{ mon_osd_min_down_reporters }}
 {% for host in groups['mons'] %}
   {% if hostvars[host]['ansible_hostname'] is defined %}
+
   [mon.{{ hostvars[host]['ansible_hostname'] }}]
     host = {{ hostvars[host]['ansible_hostname'] }}
-    mon addr = {{ hostvars[host]['ansible_' + monitor_interface ]['ipv4']['address'] }}
+    {% if monitor_interface is defined %}
+      {# 'monitor_interface' is defined, we try to get the interface address #}
+      {% if public_network is defined and public_network | is_ipv6 %}
+        {% set address = hostvars[host]['ansible_' + monitor_interface ]['ipv6'][0]['address'] %}
+    # Address found using 'monitor_interface' variable for IPv6 public network.
+    mon addr = [{{ address }}]
+      {% else %}
+        {% set address = hostvars[host]['ansible_' + monitor_interface ]['ipv4']['address'] %}
+    # Address found using 'monitor_interface' variable for IPv4 public network.
+    mon addr = {{ address }}
+      {% endif %}
+    {% elif public_network is defined %}
+      {# 'monitor_interface' is not defined, we will try to found one matching public_network in the host interfaces. #}
+      {% for interface in hostvars[host]['ansible_interfaces'] %}
+        {% set iface_details = hostvars[host]['ansible_' + interface] %}
+        {# Once 'mon_addr' is defined, we don't need to find the address. And we'll do it only on active interfaces. #}
+        {% if mon_addr is not defined and iface_details['active'] %}
+          {# We try to get IP address from the interface within the 'public_network'. #}
+          {% if public_network | is_ipv6 and iface_details['ipv6'] is defined %}
+            {% set address = iface_details['ipv6'][0]['address'] %}
+            {% if address | in_network(public_network) %}
+              {% set mon_addr = address %}
+    # Address found using {{ interface }} interface for IPv6 public network.
+    mon addr = [{{ address }}]
+            {% endif %}
+          {% elif public_network | is_ipv4 and iface_details['ipv4'] is defined %}
+            {% set address = iface_details['ipv4']['address'] %}
+            {% if address | in_network(public_network) %}
+              {% set mon_addr = address %}
+    # Address found using {{ interface }} interface for IPv4 public network.
+    mon addr = {{ address }}
+            {% endif %}
+          {% endif %}
+        {% endif %}
+        {% if loop.last %}
+          {# Last loop and we have not found any address, we will use the default interface one. #}
+          {% if mon_addr is not defined %}
+            {% if public_network | is_ipv6 %}
+    # Using default IPv6 for address because no interfaces match 'public_network'.
+    mon addr = {{ hostvars[host]['ansible_default_ipv6']['address'] }}
+            {% else %}
+    # Using default IPv4 for address because no interfaces match 'public_network'.
+    mon addr = {{ hostvars[host]['ansible_default_ipv4']['address'] }}
+            {% endif %}
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+    {% else %}
+    {# No monitor_address not public_network is defined, we use the default IPv4 address. #}
+    {# We should never go here because public_network is defined in defaults. #}
+    # Using default IPv4 for address because 'monitor_interface' and 'public_network' are not defined..
+    mon addr = {{ hostvars[host]['ansible_default_ipv4']['address'] }}
+    {% endif %}
   {% endif %}
 {% endfor %}
 
@@ -48,10 +105,18 @@
 {% endif %}
   osd journal size = {{ journal_size }}
 {% if cluster_network is defined %}
+  {% if cluster_network | is_ipv6 %}
+  cluster_network = [{{ cluster_network | address }}]/{{ cluster_network | mask }}
+  {% else %}
   cluster_network = {{ cluster_network }}
+  {% endif %}
 {% endif %}
 {% if public_network is defined %}
+  {% if public_network | is_ipv6 %}
+  public_network = [{{ public_network | address }}]/{{ public_network | mask }}
+  {% else %}
   public_network = {{ public_network }}
+  {% endif %}
 {% endif %}
   osd mon heartbeat interval = {{ osd_mon_heartbeat_interval }}
   # Performance tuning
@@ -63,6 +128,7 @@
   osd max backfills = {{ osd_max_backfills }}
   osd recovery op priority = {{ osd_recovery_op_priority }}
 {% if mds %}
+
 [mds]
 {% for host in groups['mdss'] %}
   {% if hostvars[host]['ansible_hostname'] is defined %}
@@ -71,13 +137,13 @@
   {% endif %}
 {% endfor %}
 {% endif %}
-
 {% if radosgw %}
 {% for host in groups['rgws'] %}
 {% if hostvars[host]['ansible_hostname'] is defined %}
+
 [client.radosgw.gateway]
   {% if radosgw_dns_name is defined %}
-    rgw dns name = {{ radosgw_dns_name }}
+  rgw dns name = {{ radosgw_dns_name }}
   {% endif %}
   host = {{ hostvars[host]['ansible_hostname'] }}
   keyring = /etc/ceph/keyring.radosgw.gateway


### PR DESCRIPTION
I think this one can be hard to understand.

First, I created a filter to have operations on network addresses. It need the ipcalc Python module.

The I updated the ceph.conf.j2 template. The philosophy is to have the same behaviour as before if monitor_interface is defined, but trying to find address according the public_network IP version. If monitor_interface is not defined, we try to find automatically the address looping over the interfaces to find one in the public network.

Feel free to ask me if you don't understand my changes.