### PR TITLE
Add Debian non-free repository so you can install fastcgi.

### DIFF
--- a/roles/ceph-radosgw/tasks/Debian.yml
+++ b/roles/ceph-radosgw/tasks/Debian.yml
@@ -20,6 +20,11 @@
 - name: Add Ceph extra
   apt_repository: repo='deb http://ceph.com/packages/ceph-extras/debian {{ ansible_lsb.codename }} main' state=present
 
+# TODO: Try to determine which Debian mirror is already in use on the target machine, then just append non-free
+- name: Add Debian non-free to be able to get the non-free fastcgi module
+  apt_repository: repo='deb http://mirrorservice.org/sites/ftp.debian.org/debian/ {{ ansible_lsb.codename }} non-free' state=present
+  when: ansible_distribution == "Debian"
+
 - name: Install Apache, fastcgi and Rados Gateway
   apt: pkg={{ item }} state=present
   with_items:


### PR DESCRIPTION
The fastcgi module is non-free and vanilla Debian installations normally don't have the non-free repo enabled. 

There is surely a more elegant way to do this, either by reading a preferred Debian mirror from a var or by trying to construct one from the existing configuration files. I'm happy for suggestions on those fronts.