### PR TITLE
Restart Ceph service after a configuration change

### DIFF
--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -2,3 +2,11 @@
 
 - name: "update apt cache"
   action: apt update-cache=yes
+
+- name: "restart ceph"
+  shell: service ceph restart ; service ceph-osd-all restart
+  when: socket.rc == 0 and ansible_distribution == 'Ubuntu'
+
+- name: "restart ceph"
+  command: service ceph restart
+  when: socket.rc == 0 and ansible_distribution == 'Debian' or ansible_os_family == 'RedHat'

--- a/roles/ceph-common/tasks/Debian.yml
+++ b/roles/ceph-common/tasks/Debian.yml
@@ -37,5 +37,11 @@
     - ceph-mds       #|--> they don't get update so we need to force them
     - libcephfs1     #|
 
-- name: Generate ceph configuration file
+- name: Check for a Ceph socket
+  shell: stat /var/run/ceph/*.asok > /dev/null 2>&1
+  ignore_errors: true
+  register: socket
+
+- name: Generate Ceph configuration file
   template: src=ceph.conf.j2 dest=/etc/ceph/ceph.conf owner=root group=root mode=0644
+  notify: restart ceph

--- a/roles/ceph-common/tasks/RedHat.yml
+++ b/roles/ceph-common/tasks/RedHat.yml
@@ -30,5 +30,11 @@
 - name: Install Ceph
   yum: name=ceph state=latest
 
+- name: Check for a Ceph socket
+  shell: stat /var/run/ceph/*.asok > /dev/null 2>&1
+  ignore_errors: true
+  register: socket
+
 - name: Generate Ceph configuration file
   template: src=ceph.conf.j2 dest=/etc/ceph/ceph.conf owner=root group=root mode=0644
+  notify: restart ceph


### PR DESCRIPTION
After a change is made on the configuration file we must restart the
Ceph services. I also added a check that verifies if a socker exists
because during the first play there are no services running. We check if
a socket exists, if not we don't try to restart the services, if it
exists we can restart them.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
