### PR TITLE
Disable updatedb OSD directory parsing

### DIFF
--- a/roles/ceph-common/tasks/Debian.yml
+++ b/roles/ceph-common/tasks/Debian.yml
@@ -45,3 +45,6 @@
 - name: Generate Ceph configuration file
   template: src=ceph.conf.j2 dest=/etc/ceph/ceph.conf owner=root group=root mode=0644
   notify: restart ceph
+
+- name: Disable OSD directory parsing by updatedb
+  command: updatedb -e /var/lib/ceph

--- a/roles/ceph-common/tasks/RedHat.yml
+++ b/roles/ceph-common/tasks/RedHat.yml
@@ -38,3 +38,6 @@
 - name: Generate Ceph configuration file
   template: src=ceph.conf.j2 dest=/etc/ceph/ceph.conf owner=root group=root mode=0644
   notify: restart ceph
+
+- name: Disable OSD directory parsing by updatedb
+  command: updatedb -e /var/lib/ceph


### PR DESCRIPTION
It has been reported a couple of months ago by Dan van der Ster from
CERN that updatedb was consumming 100% of CPU while parsing system's
directories. Indeed the process was parsing the OSD PG directories that
might contains billions of objects.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
