### PR TITLE
Fix restart on config change handler

### DIFF
--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -3,10 +3,10 @@
 - name: "update apt cache"
   action: apt update-cache=yes
 
-- name: "restart ceph"
+- name: "restart ceph ubuntu"
   shell: service ceph restart ; service ceph-osd-all restart
-  when: socket.rc == 0 and ansible_distribution == 'Ubuntu'
+  when: socket.rc == 0
 
-- name: "restart ceph"
+- name: "restart ceph debian redhat"
   command: service ceph restart
-  when: socket.rc == 0 and ansible_distribution == 'Debian' or ansible_os_family == 'RedHat'
+  when: socket.rc == 0

--- a/roles/ceph-common/tasks/Debian.yml
+++ b/roles/ceph-common/tasks/Debian.yml
@@ -44,7 +44,13 @@
 
 - name: Generate Ceph configuration file
   template: src=ceph.conf.j2 dest=/etc/ceph/ceph.conf owner=root group=root mode=0644
-  notify: restart ceph
+  notify: restart ceph ubuntu
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Generate Ceph configuration file
+  template: src=ceph.conf.j2 dest=/etc/ceph/ceph.conf owner=root group=root mode=0644
+  notify: restart ceph debian redhat
+  when: ansible_distribution == 'Debian' or ansible_os_family == 'RedHat'
 
 - name: Disable OSD directory parsing by updatedb
   command: updatedb -e /var/lib/ceph

--- a/roles/ceph-common/tasks/RedHat.yml
+++ b/roles/ceph-common/tasks/RedHat.yml
@@ -37,7 +37,7 @@
 
 - name: Generate Ceph configuration file
   template: src=ceph.conf.j2 dest=/etc/ceph/ceph.conf owner=root group=root mode=0644
-  notify: restart ceph
+  notify: restart ceph debian redhat
 
 - name: Disable OSD directory parsing by updatedb
   command: updatedb -e /var/lib/ceph


### PR DESCRIPTION
Prior to this patch, the first match was winning and the playbook wasn't
doing any difference both "restart ceph", adding a distro filtrer fixes
this.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
