### PR TITLE
Fix OSD update during startup

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -49,7 +49,7 @@ osd_mount_options_xfs: noatime
 osd_mon_heartbeat_interval: 30
 # CRUSH
 pool_default_crush_rule: 0
-osd_crush_update_on_start: true
+osd_crush_update_on_start: "true"
 # Object backend
 osd_objectstore: filestore
 # Performance tuning


### PR DESCRIPTION
Proviously we used osd_crush_update_on_start: true, this was interpreted
by Ansible as a boolean and appeared as 'True' inside the Ceph configuration
file. However the Ceph's init script is looking for 'true'.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
