### PR TITLE
Fix the mon.* generation in ceph.conf

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -63,7 +63,7 @@
   {% if hostvars[host]['ansible_hostname'] is defined %}
   [mon.{{ hostvars[host]['ansible_hostname'] }}]
     host = {{ hostvars[host]['ansible_hostname'] }}
-    mon addr = {{ hostvars[host]['ansible_' + monitor_interface ]['ipv4']['address'] }}
+    mon addr = {{ hostvars[host]['ansible_' + hostvars[host]['monitor_interface'] ]['ipv4']['address'] }}
   {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
The ceph.conf.j2 template currently always uses the current host facts
to get the IP address of each host in the mon loop. This is not the
expected behavior. This patch uses the correct facts to get the IP.
