### PR TITLE
Remove ansible managed header from ceph.conf

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -1,4 +1,5 @@
-# {{ ansible_managed }}
+# This file is managed by Ansible.
+# Every change will be overwritten.
 
 [global]
 {% if cephx %}


### PR DESCRIPTION
In ceph-common you load {{ ansible_managed }} at the top of the main
config file - this will trigger handlers on that file whenever an
Ansible run is made.

I'd suggest replacing it with a vanilla text comment 'managed by
Ansible' to warn
admins but avoid unnecessary cluster bounces.

fixes: #125

Signed-off-by: Sébastien Han sebastien.han@enovance.com
