### PR TITLE
ceph-osd: restart OSDs only

### DIFF
--- a/roles/ceph-osd/tasks/journal_collocation.yml
+++ b/roles/ceph-osd/tasks/journal_collocation.yml
@@ -92,4 +92,4 @@
   changed_when: False
 
 - name: Start and add that the OSD service to the init sequence
-  service: name=ceph state=started enabled=yes
+  service: name=ceph state=started enabled=yes args=osd

--- a/roles/ceph-osd/tasks/osd_directory.yml
+++ b/roles/ceph-osd/tasks/osd_directory.yml
@@ -53,4 +53,4 @@
   changed_when: False
 
 - name: Start and add that the OSD service to the init sequence
-  service: name=ceph state=started enabled=yes
+  service: name=ceph state=started enabled=yes args=osd

--- a/roles/ceph-osd/tasks/raw_journal.yml
+++ b/roles/ceph-osd/tasks/raw_journal.yml
@@ -92,4 +92,4 @@
   changed_when: False
 
 - name: Start and add that the OSD service to the init sequence
-  service: name=ceph state=started enabled=yes
+  service: name=ceph state=started enabled=yes args=osd

--- a/roles/ceph-osd/tasks/raw_multi_journal.yml
+++ b/roles/ceph-osd/tasks/raw_multi_journal.yml
@@ -93,4 +93,4 @@
   changed_when: False
 
 - name: Start and add that the OSD service to the init sequence
-  service: name=ceph state=started enabled=yes
+  service: name=ceph state=started enabled=yes args=osd


### PR DESCRIPTION
Avoid restarting other services when configuring the OSDs.
