### PR TITLE
Increase kernel.pid_max to a higher value

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -36,3 +36,6 @@
 - name: Disable OSD directory parsing by updatedb
   command: updatedb -e /var/lib/ceph
   ignore_errors: true
+
+- name: Increase PID max value to a very large value
+  sysctl: name="kernel.pid_max" value=4194303 state=present sysctl_file=/etc/sysctl.conf


### PR DESCRIPTION
While running big boxes with 72 disks it's easy to get out of PID for
all the threads needed by Ceph. Increasing the default value removes
this limitation.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
