### PR TITLE
Add a client section in the ceph configuration file

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -56,6 +56,11 @@
   debug_rgw = 0/0
 {% endif %}
 
+[client]
+  rbd cache = true
+  rbd cache writethrough until flush = true
+  admin socket = /var/run/ceph/rbd-client-$pid.asok
+
 [mon]
   mon osd down out interval = {{ mon_osd_down_out_interval }}
   mon osd min down reporters = {{ mon_osd_min_down_reporters }}


### PR DESCRIPTION
In this section we enabled the rbd cache and a socket per client.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
