### PR TITLE
monitor_interface template change

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -16,7 +16,7 @@ dummy:
 
 ## Monitor options
 #
-monitor_interface: eth1
+#monitor_interface: eth1
 #mon_osd_down_out_interval: 600
 #mon_osd_min_down_reporters: 7 # number of OSDs per host + 1
 

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -63,7 +63,7 @@
   {% if hostvars[host]['ansible_hostname'] is defined %}
   [mon.{{ hostvars[host]['ansible_hostname'] }}]
     host = {{ hostvars[host]['ansible_hostname'] }}
-    mon addr = {{ hostvars[host]['ansible_' + hostvars[host]['monitor_interface'] ]['ipv4']['address'] }}
+    mon addr = {{ hostvars[host]['ansible_' + monitor_interface]['ipv4']['address'] }}
   {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
This will fix the monitor_interface issue for Vagrant provisioning while being preferred to using group_var entries for physical deployments (untested for physical deployments).
