### PR TITLE
Fix wrong variable for cephx signature

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -5,8 +5,8 @@
   auth cluster required = cephx
   auth service required = cephx
   auth client required = cephx
-  cephx require signatures = {{ cephx_require_signatures }}
-  cephx cluster require signatures = {{ cephx_require_signatures }}
+  cephx require signatures = {{ cephx_require_signatures }} # Kernel RBD does NOT support signatures!
+  cephx cluster require signatures = {{ cephx_cluster_require_signatures }}
   cephx service require signatures = {{ cephx_service_require_signatures }}
 {% else %}
   auth cluster required = none

--- a/roles/ceph-common/vars/main.yml
+++ b/roles/ceph-common/vars/main.yml
@@ -26,7 +26,7 @@ ceph_dev_redhat_distro: centos7
 ## Ceph options
 #
 cephx: true
-cephx_require_signatures: true
+cephx_require_signatures: true # Kernel RBD does NOT support signatures!
 cephx_cluster_require_signatures: true
 cephx_service_require_signatures: false
 disable_in_memory_logs: true


### PR DESCRIPTION
Add a comment for KRBD, enabling cephx signatures will prevent you to
map RBD devices.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
