### PR TITLE
Auto generate an FSID

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -22,6 +22,14 @@
   ignore_errors: true
   register: socket
 
+- name: Generate cluster UUID
+  shell: "uuidgen | tee /etc/ceph/ceph_cluster_uuid.conf" creates=/etc/ceph/ceph_cluster_uuid.conf
+  register: cluster_uuid
+
+- name: Read cluster UUID if it already exists
+  command: cat /etc/ceph/ceph_cluster_uuid.conf removes=/etc/ceph/ceph_cluster_uuid.conf
+  register: cluster_uuid
+
 - name: Generate Ceph configuration file
   template: >
     src=ceph.conf.j2
@@ -38,4 +46,8 @@
   ignore_errors: true
 
 - name: Increase PID max value to a very large value
-  sysctl: name="kernel.pid_max" value=4194303 state=present sysctl_file=/etc/sysctl.conf
+  sysctl: >
+    name="kernel.pid_max"
+    value=4194303
+    state=present
+    sysctl_file=/etc/sysctl.conf

--- a/roles/ceph-common/vars/main.yml
+++ b/roles/ceph-common/vars/main.yml
@@ -5,7 +5,7 @@
 #
 
 # ACTIVATE THE FSID VARIABLE FOR NON-VAGRANT DEPLOYMENT
-#fsid:
+fsid: "{{ cluster_uuid.stdout }}"
 
 ## Packages branch
 ceph_stable: true # use ceph stable branch

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -18,7 +18,7 @@
     mode=0644
 
 - name: Ceph monitor mkfs
-  command: "ceph-mon --mkfs -i {{ ansible_hostname }} --keyring /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} creates=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/keyring"
+  command: "ceph-mon --mkfs -i {{ ansible_hostname }} --fsid {{ cluster_uuid.stdout }} --keyring /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} creates=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/keyring"
 
 - name: Start and add that the monitor service to the init sequence
   service: >

--- a/roles/ceph-mon/vars/main.yml
+++ b/roles/ceph-mon/vars/main.yml
@@ -2,7 +2,7 @@
 # You can override vars by using host or group vars
 
 # ACTIVATE BOTH FSID AND MONITOR_SECRET VARIABLES FOR NON-VAGRANT DEPLOYMENT
-# fsid:
+fsid: "{{ cluster_uuid.stdout }}"
 # monitor_secret:
 cephx: true
 

--- a/roles/ceph-osd/vars/main.yml
+++ b/roles/ceph-osd/vars/main.yml
@@ -6,7 +6,7 @@
 #
 
 # ACTIVATE THE FSID VARIABLE FOR NON-VAGRANT DEPLOYMENT
-# fsid:
+fsid: "{{ cluster_uuid.stdout }}"
 cephx: true
 
 # Devices to be used as OSDs


### PR DESCRIPTION
It has becomes really anoying to manually generate an fsid prior to the
inital bootstrap. This commit introduces a method that auto-generates an
fsid. If for whatever reasons you want to force your own fsid you can
simply edit these 3 files and override the fsid variable:
- roles/ceph-common/vars/main.yml
- roles/ceph-mon/vars/main.yml
- roles/ceph-osd/vars/main.yml

Signed-off-by: Sébastien Han sebastien.han@enovance.com
