### PR TITLE
added auto-discovery of OSD disks

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -33,6 +33,7 @@ dummy:
 
 ## OSD options
 #
+#osd_auto_discovery: true
 #journal_size: 100
 #pool_default_pg_num: 128
 #pool_default_pgp_num: 128

--- a/roles/ceph-osd/tasks/journal_collocation.yml
+++ b/roles/ceph-osd/tasks/journal_collocation.yml
@@ -18,10 +18,16 @@
 
 # NOTE (alahouze): if the device is a partition, the parted command below has
 # failed, this is why we check if the device is a partition too.
+- name: Automatic prepare OSD disk(s) without partitions
+  command: ceph-disk prepare "/dev/{{ item.key }}"
+  when: ansible_devices is defined and item.value.removable == "0" and item.value.partitions|count == 0 and journal_collocation and osd_auto_discovery
+  ignore_errors: True
+  with_dict: ansible_devices
+  register: prepared_osds
 
-- name: Prepare OSD disk(s)
+- name: Manually Prepare OSD disk(s)
   command: "ceph-disk prepare {{ item.2 }}"
-  when: (item.0.rc != 0 or item.1.rc != 0) and journal_collocation
+  when: (item.0.rc != 0 or item.1.rc != 0) and journal_collocation and not osd_auto_discovery
   ignore_errors: True
   with_together:
     - parted.results


### PR DESCRIPTION
Automatically prepare OSD disks on storage nodes if there is no partitions on disks(with journal_colocation)

Only active, when option osd_auto_discovery set to true
