### PR TITLE
Add support for Precise when installing ansible

### DIFF
--- a/bootstrap-ansible.sh
+++ b/bootstrap-ansible.sh
@@ -9,6 +9,7 @@ fi
 
 if [[ -x $(which lsb_release 2>/dev/null) ]]; then
   os_VENDOR=$(lsb_release -i -s)
+  os_VERSION=$(lsb_release -c -s)
   if [[ "Debian" =~ $os_VENDOR ]]; then
     apt-get update
     apt-get install python-pip python-dev git build-essential -y
@@ -18,9 +19,14 @@ if [[ -x $(which lsb_release 2>/dev/null) ]]; then
     make install
     mkdir /etc/ansible
   elif [[ "Ubuntu" =~ $os_VENDOR ]]; then
-    apt-get install -y ansible
+    if [[ "precise" =~ $os_VERSION ]]; then
+      add-apt-repository ppa:rquillo/ansible
+      apt-get update
+      apt-get install -y ansible
+    else
+      apt-get install -y ansible
+    fi
   fi
 elif [[ -r /etc/redhat-release ]]; then
   yum install -y ansible
 fi
-


### PR DESCRIPTION
Add support for precise and ppa.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
