### PR TITLE
Add support for Intank Ceph Enterprise

### DIFF
--- a/roles/ceph-common/tasks/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/install_on_redhat.yml
@@ -28,8 +28,46 @@
   command: "rpm -U http://gitbuilder.ceph.com/ceph-rpm-{{ ceph_dev_redhat_distro }}-x86_64-basic/ref/{{ ceph_dev_branch }}/noarch/ceph-release-1-0.{{ ceph_stable_redhat_distro }}.noarch.rpm creates=/etc/yum.repos.d/ceph.repo"
   when: ceph_dev
 
+- name: Create package directory
+  file: >
+    path=/tmp/ice_repo
+    state=directory
+    owner=root
+    group=root
+    mode=0644
+  when: ceph_stable_ice
+
+- name: Get ICE packages
+  get_url: >
+    url_username={{ ceph_stable_ice_user }}
+    url_password={{ ceph_stable_ice_password }}
+    url=https://download.inktank.com/enterprise/{{ ceph_stable_ice_version }}/ICE-{{ ceph_stable_ice_version }}-rhel7.tar.gz
+    dest=/tmp/ice_repo/ICE-{{ ceph_stable_ice_version }}-rhel7.tar.gz
+  when: ceph_stable_ice
+
+- name: Stat extracted repo files
+  stat: >
+    path=/tmp/ice_repo/repodata/repomd.xml
+  register: repo_exist
+
+- name: Extract packages
+  shell: cd /tmp/ice_repo && tar -xzf ICE-{{ ceph_stable_ice_version }}-rhel7.tar.gz
+  when: ceph_stable_ice and repo_exist.stat.exists == False
+
+- name: Move the extracted packages
+  shell: mv /tmp/ice_repo/ceph/*/* /tmp/ice_repo
+  when: ceph_stable_ice and repo_exist.stat.exists == False
+
+- name: Create repository
+  template: >
+    src=ice.repo.j2
+    dest=/etc/yum.repos.d/ice.repo
+    owner=root
+    group=root
+    mode=0644
+  when: ceph_stable_ice
+
 - name: Install Ceph
   yum: >
     name=ceph
     state=latest
-

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -11,6 +11,14 @@
   fail: "msg=Distribution not supported {{ ansible_os_family }}"
   when: "ansible_os_family not in ['Debian', 'RedHat']"
 
+- name: Fail on wrong distribution with wrong repo
+  fail: "msg=Inktank Ceph Enterprise can not be installed on {{ ansible_os_family }}, Red Hat Enterprise Linux 7 only"
+  when: ansible_os_family == 'Debian' and ceph_stable_ice
+
+- name: Fail on wrong distribution with wrong repo
+  fail: "msg=Inktank Ceph Enterprise can not be installed on {{ ansible_os_family }}i {{ ansible_distribution_major_version }}, Red Hat Enterprise Linux 7 only"
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version != '7' and ceph_stable_ice
+
 - include: install_on_redhat.yml
   when: ansible_os_family == 'RedHat'
 

--- a/roles/ceph-common/templates/ice.repo.j2
+++ b/roles/ceph-common/templates/ice.repo.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+[ice]
+name=Inktank Ceph Enterprise - local packages for Ceph
+baseurl=file:///tmp/ice_repo
+enabled=1
+gpgcheck=0
+protect=1
+priority=1

--- a/roles/ceph-common/vars/main.yml
+++ b/roles/ceph-common/vars/main.yml
@@ -1,13 +1,16 @@
 ---
 # You can override vars by using host or group vars
 
-## Setup options
-#
+#########
+# INSTALL
+#########
 
-# ACTIVATE THE FSID VARIABLE FOR NON-VAGRANT DEPLOYMENT
-fsid: "{{ cluster_uuid.stdout }}"
+# /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_dev /!\
 
-## Packages branch
+# STABLE
+########
+
+# COMMUNITY VERSION
 ceph_stable: true # use ceph stable branch
 ceph_stable_key: https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
 ceph_stable_release: giant # ceph stable release
@@ -15,6 +18,15 @@ ceph_stable_release: giant # ceph stable release
 # This option is needed for _both_ stable and dev version, so please always fill the right version
 # # supported distros are el6, rhel6, f18, f19, opensuse12.2, sles11, centos7 (see http://ceph.com/rpm-firefly/)
 ceph_stable_redhat_distro: el7
+
+# ENTERPRISE VERSION
+ceph_stable_ice: false # use Inktank Ceph Enterprise
+#ceph_stable_ice_version:
+#ceph_stable_ice_user:
+#ceph_stable_ice_password:
+
+# DEV
+# ###
 
 ceph_dev: false # use ceph development branch
 ceph_dev_key: https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
@@ -25,8 +37,13 @@ ceph_dev_branch: master # development branch you would like to use e.g: master, 
 # For rhel, please pay attention to the versions: 'rhel6 3' or 'rhel 4', the fullname is _very_ important.
 ceph_dev_redhat_distro: centos7
 
+###############
+# CONFIGURATION
+###############
+
 ## Ceph options
 #
+fsid: "{{ cluster_uuid.stdout }}"
 cephx: true
 cephx_require_signatures: true # Kernel RBD does NOT support signatures!
 cephx_cluster_require_signatures: true


### PR DESCRIPTION
With the appropriate subscription details you will be able to use the
Inktank Ceph Enterprise version of Ceph running on RHEL7.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
