### PR TITLE
Disable MDS and RGW from default

### DIFF
--- a/roles/ceph-common/vars/main.yml
+++ b/roles/ceph-common/vars/main.yml
@@ -95,11 +95,11 @@ osd_recovery_threads: 1
 
 ## MDS options
 #
-mds: true # disable mds configuration in ceph.conf
+mds: false # disable mds configuration in ceph.conf
 
 # Rados Gateway options
 #
-radosgw: true # referenced in monitor role too.
+radosgw: false # referenced in monitor role too.
 #radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
 
 ## Testing mode

--- a/roles/ceph-mon/vars/main.yml
+++ b/roles/ceph-mon/vars/main.yml
@@ -8,4 +8,4 @@ cephx: true
 
 # Rados Gateway options
 # referenced in common role too.
-radosgw: true
+radosgw: false


### PR DESCRIPTION
MDS and RGW are not deployed often (RGW more), so we disable them from
the default deployment to only get MONs and OSDs.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
