### PR TITLE
Add ICE Kernel module support for Red Hat systems

### DIFF
--- a/roles/ceph-common/tasks/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/install_on_redhat.yml
@@ -22,7 +22,7 @@
 
 - name: Install Inktank Ceph Enterprise repository key
   rpm_key: >
-    key=file://{{ ceph_stable_ice_temp_path }}/*/release.asc
+    key=file://{{ ceph_stable_ice_temp_path }}/release.asc
     state=present
   when: ceph_stable_ice
 
@@ -47,3 +47,11 @@
   yum: >
     name=ceph
     state=latest
+
+- name: Install Inktank Ceph Enterprise RBD Kernel modules
+  yum: >
+    name={{ item }}
+  with_items:
+    - {{ ceph_stable_ice_temp_path }}/kmod-libceph-{{ ceph_stable_ice_kmod }}.rpm
+    - {{ ceph_stable_ice_temp_path }}/kmod-rbd-{{ ceph_stable_ice_kmod }}.rpm
+  when: ceph_stable_ice

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -69,9 +69,20 @@
   get_url: >
     url_username={{ ceph_stable_ice_user }}
     url_password={{ ceph_stable_ice_password }}
-    url=https://download.inktank.com/enterprise/{{ ceph_stable_ice_version }}/ICE-{{ ceph_stable_ice_version }}-{{ ceph_stable_ice_distro }}.tar.gz
+    url={{ ceph_stable_ice_url }}/{{ ceph_stable_ice_version }}/ICE-{{ ceph_stable_ice_version }}-{{ ceph_stable_ice_distro }}.tar.gz
     dest={{ ceph_stable_ice_temp_path }}/ICE-{{ ceph_stable_ice_version }}-{{ ceph_stable_ice_distro }}.tar.gz
   when: ceph_stable_ice
+
+- name: Get ICE Kernel Modules
+  get_url: >
+    url_username={{ ceph_stable_ice_user }}
+    url_password={{ ceph_stable_ice_password }}
+    url={{ ceph_stable_ice_url }}/{{ ceph_stable_ice_kmod_version }}/{{ item }}
+    dest={{ ceph_stable_ice_temp_path }}
+  with_items:
+    - kmod-libceph-{{ ceph_stable_ice_kmod }}.rpm
+    - kmod-rbd-{{ ceph_stable_ice_kmod }}.rpm
+  when: ceph_stable_ice and ansible_os_family == 'RedHat'
 
 - name: Stat extracted repo files
   stat: >

--- a/roles/ceph-common/vars/main.yml
+++ b/roles/ceph-common/vars/main.yml
@@ -21,11 +21,14 @@ ceph_stable_redhat_distro: el7
 
 # ENTERPRISE VERSION
 ceph_stable_ice: false # use Inktank Ceph Enterprise
+#ceph_stable_ice_url: https://download.inktank.com/enterprise
 #ceph_stable_ice_temp_path: /opt/ICE/ceph-repo/
-#ceph_stable_ice_distro: # Please check the download website for the supported versions.
-#ceph_stable_ice_version:
-#ceph_stable_ice_user:
-#ceph_stable_ice_password:
+#ceph_stable_ice_kmod: 3.10-0.1.20140702gitdc9ac62.el7.x86_64
+#ceph_stable_ice_distro: rhel7 # Please check the download website for the supported versions.
+#ceph_stable_ice_version: 1.2.2
+#ceph_stable_ice_kmod_version: 1.2
+#ceph_stable_ice_user: # htaccess user
+#ceph_stable_ice_password: # htaccess password
 
 # DEV
 # ###


### PR DESCRIPTION
Install Kernel modules from ICE for Ceph RBD.

Signed-off-by: Sébastien Han sebastien.han@enovance.com
