### PR TITLE
add quotes so ansible yaml parser do not barf on it...

### DIFF
--- a/roles/ceph-common/tasks/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/install_on_redhat.yml
@@ -52,6 +52,6 @@
   yum: >
     name={{ item }}
   with_items:
-    - {{ ceph_stable_ice_temp_path }}/kmod-libceph-{{ ceph_stable_ice_kmod }}.rpm
-    - {{ ceph_stable_ice_temp_path }}/kmod-rbd-{{ ceph_stable_ice_kmod }}.rpm
+    - "{{ ceph_stable_ice_temp_path }}/kmod-libceph-{{ ceph_stable_ice_kmod }}.rpm"
+    - "{{ ceph_stable_ice_temp_path }}/kmod-rbd-{{ ceph_stable_ice_kmod }}.rpm"
   when: ceph_stable_ice


### PR DESCRIPTION
Python yaml parser is not too smart so quoting this will make it happy and of course us users :-)


ERROR: Syntax Error while loading YAML script, /ceph-ansible/roles/ceph-common/tasks/install_on_redhat.yml
Note: The error may actually appear before this position: line 55, column 38 

    with_items:
      - {{ ceph_stable_ice_temp_path }}/kmod-libceph-{{ ceph_stable_ice_kmod }}.rpm

We could be wrong, but this one looks like it might be an issue with
missing quotes.  Always quote template expression brackets when they
start a value. For instance:

    with_items:
      - {{ foo }}

Should be written as:

    with_items:
      - "{{ foo }}"
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again. 