### PR TITLE
Add a dummy ansible host file for syntax checking

### DIFF
--- a/dummy-ansible-hosts
+++ b/dummy-ansible-hosts
@@ -1,0 +1,9 @@
+# Dummy ansible host file
+# Used for syntax check
+# Before committing code please run: ansible-playbook --syntax-check site.yml -i dummy-ansible-hosts
+[mons]
+127.0.0.1
+[osds]
+127.0.0.1
+[mdss]
+127.0.0.1


### PR DESCRIPTION
The Ansible YAML syntax checker needs an inventory file.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>