### PR TITLE
Remove the fsid vars from mon and osd roles

### DIFF
--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
 # You can override vars by using host or group vars
 
-# ACTIVATE BOTH FSID AND MONITOR_SECRET VARIABLES FOR NON-VAGRANT DEPLOYMENT
-fsid: "{{ cluster_uuid.stdout }}"
+# ACTIVATE MONITOR_SECRET VARIABLE FOR NON-VAGRANT DEPLOYMENT
 # monitor_secret:
 cephx: true
 

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -4,9 +4,6 @@
 
 ## Ceph options
 #
-
-# ACTIVATE THE FSID VARIABLE FOR NON-VAGRANT DEPLOYMENT
-fsid: "{{ cluster_uuid.stdout }}"
 cephx: true
 
 # Devices to be used as OSDs


### PR DESCRIPTION
We do not need them since they get registered by the ceph-common role.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>