### PR TITLE
Bump up max open file for big cluster

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -53,6 +53,7 @@ cephx: true
 cephx_require_signatures: true # Kernel RBD does NOT support signatures!
 cephx_cluster_require_signatures: true
 cephx_service_require_signatures: false
+max_open_files: 131072
 disable_in_memory_logs: true
 
 ## Monitor options

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -15,6 +15,7 @@
   auth supported = none
 {% endif %}
   fsid = {{ fsid }}
+  max open files = {{ max_open_files }}
   osd pool default pg num = {{ pool_default_pg_num }}
   osd pool default pgp num = {{ pool_default_pgp_num }}
   osd pool default size = {{ pool_default_size }}


### PR DESCRIPTION
Big cluster will easily reach the default limit so we need to increase
it and make it configurable.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>