### PR TITLE
Bump up maximum number of open files

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -56,6 +56,13 @@
     state=present
     sysctl_file=/etc/sysctl.conf
 
+- name:  Increase the maximum number of open files
+  sysctl: >
+    name="fs.file-max"
+    value=13211539
+    state=present
+    sysctl_file=/etc/sysctl.conf
+
 - name: Create package directory
   file: >
     path={{ ceph_stable_ice_temp_path }}


### PR DESCRIPTION
Large cluster will easily reach the default value so we increase it.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>