### PR TITLE
Restructure OS tuning and add new value

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -119,5 +119,7 @@ radosgw: false # referenced in monitor role too.
 # OS TUNING
 ###########
 
-os_tuning_pid_max: 4194303
-os_tuning_file_max: 26234859
+os_tuning_params:
+  - { name: kernel.pid_max, value: 4194303 }
+  - { name: fs.file-max, value: 26234859 }
+  - { name: vm.zone_reclaim_mode, value: 0 }

--- a/roles/ceph-common/tasks/os_tuning.yml
+++ b/roles/ceph-common/tasks/os_tuning.yml
@@ -3,16 +3,10 @@
   command: updatedb -e /var/lib/ceph
   ignore_errors: true
 
-- name: Increase PID max value to a very large value
+- name: Apply OS tuning
   sysctl: >
-    name="kernel.pid_max"
-    value={{ os_tuning_pid_max }}
+    name={{ item.name }}
+    value={{ item.value }}
     state=present
     sysctl_file=/etc/sysctl.conf
-
-- name:  Increase the maximum number of open files
-  sysctl: >
-    name="fs.file-max"
-    value={{ os_tuning_file_max }}
-    state=present
-    sysctl_file=/etc/sysctl.conf
+  with_items: os_tuning_params


### PR DESCRIPTION
We now use a single task and loop over a set of params, it's easier to
add now params.

Setting zone_reclaim_mode to 0.
See the discussion on the Ceph ML:
http://lists.ceph.com/pipermail/ceph-users-ceph.com/2013-December/036211.html

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>