### PR TITLE
Ability to disable transparent hugepage

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -119,6 +119,7 @@ radosgw: false # referenced in monitor role too.
 # OS TUNING
 ###########
 
+disable_transparent_hugepage: true
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/roles/ceph-common/tasks/os_tuning.yml
+++ b/roles/ceph-common/tasks/os_tuning.yml
@@ -3,6 +3,11 @@
   command: updatedb -e /var/lib/ceph
   ignore_errors: true
 
+- name: Disable transparent hugepage
+  command: "echo never > /sys/kernel/mm/redhat_transparent_hugepage/enabled"
+  ignore_errors: true
+  when: disable_transparent_hugepage
+
 - name: Apply OS tuning
   sysctl: >
     name={{ item.name }}


### PR DESCRIPTION
In storage world it's often recommended to disable transparent hugepages
as they will tend to lower performance.
Note that this change won't survive reboot. There are several ways to
disable this permanently such as:

* rc.local
* grub boot line

It's a bit tricky to do this in Ansible since it really depends on the
OS you're running on.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>