### PR TITLE
Add yum priority plugin

### DIFF
--- a/roles/ceph-common/tasks/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/install_on_redhat.yml
@@ -7,6 +7,7 @@
     - python-pycurl
     - ntp
     - hdparm
+    - yum-plugin-priorities.noarch
 
 - name: Install the Ceph stable repository key
   rpm_key: >


### PR DESCRIPTION
Without this plugin if a Ceph version is present in a repo (let's say
epel) it will install the epel version and not the ICE version.
We install yum-plugin-priorities.noarch to honor the 'priority=1' flag.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>