### PR TITLE
Add more option to maximise sequential IO

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -79,13 +79,16 @@ cluster_network: 192.168.42.0/24
 public_network: 192.168.42.0/24
 osd_mkfs_type: xfs
 osd_mkfs_options_xfs: -f -i size=2048
-osd_mount_options_xfs: noatime
+osd_mount_options_xfs: noatime,largeio,inode64,swalloc
 osd_mon_heartbeat_interval: 30
+
 # CRUSH
 pool_default_crush_rule: 0
 osd_crush_update_on_start: "true"
+
 # Object backend
 osd_objectstore: filestore
+
 # Performance tuning
 filestore_merge_threshold: 40
 filestore_split_multiple: 8
@@ -93,6 +96,7 @@ osd_op_threads: 8
 filestore_op_threads: 8
 filestore_max_sync_interval: 5
 osd_max_scrubs: 1
+
 # Recovery tuning
 osd_recovery_max_active: 5
 osd_max_backfills: 2


### PR DESCRIPTION
Using the largeio,inode64,swalloc options usually improves sequential
workloads.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>