### PR TITLE
Fix transparent huge page sys path

### DIFF
--- a/roles/ceph-common/tasks/os_tuning.yml
+++ b/roles/ceph-common/tasks/os_tuning.yml
@@ -4,7 +4,7 @@
   ignore_errors: true
 
 - name: Disable transparent hugepage
-  command: "echo never > /sys/kernel/mm/redhat_transparent_hugepage/enabled"
+  command: "echo never > /sys/kernel/mm/transparent_hugepage/enabled"
   ignore_errors: true
   when: disable_transparent_hugepage
 


### PR DESCRIPTION
The old path was meant for old kernels...

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>