### PR TITLE
Decrease vfs cache pressure

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -128,3 +128,4 @@ os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
   - { name: vm.zone_reclaim_mode, value: 0 }
+  - { name: vm.vfs_cache_pressure, value: 50 }


### PR DESCRIPTION
On OSD servers we want to keep as much inodes and dentries in memory as
we can.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>