### PR TITLE
Improve RGW config section

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
 # {{ ansible_managed }}
 
 [global]
@@ -140,8 +141,8 @@
   {% endif %}
   host = {{ hostvars[host]['ansible_hostname'] }}
   keyring = /etc/ceph/radosgw.gateway.keyring
-  rgw socket path = /tmp/radosgw.sock
-  log file = /var/log/ceph/radosgw.log
+  rgw socket path = /tmp/radosgw-{{ hostvars[host]['ansible_hostname'] }}.sock
+  log file = /var/log/ceph/radosgw-{{ hostvars[host]['ansible_hostname'] }}.log
   rgw data = /var/lib/ceph/radosgw/{{ hostvars[host]['ansible_hostname'] }}
   rgw print continue = false
 {% endif %}


### PR DESCRIPTION
Use hostname in socket and log.
Improve jinja template so when a var doesn't exist we don't indent the
next line.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>