### PR TITLE
Fix the rgw section

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -135,7 +135,7 @@
 {% if radosgw %}
 {% for host in groups['rgws'] %}
 {% if hostvars[host]['ansible_hostname'] is defined %}
-[client.radosgw.{{ hostvars[host]['ansible_hostname'] }}]
+[client.radosgw.gateway]
   {% if radosgw_dns_name is defined %}
     rgw dns name = {{ radosgw_dns_name }}
   {% endif %}


### PR DESCRIPTION
If we use the hostname, the radosgw will lookup for a wrong secret.
Using the same name for all the gateways.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>