### PR TITLE
Bring multi RGW support

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -135,12 +135,12 @@
 {% if radosgw %}
 {% for host in groups['rgws'] %}
 {% if hostvars[host]['ansible_hostname'] is defined %}
-[client.radosgw.gateway]
+[client.radosgw.{{ hostvars[host]['ansible_hostname'] }}]
   {% if radosgw_dns_name is defined %}
     rgw dns name = {{ radosgw_dns_name }}
   {% endif %}
   host = {{ hostvars[host]['ansible_hostname'] }}
-  keyring = /etc/ceph/radosgw.gateway.keyring
+  keyring = /etc/ceph/radosgw.{{ hostvars[host]['ansible_hostname'] }}.keyring
   rgw socket path = /tmp/radosgw-{{ hostvars[host]['ansible_hostname'] }}.sock
   log file = /var/log/ceph/radosgw-{{ hostvars[host]['ansible_hostname'] }}.log
   rgw data = /var/lib/ceph/radosgw/{{ hostvars[host]['ansible_hostname'] }}

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -6,8 +6,9 @@
   wait_for: path=/etc/ceph/ceph.client.admin.keyring
 
 - name: Create RGW keyring
-  command: ceph auth get-or-create client.radosgw.gateway osd 'allow rwx' mon 'allow rw' -o /etc/ceph/radosgw.gateway.keyring creates=/etc/ceph/radosgw.gateway.keyring
+  command: ceph auth get-or-create client.radosgw.{{ hostvars[item]['ansible_hostname'] }} osd 'allow rwx' mon 'allow rw' -o /etc/ceph/radosgw.{{ hostvars[item]['ansible_hostname'] }}.keyring creates=/etc/ceph/radosgw.{{ hostvars[item]['ansible_hostname'] }}.keyring
   when: cephx and radosgw
+  with_items: groups.rgws
   changed_when: False
 
 - include: openstack_config.yml

--- a/roles/ceph-radosgw/tasks/main.yml
+++ b/roles/ceph-radosgw/tasks/main.yml
@@ -1,10 +1,19 @@
 ---
 - name: Copy RGW bootstrap key
-  copy: src=fetch/{{ fsid }}/etc/ceph/radosgw.gateway.keyring dest=/etc/ceph/radosgw.gateway.keyring owner=root group=root mode=600
+  copy: >
+    src=fetch/{{ fsid }}/etc/ceph/radosgw.{{ ansible_hostname }}.keyring
+    dest=/etc/ceph/radosgw.{{ ansible_hostname }}.keyring
+    owner=root
+    group=root
+    mode=600
   when: cephx
 
 - name: Set RGW bootstrap key permissions
-  file: path=/etc/ceph/radosgw.gateway.keyring mode=0600 owner=root group=root
+  file: >
+    path=/etc/ceph/radosgw.{{ ansible_hostname }}.keyring
+    mode=0600
+    owner=root
+    group=root
   when: cephx
 
 ## Check OS family


### PR DESCRIPTION
Now we can setup multi-rgw with the playbook.
Each rgw instance has its own key.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>