### PR TITLE
Add RBD client logs support

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -58,6 +58,7 @@ max_open_files: 131072
 
 # Logging
 disable_in_memory_logs: true # set this to false while enabling the options below
+rbd_client_log_file: /var/log/qemu/qemu-guest-$pid.log # must be writable by QEMU and allowed by SELinux or AppArmor
 
 # Debug logs
 enable_debug_global: false

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -64,7 +64,8 @@
 [client]
   rbd cache = true
   rbd cache writethrough until flush = true
-  admin socket = /var/run/ceph/$cluster-$type.$id.$pid.$cctid.asok
+  admin socket = /var/run/ceph/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
+  log file = {{ rbd_client_log_file }} # must be writable by QEMU and allowed by SELinux or AppArmor
 
 [mon]
   mon osd down out interval = {{ mon_osd_down_out_interval }}


### PR DESCRIPTION
The path must be writable by QEMU and allowed by SELinux or AppArmor

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>