### PR TITLE
Use an external file to manage Vagrant variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.vdi
 *.keyring
 fetch/4a158d27-f750-41d5-9e7f-26ce4c9d2d45/*
+vagrant_variables.yml

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,14 +1,18 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+require 'yaml'
 VAGRANTFILE_API_VERSION = '2'
 
-NMONS   = 3
-NOSDS   = 3
-NMDSS   = 0
-NRGWS   = 0
-CLIENTS = 0
-SUBNET  = '192.168.42'
+config_file=File.expand_path(File.join(File.dirname(__FILE__), 'vagrant_variables.yml'))
+settings=YAML.load_file(config_file)
+
+NMONS   = settings['mon_vms']
+NOSDS   = settings['osd_vms']
+NMDSS   = settings['mds_vms']
+NRGWS   = settings['rgw_vms']
+CLIENTS = settings['client_vms']
+SUBNET  = settings['subnet']
 
 ansible_provision = proc do |ansible|
   ansible.playbook = 'site.yml'

--- a/vagrant_variables.yml
+++ b/vagrant_variables.yml
@@ -1,0 +1,11 @@
+---
+
+# DEFINE THE NUMBER OF VMS TO RUN
+mon_vms: 3
+osd_vms: 3
+mds_vms: 0
+rgw_vms: 0
+client_vms: 0
+
+# SUBNET TO USE FOR THE VMS
+subnet: 192.168.42


### PR DESCRIPTION
This is really handy when we are testing code since we don't need to
modify the Vagrantfile, which is tracked by git.
The next commit will ignore the vagrant_variables.yml file.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>