### PR TITLE
Add support of civetweb for Rados Gateway

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -120,10 +120,12 @@ osd_recovery_threads: 1
 #
 mds: false # disable mds configuration in ceph.conf
 
-# Rados Gateway options
+## Rados Gateway options
 #
 radosgw: false # referenced in monitor role too.
 #radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
+radosgw_frontend: civetweb # supported options are 'apache' or 'civetweb', also edit roles/ceph-radosgw/defaults/main.yml
+radosgw_civetweb_port: 80
 
 ## Testing mode
 # enable this mode _only_ when you have a single node

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -145,6 +145,9 @@
   log file = /var/log/ceph/radosgw-{{ hostvars[host]['ansible_hostname'] }}.log
   rgw data = /var/lib/ceph/radosgw/{{ hostvars[host]['ansible_hostname'] }}
   rgw print continue = false
+  {% if radosgw_frontend  == 'civetweb' %}
+  rgw frontends = civetweb port={{ radosgw_civetweb_port }}
+  {% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/roles/ceph-radosgw/defaults/main.yml
+++ b/roles/ceph-radosgw/defaults/main.yml
@@ -12,3 +12,5 @@ http_100_continue: false
 # Rados Gateway options
 redhat_distro_ceph_extra: centos6.4 # supported distros are centos6.3, centos6.4, centos6, fedora18, fedora19, opensuse12.2, rhel6.3, rhel6.4, rhel6.5, rhel6, sles11sp2
 email_address: foo@bar.com
+
+radosgw_frontend: civetweb # we currently only support a single backend

--- a/roles/ceph-radosgw/tasks/install_debian.yml
+++ b/roles/ceph-radosgw/tasks/install_debian.yml
@@ -86,7 +86,7 @@
     - libapache2-mod-fastcgi
   when: purge_default_apache.changed or purge_ceph_apache.changed
 
-- name: "Install Apache, fastcgi and Rados Gateway"
+- name: "Install Apache and fastcgi"
   apt: >
     pkg={{ item }}
     state=present
@@ -94,7 +94,6 @@
   with_items:
     - apache2
     - libapache2-mod-fastcgi
-    - radosgw
 
 ## Prepare Apache
 #
@@ -118,14 +117,6 @@
 ## Prepare RGW
 #
 
-- name: Create RGW directory
-  file: >
-    path=/var/lib/ceph/radosgw/{{ ansible_fqdn }}
-    state=directory
-    owner=root
-    group=root
-    mode=0644
-
 - name: Enable Rados Gateway vhost and disable default site
   command: "{{ item }}"
   with_items:
@@ -142,13 +133,3 @@
     mode=0555
     owner=root
     group=root
-
-## If we don't perform this check Ansible will start multiple instance of radosgw
-- name: Check if RGW is started
-  command: /etc/init.d/radosgw status
-  register: rgwstatus
-  ignore_errors: True
-
-- name: Start RGW
-  command: /etc/init.d/radosgw start
-  when: rgwstatus.rc != 0

--- a/roles/ceph-radosgw/tasks/install_redhat.yml
+++ b/roles/ceph-radosgw/tasks/install_redhat.yml
@@ -15,7 +15,7 @@
 - name: Add special fastcgi repository
   command: rpm -ivh http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm
 
-- name: "Install Apache, fastcgi, and Rados Gateway"
+- name: "Install Apache and fastcgi"
   yum: >
     name={{ item }}
     state=present
@@ -23,7 +23,6 @@
     - httpd
     - mod_fastcgi
     - mod_fcgid
-    - ceph-radosgw
 
 ## Prepare Apache
 #
@@ -38,14 +37,6 @@
 ## Prepare RGW
 #
 
-- name: Create RGW directory
-  file: >
-    path=/var/lib/ceph/radosgw/{{ ansible_fqdn }}
-    state=directory
-    owner=root
-    group=root
-    mode=0644
-
 - name: Install s3gw.fcgi script
   template: >
     src=s3gw.fcgi.j2
@@ -59,13 +50,3 @@
   changed_when: False
   notify:
     - restart apache2
-
-## If we don't perform this check Ansible will start multiple instance of radosgw
-- name: Check if RGW is started
-  command: /etc/init.d/ceph-radosgw status
-  register: rgwstatus
-  ignore_errors: True
-
-- name: Start RGW
-  command: /etc/init.d/ceph-radosgw start
-  when: rgwstatus.rc != 0

--- a/roles/ceph-radosgw/tasks/main.yml
+++ b/roles/ceph-radosgw/tasks/main.yml
@@ -16,11 +16,42 @@
     group=root
   when: cephx
 
+- name: Create RGW directory
+  file: >
+    path=/var/lib/ceph/radosgw/{{ ansible_fqdn }}
+    state=directory
+    owner=root
+    group=root
+    mode=0644
+
 ## Check OS family
 #
 
 - include: install_redhat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and radosgw_frontend == 'apache'
 
 - include: install_debian.yml
+  when: ansible_os_family == 'Debian' and radosgw_frontend == 'apache'
+
+- name: "Install Rados Gateway"
+  apt: >
+    pkg=radosgw
+    state=present
+    update_cache=yes
   when: ansible_os_family == 'Debian'
+
+- name: "Install Rados Gateway"
+  yum: >
+    name=ceph-radosgw
+    state=present
+  when: ansible_os_family == 'RedHat'
+
+## If we don't perform this check Ansible will start multiple instance of radosgw
+- name: Check if RGW is started
+  command: /etc/init.d/radosgw status
+  register: rgwstatus
+  ignore_errors: True
+
+- name: Start RGW
+  command: /etc/init.d/radosgw start
+  when: rgwstatus.rc != 0


### PR DESCRIPTION
The default is now to use civet web since it has proven to be a bit more reliable and easy to setup than Apache.
We don't support multi backend yet.
Radow GW supports both CGI and civet web on the same machine.
Signed-off-by: Sébastien Han <sebastien.han@enovance.com>