### PR TITLE
Fix MDS creation for version >= 0.84

### DIFF
--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -14,6 +14,11 @@ cephx: true
 # referenced in common role too.
 radosgw: false
 
+# CephFS
+pool_default_pg_num: 128
+cephfs_data: cephfs_data
+cephfs_metadata: cephfs_metadata
+cephfs: cephfs
 
 #############
 # OPENSTACK #

--- a/roles/ceph-mon/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mon/tasks/create_mds_filesystems.yml
@@ -1,0 +1,9 @@
+---
+- name: Create filesystem pools
+  command: ceph osd pool create {{ item }} {{ pool_default_pg_num }}
+  with_items:
+    - cephfs_data
+    - cephfs_metadata
+
+- name: Create Ceph Filesystem
+  command: ceph fs new {{ cephfs }} {{ cephfs_metadata }} {{ cephfs_data }}

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -26,3 +26,7 @@
     state=started
     enabled=yes
     args=mon
+
+- name: Get Ceph monitor version
+  shell: ceph daemon mon."{{ ansible_hostname }}" version | cut -d '"' -f 4 | cut -f 1,2 -d '.'
+  register: ceph_version

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -5,8 +5,8 @@
 - include: ceph_keys.yml
   when: not ceph_containerized_deployment
 
-- include: ceph_keys.yml
-  when: not ceph_containerized_deployment
+- include: create_mds_filesystems.yml
+  when: not ceph_containerized_deployment and not {{ ceph_version.stdout | version_compare('0.84', '<') }}
 
 - include: docker.yml
   when: ceph_containerized_deployment


### PR DESCRIPTION
The ceph fs new command was introduced in Ceph 0.84. Prior to this
release, no manual steps are required to create a filesystem, and pools
named data and metadata exist by default.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>