### PR TITLE
Rework radosgw keys and data dir path

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -141,10 +141,10 @@
     rgw dns name = {{ radosgw_dns_name }}
   {% endif %}
   host = {{ hostvars[host]['ansible_hostname'] }}
-  keyring = /etc/ceph/radosgw.{{ hostvars[host]['ansible_hostname'] }}.keyring
+  keyring = /var/lib/ceph/radosgw/ceph-radosgw.{{ hostvars[host]['ansible_hostname'] }}/keyring
   rgw socket path = /tmp/radosgw-{{ hostvars[host]['ansible_hostname'] }}.sock
   log file = /var/log/ceph/radosgw-{{ hostvars[host]['ansible_hostname'] }}.log
-  rgw data = /var/lib/ceph/radosgw/{{ hostvars[host]['ansible_hostname'] }}
+  rgw data = /var/lib/ceph/radosgw/ceph-radosgw.{{ hostvars[host]['ansible_hostname'] }}
   rgw print continue = false
   {% if radosgw_frontend  == 'civetweb' %}
   rgw frontends = civetweb port={{ radosgw_civetweb_port }}

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -7,8 +7,8 @@
 
 - name: Create RGW keyring
   command: >
-    ceph auth get-or-create client.radosgw.{{ hostvars[item]['ansible_hostname'] }} osd 'allow rwx' mon 'allow rw' -o /etc/ceph/radosgw.{{ hostvars[item]['ansible_hostname'] }}.keyring
-    creates=/etc/ceph/radosgw.{{ hostvars[item]['ansible_hostname'] }}.keyring
+    ceph auth get-or-create client.radosgw.{{ hostvars[item]['ansible_hostname'] }} osd 'allow rwx' mon 'allow rw' -o /etc/ceph/ceph.client.radosgw.{{ hostvars[item]['ansible_hostname'] }}.keyring
+    creates=/etc/ceph/ceph.client.radosgw.{{ hostvars[item]['ansible_hostname'] }}.keyring
   when: cephx and radosgw
   with_items: groups.rgws
   changed_when: False

--- a/roles/ceph-radosgw/tasks/pre_requisite.yml
+++ b/roles/ceph-radosgw/tasks/pre_requisite.yml
@@ -1,25 +1,25 @@
 ---
+- name: Create RGW directory
+  file: >
+    path=/var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_fqdn }}
+    state=directory
+    owner=root
+    group=root
+    mode=0644
+
 - name: Copy RGW bootstrap key
   copy: >
-    src=fetch/{{ fsid }}/etc/ceph/radosgw.{{ ansible_hostname }}.keyring
-    dest=/etc/ceph/radosgw.{{ ansible_hostname }}.keyring
+    src=fetch/{{ fsid }}/etc/ceph/ceph.client.radosgw.{{ ansible_hostname }}.keyring
+    dest=/var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_hostname }}/keyring
     owner=root
     group=root
     mode=600
   when: cephx
 
-- name: Set RGW bootstrap key permissions
+- name: Activate RGW with upstart
   file: >
-    path=/etc/ceph/radosgw.{{ ansible_hostname }}.keyring
-    mode=0600
-    owner=root
-    group=root
-  when: cephx
-
-- name: Create RGW directory
-  file: >
-    path=/var/lib/ceph/radosgw/{{ ansible_fqdn }}
-    state=directory
+    path=/var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_fqdn }}/done
+    state=touch
     owner=root
     group=root
     mode=0644

--- a/roles/ceph-radosgw/tasks/start_radosgw.yml
+++ b/roles/ceph-radosgw/tasks/start_radosgw.yml
@@ -4,7 +4,12 @@
   command: /etc/init.d/radosgw status
   register: rgwstatus
   ignore_errors: True
+  when: ansible_distribution != "Ubuntu"
+
+- name: Start RGW
+  service: name=radosgw-all state=started
+  when: ansible_distribution == "Ubuntu"
 
 - name: Start RGW
   command: /etc/init.d/radosgw start
-  when: rgwstatus.rc != 0
+  when: rgwstatus.rc != 0 and ansible_distribution != "Ubuntu"


### PR DESCRIPTION
Fix the usage of Upstart for Ubuntu machines instead of the init.d
script.
Note that because of the way upstart init script looks at the radosgw id
the command 'start radosgw id=' is broken, you should use 'start
radosgw-all' instead.
Keep backard compatibility with the radosgw init script as well by using
client prefixed by 'client.radosgw'.

Sorry this will probably break current RGW installations...

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>