### PR TITLE
Implement Ceph REST API

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -111,6 +111,13 @@ dummy:
 #radosgw: false # referenced in monitor role too.
 #radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
 
+## REST API options
+#
+#restapi: false # disable restapi configuration in ceph.conf
+#restapi_public_addr: 0.0.0.0:5000
+#restapi_base_url: /api/v0.1
+#restapi_log_level: warning
+
 ## Testing mode
 # enable this mode _only_ when you have a single node
 # if you don't want it keep the option commented

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -128,6 +128,14 @@ radosgw: false # referenced in monitor role too.
 radosgw_frontend: civetweb # supported options are 'apache' or 'civetweb', also edit roles/ceph-radosgw/defaults/main.yml
 radosgw_civetweb_port: 80
 
+## REST API options
+#
+restapi: false # disable restapi configuration in ceph.conf
+restapi_interface: eth1
+restapi_port: 5000
+restapi_base_url: /api/v0.1
+restapi_log_level: warning # available level are: critical, error, warning, info, debug
+
 ## Testing mode
 # enable this mode _only_ when you have a single node
 # if you don't want it keep the option commented

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -152,3 +152,12 @@
 {% endif %}
 {% endfor %}
 {% endif %}
+
+{% if restapi %}
+[client.restapi]
+  public addr = {{ hostvars[inventory_hostname]['ansible_' + restapi_interface]['ipv4']['address'] }}:{{ restapi_port }}
+  restapi base url = {{ restapi_base_url }}
+  restapi log level = {{ restapi_log_level }}
+  keyring = /var/lib/ceph/restapi/ceph-restapi/keyring
+  log file = /var/log/ceph/ceph-restapi.log
+{% endif %}

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -20,6 +20,11 @@ cephfs_data: cephfs_data
 cephfs_metadata: cephfs_metadata
 cephfs: cephfs
 
+# Ceph REST API
+# referenced in common role too.
+restapi: false
+
+
 #############
 # OPENSTACK #
 #############

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -13,6 +13,13 @@
   with_items: groups.rgws
   changed_when: False
 
+- name: Create Ceph REST API keyring
+  command: >
+    ceph auth get-or-create client.restapi osd 'allow *' mon 'allow *' -o /etc/ceph/ceph.client.restapi.keyring
+    creates=/etc/ceph/ceph.client.restapi.keyring
+  when: cephx and restapi
+  changed_when: False
+
 - include: openstack_config.yml
   when: openstack_config and cephx
 
@@ -20,6 +27,15 @@
   shell: ls -1 /etc/ceph/*.keyring
   register: ceph_keys
   when: cephx
+
+- name: Set keys permissions
+  file: >
+    path={{ item }}
+    mode=0600
+    owner=root
+    group=root
+  with_items:
+    - "{{ ceph_keys.stdout_lines }}"
 
 - name: Copy keys to the ansible server
   fetch: >

--- a/roles/ceph-restapi/tasks/main.yml
+++ b/roles/ceph-restapi/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- include: pre_requisite.yml
+
+- name: Check if Ceph REST API is already started
+  shell: "ps aux|grep [c]eph-rest-api"
+  register: restapi_status
+  ignore_errors: True
+
+- name: Start Ceph REST API
+  shell: "nohup ceph-rest-api -n client.restapi &"
+  when: restapi_status.rc != 0

--- a/roles/ceph-restapi/tasks/pre_requisite.yml
+++ b/roles/ceph-restapi/tasks/pre_requisite.yml
@@ -1,0 +1,25 @@
+---
+- name: Create Ceph REST API directory
+  file: >
+    path=/var/lib/ceph/restapi/ceph-restapi
+    state=directory
+    owner=root
+    group=root
+    mode=0644
+
+- name: Copy Ceph REST API keyring
+  copy: >
+    src=fetch/{{ fsid }}/etc/ceph/ceph.client.restapi.keyring
+    dest=/var/lib/ceph/restapi/ceph-restapi/keyring
+    owner=root
+    group=root
+    mode=600
+  when: cephx
+
+- name: Activate Ceph REST API with upstart
+  file: >
+    path=/var/lib/ceph/restapi/ceph-restapi/done
+    state=touch
+    owner=root
+    group=root
+    mode=0644

--- a/site.yml
+++ b/site.yml
@@ -14,6 +14,7 @@
   sudo: True
   roles:
   - ceph-mon
+  - ceph-restapi
 
 - hosts: osds
   sudo: True


### PR DESCRIPTION
Now the Ceph REST API can be deployed.
Default implementation deploys it on the same nodes as the monitors
which should be fine.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>