### PR TITLE
Enforce var pool creation

### DIFF
--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -6,7 +6,7 @@
   when: not ceph_containerized_deployment
 
 - include: create_mds_filesystems.yml
-  when: not ceph_containerized_deployment and not {{ ceph_version.stdout | version_compare('0.84', '<') }}
+  when: not ceph_containerized_deployment and not {{ ceph_version.stdout | version_compare('0.84', '<') }} and mds
 
 - include: docker.yml
   when: ceph_containerized_deployment


### PR DESCRIPTION
Make sure that 'mds' is enabled before creating the filesystem.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>