### PR TITLE
Fix RGW startup

### DIFF
--- a/roles/ceph-radosgw/tasks/start_radosgw.yml
+++ b/roles/ceph-radosgw/tasks/start_radosgw.yml
@@ -4,7 +4,6 @@
   command: /etc/init.d/radosgw status
   register: rgwstatus
   ignore_errors: True
-  when: ansible_distribution != "Ubuntu"
 
 - name: Start RGW
   service: name=radosgw-all state=started


### PR DESCRIPTION
If the distribution wasn't Ubuntu, the check wasn't performed so the
evaluation in the task later wasn't possible.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>