### PR TITLE
Default client is already client.restapi

### DIFF
--- a/roles/ceph-restapi/tasks/main.yml
+++ b/roles/ceph-restapi/tasks/main.yml
@@ -7,5 +7,5 @@
   ignore_errors: True
 
 - name: Start Ceph REST API
-  shell: "nohup ceph-rest-api -n client.restapi &"
+  shell: "nohup ceph-rest-api &"
   when: restapi_status.rc != 0


### PR DESCRIPTION
No need to specify it.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>