### PR TITLE
Activate either sysvinit or upstart

### DIFF
--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -23,14 +23,3 @@
   command: >
     ceph-mon --mkfs -i {{ ansible_hostname }} --fsid {{ fsid }} --keyring /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
     creates=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/keyring
-
-- name: Start and add that the monitor service to the init sequence
-  service: >
-    name=ceph
-    state=started
-    enabled=yes
-    args=mon
-
-- name: Get Ceph monitor version
-  shell: ceph daemon mon."{{ ansible_hostname }}" version | cut -d '"' -f 4 | cut -f 1,2 -d '.'
-  register: ceph_version

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -2,6 +2,9 @@
 - include: deploy_monitors.yml
   when: not ceph_containerized_deployment
 
+- include: start_monitor.yml
+  when: not ceph_containerized_deployment
+
 - include: ceph_keys.yml
   when: not ceph_containerized_deployment
 

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -1,0 +1,44 @@
+---
+- name: Activate monitor with upstart
+  file: >
+    path=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/{{ item }}
+    state=touch
+    owner=root
+    group=root
+    mode=0600
+  with_items:
+    - done
+    - upstart
+  when: ansible_distribution == "Ubuntu"
+
+- name: Activate monitor with sysvinit
+  file: >
+    path=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/{{ item }}
+    state=touch
+    owner=root
+    group=root
+    mode=0600
+  with_items:
+    - done
+    - sysvinit
+  when: ansible_distribution != "Ubuntu"
+
+- name: Start and add that the monitor service to the init sequence (Ubuntu)
+  service: >
+    name=ceph-mon
+    state=started
+    enabled=yes
+    args="id={{ ansible_hostname }}"
+  when: ansible_distribution == "Ubuntu"
+
+- name: Start and add that the monitor service to the init sequence
+  service: >
+    name=ceph
+    state=started
+    enabled=yes
+    args=mon
+  when: ansible_distribution != "Ubuntu"
+
+- name: Get Ceph monitor version
+  shell: ceph daemon mon."{{ ansible_hostname }}" version | cut -d '"' -f 4 | cut -f 1,2 -d '.'
+  register: ceph_version


### PR DESCRIPTION
Depending on the distro, init scripts will look for different files to
be available on the ceph data dir.
Fixing the upstart support here.

Handler might have to be reworked (again...) eventually... #238

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>