### PR TITLE
Rework upstart and sysvinit

### DIFF
--- a/roles/ceph-mds/tasks/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/pre_requisite.yml
@@ -34,9 +34,42 @@
     group=root
   when: cephx
 
-- name: Start and add that the MDS service to the init sequence
+- name: Activate metadata server with upstart
+  file: >
+    path=/var/lib/ceph/mds/ceph-{{ ansible_hostname }}/{{ item }}
+    state=touch
+    owner=root
+    group=root
+    mode=0600
+  with_items:
+    - done
+    - upstart
+  when: ansible_distribution == "Ubuntu"
+
+- name: Activate metadata server with sysvinit
+  file: >
+    path=/var/lib/ceph/mds/ceph-{{ ansible_hostname }}/{{ item }}
+    state=touch
+    owner=root
+    group=root
+    mode=0600
+  with_items:
+    - done
+    - sysvinit
+  when: ansible_distribution != "Ubuntu"
+
+- name: Start and add that the metadata service to the init sequence (Ubuntu)
+  service: >
+    name=ceph-mds
+    state=started
+    enabled=yes
+    args="id={{ ansible_hostname }}"
+  when: ansible_distribution == "Ubuntu"
+
+- name: Start and add that the metadata service to the init sequence
   service: >
     name=ceph
     state=started
     enabled=yes
     args=mds
+  when: ansible_distribution != "Ubuntu"

--- a/roles/ceph-radosgw/tasks/main.yml
+++ b/roles/ceph-radosgw/tasks/main.yml
@@ -4,10 +4,10 @@
   when: not ceph_containerized_deployment
 
 - include: install_redhat.yml
-  when: ansible_os_family == 'RedHat' and radosgw_frontend == 'apache'
+  when: ansible_os_family == 'RedHat' and radosgw_frontend == 'apache' and not ceph_containerized_deployment
 
 - include: install_debian.yml
-  when: ansible_os_family == 'Debian' and radosgw_frontend == 'apache'
+  when: ansible_os_family == 'Debian' and radosgw_frontend == 'apache' and not ceph_containerized_deployment
 
 - name: "Install Rados Gateway"
   apt: >
@@ -23,6 +23,7 @@
   when: ansible_os_family == 'RedHat' and not ceph_containerized_deployment
 
 - include: start_radosgw.yml
+  when: not ceph_containerized_deployment
 
 - include: docker.yml
   when: ceph_containerized_deployment

--- a/roles/ceph-radosgw/tasks/pre_requisite.yml
+++ b/roles/ceph-radosgw/tasks/pre_requisite.yml
@@ -18,8 +18,12 @@
 
 - name: Activate RGW with upstart
   file: >
-    path=/var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_fqdn }}/done
+    path=/var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_fqdn }}/{{ item }}
     state=touch
     owner=root
     group=root
     mode=0644
+  with_items:
+    - done
+    - upstart
+  when: ansible_distribution == "Ubuntu"

--- a/roles/ceph-restapi/tasks/pre_requisite.yml
+++ b/roles/ceph-restapi/tasks/pre_requisite.yml
@@ -18,8 +18,41 @@
 
 - name: Activate Ceph REST API with upstart
   file: >
-    path=/var/lib/ceph/restapi/ceph-restapi/done
+    path=/var/lib/ceph/restapi/{{ item }}
     state=touch
     owner=root
     group=root
-    mode=0644
+    mode=0600
+  with_items:
+    - done
+    - upstart
+  when: ansible_distribution == "Ubuntu"
+
+- name: Activate Ceph REST API with sysvinit
+  file: >
+    path=/var/lib/ceph/restapi/{{ item }}
+    state=touch
+    owner=root
+    group=root
+    mode=0600
+  with_items:
+    - done
+    - sysvinit
+  when: ansible_distribution != "Ubuntu"
+
+# NOTE (leseb): will uncomment this when this https://github.com/ceph/ceph/pull/4144 lands
+#- name: Start and add that the Ceph REST API service to the init sequence (Ubuntu)
+#  service: >
+#    name=ceph-restapi
+#    state=started
+#    enabled=yes
+#    args="id={{ ansible_hostname }}"
+#  when: ansible_distribution == "Ubuntu"
+#
+#- name: Start and add that the Ceph REST API service to the init sequence
+#  service: >
+#    name=ceph
+#    state=started
+#    enabled=yes
+#    args=restapi
+#  when: ansible_distribution != "Ubuntu"


### PR DESCRIPTION
Once again and hopefully final commit to rework the support of both
upstart and sysvinit. As from now, Ubuntu systems will use upstart and
the others will use sysvinit.
A later commit might include the support of systemd as the unit files
come out. This will be for Hammer so probably soon.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>