### PR TITLE
Make more boxes available

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,7 @@ NMDSS   = settings['mds_vms']
 NRGWS   = settings['rgw_vms']
 CLIENTS = settings['client_vms']
 SUBNET  = settings['subnet']
+BOX     = settings['vagrant_box']
 
 ansible_provision = proc do |ansible|
   ansible.playbook = 'site.yml'
@@ -63,7 +64,7 @@ def create_vmdk(name, size)
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'ubuntu/trusty64'
+  config.vm.box = BOX
   config.ssh.insert_key = false # workaround for https://github.com/mitchellh/vagrant/issues/5048
 
   (0..CLIENTS - 1).each do |i|

--- a/vagrant_variables.yml
+++ b/vagrant_variables.yml
@@ -9,3 +9,12 @@ client_vms: 0
 
 # SUBNET TO USE FOR THE VMS
 subnet: 192.168.42
+
+# VAGRANT BOX
+# Fedora: http://download.fedoraproject.org/pub/fedora/linux/releases/test/22_Alpha/Cloud/x86_64/Images/Fedora-Cloud-Atomic-Vagrant-22_Alpha-20150305.x86_64.vsphere.ova
+# Ubuntu: ubuntu/trusty
+# CentOS: chef/centos-7.0
+# For more boxes have a look at:
+#   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
+#   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
+vagrant_box: ubuntu/trusty64


### PR DESCRIPTION
The box can be configured thanks to a new var, look at vagrant_variables
and select your box.
Handy to test several distros deployment.

Signed-off-by: Sébastien Han <sebastien.han@enovance.com>