### PR TITLE
Allow restapi=false

### DIFF
--- a/roles/ceph-restapi/tasks/main.yml
+++ b/roles/ceph-restapi/tasks/main.yml
@@ -1,12 +1,14 @@
 ---
 - include: pre_requisite.yml
+  when: restapi
 
 - name: Check if Ceph REST API is already started
   shell: "ps aux|grep [c]eph-rest-api"
   register: restapi_status
+  when: restapi
   ignore_errors: True
 
 - name: Start Ceph REST API
   shell: "nohup ceph-rest-api &"
-  when: restapi_status.rc != 0
+  when: restapi and restapi_status.rc != 0
   changed_when: False

--- a/roles/ceph-restapi/tasks/main.yml
+++ b/roles/ceph-restapi/tasks/main.yml
@@ -1,14 +1,12 @@
 ---
 - include: pre_requisite.yml
-  when: restapi
 
 - name: Check if Ceph REST API is already started
   shell: "ps aux|grep [c]eph-rest-api"
   register: restapi_status
-  when: restapi
   ignore_errors: True
 
 - name: Start Ceph REST API
   shell: "nohup ceph-rest-api &"
-  when: restapi and restapi_status.rc != 0
+  when: restapi_status.rc != 0
   changed_when: False

--- a/site.yml
+++ b/site.yml
@@ -14,7 +14,7 @@
   sudo: True
   roles:
   - ceph-mon
-  - ceph-restapi
+  - { role: ceph-restapi, when: restapi }
 
 - hosts: osds
   sudo: True


### PR DESCRIPTION
Just a quick PR to allow specifying `restapi=false` in Ansible to skip the tasks in `ceph-restapi` role.