### PR TITLE
Use a bootstrap key for rgw

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -143,15 +143,15 @@
 {% if radosgw %}
 {% for host in groups['rgws'] %}
 {% if hostvars[host]['ansible_hostname'] is defined %}
-[client.radosgw.{{ hostvars[host]['ansible_hostname'] }}]
+[client.rgw.{{ hostvars[host]['ansible_hostname'] }}]
   {% if radosgw_dns_name is defined %}
     rgw dns name = {{ radosgw_dns_name }}
   {% endif %}
   host = {{ hostvars[host]['ansible_hostname'] }}
-  keyring = /var/lib/ceph/radosgw/ceph-radosgw.{{ hostvars[host]['ansible_hostname'] }}/keyring
+  keyring = /var/lib/ceph/radosgw/ceph-rgw.{{ hostvars[host]['ansible_hostname'] }}/keyring
   rgw socket path = /tmp/radosgw-{{ hostvars[host]['ansible_hostname'] }}.sock
-  log file = /var/log/ceph/radosgw-{{ hostvars[host]['ansible_hostname'] }}.log
-  rgw data = /var/lib/ceph/radosgw/ceph-radosgw.{{ hostvars[host]['ansible_hostname'] }}
+  log file = /var/log/radosgw/radosgw-{{ hostvars[host]['ansible_hostname'] }}.log
+  rgw data = /var/lib/ceph/radosgw/ceph-rgw.{{ hostvars[host]['ansible_hostname'] }}
   rgw print continue = false
   {% if radosgw_frontend  == 'civetweb' %}
   rgw frontends = civetweb port={{ radosgw_civetweb_port }}

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -4,14 +4,6 @@
 - name: wait for client.admin key exists
   wait_for: path=/etc/ceph/ceph.client.admin.keyring
 
-- name: create RGW keyring
-  command: >
-    ceph auth get-or-create client.radosgw.{{ hostvars[item]['ansible_hostname'] }} osd 'allow rwx' mon 'allow rw' -o /etc/ceph/ceph.client.radosgw.{{ hostvars[item]['ansible_hostname'] }}.keyring
-    creates=/etc/ceph/ceph.client.radosgw.{{ hostvars[item]['ansible_hostname'] }}.keyring
-  when: cephx and radosgw
-  with_items: groups.rgws
-  changed_when: False
-
 - name: create Ceph REST API keyring
   command: >
     ceph auth get-or-create client.restapi osd 'allow *' mon 'allow *' -o /etc/ceph/ceph.client.restapi.keyring
@@ -46,6 +38,7 @@
   with_items:
     - "{{ ceph_keys.stdout_lines }}"
     - /var/lib/ceph/bootstrap-osd/ceph.keyring
+    - /var/lib/ceph/bootstrap-rgw/ceph.keyring
     - /var/lib/ceph/bootstrap-mds/ceph.keyring
 
 - name: drop in a motd script to report status when logging in

--- a/roles/ceph-radosgw/tasks/pre_requisite.yml
+++ b/roles/ceph-radosgw/tasks/pre_requisite.yml
@@ -1,24 +1,42 @@
 ---
-- name: create RGW directory
+- name: create RGW directories
   file: >
-    path=/var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_hostname }}
+    path={{ item }}
     state=directory
     owner=root
     group=root
     mode=0644
+  with_items:
+    - /var/lib/ceph/bootstrap-rgw
+    - /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}
 
 - name: copy RGW bootstrap key
   copy: >
-    src=fetch/{{ fsid }}/etc/ceph/ceph.client.radosgw.{{ ansible_hostname }}.keyring
-    dest=/var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_hostname }}/keyring
+    src=fetch/{{ fsid }}/var/lib/ceph/bootstrap-rgw/ceph.keyring
+    dest=/var/lib/ceph/bootstrap-rgw/ceph.keyring
     owner=root
     group=root
     mode=600
   when: cephx
 
+- name: create RGW keyring
+  command: >
+    ceph --cluster ceph --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/ceph.keyring auth get-or-create client.rgw.{{ ansible_hostname }} osd 'allow rwx' mon 'allow rw' -o /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/keyring
+    creates=/var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/keyring
+  when: cephx
+  changed_when: False
+
+- name: set RGW key permissions
+  file: >
+    path=/var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/keyring
+    mode=0600
+    owner=root
+    group=root
+  when: cephx
+
 - name: activate RGW with upstart
   file: >
-    path=/var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_hostname }}/{{ item }}
+    path=/var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/{{ item }}
     state=touch
     owner=root
     group=root


### PR DESCRIPTION
Following the best practice, we don't create a key from the monitor but
we really on the initial keys created by the mons to bootstrap each
daemon.

Signed-off-by: Sébastien Han <seb@redhat.com>