### PR TITLE
Create client socket path

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -75,7 +75,7 @@ rbd_concurrent_management_ops: 20
 rbd_client_directories: false # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions, this WON'T work if libvirt and kvm are installed
 rbd_client_log_file: /var/log/rbd-clients/qemu-guest-$pid.log # must be writable by QEMU and allowed by SELinux or AppArmor
 rbd_client_log_path: /var/log/rbd-clients/
-rbd_client_admin_socket_path: /var/run/ceph/rbd-clients/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
+rbd_client_admin_socket_path: /var/run/ceph/rbd-clients/ # must be writable by QEMU and allowed by SELinux or AppArmor
 
 ## Monitor options
 #

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -50,3 +50,11 @@
     - restart ceph osds on ubuntu
     - restart ceph mdss
     - restart ceph rgws
+
+- name: create rbd client directory
+  file: >
+    path={{ rbd_client_admin_socket_path }}
+    state=directory
+    owner=root
+    group=root
+    mode=0644

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -65,7 +65,7 @@
   rbd cache = {{ rbd_cache }}
   rbd cache writethrough until flush = true
   rbd concurrent management ops = {{ rbd_concurrent_management_ops }}
-  admin socket = {{ rbd_client_admin_socket_path }} # must be writable by QEMU and allowed by SELinux or AppArmor
+  admin socket = {{ rbd_client_admin_socket_path }}/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
   log file = {{ rbd_client_log_file }} # must be writable by QEMU and allowed by SELinux or AppArmor
 
 [mon]


### PR DESCRIPTION
This will avoid some error messages from the client when running a
command with the CLI or other.

Signed-off-by: Sébastien Han <seb@redhat.com>