### PR TITLE
Correct the logic for running 'ceph-disk prepare'

### DIFF
--- a/roles/ceph-osd/tasks/raw_multi_journal.yml
+++ b/roles/ceph-osd/tasks/raw_multi_journal.yml
@@ -12,7 +12,9 @@
 # failed, this is why we check if the device is a partition too.
 - name: prepare OSD disk(s)
   command: "ceph-disk prepare {{ item.2 }} {{ item.3 }}"
-  when: (item.0.rc != 0 or item.1.rc != 0) and raw_multi_journal
+  when: item.0.rc != 0 and
+        item.1.rc != 0 and
+        raw_multi_journal
   ignore_errors: True
   with_together:
     - parted.results


### PR DESCRIPTION
The logic was broken here for repeated runs.  We only want to run
'ceph-disk prepare' when the disk does not contain a ceph partition, is
not a partition, and raw_multi_journal is set.  Previously it would
attempt to run 'ceph-disk prepare' when there was a ceph partition
because the second half of the 'or' was still true since it isn't a
partition.