### PR TITLE
ceph-common was running twice

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,16 +1,6 @@
 ---
 # Defines deployment design and assigns role to server groups
 
-- hosts:
-  - mons
-  - osds
-  - mdss
-  - rgws
-  - clients # Kernel RBD does NOT support signatures for Kernels < 3.18! Make sure to set cephx_require_signatures: false
-  sudo: True
-  roles:
-  - { role: ceph-common, when: not docker }
-
 - hosts: mons
   sudo: True
   roles:


### PR DESCRIPTION
Sinxe each Ceph role (except ceph-common) has a dependancy to
ceph-common we don't need to declare ceph-common again.
Prior to this change the ceph-common role was running twice, thing that
wasn't really elegant.

Signed-off-by: leseb <seb@redhat.com>