### PR TITLE
Only apply os-tuning to OSD nodes

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -2,6 +2,7 @@
 - include: os_check.yml
 
 - include: os_tuning.yml
+  when: osd_group_name in group_names
 
 - include: prerequisite_ice.yml
   when: ceph_stable_ice


### PR DESCRIPTION
There is no need to apply these tuning flags to all the nodes.

Signed-off-by: leseb <seb@redhat.com>