### PR TITLE
Use local_action to ensure Ansible executes under python2

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -32,18 +32,14 @@
   register: socketrgw
 
 - name: generate cluster UUID
-  shell: >
-    uuidgen | tee fetch/ceph_cluster_uuid.conf
+  local_action: shell uuidgen | tee fetch/ceph_cluster_uuid.conf
     creates=fetch/ceph_cluster_uuid.conf
-  connection: local
   register: cluster_uuid
   sudo: false
 
 - name: read cluster UUID if it already exists
-  command: >
-    cat fetch/ceph_cluster_uuid.conf
+  local_action: command cat fetch/ceph_cluster_uuid.conf
     removes=fetch/ceph_cluster_uuid.conf
-  connection: local
   changed_when: false
   register: cluster_uuid
   sudo: false


### PR DESCRIPTION
`connection: local` opens an SSH connection to localhost, using whatever python interpreter in env. Ansible doesn't run under python3, which a lot of distributions have as default nowadays. Using `local_action` executes the action from the Ansible process on the host, so it's also more efficient.