### PR TITLE
Make zap option more secure

### DIFF
--- a/roles/ceph-osd/tasks/journal_collocation.yml
+++ b/roles/ceph-osd/tasks/journal_collocation.yml
@@ -1,8 +1,8 @@
 ---
 ## SCENARIO 1: JOURNAL AND OSD_DATA ON THE SAME DEVICE
 
-- include: zap_devices.yml
 - include: check_devices.yml
+- include: zap_devices.yml
 
 # NOTE (leseb): the prepare process must be parallelized somehow...
 # if you have 64 disks with 4TB each, this will take a while

--- a/roles/ceph-osd/tasks/raw_multi_journal.yml
+++ b/roles/ceph-osd/tasks/raw_multi_journal.yml
@@ -1,8 +1,8 @@
 ---
 ## SCENARIO 3: N JOURNAL DEVICES FOR N OSDS
 
-- include: zap_devices.yml
 - include: check_devices.yml
+- include: zap_devices.yml
 
 # NOTE (leseb): the prepare process must be parallelized somehow...
 # if you have 64 disks with 4TB each, this will take a while

--- a/roles/ceph-osd/tasks/zap_devices.yml
+++ b/roles/ceph-osd/tasks/zap_devices.yml
@@ -3,17 +3,27 @@
 # in ceph-disk failing to prepare OSD. Thus zapping them prior to prepare the OSD
 # ensures that the device will get successfully prepared.
 - name: erasing partitions and labels from OSD disk(s)
-  command: ceph-disk zap {{ item }}
-  with_items: devices
+  command: ceph-disk zap {{ item.2 }}
   changed_when: false
+  with_together:
+    - parted.results
+    - ispartition.results
+    - devices
   when:
+    item.0.rc != 0 and
+    item.1.rc != 0 and
     zap_devices and
     (journal_collocation or raw_multi_journal)
 
 - name: erasing partitions and labels from the journal device(s)
-  command: ceph-disk zap {{ item }}
-  with_items: raw_journal_devices
+  command: ceph-disk zap {{ item.2 }}
   changed_when: false
+  with_together:
+    - parted.results
+    - ispartition.results
+    - raw_journal_devices
   when:
+    item.0.rc != 0 and
+    item.1.rc != 0 and
     zap_devices and
     raw_multi_journal


### PR DESCRIPTION
Prior to this change, the zap was executed during every play, this was
not ideal. Now we do check if there is a 'ceph' partition. If so we skip
the zap.

Signed-off-by: leseb <seb@redhat.com>