### PR TITLE
Re-use public network for private network

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -121,8 +121,8 @@ dummy:
 #pool_default_pgp_num: 128
 #pool_default_size: 2
 #pool_default_min_size: 1
-#cluster_network: 0.0.0.0/0
 #public_network: 0.0.0.0/0
+#cluster_network: {{ public_network }}
 #osd_mkfs_type: xfs
 #osd_mkfs_options_xfs: -f -i size=2048
 #osd_mount_options_xfs: noatime

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -128,8 +128,8 @@ pool_default_pg_num: 128
 pool_default_pgp_num: 128
 pool_default_size: 2
 pool_default_min_size: 1
-cluster_network: 0.0.0.0/0
 public_network: 0.0.0.0/0
+cluster_network: {{ public_network }}
 osd_mkfs_type: xfs
 osd_mkfs_options_xfs: -f -i size=2048
 osd_mount_options_xfs: noatime,largeio,inode64,swalloc


### PR DESCRIPTION
We don't always have a dedicated cluster network so we can by default
re-use the public network value.
This is just laziness :).

Signed-off-by: leseb <seb@redhat.com>