### PR TITLE
Improve purge playbook

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -12,21 +12,27 @@
 
   tasks:
 
-  - name: Purge Ceph
+  - name: disk zap
+    command: /usr/sbin/sgdisk --zap-all --clear --mbrtogpt -g -- {{ item }}
+    with_items: devices
+    ignore_errors: true
+
+  - name: disk zap
+    command: /usr/sbin/sgdisk --zap-all --clear --mbrtogpt -g -- {{ item }}
+    with_items: devices
+    ignore_errors: true
+
+  - name: call partprobe
+    command: partprobe
+
+  - name: purge ceph
     command: ceph-deploy purge {{ ansible_fqdn }}
     delegate_to: 127.0.0.1
 
-  - name: Remove OSD data
+  - name: remove osd data
     shell: rm -rf /var/lib/ceph/osd/*/*
     ignore_errors: true
 
-  - name: Purge remaining data
+  - name: purge remaining data
     command: ceph-deploy purgedata {{ ansible_fqdn }}
     delegate_to: 127.0.0.1
-
-  - name: Purge partitions
-    shell: parted -s {{ item[0] }} rm {{ item[1] }}
-    with_nested:
-      - devices
-      - partitions
-    ignore_errors: true

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -129,7 +129,7 @@ pool_default_pgp_num: 128
 pool_default_size: 2
 pool_default_min_size: 1
 public_network: 0.0.0.0/0
-cluster_network: {{ public_network }}
+cluster_network: "{{ public_network }}"
 osd_mkfs_type: xfs
 osd_mkfs_options_xfs: -f -i size=2048
 osd_mount_options_xfs: noatime,largeio,inode64,swalloc


### PR DESCRIPTION
We run a zap twice here since we can't combine with_items and
with_sequence yet. This will land in Ansible 2.0. We destroy all the
partitions and re-create new labels as well. We do this twice just
because sometimes one is not sufficient. We also call partprobe to make
sure that the kernel sees the changes.

Signed-off-by: leseb <seb@redhat.com>