### PR TITLE
Add support for image format

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -100,6 +100,7 @@ dummy:
 #rbd_client_admin_socket_path: /var/run/ceph/rbd-clients/
 #rbd_default_features: 3
 #rbd_default_map_options: rw
+#rbd_default_format: 2
 
 ## Monitor options
 #

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -108,6 +108,7 @@ rbd_client_log_path: /var/log/rbd-clients/
 rbd_client_admin_socket_path: /var/run/ceph/rbd-clients # must be writable by QEMU and allowed by SELinux or AppArmor
 rbd_default_features: 3
 rbd_default_map_options: rw
+rbd_default_format: 2
 
 ## Monitor options
 #

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -69,6 +69,7 @@
   log file = {{ rbd_client_log_file }} # must be writable by QEMU and allowed by SELinux or AppArmor
   rbd default map options = {{ rbd_default_map_options }}
   rbd default features = {{ rbd_default_features }} # sum features digits
+  rbd default format = {{ rbd_default_format }}
 
 [mon]
   mon osd down out interval = {{ mon_osd_down_out_interval }}


### PR DESCRIPTION
By default, we want to use format 2.
This closely works with rbd features as well.

Signed-off-by: leseb <seb@redhat.com>