### PR TITLE
Generate initial monitor key dynamically

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -105,7 +105,7 @@ dummy:
 ## Monitor options
 #
 #monitor_interface: interface
-#monitor_secret: "{{ ceph_mon_key.stdout }}"
+#monitor_secret: "{{ monitor_keyring.stdout }}"
 #mon_osd_down_out_interval: 600
 #mon_osd_min_down_reporters: 7 # number of OSDs per host + 1
 #mon_clock_drift_allowed: .15

--- a/group_vars/all
+++ b/group_vars/all
@@ -105,7 +105,7 @@ dummy:
 ## Monitor options
 #
 #monitor_interface: interface
-#monitor_secret:
+#monitor_secret: "{{ ceph_mon_key.stdout }}"
 #mon_osd_down_out_interval: 600
 #mon_osd_min_down_reporters: 7 # number of OSDs per host + 1
 #mon_clock_drift_allowed: .15

--- a/group_vars/mons
+++ b/group_vars/mons
@@ -11,7 +11,7 @@ dummy:
 
 # ACTIVATE BOTH FSID AND MONITOR_SECRET VARIABLES FOR NON-VAGRANT DEPLOYMENT
 #fsid: "{{ cluster_uuid.stdout }}"
-#monitor_secret: "{{ ceph_mon_key.stdout }}"
+#monitor_secret: "{{ monitor_keyring.stdout }}"
 #cephx: true
 
 # CephFS

--- a/group_vars/mons
+++ b/group_vars/mons
@@ -11,7 +11,7 @@ dummy:
 
 # ACTIVATE BOTH FSID AND MONITOR_SECRET VARIABLES FOR NON-VAGRANT DEPLOYMENT
 #fsid: "{{ cluster_uuid.stdout }}"
-#monitor_secret:
+#monitor_secret: "{{ ceph_mon_key.stdout }}"
 #cephx: true
 
 # CephFS

--- a/roles/ceph-common/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/check_mandatory_vars.yml
@@ -14,10 +14,6 @@
     not ceph_stable_rh_storage_cdn_install and
     not ceph_stable_rh_storage_iso_install
 
-- name: make sure a monitor secret is defined
-  fail: msg"monitor_secret must be defined. Go edit group_vars/all or read https://github.com/ceph/ceph-ansible/wiki"
-  when: monitor_secret is not defined
-
 - name: make sure journal_size configured
   fail: msg="journal_size must be configured. See http://ceph.com/docs/master/rados/configuration/osd-config-ref/"
   when: journal_size|int == 0

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -9,7 +9,7 @@ rgw_group_name: rgws
 
 # ACTIVATE BOTH FSID AND MONITOR_SECRET VARIABLES FOR NON-VAGRANT DEPLOYMENT
 fsid: "{{ cluster_uuid.stdout }}"
-monitor_secret: "{{ ceph_mon_key.stdout }}"
+monitor_secret: "{{ monitor_keyring.stdout }}"
 cephx: true
 
 # CephFS

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -9,7 +9,7 @@ rgw_group_name: rgws
 
 # ACTIVATE BOTH FSID AND MONITOR_SECRET VARIABLES FOR NON-VAGRANT DEPLOYMENT
 fsid: "{{ cluster_uuid.stdout }}"
-#monitor_secret:
+monitor_secret: "{{ ceph_mon_key.stdout }}"
 cephx: true
 
 # CephFS

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -1,7 +1,22 @@
 ---
+- name: generate monitor initial keyring
+  local_action: >
+    shell python -c "import os ; import struct ; import time; import base64 ; key = os.urandom(16) ; header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ; print base64.b64encode(header + key)' > fetch/ceph_mon_key.con"
+    creates=fetch/ceph_mon_key.conf
+  register: ceph_mon_key
+  sudo: false
+
+- name: read monitor initial keyring if it already exists
+  local_action: >
+    command cat fetch/ceph_mon_key.conf
+    removes=fetch/ceph_mon_key.conf
+  changed_when: false
+  register: ceph_mon_key
+  sudo: false
+
 - name: create monitor initial keyring
   command: >
-    ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} --create-keyring --name=mon. --add-key={{ monitor_secret | mandatory }} --cap mon 'allow *'
+    ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} --create-keyring --name=mon. --add-key={{ monitor_secret }} --cap mon 'allow *'
     creates=/var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
 
 - name: set initial monitor key permissions

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -1,17 +1,17 @@
 ---
 - name: generate monitor initial keyring
   local_action: >
-    shell python -c "import os ; import struct ; import time; import base64 ; key = os.urandom(16) ; header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ; print base64.b64encode(header + key)' > fetch/ceph_mon_key.con"
-    creates=fetch/ceph_mon_key.conf
-  register: ceph_mon_key
+    shell python -c "import os ; import struct ; import time; import base64 ; key = os.urandom(16) ; header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ; print base64.b64encode(header + key)' > fetch/monitor_keyring.conf"
+    creates=fetch/monitor_keyring.conf
+  register: monitor_keyring
   sudo: false
 
 - name: read monitor initial keyring if it already exists
   local_action: >
-    command cat fetch/ceph_mon_key.conf
-    removes=fetch/ceph_mon_key.conf
+    command cat fetch/monitor_keyring.conf
+    removes=fetch/monitor_keyring.conf
   changed_when: false
-  register: ceph_mon_key
+  register: monitor_keyring
   sudo: false
 
 - name: create monitor initial keyring

--- a/roles/ceph-restapi/tasks/start_restapi.yml
+++ b/roles/ceph-restapi/tasks/start_restapi.yml
@@ -1,6 +1,7 @@
 ---
 - name: check if Ceph REST API is already started
   shell: "pgrep ceph-rest-api"
+  changed_when: false
   ignore_errors: true
   register: restapi_status
 


### PR DESCRIPTION
Cool stuff :). We don't need to specify an initial monitor key anymore.
A key will automatically be generated.

The default key can always be overriden with the `monitor_secret`
variable.

Signed-off-by: leseb <seb@redhat.com>