### PR TITLE
Define dependencies in ceph-common's meta/main.yml

### DIFF
--- a/roles/ceph-common/meta/main.yml
+++ b/roles/ceph-common/meta/main.yml
@@ -10,3 +10,4 @@ galaxy_info:
         - trusty
   categories:
     - system
+dependencies: []


### PR DESCRIPTION
I'm currently getting a KeyError due to missing 'dependencies' on this
role when I attempt to install it with ansible-galaxy (ansible 1.9.2).
This commit simply defines an empty dependencies list so that
ansible-galaxy executes correctly.