### PR TITLE
Use serial to deploy ceph-mon in docker

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -6,6 +6,7 @@
   roles:
   - ceph-mon
   - { role: ceph-restapi, when: restapi_group_name is defined and restapi_group_name in group_names }
+  #serial: 1 # ENABLE THIS WHEN DEPLOYING MONITORS ON DOCKER CONTAINERS
 
 - hosts: osds
   sudo: True


### PR DESCRIPTION
If we don't do this we will hand up having N separate clusters.

Signed-off-by: Sébastien Han <seb@redhat.com>