### PR TITLE
Expose rgw ports

### DIFF
--- a/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
+++ b/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
@@ -4,6 +4,7 @@
     image="{{ ceph_rgw_docker_username }}/{{ ceph_rgw_docker_imagename }}"
     name=ceph-{{ ansible_hostname }}-rgw
     expose={{ ceph_rgw_civetweb_port }}
+    ports="{{ ceph_rgw_civetweb_port }}:{{ ceph_rgw_civetweb_port }}"
     state=running
     env="CEPH_DAEMON=RGW,{{ ceph_rgw_docker_extra_env }}"
     volumes="/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph"


### PR DESCRIPTION
The 'ports' option was missing, so in order to expose a port we need
"expose" and "ports" options.

Signed-off-by: Sébastien Han <seb@redhat.com>