### PR TITLE
Move parted to the end of the playbook

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -22,9 +22,6 @@
     with_items: devices
     failed_when: false
 
-  - name: call partprobe
-    command: partprobe
-
   - name: purge ceph
     command: ceph-deploy purge {{ ansible_fqdn }}
     delegate_to: 127.0.0.1
@@ -36,3 +33,6 @@
   - name: purge remaining data
     command: ceph-deploy purgedata {{ ansible_fqdn }}
     delegate_to: 127.0.0.1
+
+  - name: call partprobe
+    command: partprobe


### PR DESCRIPTION
If we call partprobe directly after the partition deletion the task will
get stucked.

Signed-off-by: Sébastien Han <seb@redhat.com>