### PR TITLE
Revert "Use stat module instead of shell"

### DIFF
--- a/cluster-os-migration.yml
+++ b/cluster-os-migration.yml
@@ -284,13 +284,13 @@
       when: migration_completed.stat.exists == False
 
     - name: Check if sysvinit
-      stat: path=/var/lib/ceph/osd/ceph-*/sysvinit
+      shell: stat /var/lib/ceph/osd/ceph-*/sysvinit
       register: osdsysvinit
       failed_when: false
       changed_when: False
 
     - name: Check if upstart
-      stat: path=/var/lib/ceph/osd/ceph-*/upstart
+      shell: stat /var/lib/ceph/osd/ceph-*/upstart
       register: osdupstart
       failed_when: false
       changed_when: False
@@ -329,14 +329,14 @@
       service: >
         name=ceph-osd-all
         state=stopped
-      when: osdupstart.stat.exists and migration_completed.stat.exists == False
+      when: osdupstart.rc == 0 and migration_completed.stat.exists == False
 
     - name: Gracefully stop the OSDs (Sysvinit)
       service: >
         name=ceph
         state=stopped
         args=mon
-      when: osdsysvinit.stat.exists and migration_completed.stat.exists == False
+      when: osdsysvinit.rc == 0 and migration_completed.stat.exists == False
 
     - name: Wait for the OSDs to be down
       local_action: >

--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -5,63 +5,63 @@
 - name: restart ceph mons
   command: service ceph restart mon
   when:
-    socket.stat.exists and
+    socket.rc == 0 and
     ansible_distribution != 'Ubuntu' and
     mon_group_name in group_names
 
 - name: restart ceph mons on ubuntu
   command: restart ceph-mon-all
   when:
-    socket.stat.exists and
+    socket.rc == 0 and
     ansible_distribution == 'Ubuntu' and
     mon_group_name in group_names
 
 - name: restart ceph osds
   command: service ceph restart osd
   when:
-    socket.stat.exists and
+    socket.rc == 0 and
     ansible_distribution != 'Ubuntu' and
     osd_group_name in group_names
 
 - name: restart ceph osds on ubuntu
   command: restart ceph-osd-all
   when:
-    socket.stat.exists and
+    socket.rc == 0 and
     ansible_distribution == 'Ubuntu' and
     osd_group_name in group_names
 
 - name: restart ceph mdss on ubuntu
   command: restart ceph-mds-all
   when:
-    socket.stat.exists and
+    socket.rc == 0 and
     ansible_distribution == 'Ubuntu' and
     mds_group_name in group_names
 
 - name: restart ceph mdss
   command: service ceph restart mds
   when:
-    socket.stat.exists and
+    socket.rc == 0 and
     ansible_distribution != 'Ubuntu' and
     mds_group_name in group_names
 
 - name: restart ceph rgws on ubuntu
   command: restart ceph-all
   when:
-    socketrgw.stat.exists and
+    socketrgw.rc == 0 and
     ansible_distribution == 'Ubuntu' and
     rgw_group_name in group_names
 
 - name: restart ceph rgws
   command: /etc/init.d/radosgw restart
   when:
-    socketrgw.stat.exists and
+    socketrgw.rc == 0 and
     ansible_distribution != 'Ubuntu' and
     rgw_group_name in group_names
 
 - name: restart ceph rgws on red hat
   command: /etc/init.d/ceph-radosgw restart
   when:
-    socketrgw.stat.exists and
+    socketrgw.rc == 0 and
     ansible_os_family == 'RedHat' and
     rgw_group_name in group_names
 

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -38,13 +38,13 @@
     rgw_group_name in group_names
 
 - name: check for a ceph socket
-  stat: path=/var/run/ceph/*.asok
+  shell: "stat /var/run/ceph/*.asok > /dev/null 2>&1"
   changed_when: false
   failed_when: false
   register: socket
 
 - name: check for a rados gateway socket
-  stat: path={{ rbd_client_admin_socket_path }}*.asok
+  shell: "stat {{ rbd_client_admin_socket_path }}*.asok > /dev/null 2>&1"
   changed_when: false
   failed_when: false
   register: socketrgw

--- a/rolling_update.yml
+++ b/rolling_update.yml
@@ -90,12 +90,12 @@
 
   post_tasks:
     - name: Check if sysvinit
-      stat: path=/var/lib/ceph/osd/ceph-*/sysvinit
+      shell: stat /var/lib/ceph/osd/ceph-*/sysvinit
       register: osdsysvinit
       failed_when: false
 
     - name: Check if upstart
-      stat: path=/var/lib/ceph/osd/ceph-*/upstart
+      shell: stat /var/lib/ceph/osd/ceph-*/upstart
       register: osdupstart
       failed_when: false
 
@@ -103,14 +103,14 @@
       service: >
         name=ceph-osd-all
         state=restarted
-      when: osdupstart.stat.exists
+      when: osdupstart.rc == 0
 
     - name: Gracefully stop the OSDs (Sysvinit)
       service: >
         name=ceph
         state=restarted
         args=osd
-      when: osdsysvinit.stat.exists
+      when: osdsysvinit.rc == 0
 
     - name: Waiting for clean PGs...
       shell: >


### PR DESCRIPTION
Reverts ceph/ceph-ansible#367

Shoot. Real sorry about this, but I think it's best if we revert this for now. We were using a custom Ansible and it was working fine but upon testing with an old version of Ansible it appears one of the checks isn't working properly. 