### PR TITLE
Use latest packages

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -52,7 +52,7 @@
 - name: install ceph
   apt: >
     pkg={{ item }}
-    state=present
+    state=latest
   with_items:
     - ceph
     - ceph-common    #|
@@ -64,7 +64,7 @@
 - name: install rados gateway
   apt: >
     pkg=radosgw
-    state=present
+    state=latest
     update_cache=yes
   when:
     rgw_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -69,13 +69,13 @@
 - name: install ceph
   yum: >
     name=ceph
-    state=present
+    state=latest
   when: not ceph_stable_rh_storage
 
 - name: install red hat storage ceph mon
   yum: >
     name={{ item }}
-    state=present
+    state=latest
   with_items:
     - ceph
     - ceph-mon
@@ -86,7 +86,7 @@
 - name: install red hat storage ceph osd
   yum: >
     name={{ item }}
-    state=present
+    state=latest
   with_items:
     - ceph
     - ceph-osd
@@ -105,7 +105,7 @@
 - name: install rados gateway
   yum: >
     name=ceph-radosgw
-    state=present
+    state=latest
   when:
     rgw_group_name in group_names
 


### PR DESCRIPTION
Fix back the rolling update playbook.
However every single time the playbook will run it will check for new
packages and install the latest ones. I don't think this is always the
desired behaviour. We need to find a way to conciliate both...

Signed-off-by: Sébastien Han <seb@redhat.com>