### PR TITLE
Remove parition check from ceph-osd role

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -3,7 +3,7 @@
 # partition.
 - name: activate osd(s) when device is a disk
   command: |
-    ceph-disk activate {{ item.2 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
+    ceph-disk activate {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
   with_together:
     - ispartition.results
     - devices

--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -5,14 +5,11 @@
   command: |
     ceph-disk activate {{ item.2 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
   with_together:
-    - parted.results
     - ispartition.results
     - devices
   changed_when: false
-  failed_when: false 
-  when:
-    item.0.rc == 0 and
-    item.1.rc != 0
+  failed_when: false
+  when: item.0.rc != 0
 
 # NOTE (leseb): this task is for partitions because we don't explicitly use a partition.
 - name: activate osd(s) when device is a partition


### PR DESCRIPTION
I'm removing the ceph paritition check from `activate osd(s) when device is a disk` 
because the ceph parition does not exist when parted was registered (on a fresh install). 
This was causing the activate step to be skipped.