### PR TITLE
Fix for error when the nodes don't have the same interface name.

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -91,7 +91,7 @@
   {% if hostvars[host]['ansible_hostname'] is defined %}
   [mon.{{ hostvars[host]['ansible_hostname'] }}]
     host = {{ hostvars[host]['ansible_hostname'] }}
-    mon addr = {{ hostvars[host]['ansible_' + monitor_interface]['ipv4']['address'] }}
+    mon addr = {{ hostvars[host]['ansible_' + hostvars[host][monitor_interface]]['ipv4']['address'] }}
   {% endif %}
 {% endfor %}
 

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -91,7 +91,7 @@
   {% if hostvars[host]['ansible_hostname'] is defined %}
   [mon.{{ hostvars[host]['ansible_hostname'] }}]
     host = {{ hostvars[host]['ansible_hostname'] }}
-    mon addr = {{ hostvars[host]['ansible_' + hostvars[host][monitor_interface]]['ipv4']['address'] }}
+    mon addr = {{ hostvars[host]['ansible_' + hostvars[host]['monitor_interface']]['ipv4']['address'] }}
   {% endif %}
 {% endfor %}
 

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -91,7 +91,7 @@
   {% if hostvars[host]['ansible_hostname'] is defined %}
   [mon.{{ hostvars[host]['ansible_hostname'] }}]
     host = {{ hostvars[host]['ansible_hostname'] }}
-    mon addr = {{ hostvars[host]['ansible_' + hostvars[host]['monitor_interface']]['ipv4']['address'] }}
+    mon addr = {{ hostvars[host]['ansible_' + (hostvars[host]['monitor_interface'] if hostvars[host]['monitor_interface'] is defined else monitor_interface) ]['ipv4']['address'] }}
   {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
This is a rare case but it happens. Since we're just calling
`monitor_interface` and not `hostvars[host]['monitor_interface'],
an error may occur when the current host's interface does not
exist on the other hosts. (eg. eth0 exists for node0, but it does
not exist on node1 and node2)

Fix for this is to use hostvars[host]['monitor_interface']