### PR TITLE
Prevent failure from race creating fetch directory

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -53,6 +53,7 @@
   local_action: file path=fetch state=directory
   changed_when: false
   sudo: false
+  run_once: true
 
 - name: generate cluster uuid
   local_action: shell uuidgen | tee fetch/ceph_cluster_uuid.conf


### PR DESCRIPTION
When multiple monitor hosts attempt to create the fetch directory there
is the potential for the task to fail with:

  "OSError: [Errno 17] File exists: 'fetch'"

This appear to be an issue with the file module trying to create the
same directory at the same time when the tasks has been delegated to a
single host.

This commit enables run_once on the affected task which should address
the issue.