### PR TITLE
Get Ceph from distro repository (debian-based)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ monitor. If using these playbooks in production, you must generate your own `fsi
 in `group_vars/all` and `monitor_secret` in `group_vars/mons`. Those files contain
 information about how to generate appropriate values for these variables.
 
+## Specifying package origin (Debian-based only)
+
+By default, ceph-common installs from Ceph APT repository. However, you
+can set `ceph_origin` to "distro" to install Ceph from your default repository.
+
+
+If you want to use "backports", you can set "true" to `ceph_use_distro_backports`.
+Attention, ceph-common doesn't manage backports repository, you must add it yourself.
+
+
 ## Vagrant Demo
 
 [![Ceph-ansible Vagrant Demo](http://img.youtube.com/vi/E8-96NamLDo/0.jpg)](https://youtu.be/E8-96NamLDo "Deploy Ceph with Ansible (Vagrant demo)")

--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -28,6 +28,11 @@ dummy:
 #  - epel-release
 #  - ntp
 
+## Configure package origin (Debian-based only)
+#
+#ceph_origin: 'upstream' # or 'distro'
+#ceph_use_distro_backports: false
+
 # STABLE
 ########
 

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -25,6 +25,12 @@ redhat_package_dependencies:
   - epel-release
   - ntp
 
+## Configure package origin (Debian-based only)
+#
+ceph_origin: 'upstream' # or 'distro'
+ceph_use_distro_backports: false
+
+
 # STABLE
 ########
 

--- a/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
@@ -1,0 +1,40 @@
+---
+
+- name: install the ceph repository stable key
+  apt_key: >
+    data="{{ lookup('file', '../../files/cephstable.asc') }}"
+    state=present
+  when: ceph_stable
+
+- name: install the ceph development repository key
+  apt_key: >
+    data="{{ lookup('file', '../../files/cephdev.asc') }}"
+    state=present
+  when: ceph_dev
+
+- name: install intank ceph enterprise repository key
+  apt_key: >
+    data="{{ lookup('file', '../../files/cephstableice.asc') }}"
+    state=present
+  when: ceph_stable_ice
+
+- name: add ceph stable repository
+  apt_repository: >
+    repo="deb http://ceph.com/debian-{{ ceph_stable_release }}/ {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
+    state=present
+  changed_when: false
+  when: ceph_stable
+
+- name: add ceph development repository
+  apt_repository: >
+    repo="deb http://gitbuilder.ceph.com/ceph-deb-{{ ansible_lsb.codename }}-x86_64-basic/ref/{{ ceph_dev_branch }} {{ ansible_lsb.codename }} main"
+    state=present
+  changed_when: false
+  when: ceph_dev
+
+- name: add inktank ceph enterprise repository
+  apt_repository: >
+    repo="deb file://{{ ceph_stable_ice_temp_path }} {{ ansible_lsb.codename }} main"
+    state=present
+  changed_when: false
+  when: ceph_stable_ice

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -7,49 +7,15 @@
     cache_valid_time=3600
   with_items: debian_package_dependencies
 
-- name: install the ceph repository stable key
-  apt_key: >
-    data="{{ lookup('file', '../../files/cephstable.asc') }}"
-    state=present
-  when: ceph_stable
-
-- name: install the ceph development repository key
-  apt_key: >
-    data="{{ lookup('file', '../../files/cephdev.asc') }}"
-    state=present
-  when: ceph_dev
-
-- name: install intank ceph enterprise repository key
-  apt_key: >
-    data="{{ lookup('file', '../../files/cephstableice.asc') }}"
-    state=present
-  when: ceph_stable_ice
-
-- name: add ceph stable repository
-  apt_repository: >
-    repo="deb http://ceph.com/debian-{{ ceph_stable_release }}/ {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
-    state=present
-  changed_when: false
-  when: ceph_stable
-
-- name: add ceph development repository
-  apt_repository: >
-    repo="deb http://gitbuilder.ceph.com/ceph-deb-{{ ansible_lsb.codename }}-x86_64-basic/ref/{{ ceph_dev_branch }} {{ ansible_lsb.codename }} main"
-    state=present
-  changed_when: false
-  when: ceph_dev
-
-- name: add inktank ceph enterprise repository
-  apt_repository: >
-    repo="deb file://{{ ceph_stable_ice_temp_path }} {{ ansible_lsb.codename }} main"
-    state=present
-  changed_when: false
-  when: ceph_stable_ice
+- name: configure Ceph APT repository
+  include: debian_ceph_repository.yml
+  when: ceph_origin == 'upstream'
 
 - name: install ceph
   apt: >
     pkg={{ item }}
     state=latest
+    default_release={{ ansible_distribution_release }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}
   with_items:
     - ceph
     - ceph-common    #|

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -7,7 +7,7 @@
     cache_valid_time=3600
   with_items: debian_package_dependencies
 
-- name: configure Ceph APT repository
+- name: configure ceph apt repository
   include: debian_ceph_repository.yml
   when: ceph_origin == 'upstream'
 


### PR DESCRIPTION
Hi,

Some people prefers install package from their distro. This PR provides this feature as optional (default stays from ceph).

Cheers,

Emilien