### PR TITLE
Vagrant storagectl as option

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,7 @@ CLIENTS    = settings['client_vms']
 SUBNET     = settings['subnet']
 BOX        = settings['vagrant_box']
 MEMORY     = settings['memory']
+STORAGECTL = settings['vagrant_storagectl']
 
 ansible_provision = proc do |ansible|
   ansible.playbook = 'site.yml'
@@ -122,7 +123,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           # It is set when the base box is made in our case ubuntu/trusty64.
           # Be careful while changing the box.
           vb.customize ['storageattach', :id,
-                        '--storagectl', 'SATAController',
+                        '--storagectl', STORAGECTL,
                         '--port', 3 + d,
                         '--device', 0,
                         '--type', 'hdd',

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -21,3 +21,4 @@ memory: 256
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: ubuntu/trusty64
+vagrant_storagectl: 'SATAController'


### PR DESCRIPTION
Hi,

On many Vagrant boxes, default controller is not "SATAController". This PR provides a new option. You can use now every boxes you want without editing Vagrantfile.

Example:  "deb/wheezy-amd64" uses "SATA Controller".

Cheers!

Emilien