### PR TITLE
Enable optional-rpms on official RHEL for yum-plugin-priorities

### DIFF
--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_cdn_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_cdn_install.yml
@@ -4,6 +4,17 @@
   register: subscription
   changed_when: false
 
+- name: check if the red hat optional repo is present
+  shell: yum --noplugins --cacheonly repolist | grep -sq rhel-7-server-optional-rpms
+  changed_when: false
+  failed_when: false
+  register: rh_optional_repo
+
+- name: enable red hat optional repository
+  command: subscription-manager repos --enable rhel-7-server-optional-rpms
+  changed_when: false
+  when: rh_optional_repo.rc != 0
+
 - name: check if the red hat storage monitor repo is already present
   shell: yum --noplugins --cacheonly repolist | grep -sq rhel-7-server-rhceph-1.3-mon-rpms
   changed_when: false


### PR DESCRIPTION
Hey @leseb 

An extra to #384 

Not sure if this is the solution we want or if we want to force optional-rpms onto the user at all. This is the only option if we want to install yum-plugin-priorities without adding non-RH repo's. (official RH support compliance, etc.)

Let me know what you think!

Timo