### PR TITLE
Make fetch directory configurable

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -4,6 +4,12 @@
 # Dummy variable to avoid error because ansible does not recognize the file as a good configuration file when no variable in it.
 dummy:
 
+###########
+# GENERAL #
+###########
+
+#fetch_directory: fetch/
+
 #########
 # INSTALL
 #########

--- a/group_vars/mdss.sample
+++ b/group_vars/mdss.sample
@@ -1,7 +1,14 @@
 ---
+
 dummy:
 
+###########
+# GENERAL #
+###########
+
 #cephx: true
+
+#fetch_directory: fetch/
 
 
 ##########

--- a/group_vars/mons.sample
+++ b/group_vars/mons.sample
@@ -33,6 +33,8 @@ dummy:
 #  - nosizechange
 #
 
+#fetch_directory: fetch/
+
 #############
 # OPENSTACK #
 #############

--- a/group_vars/osds.sample
+++ b/group_vars/osds.sample
@@ -5,6 +5,12 @@
 # Dummy variable to avoid error because ansible does not recognize the file as a good configuration file when no variable in it.
 dummy:
 
+###########
+# GENERAL #
+###########
+
+#fetch_directory: fetch/
+
 ####################
 # OSD CRUSH LOCATION
 ####################

--- a/group_vars/restapis.sample
+++ b/group_vars/restapis.sample
@@ -4,6 +4,12 @@
 # Dummy variable to avoid error because ansible does not recognize the file as a good configuration file when no variable in it.
 dummy:
 
+###########
+# GENERAL #
+###########
+
+#fetch_directory: fetch/
+
 ##########
 # DOCKER #
 ##########

--- a/group_vars/rgws.sample
+++ b/group_vars/rgws.sample
@@ -1,6 +1,10 @@
 ---
 dummy:
 
+###########
+# GENERAL #
+###########
+
 ## Ceph options
 #
 #cephx: true
@@ -9,6 +13,8 @@ dummy:
 # a new entry /etc/sudoers.d/ceph will be created
 # allowing root to not require tty
 #radosgw_user: root
+
+#fetch_directory: fetch/
 
 ##########
 # DOCKER #

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -2,6 +2,12 @@
 # You can override vars by using host or group vars
 
 ###########
+# GENERAL #
+###########
+
+fetch_directory: fetch/
+
+###########
 # INSTALL #
 ###########
 

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -50,21 +50,21 @@
   register: socketrgw
 
 - name: create a local fetch directory if it doesn't exist
-  local_action: file path=fetch state=directory
+  local_action: file path={{ fetch_directory }} state=directory
   changed_when: false
   sudo: false
   run_once: true
 
 - name: generate cluster uuid
-  local_action: shell uuidgen | tee fetch/ceph_cluster_uuid.conf
-    creates=fetch/ceph_cluster_uuid.conf
+  local_action: shell uuidgen | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
+    creates={{ fetch_directory }}/ceph_cluster_uuid.conf
   register: cluster_uuid
   sudo: false
   when: fsid != '4a158d27-f750-41d5-9e7f-26ce4c9d2d45'
 
 - name: read cluster uuid if it already exists
-  local_action: command cat fetch/ceph_cluster_uuid.conf
-    removes=fetch/ceph_cluster_uuid.conf
+  local_action: command cat {{ fetch_directory }}/ceph_cluster_uuid.conf
+    removes={{ fetch_directory }}/ceph_cluster_uuid.conf
   changed_when: false
   register: cluster_uuid
   sudo: false

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
 # You can override vars by using host or group vars
 
+###########
+# GENERAL #
+###########
+
+fetch_directory: fetch/
+
 cephx: true
 
 

--- a/roles/ceph-mds/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-mds/tasks/docker/fetch_configs.yml
@@ -18,7 +18,7 @@
 
 - name: try to fetch ceph config and keys
   copy: >
-    src=fetch/docker_mon_files/{{ item.0 }}
+    src={{ fetch_directory }}/docker_mon_files/{{ item.0 }}
     dest={{ item.0 }}
     owner=root
     group=root

--- a/roles/ceph-mds/tasks/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/pre_requisite.yml
@@ -3,7 +3,7 @@
 
 - name: copy mds bootstrap key
   copy: >
-    src=fetch/{{ fsid }}/var/lib/ceph/bootstrap-mds/ceph.keyring
+    src={{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-mds/ceph.keyring
     dest=/var/lib/ceph/bootstrap-mds/ceph.keyring
     owner=root
     group=root

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -5,6 +5,8 @@
 # GENERAL #
 ###########
 
+fetch_directory: fetch/
+
 rgw_group_name: rgws
 
 # ACTIVATE BOTH FSID AND MONITOR_SECRET VARIABLES FOR NON-VAGRANT DEPLOYMENT

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -36,7 +36,7 @@
 - name: copy keys to the ansible server
   fetch: >
     src={{ item }}
-    dest=fetch/{{ fsid }}/{{ item }}
+    dest={{ fetch_directory }}/{{ fsid }}/{{ item }}
     flat=yes
   with_items:
     - "{{ ceph_keys.stdout_lines }}"

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -1,16 +1,16 @@
 ---
 - name: generate monitor initial keyring
   local_action: >
-    shell python -c "import os ; import struct ; import time; import base64 ; key = os.urandom(16) ; header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ; print base64.b64encode(header + key)" | tee fetch/monitor_keyring.conf
-    creates=fetch/monitor_keyring.conf
+    shell python -c "import os ; import struct ; import time; import base64 ; key = os.urandom(16) ; header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ; print base64.b64encode(header + key)" | tee {{ fetch_directory }}/monitor_keyring.conf
+    creates={{ fetch_directory }}/monitor_keyring.conf
   register: monitor_keyring
   sudo: false
   when: monitor_secret != 'AQAWqilTCDh7CBAAawXt6kyTgLFCxSvJhTEmuw=='
 
 - name: read monitor initial keyring if it already exists
   local_action: >
-    command cat fetch/monitor_keyring.conf
-    removes=fetch/monitor_keyring.conf
+    command cat {{ fetch_directory }}/monitor_keyring.conf
+    removes={{ fetch_directory }}/monitor_keyring.conf
   changed_when: false
   register: monitor_keyring
   sudo: false

--- a/roles/ceph-mon/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mon/tasks/docker/copy_configs.yml
@@ -2,7 +2,7 @@
 - name: push ceph files to the ansible server
   fetch: >
     src={{ item.0 }}
-    dest=fetch/docker_mon_files/{{ item.0 }}
+    dest={{ fetch_directory }}/docker_mon_files/{{ item.0 }}
     flat=yes
   with_together:
     - ceph_config_keys

--- a/roles/ceph-mon/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-mon/tasks/docker/fetch_configs.yml
@@ -20,7 +20,7 @@
 
 - name: try to fetch ceph config and keys
   copy: >
-    src=fetch/docker_mon_files/{{ item.0 }}
+    src={{ fetch_directory }}/docker_mon_files/{{ item.0 }}
     dest={{ item.0 }}
     owner=root
     group=root

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -2,6 +2,12 @@
 # You can override default vars defined in defaults/main.yml here,
 # but I would advice to use host or group vars instead
 
+###########
+# GENERAL #
+###########
+
+fetch_directory: fetch/
+
 ####################
 # OSD CRUSH LOCATION
 ####################

--- a/roles/ceph-osd/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-osd/tasks/docker/fetch_configs.yml
@@ -15,7 +15,7 @@
 
 - name: try to fetch ceph config and keys
   copy: >
-    src=fetch/docker_mon_files/{{ item.0 }}
+    src={{ fetch_directory }}/docker_mon_files/{{ item.0 }}
     dest={{ item.0 }}
     owner=root
     group=root

--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -13,7 +13,7 @@
 
 - name: copy osd bootstrap key
   copy: >
-    src=fetch/{{ fsid }}/var/lib/ceph/bootstrap-osd/ceph.keyring
+    src={{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-osd/ceph.keyring
     dest=/var/lib/ceph/bootstrap-osd/ceph.keyring
     owner=root
     group=root

--- a/roles/ceph-restapi/defaults/main.yml
+++ b/roles/ceph-restapi/defaults/main.yml
@@ -1,4 +1,11 @@
 ---
+
+###########
+# GENERAL #
+###########
+
+fetch_directory: fetch/
+
 ##########
 # DOCKER #
 ##########

--- a/roles/ceph-restapi/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-restapi/tasks/docker/fetch_configs.yml
@@ -15,7 +15,7 @@
 
 - name: try to fetch ceph config and keys
   copy: >
-    src=fetch/docker_mon_files/{{ item.0 }}
+    src={{ fetch_directory }}/docker_mon_files/{{ item.0 }}
     dest={{ item.0 }}
     owner=root
     group=root

--- a/roles/ceph-restapi/tasks/pre_requisite.yml
+++ b/roles/ceph-restapi/tasks/pre_requisite.yml
@@ -9,7 +9,7 @@
 
 - name: copy ceph rest api keyring
   copy: >
-    src=fetch/{{ fsid }}/etc/ceph/ceph.client.restapi.keyring
+    src={{ fetch_directory }}/{{ fsid }}/etc/ceph/ceph.client.restapi.keyring
     dest=/var/lib/ceph/restapi/ceph-restapi/keyring
     owner=root
     group=root

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
 # You can override vars by using host or group vars
 
+###########
+# GENERAL #
+###########
+
+fetch_directory: fetch/
+
 ## Ceph options
 #
 cephx: true

--- a/roles/ceph-rgw/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-rgw/tasks/docker/fetch_configs.yml
@@ -15,7 +15,7 @@
 
 - name: try to fetch ceph config and keys
   copy: >
-    src=fetch/docker_mon_files/{{ item.0 }}
+    src={{ fetch_directory }}/docker_mon_files/{{ item.0 }}
     dest={{ item.0 }}
     owner=root
     group=root

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -12,7 +12,7 @@
 
 - name: copy rados gateway bootstrap key
   copy: >
-    src=fetch/{{ fsid }}/var/lib/ceph/bootstrap-rgw/ceph.keyring
+    src={{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-rgw/ceph.keyring
     dest=/var/lib/ceph/bootstrap-rgw/ceph.keyring
     owner=root
     group=root


### PR DESCRIPTION
Currently, the fetch directory is created in your working directory
(where ansible is run from).  We prefer to not keep any state in this
directory and would prefer to have the fetch directory configurable so
we can store it outside of our code checkout.

This commit creates a new variable in each role called
`fetch_directory` (defaulting to the previous value of 'fetch/'), and
then updates each reference to 'fetch' to use the new variable instead.

Closes issue #383