### PR TITLE
fixing sysctl command to take whitespace-separated multi values for a key

### DIFF
--- a/roles/ceph-common/tasks/misc/system_tuning.yml
+++ b/roles/ceph-common/tasks/misc/system_tuning.yml
@@ -18,8 +18,8 @@
 
 - name: apply operating system tuning
   sysctl: >
-    name={{ item.name }}
-    value={{ item.value }}
+    name="{{ item.name }}"
+    value="{{ item.value }}"
     state=present
     sysctl_file=/etc/sysctl.conf
     ignoreerrors=yes


### PR DESCRIPTION
https://github.com/ceph/ceph-ansible/issues/397