### PR TITLE
Support setting the "mon pg warn max object skew" in ceph.conf

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -138,6 +138,7 @@ dummy:
 #mon_osd_report_timeout: 300
 #mon_pg_warn_max_per_osd: 0 # disable complains about low pgs numbers per osd
 #mon_osd_allow_primary_affinity: "true"
+#mon_pg_warn_max_object_skew: 10 # set to 20 or higher to disable complaints about number of PGs being too low if some pools have very few objects bringing down the average number of objects per pool. This happens when running RadosGW. Ceph default is 10
 
 ## OSD options
 #

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -146,6 +146,7 @@ mon_osd_nearfull_ratio: .85
 mon_osd_report_timeout: 300
 mon_pg_warn_max_per_osd: 0 # disable complains about low pgs numbers per osd
 mon_osd_allow_primary_affinity: "true"
+mon_pg_warn_max_object_skew: 10 # set to 20 or higher to disable complaints about number of PGs being too low if some pools have very few objects bringing down the average number of objects per pool. This happens when running RadosGW. Ceph default is 10
 
 ## OSD options
 #

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -81,6 +81,7 @@
   mon osd report timeout = {{ mon_osd_report_timeout }}
   mon pg warn max per osd = {{ mon_pg_warn_max_per_osd }}
   mon osd allow primary affinity = {{ mon_osd_allow_primary_affinity }}
+  mon pg warn max object skew = {{ mon_pg_warn_max_object_skew }}
 
 {% if enable_debug_mon %}
   debug mon = {{ debug_mon_level }}


### PR DESCRIPTION
It should be used to disable health warnings about number of PGs
being too low if some pools have very few objects bringing down
the average number of objects per pool. This happens when running RadosGW.

The default is 10 and since the warnings only occur with some use cases,
the default here is 10 as well. Set to 20 or more to silence the warnings.