### PR TITLE
Fix and improve checks when ceph_origin == 'distro'

### DIFF
--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -1,8 +1,16 @@
 ---
+- name: make sure an installation origin was chosen
+  fail:
+    msg: "choose an installation origin"
+  when:
+    ceph_origin != 'upstream' and
+    ceph_origin != 'distro'
+
 - name: make sure an installation source was chosen
   fail:
-    msg: "choose an installation source or read https://github.com/ceph/ceph-ansible/wiki"
+    msg: "choose an upstream installation source or read https://github.com/ceph/ceph-ansible/wiki"
   when:
+    ceph_origin == 'upstream' and
     not ceph_stable and
     not ceph_dev and
     not ceph_stable_ice and


### PR DESCRIPTION
Hi,

If you use `ceph_origin` == 'distro' and you don't set to true `ceph_stable`... `ceph_common` fails.

This PR fix this issue and manages well ceph_origin / "ceph sources" (when `ceph_origin` == 'upstream').

Cheers!

Emilien