### PR TITLE
fix regex for partition names, enhance for NVM

### DIFF
--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -4,9 +4,8 @@
 # it should exist we rc=0 and don't do anything unless we do something like --force
 # As as a final word, I prefer to keep the partition check instead of running ceph-disk prepare with "failed_when: false"
 # I believe it's safer
-
 - name: check if the device is a partition or a disk
-  shell: "echo '{{ item }}' | egrep '/dev/[sd[a-z]{1,2}|hd[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p][0-9]{1,2}'"
+  shell: "echo '{{ item }}' | egrep '/dev/[sd[a-z]{1,2}|hd[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p][0-9]{1,2}$'"
   with_items: devices
   changed_when: false
   failed_when: false

--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -4,8 +4,14 @@
 # it should exist we rc=0 and don't do anything unless we do something like --force
 # As as a final word, I prefer to keep the partition check instead of running ceph-disk prepare with "failed_when: false"
 # I believe it's safer
-- name: check if the device is a partition or a disk
-  shell: "echo '{{ item }}' | egrep '/dev/[sd[a-z]{1,2}|hd[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p][0-9]{1,2}$'"
+#
+# regex syntax uses (pat1|pat2|...|patN) for different families of device
+# names, but has a common expression for partition number at the end.
+# allow 2-digit partition numbers so fast SSDs can be shared by > 9 disks
+# for SSD journals.
+
+- name: check if the device is a partition
+  shell: "echo '{{ item }}' | egrep '/dev/(sd[a-z]{1,2}|hd[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p)[0-9]{1,2}$'"
   with_items: devices
   changed_when: false
   failed_when: false

--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -4,8 +4,9 @@
 # it should exist we rc=0 and don't do anything unless we do something like --force
 # As as a final word, I prefer to keep the partition check instead of running ceph-disk prepare with "failed_when: false"
 # I believe it's safer
+
 - name: check if the device is a partition or a disk
-  shell: "echo '{{ item }}' | egrep '/dev/(([a-z]{3,4}[0-9]$)|(cciss/c[0-9]{1}d[0-9]{1}p[0-9]$))'"
+  shell: "echo '{{ item }}' | egrep '/dev/[sd[a-z]{1,2}|hd[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p][0-9]{1,2}'"
   with_items: devices
   changed_when: false
   failed_when: false


### PR DESCRIPTION
Improve regular expression for recognizing partition name.  Regex now uses "or" syntax to represent different families of devices - SCSI, IDE, CCISS, NVM, and it's easy to add others.  The partition number is factored out at the end.  Learned from previous version that we could control how many letters or digits to allow - I allow for 2 digits in partition number so poor folk like me can have >= 10 disks/SSD in their journal device.  

In the future, should we just ask Linux if it's a block device, and then look for a partition number on the end?  That would be a much simpler regex to maintain.