### PR TITLE
Changed URL for Ceph release and developer GPG keys, because previous…

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -44,7 +44,7 @@ dummy:
 
 # COMMUNITY VERSION
 #ceph_stable: false # use ceph stable branch
-#ceph_stable_key: https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+#ceph_stable_key: https://download.ceph.com/keys/release.asc
 #ceph_stable_release: hammer # ceph stable release
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
@@ -90,7 +90,7 @@ dummy:
 # ###
 
 #ceph_dev: false # use ceph development branch
-#ceph_dev_key: https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+#ceph_dev_key: https://download.ceph.com/keys/autobuild.asc
 #ceph_dev_branch: master # development branch you would like to use e.g: master, wip-hack
 
 # supported distros are centos6, centos7, fc17, fc18, fc19, fc20, fedora17, fedora18,

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -42,7 +42,7 @@ ceph_use_distro_backports: false # DEBIAN ONLY
 
 # COMMUNITY VERSION
 ceph_stable: false # use ceph stable branch
-ceph_stable_key: https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+ceph_stable_key: https://download.ceph.com/keys/release.asc
 ceph_stable_release: hammer # ceph stable release
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
@@ -88,7 +88,7 @@ ceph_stable_rh_storage_repository_path: /tmp/rh-storage-repo # where to copy iso
 # ###
 
 ceph_dev: false # use ceph development branch
-ceph_dev_key: https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
+ceph_dev_key: https://download.ceph.com/keys/autobuild.asc
 ceph_dev_branch: master # development branch you would like to use e.g: master, wip-hack
 
 # supported distros are centos6, centos7, fc17, fc18, fc19, fc20, fedora17, fedora18,

--- a/roles/ceph-common/templates/ceph-extra.repo
+++ b/roles/ceph-common/templates/ceph-extra.repo
@@ -7,7 +7,7 @@ enabled=1
 priority=2
 gpgcheck=1
 type=rpm-md
-gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+gpgkey=https://download.ceph.com/keys/release.asc
 
 {% if (redhat_distro_ceph_extra != "centos6.4" and redhat_distro_ceph_extra !=  "rhel6.4" and redhat_distro_ceph_extra !=  "rhel6.5") %}
 [ceph-extras-noarch]
@@ -17,7 +17,7 @@ enabled=1
 priority=2
 gpgcheck=1
 type=rpm-md
-gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+gpgkey=https://download.ceph.com/keys/release.asc
 {% endif %}
 
 [ceph-extras-source]
@@ -27,4 +27,4 @@ enabled=1
 priority=2
 gpgcheck=1
 type=rpm-md
-gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+gpgkey=https://download.ceph.com/keys/release.asc


### PR DESCRIPTION
… key URL suffers sporadic timeouts.

This addresses the issue I've been having in #403 and #413. It's also being discussed on the Ceph-users mailing list that there are ipv6 issues with the other URL.