### PR TITLE
Ability  to collocate bare metal and container

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -226,10 +226,3 @@ dummy:
 #  - { name: fs.file-max, value: 26234859 }
 #  - { name: vm.zone_reclaim_mode, value: 0 }
 #  - { name: vm.vfs_cache_pressure, value: 50 }
-
-
-##########
-# DOCKER #
-##########
-
-#docker: false

--- a/group_vars/mdss.sample
+++ b/group_vars/mdss.sample
@@ -15,7 +15,7 @@ dummy:
 # DOCKER #
 ##########
 
-#ceph_containerized_deployment: false
+#mds_containerized_deployment: false
 #ceph_mds_docker_username: ceph
 #ceph_mds_docker_imagename: daemon
 #ceph_mds_docker_extra_env: "MDS_NAME={{ ansible_hostname }}" # comma separated variables

--- a/group_vars/mons.sample
+++ b/group_vars/mons.sample
@@ -55,7 +55,7 @@ dummy:
 # DOCKER #
 ##########
 
-#ceph_containerized_deployment: false
+#mon_containerized_deployment: false
 #ceph_mon_docker_username: ceph
 #ceph_mon_docker_imagename: "daemon"
 #ceph_mon_docker_interface: eth0

--- a/group_vars/osds.sample
+++ b/group_vars/osds.sample
@@ -113,7 +113,7 @@ osd_crush_location: "'root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} host
 # DOCKER #
 ##########
 
-#ceph_containerized_deployment: false
+#osd_containerized_deployment: false
 #ceph_osd_docker_username: ceph
 #ceph_osd_docker_imagename: daemon
 #ceph_osd_docker_extra_env: "CEPH_DAEMON=OSD_CEPH_DISK" # comma separated variables

--- a/group_vars/restapis.sample
+++ b/group_vars/restapis.sample
@@ -14,7 +14,7 @@ dummy:
 # DOCKER #
 ##########
 
-#ceph_containerized_deployment: false
+#restapi_containerized_deployment: false
 #ceph_restapi_docker_interface: eth0
 #ceph_restapi_port: 5000
 #ceph_restapi_docker_username: ceph

--- a/group_vars/rgws.sample
+++ b/group_vars/rgws.sample
@@ -20,7 +20,7 @@ dummy:
 # DOCKER #
 ##########
 
-#ceph_containerized_deployment: false
+#rgw_containerized_deployment: false
 #ceph_rgw_docker_username: ceph
 #ceph_rgw_docker_imagename: daemon
 #ceph_rgw_civetweb_port: 80

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -14,7 +14,7 @@ cephx: true
 # DOCKER #
 ##########
 
-ceph_containerized_deployment: false
+mds_containerized_deployment: false
 ceph_mds_docker_username: ceph
 ceph_mds_docker_imagename: daemon
 ceph_mds_docker_extra_env: "MDS_NAME={{ ansible_hostname }}" # comma separated variables

--- a/roles/ceph-mds/meta/main.yml
+++ b/roles/ceph-mds/meta/main.yml
@@ -11,4 +11,4 @@ galaxy_info:
   categories:
     - system
 dependencies:
-  - { role: ceph-common, when: not docker }
+  - { role: ceph-common, when: not mds_containerized_deployment }

--- a/roles/ceph-mds/tasks/main.yml
+++ b/roles/ceph-mds/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: pre_requisite.yml
-  when: not ceph_containerized_deployment
+  when: not mds_containerized_deployment
 
 - include: ./docker/main.yml
-  when: ceph_containerized_deployment
+  when: mds_containerized_deployment

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -60,7 +60,7 @@ openstack_keys:
 # DOCKER #
 ##########
 
-ceph_containerized_deployment: false
+mon_containerized_deployment: false
 ceph_mon_docker_interface: eth0
 #ceph_mon_docker_subnet: # subnet of the ceph_mon_docker_interface
 ceph_mon_docker_username: ceph

--- a/roles/ceph-mon/meta/main.yml
+++ b/roles/ceph-mon/meta/main.yml
@@ -11,4 +11,4 @@ galaxy_info:
   categories:
     - system
 dependencies:
-  - { role: ceph-common, when: not docker }
+  - { role: ceph-common, when: not mon_containerized_deployment }

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - include: deploy_monitors.yml
-  when: not ceph_containerized_deployment
+  when: not mon_containerized_deployment
 
 - include: start_monitor.yml
-  when: not ceph_containerized_deployment
+  when: not mon_containerized_deployment
 
 - include: ceph_keys.yml
-  when: not ceph_containerized_deployment
+  when: not mon_containerized_deployment
 
 - include: create_mds_filesystems.yml
   when:
@@ -16,7 +16,7 @@
 - include: secure_cluster.yml
   when:
     secure_cluster and
-    not ceph_containerized_deployment
+    not mon_containerized_deployment
 
 - include: ./docker/main.yml
-  when: ceph_containerized_deployment
+  when: mon_containerized_deployment

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -108,7 +108,7 @@ osd_directory: false
 # DOCKER #
 ##########
 
-ceph_containerized_deployment: false
+osd_containerized_deployment: false
 ceph_osd_docker_username: ceph
 ceph_osd_docker_imagename: daemon
 ceph_osd_docker_extra_env: "CEPH_DAEMON=OSD_CEPH_DISK" # comma separated variables

--- a/roles/ceph-osd/meta/main.yml
+++ b/roles/ceph-osd/meta/main.yml
@@ -11,4 +11,4 @@ galaxy_info:
   categories:
     - system
 dependencies:
-  - { role: ceph-common, when: not docker }
+  - { role: ceph-common, when: not osd_containerized_deployment }

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
 - include: pre_requisite.yml
-  when: not ceph_containerized_deployment
+  when: not osd_containerized_deployment
 
 - include: ./scenarios/journal_collocation.yml
-  when: journal_collocation and not ceph_containerized_deployment
+  when: journal_collocation and not osd_containerized_deployment
 
 - include: ./scenarios/raw_multi_journal.yml
-  when: raw_multi_journal and not ceph_containerized_deployment
+  when: raw_multi_journal and not osd_containerized_deployment
 
 - include: ./scenarios/osd_directory.yml
-  when: osd_directory and not ceph_containerized_deployment
+  when: osd_directory and not osd_containerized_deployment
 
 - include: ./docker/main.yml
-  when: ceph_containerized_deployment
+  when: osd_containerized_deployment

--- a/roles/ceph-restapi/defaults/main.yml
+++ b/roles/ceph-restapi/defaults/main.yml
@@ -10,7 +10,7 @@ fetch_directory: fetch/
 # DOCKER #
 ##########
 
-ceph_containerized_deployment: false
+restapi_containerized_deployment: false
 ceph_restapi_docker_interface: eth0
 ceph_restapi_port: 5000
 ceph_restapi_docker_username: ceph

--- a/roles/ceph-restapi/meta/main.yml
+++ b/roles/ceph-restapi/meta/main.yml
@@ -11,4 +11,4 @@ galaxy_info:
   categories:
     - system
 dependencies:
-  - { role: ceph-common, when: not docker }
+  - { role: ceph-common, when: not restapi_containerized_deployment }

--- a/roles/ceph-restapi/tasks/main.yml
+++ b/roles/ceph-restapi/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - include: pre_requisite.yml
-  when: not ceph_containerized_deployment
+  when: not restapi_containerized_deployment
 
 - include: start_restapi.yml
-  when: not ceph_containerized_deployment
+  when: not restapi_containerized_deployment
 
 - include: ./docker/main.yml
-  when: ceph_containerized_deployment
+  when: restapi_containerized_deployment

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -20,7 +20,7 @@ radosgw_user: root
 # DOCKER #
 ##########
 
-ceph_containerized_deployment: false
+rgw_containerized_deployment: false
 ceph_rgw_civetweb_port: 80
 ceph_rgw_docker_username: ceph
 ceph_rgw_docker_imagename: daemon

--- a/roles/ceph-rgw/meta/main.yml
+++ b/roles/ceph-rgw/meta/main.yml
@@ -11,4 +11,4 @@ galaxy_info:
   categories:
     - system
 dependencies:
-  - { role: ceph-common, when: not docker }
+  - { role: ceph-common, when: not rgw_containerized_deployment }

--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - include: pre_requisite.yml
-  when: not ceph_containerized_deployment
+  when: not rgw_containerized_deployment
 
 - include: openstack-keystone.yml
   when: radosgw_keystone
 
 - include: start_radosgw.yml
-  when: not ceph_containerized_deployment
+  when: not rgw_containerized_deployment
 
 - include: ./docker/main.yml
-  when: ceph_containerized_deployment
+  when: rgw_containerized_deployment


### PR DESCRIPTION
Since we renamed the variables and removed the old 'docker' variable we
can now collocate container daemons with standard bare metal deployment.
For instance, monitors can be containerized but osds can be deployed
traditionally.

Signed-off-by: Sébastien Han <seb@redhat.com>