### PR TITLE
This change address radosgw not getting started on CentOS

### DIFF
--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -29,4 +29,4 @@
     name: ceph-radosgw
     state: started
     enabled: yes
-  when: ansible_distribution == 'RedHat'
+  when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
* The explicit check of 'ansible_distribution' being 'RedHat'
  will not work on CentOS hosts.
* Check the value of 'ansible_os_family' instead.