### PR TITLE
Defaults for the ceph-mon role should be setting the 'mon_group_name'

### DIFF
--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -7,7 +7,7 @@
 
 fetch_directory: fetch/
 
-rgw_group_name: rgws
+mon_group_name: mons
 
 # ACTIVATE BOTH FSID AND MONITOR_SECRET VARIABLES FOR NON-VAGRANT DEPLOYMENT
 fsid: "{{ cluster_uuid.stdout }}"


### PR DESCRIPTION
Without this, and if all these group name variables are commented out in ```group_vars/all```, then the handler in ```ceph-common``` that depends on the value of ```mon_group_name``` would fail:

```
NOTIFIED: [ceph-common | restart ceph mons] ***********************************
fatal: [ctrl-gprt] => error while evaluating conditional: socket.rc == 0 and ansible_distribution != 'Ubuntu' and mon_group_name in group_names
```

which does look like some sort of unexpected behaviour on Ansible because those ```*_group_name``` defaults are set in the ```ceph-common``` role. I'm using Ansible 1.9.4.