### PR TITLE
Check partition status

### DIFF
--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -17,6 +17,40 @@
   failed_when: false
   register: ispartition
 
+- name: check the partition status of the osd disks
+  shell: "parted --script {{ item }} print > /dev/null 2>&1"
+  with_items: devices
+  changed_when: false
+  failed_when: false
+  register: osd_partition_status
+  when:
+    journal_collocation or
+    raw_multi_journal
+
+- name: check the partition status of the journal devices
+  shell: "parted --script {{ item }} print > /dev/null 2>&1"
+  with_items: raw_journal_devices
+  changed_when: false
+  failed_when: false
+  register: journal_partition_status
+  when: raw_multi_journal
+
+- name: fix partitions gpt header or labels of the osd disks
+  shell: sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }}
+  with_together:
+    - osd_partition_status.results
+    - devices
+  changed_when: false
+  when: (journal_collocation or raw_multi_journal) and item.0.rc != 0
+
+- name: fix partitions gpt header or labels of the journal devices
+  shell: sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }}
+  with_together:
+    - journal_partition_status.results
+    - raw_journal_devices
+  changed_when: false
+  when: raw_multi_journal and item.0.rc != 0
+
 - name: if partition named 'ceph' exists
   shell: "parted --script {{ item }} print | egrep -sq '^ 1.*ceph'"
   with_items: devices


### PR DESCRIPTION
Verify that partitions (for both osd disks and journal disks) are sane
before attempting to prepare the device. Fail if parted fails for
whatever reason.

Closes: #437

Signed-off-by: Sébastien Han <seb@redhat.com>