### PR TITLE
Add systemd-specific start/restart tasks/handlers for el7/infernalis

### DIFF
--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -8,7 +8,26 @@
   when:
     socket.rc == 0 and
     ansible_distribution != 'Ubuntu' and
-    mon_group_name in group_names
+    mon_group_name in group_names and
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
+
+- name: restart ceph mons with systemd
+  service:
+      name: ceph-mon@{{ ansible_hostname }}
+      state: restarted
+  when:
+    socket.rc == 0 and
+    ansible_distribution != 'Ubuntu' and
+    mon_group_name in group_names and not
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
 
 - name: restart ceph mons on ubuntu
   command: restart ceph-mon-all
@@ -22,7 +41,29 @@
   when:
     socket.rc == 0 and
     ansible_distribution != 'Ubuntu' and
-    osd_group_name in group_names
+    osd_group_name in group_names and
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
+
+# This does not just restart OSDs but everything else too. Unfortunately
+# at this time the ansible role does not have an OSD id list to use
+# for restarting them specifically.
+- name: restart ceph osds with systemd
+  service:
+    name: ceph.target
+    state: restarted
+  when:
+    socket.rc == 0 and
+    ansible_distribution != 'Ubuntu' and
+    osd_group_name in group_names and not
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
 
 - name: restart ceph osds on ubuntu
   command: restart ceph-osd-all
@@ -43,7 +84,27 @@
   when:
     socket.rc == 0 and
     ansible_distribution != 'Ubuntu' and
-    mds_group_name in group_names
+    mds_group_name in group_names and
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
+
+
+- name: restart ceph mdss with systemd
+  service:
+      name: ceph-mds@{{ ansible_hostname }}
+      state: restarted
+  when:
+    socket.rc == 0 and
+    ansible_distribution != 'Ubuntu' and
+    mds_group_name in group_names and not
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
 
 - name: restart ceph rgws on ubuntu
   command: restart ceph-all
@@ -57,14 +118,38 @@
   when:
     socketrgw.rc == 0 and
     ansible_distribution != 'Ubuntu' and
-    rgw_group_name in group_names
+    rgw_group_name in group_names and
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
 
 - name: restart ceph rgws on red hat
   command: /etc/init.d/ceph-radosgw restart
   when:
     socketrgw.rc == 0 and
     ansible_os_family == 'RedHat' and
-    rgw_group_name in group_names
+    rgw_group_name in group_names and
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
+
+- name: restart ceph rgws with systemd
+  service:
+    name: ceph-rgw@{{ ansible_hostname }}
+    state: restarted
+  when:
+    socketrgw.rc == 0 and
+    ansible_distribution != 'Ubuntu' and
+    rgw_group_name in group_names and not
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
 
 - name: restart apache2
   service:

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -88,13 +88,17 @@
   notify:
     - restart ceph mons
     - restart ceph mons on ubuntu
+    - restart ceph mons with systemd
     - restart ceph osds
     - restart ceph osds on ubuntu
+    - restart ceph osds with systemd
     - restart ceph mdss
     - restart ceph mdss on ubuntu
+    - restart ceph mdss with systemd
     - restart ceph rgws
     - restart ceph rgws on ubuntu
     - restart ceph rgws on red hat
+    - restart ceph rgws with systemd
 
 - name: create rbd client directory
   file:

--- a/roles/ceph-mds/tasks/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/pre_requisite.yml
@@ -208,11 +208,30 @@
   changed_when: false
   when: ansible_distribution == "Ubuntu"
 
-- name: start and add that the metadata service to the init sequence
+- name: start and add that the metadata service to the init sequence (before infernalis)
   service:
     name: ceph
     state: started
     enabled: yes
     args: mds
   changed_when: false
-  when: ansible_distribution != "Ubuntu"
+  when: ansible_distribution != "Ubuntu" and
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
+
+
+- name: start and add that the metadata service to the init sequence (for or after infernalis)
+  service:
+    name: ceph-mds@{{ ansible_hostname }}
+    state: started
+    enabled: yes
+  changed_when: false
+  when: ansible_distribution != "Ubuntu" and not
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -44,7 +44,27 @@
 - name: start and add that the monitor service to the init sequence
   command: service ceph start mon
   changed_when: false
-  when: ansible_distribution != "Ubuntu"
+  when:
+    ansible_distribution != "Ubuntu" and
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
+
+- name: start and add that the monitor service to the init sequence (for or after infernalis)
+  service:
+      name: ceph-mon@{{ ansible_hostname }}
+      state: started
+      enabled: yes
+  changed_when: false
+  when:
+    ansible_distribution != "Ubuntu" and not
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
 
 - name: collect admin and bootstrap keys
   command: ceph-create-keys --id {{ ansible_hostname }}

--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -23,8 +23,29 @@
 - include: osd_fragment.yml
   when: crush_location
 
-- name: start and add that the osd service(s) to the init sequence
+- name: start and add that the osd service(s) to the init sequence (before infernalis)
   service:
     name: ceph
     state: started
     enabled: yes
+  when:
+    ansible_distribution == "Ubuntu" or
+    (ceph_stable_release == 'dumpling' or
+     ceph_stable_release == 'emperor' or
+     ceph_stable_release == 'firefly' or
+     ceph_stable_release == 'giant' or
+     ceph_stable_release == 'hammer')
+
+- name: start and add that the osd service(s) to the init sequence (on or after infernalis)
+  service:
+    name: ceph.target
+    state: started
+    enabled: yes
+  when:
+    ansible_distribution != "Ubuntu" and not
+    (ceph_stable_release == 'dumpling' or
+     ceph_stable_release == 'emperor' or
+     ceph_stable_release == 'firefly' or
+     ceph_stable_release == 'giant' or
+     ceph_stable_release == 'hammer')
+

--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -24,9 +24,26 @@
     state: started
   when: ansible_distribution == 'Ubuntu'
 
-- name: start rgw on red hat
+- name: start rgw on red hat (before or on infernalis)
   service:
     name: ceph-radosgw
     state: started
     enabled: yes
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
+
+- name: start rgw on red hat (after infernalis)
+  service:
+    name: ceph-radosgw@{{ ansible_hostname }}
+    state: started
+    enabled: yes
+  when: ansible_os_family == 'RedHat' and not
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')


### PR DESCRIPTION
This makes the roles work on el7; the old sysv-initscript invocations no longer work. Unfortunately the "restart osd with systemd" handler is now a "restart everything on the node" handler at the moment (to fix this a list of OSD-ids would need to be generated somehow, there no longer is a "restart all osds" option like in SysV and Upstart).