### PR TITLE
Tweak the ansible configuration file

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,18 @@
 [defaults]
 ansible_managed = Please do not change this file directly since it is managed by Ansible and will be overwritten
+forks = 10
+host_key_checking = False
+remote_user = vagrant
+roles_path = roles/
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /tmp/ansible/facts
+fact_caching_timeout = 600
+
+[privilege_escalation]
+become = False
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s
+control_path = %(directory)s/%%h-%%r
+#pipelining = True # enable user root or disable the requiretty option for the remote_user


### PR DESCRIPTION
This change reduces the time to run ansible.
Note that when pipelining is enabled root should be used or
disable the requiretty option for the remote_user

Signed-off-by: Sébastien Han <seb@redhat.com>