### PR TITLE
Moving out the restapi from the mons

### DIFF
--- a/site.yml.sample
+++ b/site.yml.sample
@@ -5,7 +5,6 @@
   sudo: True
   roles:
   - ceph-mon
-  - { role: ceph-restapi, when: restapi_group_name is defined and restapi_group_name in group_names }
   #serial: 1 # ENABLE THIS WHEN DEPLOYING MONITORS ON DOCKER CONTAINERS
 
 - hosts: osds
@@ -22,3 +21,8 @@
   sudo: True
   roles:
   - ceph-rgw
+
+- hosts: restapis
+  sudo: True
+  roles:
+  - ceph-restapi


### PR DESCRIPTION
This has the tendency to make the ceph-mon play unnecessary longer when not
activated.

Signed-off-by: Sébastien Han <seb@redhat.com>