### PR TITLE
Add run_once to 'copy keys to the ansible server'

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -39,6 +39,7 @@
     src: "{{ item }}"
     dest: "{{ fetch_directory }}/{{ fsid }}/{{ item }}"
     flat: yes
+  run_once: true
   with_items:
     - "{{ ceph_keys.stdout_lines }}"
     - /var/lib/ceph/bootstrap-osd/ceph.keyring


### PR DESCRIPTION
I have seen a number of failures on this task due to mismatch of
checksum of source file and destination.  I suspect this is due to a
race condition caused by several hosts simultaneously copying the same
file to single location on the deployment server.

This change simply updates the 'copy keys to the ansible server' task
by adding 'run_once', which limits the task to being run on a single
MON host.

Closes issue #410