### PR TITLE
fixes ceph_stable_release logic mentioned in issue #446

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -47,6 +47,16 @@ dummy:
 #ceph_stable_key: https://download.ceph.com/keys/release.asc
 #ceph_stable_release: infernalis # ceph stable release
 
+####################
+## Stable Releases #
+####################
+#ceph_stable_releases:
+#  - dumpling
+#  - emperor
+#  - firefly
+#  - giant
+#  - hammer
+#          
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://ceph.com/debian-{{ ceph_stable_release }}/dists/
 # for more info read: https://github.com/ceph/ceph-ansible/issues/305

--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -47,9 +47,9 @@ dummy:
 #ceph_stable_key: https://download.ceph.com/keys/release.asc
 #ceph_stable_release: infernalis # ceph stable release
 
-####################
-## Stable Releases #
-####################
+###################
+# Stable Releases #
+###################
 #ceph_stable_releases:
 #  - dumpling
 #  - emperor

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -45,9 +45,9 @@ ceph_stable: false # use ceph stable branch
 ceph_stable_key: https://download.ceph.com/keys/release.asc
 ceph_stable_release: infernalis # ceph stable release
 
-####################
-## Stable Releases #
-####################
+###################
+# Stable Releases #
+###################
 ceph_stable_releases:
   - dumpling
   - emperor

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -45,6 +45,16 @@ ceph_stable: false # use ceph stable branch
 ceph_stable_key: https://download.ceph.com/keys/release.asc
 ceph_stable_release: infernalis # ceph stable release
 
+####################
+## Stable Releases #
+####################
+ceph_stable_releases:
+  - dumpling
+  - emperor
+  - firefly
+  - giant
+  - hammer
+
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://ceph.com/debian-{{ ceph_stable_release }}/dists/
 # for more info read: https://github.com/ceph/ceph-ansible/issues/305

--- a/roles/ceph-mds/tasks/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/pre_requisite.yml
@@ -6,12 +6,7 @@
     owner: ceph
     group: ceph
     mode: 0755
-  when:
-    ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer'
+  when: ceph_stable_release not in ceph_stable_releases
 
 - name: create bootstrap-mds directory (before infernalis release)
   file:
@@ -20,13 +15,7 @@
     owner: root
     group: root
     mode: 0755
-  when:
-    cephx and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+  when: cephx and ceph_stable_release in ceph_stable_releases
 
 - name: copy mds bootstrap key (for or after infernalis release)
   copy:
@@ -36,12 +25,7 @@
     group: ceph
     mode: 0600
   when:
-    cephx and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+    cephx and ceph_stable_release not in ceph_stable_releases
 
 - name: copy mds bootstrap key (before infernalis release)
   copy:
@@ -51,12 +35,7 @@
     group: root
     mode: 0600
   when:
-    cephx and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+    cephx and ceph_stable_release in ceph_stable_releases
 
 - name: create mds directory (for or after infernalis release)
   file:
@@ -66,12 +45,7 @@
     group: ceph
     mode: 0755
   when:
-    cephx and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+    cephx and ceph_stable_release not in ceph_stable_releases
 
 - name: create mds directory (before infernalis release)
   file:
@@ -81,12 +55,7 @@
     group: root
     mode: 0755
   when:
-    cephx and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+    cephx and ceph_stable_release in ceph_stable_releases
 
 - name: create mds keyring
   command: ceph --cluster ceph --name client.bootstrap-mds --keyring /var/lib/ceph/bootstrap-mds/ceph.keyring auth get-or-create mds.{{ ansible_hostname }} osd 'allow rwx' mds 'allow' mon 'allow profile mds' -o /var/lib/ceph/mds/ceph-{{ ansible_hostname }}/keyring
@@ -103,11 +72,7 @@
     group: ceph
   when:
     cephx and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+    ceph_stable_release not in ceph_stable_releases
 
 - name: set mds key permissions (before infernalis)
   file:
@@ -116,12 +81,7 @@
     owner: root
     group: root
   when:
-    cephx and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+    cephx and ceph_stable_release in ceph_stable_releases
 
 - name: activate metadata server with upstart (for or after infernalis release)
   file:
@@ -136,11 +96,7 @@
   changed_when: false
   when:
     ansible_distribution == "Ubuntu" and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+    ceph_stable_release not in ceph_stable_releases
 
 - name: activate metadata server with upstart (before infernalis release)
   file:
@@ -154,12 +110,7 @@
     - upstart
   changed_when: false
   when:
-    ansible_distribution == "Ubuntu" and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+    ansible_distribution == "Ubuntu" and ceph_stable_release in ceph_stable_releases
 
 - name: activate metadata server with sysvinit (for or after infernalis release)
   file:
@@ -174,11 +125,7 @@
   changed_when: false
   when:
     ansible_distribution != "Ubuntu" and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+    ceph_stable_release not in ceph_stable_releases
 
 - name: activate metadata server with sysvinit (before infernalis release)
   file:
@@ -192,12 +139,7 @@
     - sysvinit
   changed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+    ansible_distribution != "Ubuntu" and ceph_stable_release in ceph_stable_releases
 
 - name: start and add that the metadata service to the init sequence (ubuntu)
   service:
@@ -215,13 +157,7 @@
     enabled: yes
     args: mds.{{ ansible_hostname }}
   changed_when: false
-  when: ansible_distribution != "Ubuntu" and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
-
+  when: ansible_distribution != "Ubuntu" and ceph_stable_release in ceph_stable_releases
 
 - name: start and add that the metadata service to the init sequence (for or after infernalis)
   service:
@@ -229,9 +165,4 @@
     state: started
     enabled: yes
   changed_when: false
-  when: ansible_distribution != "Ubuntu" and not
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+  when: ansible_distribution != "Ubuntu" and ceph_stable_release not in ceph_stable_releases

--- a/roles/ceph-mds/tasks/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/pre_requisite.yml
@@ -7,10 +7,10 @@
     group: ceph
     mode: 0755
   when:
-    ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer'
 
 - name: create bootstrap-mds directory (before infernalis release)
@@ -37,10 +37,10 @@
     mode: 0600
   when:
     cephx and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: copy mds bootstrap key (before infernalis release)
@@ -67,18 +67,18 @@
     mode: 0755
   when:
     cephx and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: create mds directory (before infernalis release)
   file:
     path: /var/lib/ceph/mds/ceph-{{ ansible_hostname }}
     state: directory
-    owner: ceph
-    group: cephh
+    owner: root
+    group: root
     mode: 0755
   when:
     cephx and
@@ -103,10 +103,10 @@
     group: ceph
   when:
     cephx and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: set mds key permissions (before infernalis)
@@ -136,10 +136,10 @@
   changed_when: false
   when:
     ansible_distribution == "Ubuntu" and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: activate metadata server with upstart (before infernalis release)
@@ -174,10 +174,10 @@
   changed_when: false
   when:
     ansible_distribution != "Ubuntu" and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: activate metadata server with sysvinit (before infernalis release)
@@ -213,7 +213,7 @@
     name: ceph
     state: started
     enabled: yes
-    args: mds
+    args: mds.{{ ansible_hostname }}
   changed_when: false
   when: ansible_distribution != "Ubuntu" and
     (ceph_stable_release == 'dumpling' or

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -25,12 +25,7 @@
     mode: 0600
     owner: ceph
     group: ceph
-  when:
-    ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer'
+  when: ceph_stable_release not in ceph_stable_releases
 
 - name: create monitor directory (for or after infernalis release)
   file:
@@ -39,12 +34,7 @@
     owner: ceph
     group: ceph
     mode: 0755
-  when:
-    ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer'
+  when: ceph_stable_release not in ceph_stable_releases
 
 - name: set initial monitor key permissions (before infernalis release)
   file:
@@ -52,12 +42,7 @@
     mode: 0600
     owner: root
     group: root
-  when:
-    ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer'
+  when: ceph_stable_release in ceph_stable_releases
 
 - name: create monitor directory (before infernalis release)
   file:
@@ -66,31 +51,16 @@
     owner: root
     group: root
     mode: 0755
-  when:
-    ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer'
+  when: ceph_stable_release in ceph_stable_releases
 
 - name: ceph monitor mkfs (for or after infernalis release)
   command: ceph-mon --setuser ceph --setgroup ceph --mkfs -i {{ ansible_hostname }} --fsid {{ fsid }} --keyring /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
   args:
     creates: /var/lib/ceph/mon/ceph-{{ ansible_hostname }}/keyring
-  when:
-    ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer'
+  when: ceph_stable_release not in ceph_stable_releases
 
 - name: ceph monitor mkfs (before infernalis release)
   command: ceph-mon --mkfs -i {{ ansible_hostname }} --fsid {{ fsid }} --keyring /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
   args:
     creates: /var/lib/ceph/mon/ceph-{{ ansible_hostname }}/keyring
-  when:
-    ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer'
+  when: ceph_stable_release in ceph_stable_releases

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -26,10 +26,10 @@
     owner: ceph
     group: ceph
   when:
-    ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer'
 
 - name: create monitor directory (for or after infernalis release)
@@ -40,10 +40,10 @@
     group: ceph
     mode: 0755
   when:
-    ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer'
 
 - name: set initial monitor key permissions (before infernalis release)
@@ -78,10 +78,10 @@
   args:
     creates: /var/lib/ceph/mon/ceph-{{ ansible_hostname }}/keyring
   when:
-    ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer'
 
 - name: ceph monitor mkfs (before infernalis release)

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -9,7 +9,14 @@
   with_items:
     - done
     - upstart
-  when: ansible_distribution == "Ubuntu"
+  when:
+    ansible_distribution == "Ubuntu" and
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
+    ceph_stable_release != 'hammer')
+
   changed_when: false
 
 - name: activate monitor with upstart before infernalis release

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -9,13 +9,8 @@
   with_items:
     - done
     - upstart
-  when:
-    ansible_distribution == "Ubuntu" and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+  when: 
+    ansible_distribution == "Ubuntu" and ceph_stable_release not in ceph_stable_releases
 
   changed_when: false
 
@@ -31,11 +26,7 @@
     - upstart
   when:
     ansible_distribution == "Ubuntu" and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+    ceph_stable_release in ceph_stable_releases
   changed_when: false
 
 - name: start and add that the monitor service to the init sequence (ubuntu)
@@ -53,11 +44,7 @@
   changed_when: false
   when:
     ansible_distribution != "Ubuntu" and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+    ceph_stable_release in ceph_stable_releases
 
 - name: start and add that the monitor service to the init sequence (for or after infernalis)
   service:
@@ -66,12 +53,8 @@
       enabled: yes
   changed_when: false
   when:
-    ansible_distribution != "Ubuntu" and not
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+    ansible_distribution != "Ubuntu" and
+    ceph_stable_release not in ceph_stable_releases
 
 - name: collect admin and bootstrap keys
   command: ceph-create-keys --id {{ ansible_hostname }}

--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -20,10 +20,10 @@
     mode: 0755
   when:
     cephx and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: create bootstrap-osd directory (before infernalis release)
@@ -50,10 +50,10 @@
     mode: 0600
   when:
     cephx and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: copy osd bootstrap key (before infernalis release)

--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -18,13 +18,7 @@
     owner: ceph
     group: ceph
     mode: 0755
-  when:
-    cephx and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+  when: cephx and ceph_stable_release not in ceph_stable_releases
 
 - name: create bootstrap-osd directory (before infernalis release)
   file:
@@ -33,13 +27,7 @@
     owner: root
     group: root
     mode: 0755
-  when:
-    cephx and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+  when: cephx and ceph_stable_release in ceph_stable_releases
 
 - name: copy osd bootstrap key (for or after infernalis release)
   copy:
@@ -48,13 +36,7 @@
     owner: ceph
     group: ceph
     mode: 0600
-  when:
-    cephx and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+  when: cephx and ceph_stable_release not in ceph_stable_releases
 
 - name: copy osd bootstrap key (before infernalis release)
   copy:
@@ -63,10 +45,4 @@
     owner: root
     group: root
     mode: 600
-  when:
-    cephx and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+  when: cephx and ceph_stable_release in ceph_stable_releases

--- a/roles/ceph-restapi/tasks/pre_requisite.yml
+++ b/roles/ceph-restapi/tasks/pre_requisite.yml
@@ -6,12 +6,7 @@
     owner: ceph
     group: ceph
     mode: 0755
-  when:
-    ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer'
+  when: ceph_stable_release not in ceph_stable_releases
 
 - name: create ceph rest api directory (before infernalis release)
   file:
@@ -20,12 +15,7 @@
     owner: root
     group: root
     mode: 0755
-  when:
-    ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer'
+  when: ceph_stable_release in ceph_stable_releases
 
 - name: copy ceph rest api keyring (for or after infernalis release)
   copy:
@@ -35,12 +25,7 @@
     group: ceph
     mode: 600
   when:
-    cephx and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+    cephx and ceph_stable_release not in ceph_stable_releases
 
 - name: copy ceph rest api keyring (before infernalis release)
   copy:
@@ -50,12 +35,7 @@
     group: root
     mode: 600
   when:
-    cephx and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+    cephx and ceph_stable_release in ceph_stable_releases
 
 - name: activate ceph rest api with upstart (for or after infernalis release)
   file:
@@ -69,12 +49,7 @@
     - upstart
   changed_when: false
   when:
-    ansible_distribution == "Ubuntu" and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+    ansible_distribution == "Ubuntu" and ceph_stable_release not in ceph_stable_releases
 
 - name: activate ceph rest api with upstart (before infernalis release)
   file:
@@ -88,12 +63,7 @@
     - upstart
   changed_when: false
   when:
-    ansible_distribution == "Ubuntu" and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
-    ceph_stable_release != 'hammer')
+    ansible_distribution == "Ubuntu" and ceph_stable_release not in ceph_stable_releases
 
 - name: activate ceph rest api with sysvinit (for or after infernalis release))
   file:
@@ -106,12 +76,7 @@
     - done
     - sysvinit
   when:
-    ansible_distribution != "Ubuntu" and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+    ansible_distribution != "Ubuntu" and ceph_stable_release not in ceph_stable_releases
 
 - name: activate ceph rest api with sysvinit (before infernalis release))
   file:
@@ -124,12 +89,7 @@
     - done
     - sysvinit
   when:
-    ansible_distribution != "Ubuntu" and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
-    ceph_stable_release != 'hammer')
+    ansible_distribution != "Ubuntu" and ceph_stable_release not in ceph_stable_releases
 
 # NOTE (leseb): will uncomment this when this https://github.com/ceph/ceph/pull/4144 lands
 #- name: start and add that the Ceph REST API service to the init sequence (Ubuntu)

--- a/roles/ceph-restapi/tasks/pre_requisite.yml
+++ b/roles/ceph-restapi/tasks/pre_requisite.yml
@@ -7,10 +7,10 @@
     group: ceph
     mode: 0755
   when:
-    ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer'
 
 - name: create ceph rest api directory (before infernalis release)
@@ -36,10 +36,10 @@
     mode: 600
   when:
     cephx and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: copy ceph rest api keyring (before infernalis release)
@@ -70,10 +70,10 @@
   changed_when: false
   when:
     ansible_distribution == "Ubuntu" and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: activate ceph rest api with upstart (before infernalis release)
@@ -107,10 +107,10 @@
     - sysvinit
   when:
     ansible_distribution != "Ubuntu" and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: activate ceph rest api with sysvinit (before infernalis release))

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -9,12 +9,7 @@
   with_items:
     - /var/lib/ceph/bootstrap-rgw
     - /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}
-  when:
-    ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer'
+  when: ceph_stable_release not in ceph_stable_releases
 
 - name: create rados gateway directories (before infernalis release)
   file:
@@ -26,12 +21,7 @@
   with_items:
     - /var/lib/ceph/bootstrap-rgw
     - /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}
-  when:
-    ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer'
+  when: ceph_stable_release in ceph_stable_releases
 
 - name: copy rados gateway bootstrap key (for or after infernalis release)
   copy:
@@ -40,13 +30,7 @@
     owner: ceph
     group: ceph
     mode: 0600
-  when:
-    cephx and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+  when: cephx and ceph_stable_release not in ceph_stable_releases
 
 - name: copy rados gateway bootstrap key (before infernalis release)
   copy:
@@ -55,13 +39,7 @@
     owner: root
     group: root
     mode: 0600
-  when:
-    cephx and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+  when: cephx and ceph_stable_release in ceph_stable_releases
 
 - name: create rados gateway keyring
   command: ceph --cluster ceph --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/ceph.keyring auth get-or-create client.rgw.{{ ansible_hostname }} osd 'allow rwx' mon 'allow rw' -o /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/keyring
@@ -76,13 +54,7 @@
     mode: 0600
     owner: ceph
     group: ceph
-  when:
-    cephx and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+  when: cephx and ceph_stable_release not in ceph_stable_releases
 
 - name: set rados gateway key permissions (before infernalis release)
   file:
@@ -90,13 +62,7 @@
     mode: 0600
     owner: root
     group: root
-  when:
-    cephx and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+  when: cephx and ceph_stable_release in ceph_stable_releases
 
 - name: activate rados gateway with upstart (for or after infernalis release)
   file:
@@ -110,12 +76,7 @@
     - upstart
   changed_when: false
   when:
-    ansible_distribution == "Ubuntu" and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+    ansible_distribution == "Ubuntu" and ceph_stable_release not in ceph_stable_releases
 
 - name: activate rados gateway with upstart (before infernalis release)
   file:
@@ -129,12 +90,7 @@
     - upstart
   changed_when: false
   when:
-    ansible_distribution == "Ubuntu" and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+    ansible_distribution == "Ubuntu" and ceph_stable_release in ceph_stable_releases
 
 - name: activate rados gateway with sysvinit (for or after infernalis release)
   file:
@@ -148,12 +104,7 @@
     - sysvinit
   changed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
-    (ceph_stable_release != 'dumpling' and
-    ceph_stable_release != 'emperor' and
-    ceph_stable_release != 'firefly' and
-    ceph_stable_release != 'giant' and
-    ceph_stable_release != 'hammer')
+    ansible_distribution != "Ubuntu" and ceph_stable_release not in ceph_stable_releases
 
 - name: activate rados gateway with sysvinit (before infernalis release)
   file:
@@ -167,12 +118,7 @@
     - sysvinit
   changed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+    ansible_distribution != "Ubuntu" and ceph_stable_release in ceph_stable_releases
 
 - name: generate rados gateway sudoers file
   template:

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -10,10 +10,10 @@
     - /var/lib/ceph/bootstrap-rgw
     - /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}
   when:
-    ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer'
 
 - name: create rados gateway directories (before infernalis release)
@@ -42,10 +42,10 @@
     mode: 0600
   when:
     cephx and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: copy rados gateway bootstrap key (before infernalis release)
@@ -78,10 +78,10 @@
     group: ceph
   when:
     cephx and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: set rados gateway key permissions (before infernalis release)
@@ -111,10 +111,10 @@
   changed_when: false
   when:
     ansible_distribution == "Ubuntu" and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: activate rados gateway with upstart (before infernalis release)
@@ -149,10 +149,10 @@
   changed_when: false
   when:
     ansible_distribution != "Ubuntu" and
-    (ceph_stable_release != 'dumpling' or
-    ceph_stable_release != 'emperor' or
-    ceph_stable_release != 'firefly' or
-    ceph_stable_release != 'giant' or
+    (ceph_stable_release != 'dumpling' and
+    ceph_stable_release != 'emperor' and
+    ceph_stable_release != 'firefly' and
+    ceph_stable_release != 'giant' and
     ceph_stable_release != 'hammer')
 
 - name: activate rados gateway with sysvinit (before infernalis release)


### PR DESCRIPTION
fixes ceph_stable_release logic mentioned in issue #446

I changed the argument used for starting the mds server. (pre
infernalis)
```
service ceph start mds
```
errors, while
```
service ceph start mds.$hostname
```
correctly starts the service.

I also changed the mds directory ownership from ceph:cephh to root:root
again, for pre-infernalis.

And finally, add the ceph_stable_releases checks for the upstart
activation task `for or after infernalis release'.