### PR TITLE
corrections for infernalis on EL7

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -30,6 +30,7 @@ redhat_package_dependencies:
   - yum-plugin-priorities.noarch
   - epel-release
   - ntp
+  - python-setuptools
 
 ## Configure package origin
 #

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -100,10 +100,30 @@
     - restart ceph rgws on red hat
     - restart ceph rgws with systemd
 
-- name: create rbd client directory
+- name: create rbd client directory on other
   file:
     path: "{{ rbd_client_admin_socket_path }}"
     state: directory
     owner: root
     group: root
     mode: 0644
+  when: ansible_os_family != 'RedHat' or
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')
+
+- name: create rbd client directory on red hat (for infernalis or after and systemd and ceph user)
+  file:
+    path: "{{ rbd_client_admin_socket_path }}"
+    state: directory
+    owner: ceph
+    group: ceph
+    mode: 0744
+  when: ansible_os_family == 'RedHat' and not
+    (ceph_stable_release == 'dumpling' or
+    ceph_stable_release == 'emperor' or
+    ceph_stable_release == 'firefly' or
+    ceph_stable_release == 'giant' or
+    ceph_stable_release == 'hammer')

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -107,7 +107,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ceph_stable_release in ceph_stable_releases
+  when: not is_ceph_infernalis
 
 - name: create rbd client directory on red hat (for infernalis or after)
   file:
@@ -116,4 +116,4 @@
     owner: ceph
     group: ceph
     mode: 0770
-  when: ceph_stable_release not in ceph_stable_releases
+  when: is_ceph_infernalis

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -115,5 +115,5 @@
     state: directory
     owner: ceph
     group: ceph
-    mode: 0744
+    mode: 0770
   when: ceph_stable_release not in ceph_stable_releases

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -117,3 +117,9 @@
     group: ceph
     mode: 0770
   when: is_ceph_infernalis
+
+# NOTE (leseb): be careful with the following
+# somehow the YAML syntax using "is_ceph_infernalis: {{"
+# does NOT work, so we keep this syntax styling...
+- set_fact:
+    is_ceph_infernalis={{ (ceph_stable and ceph_stable_release not in ceph_stable_releases) or (ceph_stable_rh_storage and (rh_storage_version.stdout | version_compare('0.94', '>'))) }}

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -100,30 +100,20 @@
     - restart ceph rgws on red hat
     - restart ceph rgws with systemd
 
-- name: create rbd client directory on other
+- name: create rbd client directory (before infernalis)
   file:
     path: "{{ rbd_client_admin_socket_path }}"
     state: directory
     owner: root
     group: root
     mode: 0644
-  when: ansible_os_family != 'RedHat' or
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+  when: ceph_stable_release in ceph_stable_releases
 
-- name: create rbd client directory on red hat (for infernalis or after and systemd and ceph user)
+- name: create rbd client directory on red hat (for infernalis or after)
   file:
     path: "{{ rbd_client_admin_socket_path }}"
     state: directory
     owner: ceph
     group: ceph
     mode: 0744
-  when: ansible_os_family == 'RedHat' and not
-    (ceph_stable_release == 'dumpling' or
-    ceph_stable_release == 'emperor' or
-    ceph_stable_release == 'firefly' or
-    ceph_stable_release == 'giant' or
-    ceph_stable_release == 'hammer')
+  when: ceph_stable_release not in ceph_stable_releases


### PR DESCRIPTION
CentOS7 needs python-setuptools for /usr/bin/ceph-detect-init so I added this to the redhat dependencies.

The playbook hangs at gathering the mon keys, which is a result of ceph-mon not being able to create the sock in /var/run/ceph because of permissions.