### PR TITLE
Use /var/log/ceph for rgw logs

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -166,7 +166,7 @@
   host = {{ hostvars[host]['ansible_hostname'] }}
   keyring = /var/lib/ceph/radosgw/ceph-rgw.{{ hostvars[host]['ansible_hostname'] }}/keyring
   rgw socket path = /tmp/radosgw-{{ hostvars[host]['ansible_hostname'] }}.sock
-  log file = /var/log/radosgw/radosgw-{{ hostvars[host]['ansible_hostname'] }}.log
+  log file = /var/log/ceph/radosgw-{{ hostvars[host]['ansible_hostname'] }}.log
   rgw data = /var/lib/ceph/radosgw/ceph-rgw.{{ hostvars[host]['ansible_hostname'] }}
   rgw print continue = false
   {% if radosgw_frontend  == 'civetweb' %}


### PR DESCRIPTION
We should not bother having another directory for this. So we stick with
the default logging dir.

Signed-off-by: Sébastien Han <seb@redhat.com>