### PR TITLE
Change default civetweb port to 8080

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -210,7 +210,7 @@ osd_deep_scrub_stride: 1048576
 #
 #radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
 radosgw_frontend: civetweb # supported options are 'apache' or 'civetweb', also edit roles/ceph-rgw/defaults/main.yml
-radosgw_civetweb_port: 80
+radosgw_civetweb_port: 8080 # on Infernalis we get: "set_ports_option: cannot bind to 80: 13 (Permission denied)"
 radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
 radosgw_keystone_admin_token: password


### PR DESCRIPTION
Because of some permission issue, likely due to the recent ceph user, if
80 is used for civetweb we get:

set_ports_option: cannot bind to 80: 13 (Permission denied)

Changing the port to 8080 until this gets solved.

Signed-off-by: Sébastien Han <seb@redhat.com>