### PR TITLE
fixed for infernalis on EL7

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -30,6 +30,7 @@ redhat_package_dependencies:
   - yum-plugin-priorities.noarch
   - epel-release
   - ntp
+  - python-setuptools
 
 ## Configure package origin
 #

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -100,13 +100,23 @@
     - restart ceph rgws on red hat
     - restart ceph rgws with systemd
 
-- name: create rbd client directory
+- name: create rbd client directory (before infernalis)
   file:
     path: "{{ rbd_client_admin_socket_path }}"
     state: directory
     owner: root
     group: root
     mode: 0644
+  when: not is_ceph_infernalis
+
+- name: create rbd client directory (for infernalis or after)
+  file:
+    path: "{{ rbd_client_admin_socket_path }}"
+    state: directory
+    owner: ceph
+    group: ceph
+    mode: 0770
+  when: is_ceph_infernalis
 
 # NOTE (leseb): be careful with the following
 # somehow the YAML syntax using "is_ceph_infernalis: {{"

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -37,6 +37,12 @@
     radosgw_frontend == 'apache' and
     rgw_group_name in group_names
 
+# NOTE (leseb): be careful with the following
+# somehow the YAML syntax using "is_ceph_infernalis: {{"
+# does NOT work, so we keep this syntax styling...
+- set_fact:
+    is_ceph_infernalis={{ (ceph_stable and ceph_stable_release not in ceph_stable_releases) or (ceph_stable_rh_storage and (rh_storage_version.stdout | version_compare('0.94', '>'))) }}
+
 - name: check for a ceph socket
   shell: "stat /var/run/ceph/*.asok > /dev/null 2>&1"
   changed_when: false
@@ -99,12 +105,6 @@
     - restart ceph rgws on ubuntu
     - restart ceph rgws on red hat
     - restart ceph rgws with systemd
-
-# NOTE (leseb): be careful with the following
-# somehow the YAML syntax using "is_ceph_infernalis: {{"
-# does NOT work, so we keep this syntax styling...
-- set_fact:
-    is_ceph_infernalis={{ (ceph_stable and ceph_stable_release not in ceph_stable_releases) or (ceph_stable_rh_storage and (rh_storage_version.stdout | version_compare('0.94', '>'))) }}
 
 - name: create rbd client directory (before infernalis)
   file:

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -100,6 +100,12 @@
     - restart ceph rgws on red hat
     - restart ceph rgws with systemd
 
+# NOTE (leseb): be careful with the following
+# somehow the YAML syntax using "is_ceph_infernalis: {{"
+# does NOT work, so we keep this syntax styling...
+- set_fact:
+    is_ceph_infernalis={{ (ceph_stable and ceph_stable_release not in ceph_stable_releases) or (ceph_stable_rh_storage and (rh_storage_version.stdout | version_compare('0.94', '>'))) }}
+
 - name: create rbd client directory (before infernalis)
   file:
     path: "{{ rbd_client_admin_socket_path }}"
@@ -118,8 +124,3 @@
     mode: 0770
   when: is_ceph_infernalis
 
-# NOTE (leseb): be careful with the following
-# somehow the YAML syntax using "is_ceph_infernalis: {{"
-# does NOT work, so we keep this syntax styling...
-- set_fact:
-    is_ceph_infernalis={{ (ceph_stable and ceph_stable_release not in ceph_stable_releases) or (ceph_stable_rh_storage and (rh_storage_version.stdout | version_compare('0.94', '>'))) }}


### PR DESCRIPTION
EL7 needs python-setuptools as a dependency
when running under ceph user the /var/run/ceph directory needs to be owned by ceph