### PR TITLE
ceph-mon: only generate keys and slurp them to the host once.

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -4,6 +4,7 @@
 - name: wait for client.admin key exists
   wait_for:
     path: /etc/ceph/ceph.client.admin.keyring
+  run_once: true
 
 - name: create ceph rest api keyring
   command: ceph auth get-or-create client.restapi osd 'allow *' mon 'allow *' -o /etc/ceph/ceph.client.restapi.keyring
@@ -46,6 +47,7 @@
     - /var/lib/ceph/bootstrap-rgw/ceph.keyring
     - /var/lib/ceph/bootstrap-mds/ceph.keyring
   when: cephx
+  run_once: true
 
 - name: drop in a motd script to report status when logging in
   copy:


### PR DESCRIPTION
Hey folks! We're seeing this behavior in our project which relies heavily on the ceph-ansible project. I am pretty sure this fixes this issue:

```
TASK: [ceph-mon | copy keys to the ansible server] **************************** 
changed: [mon1] => (item=/etc/ceph/ceph.client.admin.keyring)
ok: [mon2] => (item=/etc/ceph/ceph.client.admin.keyring)
ok: [mon0] => (item=/etc/ceph/ceph.client.admin.keyring)
changed: [mon0] => (item=/var/lib/ceph/bootstrap-osd/ceph.keyring)
fatal: [mon2] => Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/ansible/runner/__init__.py", line 582, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/usr/lib/pymodules/python2.7/ansible/runner/__init__.py", line 811, in _executor_internal
    complex_args=complex_args
  File "/usr/lib/pymodules/python2.7/ansible/runner/__init__.py", line 1032, in _executor_internal_inner
    result = handler.run(conn, tmp, module_name, module_args, inject, complex_args)
  File "/usr/lib/pymodules/python2.7/ansible/runner/action_plugins/fetch.py", line 141, in run
    os.makedirs(os.path.dirname(dest))
  File "/usr/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 17] File exists: '/var/jenkins/workspace/Volplugin_CI/src/github.com/contiv/volplugin/ansible/fetch/4a158d27-f750-41d5-9e7f-26ce4c9d2d45/var/lib/ceph/bootstrap-osd'
```

Which you can see in action here: http://contiv.ngrok.io/job/Volplugin_CI/184/console

Note that we're using a slightly outdated version of the ceph-ansible repo that we've forked out. There is one other patch but it does not interfere with this one in any way. That said, if you want to investigate the rest of it, it's here: https://github.com/contiv/volplugin/tree/master/ansible

Thanks!

Signed-off-by: Erik Hollensbe <github@hollensbe.org>