### PR TITLE
Check for blocked ports

### DIFF
--- a/roles/ceph-common/tasks/checks/check_firewall.yml
+++ b/roles/ceph-common/tasks/checks/check_firewall.yml
@@ -1,0 +1,80 @@
+---
+- name: check if nmap is installed
+  shell: "command -v nmap"
+  changed_when: false
+  failed_when: false
+  register: nmapexist
+
+- name: fail if nmap is not present
+  fail:
+      msg: "nmap is needed to make sure ceph ports are not filtered, please install it"
+  when: nmapexist.rc != 0
+
+- name: check if monitor port is not filtered
+  local_action: shell nmap -p 6789 {{ item }} {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] }} | grep -sqo filtered
+  changed_when: false
+  failed_when: false
+  with_items: groups.{{ mon_group_name }}
+  register: monportstate
+  register: monportstate
+  when: mon_group_name in group_names
+
+- name: fail if monitor port is filtered
+  fail:
+      msg: "Please allow port 6789 on your firewall"
+  with_items: monportstate.results
+  when:
+    item.rc == 0 and
+    mon_group_name is defined and
+    mon_group_name in group_names
+
+- name: check if osd and mds range is not filtered
+  local_action: shell nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
+  changed_when: false
+  failed_when: false
+  with_items: groups.{{ osd_group_name }}
+  register: osdrangestate
+  when: osd_group_name in group_names
+
+- name: fail if osd and mds range is filtered (osd hosts)
+  fail:
+      msg: "Please allow range from 6800 to 7300 on your firewall"
+  with_items: osdrangestate.results
+  when:
+    item.rc == 0 and
+    osd_group_name is defined and
+    osd_group_name in group_names
+
+- name: check if osd and mds range is not filtered
+  local_action: shell nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
+  changed_when: false
+  failed_when: false
+  with_items: groups.{{ mds_group_name }}
+  register: mdsrangestate
+  when: mds_group_name in group_names
+
+- name: fail if osd and mds range is filtered (mds hosts)
+  fail:
+      msg: "Please allow range from 6800 to 7300 on your firewall"
+  with_items: mdsrangestate.results
+  when:
+    item.rc == 0 and
+    mds_group_name is defined and
+    mds_group_name in group_names
+
+- name: check if rados gateway port is not filtered
+  local_action: shell nmap -p {{ radosgw_civetweb_port }} {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
+  changed_when: false
+  failed_when: false
+  with_items: groups.rgws
+  register: rgwportstate
+  when: rgw_group_name in group_names
+
+- name: fail if rados gateway port is filtered
+  fail:
+      msg: "Please allow port {{ radosgw_civetweb_port }} on your firewall"
+  with_items: rgwportstate.results
+  when:
+    item.rc == 0 and
+    rgw_group_name is defined and
+    rgw_group_name in group_names

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -3,6 +3,8 @@
 
 - include: ./checks/check_mandatory_vars.yml
 
+- include: ./checks/check_firewall.yml
+
 - include: ./misc/system_tuning.yml
   when: osd_group_name in group_names
 


### PR DESCRIPTION
As raised in #466 it is important in order to avoid unnecessary
troubleshooting to check that ceph ports are allowed on the platform.
The check runs a nmap command from the host running Ansible
to all the ceph nodes with their respective ports.

Signed-off-by: Sébastien Han <seb@redhat.com>