### PR TITLE
Stable rh storage repo

### DIFF
--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_iso_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_iso_install.yml
@@ -24,9 +24,17 @@
   args:
     creates: "{{ ceph_stable_rh_storage_repository_path }}/README"
 
-- name: mount red hat storage iso file
+- name: unmount red hat storage iso file
   mount:
     name: "{{ ceph_stable_rh_storage_mount_path }}"
     src: "{{ ceph_stable_rh_storage_iso_path }}"
     fstype: iso9660
     state: unmounted
+
+- name: create repo file for Ceph
+  template:
+    src: templates/redhat_storage_repo.j2
+    dest: /etc/yum.repos.d/ceph.repo
+    force: yes
+    mode: 644
+

--- a/templates/redhat_storage_repo.j2
+++ b/templates/redhat_storage_repo.j2
@@ -1,0 +1,36 @@
+# {{ ansible_managed }}
+[rh_storage_mon]
+name=Red Hat Storage Ceph - local packages for Ceph
+baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/MON
+enabled=1
+gpgcheck=1
+type=rpm-md
+priority=1
+gpgkey=file://{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release
+
+[rh_storage_osd]
+name=Red Hat Storage Ceph - local packages for Ceph
+baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/OSD
+enabled=1
+gpgcheck=1
+type=rpm-md
+priority=1
+gpgkey=file://{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release
+
+[rh_storage_calamari]
+name=Red Hat Storage Ceph - local packages for Ceph
+baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/Calamari
+enabled=1
+gpgcheck=1
+type=rpm-md
+priority=1
+gpgkey=file://{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release
+
+[rh_storage_installer]
+name=Red Hat Storage Ceph - local packages for Ceph
+baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/Installer
+enabled=1
+gpgcheck=1
+type=rpm-md
+priority=1
+gpgkey=file://{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release


### PR DESCRIPTION
For ceph_stable_rh_storage: true option, the repo file wasn't getting created for some reason.  Does this make sense to you?  Specifically from group_vars/all:

ceph_origin: 'distro'
ceph_stable_rh_storage: true
ceph_stable_rh_storage_iso_install: true # usually used when nodes don't have access to cdn.redhat.com
