### PR TITLE
allow customization of debian ceph stable repo url

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -46,6 +46,7 @@ dummy:
 #ceph_stable: false # use ceph stable branch
 #ceph_stable_key: https://download.ceph.com/keys/release.asc
 #ceph_stable_release: infernalis # ceph stable release
+#ceph_stable_repo: "http://ceph.com/debian-{{ ceph_stable_release }}"
 
 ###################
 # Stable Releases #

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -45,6 +45,7 @@ ceph_use_distro_backports: false # DEBIAN ONLY
 ceph_stable: false # use ceph stable branch
 ceph_stable_key: https://download.ceph.com/keys/release.asc
 ceph_stable_release: infernalis # ceph stable release
+ceph_stable_repo: "http://ceph.com/debian-{{ ceph_stable_release }}"
 
 ###################
 # Stable Releases #

--- a/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
@@ -20,7 +20,7 @@
 
 - name: add ceph stable repository
   apt_repository:
-    repo: "deb http://ceph.com/debian-{{ ceph_stable_release }}/ {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
+    repo: "deb {{ ceph_stable_repo }} {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
     state: present
   changed_when: false
   when: ceph_stable


### PR DESCRIPTION
My ceph cluster is not connected to the internet and must use local repo sources. Unfortunately at this time that is not possible with this role. My change moves the repo url to a defaults variable to allow overriding it.