### PR TITLE
don't systemctl enable ceph-mon

### DIFF
--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -50,7 +50,6 @@
   service:
       name: ceph-mon@{{ ansible_hostname }}
       state: started
-      enabled: yes
   changed_when: false
   when:
     ansible_distribution != "Ubuntu" and


### PR DESCRIPTION
tthis fixes the following problem:

```console
TASK: [ceph-mon | start and add that the monitor service to the init sequence (for or after infernalis)] *** 
failed: [mon0] => {"changed": false, "failed": true}
msg: Error when trying to enable ceph-mon@ceph-mon0: rc=1 Failed to issue method call: No such file or directory
```

@leseb 