### PR TITLE
systemd unit files fixes for infernalis

### DIFF
--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -47,8 +47,9 @@
     not is_ceph_infernalis
 
 - name: enable systemd unit file for mon instance (for or after infernalis)
-  command: "ln -s /usr/lib/systemd/system/ceph-mon@.service /etc/systemd/system/multi-user.target.wants/ceph-mon@{{ ansible_hostname }}.service"
+  file: src=/usr/lib/systemd/system/ceph-mon@.service dest=/etc/systemd/system/multi-user.target.wants/ceph-mon@{{ ansible_hostname }}.service state=link
   changed_when: false
+  failed_when: false
   when:
     ansible_distribution != "Ubuntu" and
     is_ceph_infernalis

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -47,7 +47,10 @@
     not is_ceph_infernalis
 
 - name: enable systemd unit file for mon instance (for or after infernalis)
-  file: src=/usr/lib/systemd/system/ceph-mon@.service dest=/etc/systemd/system/multi-user.target.wants/ceph-mon@{{ ansible_hostname }}.service state=link
+  file:
+    src: /usr/lib/systemd/system/ceph-mon@.service
+    dest: /etc/systemd/system/multi-user.target.wants/ceph-mon@{{ ansible_hostname }}.service
+    state: link
   changed_when: false
   failed_when: false
   when:

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -46,6 +46,13 @@
     ansible_distribution != "Ubuntu" and
     not is_ceph_infernalis
 
+- name: enable systemd unit file for mon instance (for or after infernalis)
+  command: "ln -s /usr/lib/systemd/system/ceph-mon@.service /etc/systemd/system/multi-user.target.wants/ceph-mon@{{ ansible_hostname }}.service"
+  changed_when: false
+  when:
+    ansible_distribution != "Ubuntu" and
+    is_ceph_infernalis
+
 - name: start and add that the monitor service to the init sequence (for or after infernalis)
   service:
       name: ceph-mon@{{ ansible_hostname }}

--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -32,11 +32,30 @@
     ansible_distribution != "Ubuntu" and
     not is_ceph_infernalis
 
+- name: get osd id (for or after infernalis)
+  shell: "ls /var/lib/ceph/osd/ |grep -oh '[0-9]*'"
+  changed_when: false
+  failed_when: false
+  register: osd_id
+  when:
+    ansible_distribution != "Ubuntu" and
+    is_ceph_infernalis
+
+- name: enable osd service instance(s) (for or after infernalis)
+  file:  src=/usr/lib/systemd/system/ceph-osd@.service dest=/etc/systemd/system/multi-user.target.wants/ceph-osd@{{ item }}.service state=link
+  with_items: osd_id.stdout_lines
+  failed_when: false
+  when:
+    ansible_distribution != "Ubuntu" and
+    is_ceph_infernalis
+
 - name: start and add that the osd service(s) to the init sequence (for or after infernalis)
   service:
-    name: ceph.target
+    name: ceph-osd@{{ item }}
     state: started
     enabled: yes
+  with_items: osd_id.stdout_lines
+  changed_when: false
   when:
     ansible_distribution != "Ubuntu" and
     is_ceph_infernalis

--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -42,7 +42,10 @@
     is_ceph_infernalis
 
 - name: enable osd service instance(s) (for or after infernalis)
-  file:  src=/usr/lib/systemd/system/ceph-osd@.service dest=/etc/systemd/system/multi-user.target.wants/ceph-osd@{{ item }}.service state=link
+  file:
+    src:  /usr/lib/systemd/system/ceph-osd@.service
+    dest: /etc/systemd/system/multi-user.target.wants/ceph-osd@{{ item }}.service
+    state: link
   with_items: osd_id.stdout_lines
   failed_when: false
   when:


### PR DESCRIPTION
make sym link to `ceph-mon@.service` and `ceph-osd@.service`, so `systemctl enable` doesn't complain.

@leseb 