### PR TITLE
install Red Hat Ceph Storage repo when needed

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -7,7 +7,7 @@
 
 - name: configure ceph yum repository
   include: redhat_ceph_repository.yml
-  when: ceph_origin == 'upstream'
+  when: ceph_origin == 'upstream' or ceph_stable_rh_storage
 
 - name: install ceph
   yum:

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -7,7 +7,8 @@
 
 - name: configure ceph yum repository
   include: redhat_ceph_repository.yml
-  when: ceph_origin == 'upstream' or ceph_stable_rh_storage
+  when: ceph_origin == 'upstream' or 
+        ceph_stable_rh_storage
 
 - name: install ceph
   yum:

--- a/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
@@ -48,7 +48,7 @@
 
 - name: add red hat storage repository
   template:
-    src: redhat_storage_repo.j2
+    src: ../../templates/redhat_storage_repo.j2
     dest: /etc/yum.repos.d/rh_storage.repo
     owner: root
     group: root


### PR DESCRIPTION
The code to install RHCS repo template was there but was not getting enabled.  Also, because we have tasks/installs/ subdirectory, ansible was not finding the template file.  These 2 lines of code change seem to resolve the problem.  Do they break anything else?   Would it be possible to have regression tests check RHCS case also?