### PR TITLE
help ansible find repo template from installs subdirectory

### DIFF
--- a/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
@@ -48,7 +48,7 @@
 
 - name: add red hat storage repository
   template:
-    src: redhat_storage_repo.j2
+    src: ../../templates/redhat_storage_repo.j2
     dest: /etc/yum.repos.d/rh_storage.repo
     owner: root
     group: root


### PR DESCRIPTION
here is a PR with just the change to the path for the repo template - if you run without this you get an error like this.  Ansible seems to be checking ../templates, assuming that all yaml files will run from inside tasks/ subdirectory and not a directory nested inside it.

fatal: [rhs-cli-01] => input file not found at /mnt/oldroot/home/ben/ceph/dm-cache/ceph-ansible/roles/ceph-common/tasks/templates/redhat_storage_repo.j2 or /mnt/oldroot/home/ben/ceph/dm-cache/ceph-ansible/redhat_storage_repo.j2

BTW a similar change would be needed for RHCS 1.2 (Inktank Ceph Enterprise).