### PR TITLE
Configurable Ceph Conf Directory Permissions

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -10,6 +10,20 @@ dummy:
 
 #fetch_directory: fetch/
 
+###############
+# PERMISSIONS #
+###############
+
+# Permissions for /etc/ceph configuration directory
+#conf_directory_owner: root
+#conf_directory_group: root
+#conf_directory_mode: 644
+
+# Permissions for /etc/ceph/ceph.conf configuration file
+#conf_file_owner: root
+#conf_file_group: root
+#conf_file_mode: 644
+
 #########
 # INSTALL
 #########

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -7,6 +7,20 @@
 
 fetch_directory: fetch/
 
+###############
+# PERMISSIONS #
+###############
+
+# Permissions for /etc/ceph configuration directory
+conf_directory_owner: root
+conf_directory_group: root
+conf_directory_mode: 644
+
+# Permissions for /etc/ceph/ceph.conf configuration file
+conf_file_owner: root
+conf_file_group: root
+conf_file_mode: 644
+
 ###########
 # INSTALL #
 ###########

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -82,17 +82,17 @@
   file:
       path: /etc/ceph
       state: directory
-      owner: root
-      group: root
-      mode: 0644
+      owner: "{{ conf_directory_owner }}"
+      group: "{{ conf_directory_group }}"
+      mode: "{{ conf_directory_mode }}"
 
 - name: generate ceph configuration file
   config_template:
     src: ceph.conf.j2
     dest: /etc/ceph/ceph.conf
-    owner: "root"
-    group: "root"
-    mode: "0644"
+    owner: "{{ conf_file_owner }}"
+    group: "{{ conf_file_group }}"
+    mode: "{{ conf_file_mode }}"
     config_overrides: "{{ ceph_conf_overrides }}"
     config_type: ini
   notify:


### PR DESCRIPTION
This change allows for configurable Ceph Conf Directory permissions. This
is required for integrators of Ceph, like OpenStack Cinder, which needs to
read from /etc/ceph for operation.