### PR TITLE
ceph-osd: Change ownership of osd directories.

### DIFF
--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -54,3 +54,15 @@
   when:
     cephx and
     not is_ceph_infernalis
+
+- name: set ownership for osd directories
+  set_fact:
+    osd_dir_owner: "root"
+    osd_dir_group: "root"
+  when: not is_ceph_infernalis
+
+- name: set ownership for osd directories
+  set_fact:
+    osd_dir_owner: "ceph"
+    osd_dir_group: "ceph"
+  when: is_ceph_infernalis

--- a/roles/ceph-osd/tasks/scenarios/osd_directory.yml
+++ b/roles/ceph-osd/tasks/scenarios/osd_directory.yml
@@ -8,8 +8,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: root
-    group: root
+    owner: "{{ osd_dir_owner }}"
+    group: "{{ osd_dir_group }}"
   with_items: osd_directories
 
 # NOTE (leseb): the prepare process must be parallelized somehow...


### PR DESCRIPTION
When using the 4th scenario in ceph-osd role (directory instead of a disk for osd), the directories given in the `osd_directories` variable in `group_vars/osds` are created with `root:root` ownership.
This cause the command `ceph-disk activate` to fail in the task 'activate OSD(s)' in `roles/ceph-osd/tasks/scenarios/osd_directory.yml` because of
the arguments `--setuser ceph --setgroup ceph` that are passed to the command `/usr/bin/ceph-osd` launched by `ceph-disk activate`.