### PR TITLE
Adding python-setuptools dependency for CentOS 7.

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -47,7 +47,7 @@ dummy:
 #  - yum-plugin-priorities.noarch
 #  - epel-release
 #  - ntp
-
+#  - python-setuptools
 ## Configure package origin
 #
 #ceph_origin: 'upstream' # or 'distro'

--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -48,6 +48,7 @@ dummy:
 #  - epel-release
 #  - ntp
 #  - python-setuptools
+
 ## Configure package origin
 #
 #ceph_origin: 'upstream' # or 'distro'


### PR DESCRIPTION
Ceph-detect-init requires python-setuptools, when using upstream repositories.