### PR TITLE
updates related to using vagrant and virtualbox for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Clone me:
 
 ```bash
 git clone https://github.com/ceph/ceph-ansible.git
-cp vagrant_variables.yml.sample vagrant_variables.yml
 ```
 
 ## What does it do?
@@ -32,12 +31,25 @@ More details:
 * A rolling upgrade playbook was written, an upgrade from Dumpling to Emperor was performed and worked.
 
 
-## Setup with Vagrant
+## Setup with Vagrant using virtualbox provider
 
-Run your virtual machines:
+* Create vagrant_variables.yml
 
-```bash
-$ vagrant up --provider=virtualbox
+```
+$ cp vagrant_variables.yml.sample vagrant_variables.yml
+```
+
+* Create site.yml
+
+```
+$ cp site.yml.sample site.yml
+```
+
+* Create VMs
+
+```
+$ vagrant up --no-provision --provider=virtualbox
+$ vagrant provision
 ...
 ...
 ...

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,6 +43,7 @@ ansible_provision = proc do |ansible|
     cluster_network: "#{SUBNET}.0/24",
     public_network: "#{SUBNET}.0/24",
     devices: settings['disks'],
+    os_tuning_params: settings['os_tuning_params']
   }
   ansible.limit = 'all'
 end

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -35,3 +35,7 @@ vagrant_box: ubuntu/trusty64
 
 # use vagrant_storagectl: 'SATA Controller' for CentOS
 vagrant_storagectl: 'SATAController'
+
+os_tuning_params:
+  - { name: kernel.pid_max, value: 4194303 }
+  - { name: fs.file-max, value: 26234859 }


### PR DESCRIPTION
I was going through the readme and trying to get things going with vagrant and virtualbox and having some difficulties. Specifically, the vm.* settings in ``os_tuning_params`` were locking up my OSDs and ansible was losing the ssh connection to the nodes.  With these updates I'm able to get everything up and running. I was using vagrant==1.8.1 and virtualbox==5.0.4

I have not tested yet if anything here causes trouble for libvirt.