### PR TITLE
Add defaults for ceph_stable_ice_tmp_path and ceph_stable_ice_kmod

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -86,8 +86,11 @@ ceph_stable_redhat_distro: el7
 # ENTERPRISE VERSION ICE (old, prior to the 1.3)
 ceph_stable_ice: false # use Inktank Ceph Enterprise
 #ceph_stable_ice_url: https://download.inktank.com/enterprise
-#ceph_stable_ice_temp_path: /opt/ICE/ceph-repo/
-#ceph_stable_ice_kmod: 3.10-0.1.20140702gitdc9ac62.el7.x86_64
+# these two variables are used in `with_items` and starting
+# with ansible 2.0 these need to be defined even if the tasks's
+# `when` clause doesn't evaluate to true
+ceph_stable_ice_temp_path: /opt/ICE/ceph-repo/
+ceph_stable_ice_kmod: 3.10-0.1.20140702gitdc9ac62.el7.x86_64
 #ceph_stable_ice_distro: rhel7 # Please check the download website for the supported versions.
 #ceph_stable_ice_version: 1.2.2
 #ceph_stable_ice_kmod_version: 1.2


### PR DESCRIPTION
It seems that in ansible 2.0 even if a task is skipped by it's `when`
clause not evaluating to true the variables in the play are still
rendered. Because these were not defined in defaults/main.yml ansible
was failing in installs/install_on_redhat where those variables are
being used in a `with_items` stanza.

An example of this failure can be seen here: https://jenkins.ceph.com/job/ceph-ansible-pull-requests/39/console

Signed-off-by: Andrew Schoen <aschoen@redhat.com>