### PR TITLE
Control when ceph packages get updated

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -34,6 +34,11 @@ dummy:
 #mds_group_name: mdss
 #restapi_group_name: restapis
 
+# This variable determines if ceph packages can be updated.  If False, the
+# package resources will use "state=present".  If True, they will use
+# "state=latest".
+#upgrade_ceph_packages: False
+
 # /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_dev /!\
 
 #debian_package_dependencies:

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -31,6 +31,11 @@ rgw_group_name: rgws
 mds_group_name: mdss
 restapi_group_name: restapis
 
+# This variable determines if ceph packages can be updated.  If False, the
+# package resources will use "state=present".  If True, they will use
+# "state=latest".
+upgrade_ceph_packages: False
+
 # /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_dev /!\
 
 debian_package_dependencies:

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -14,7 +14,7 @@
 - name: install ceph
   apt:
     pkg: "{{ item }}"
-    state: latest
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     default_release: "{{ ansible_distribution_release }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
   with_items:
     - ceph
@@ -27,7 +27,7 @@
 - name: install rados gateway
   apt:
     pkg: radosgw
-    state: latest
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     update_cache: yes
   when:
     rgw_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -20,13 +20,13 @@
 - name: install ceph
   yum:
     name: ceph
-    state: latest
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when: not ceph_stable_rh_storage
 
 - name: install red hat storage ceph mon
   yum:
     name: "{{ item }}"
-    state: latest
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   with_items:
     - ceph
     - ceph-mon
@@ -38,7 +38,7 @@
 - name: install red hat storage ceph mon
   dnf:
     name: "{{ item }}"
-    state: latest
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   with_items:
     - ceph
     - ceph-mon
@@ -50,7 +50,7 @@
 - name: install red hat storage ceph osd
   yum:
     name: "{{ item }}"
-    state: latest
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   with_items:
     - ceph
     - ceph-osd
@@ -62,7 +62,7 @@
 - name: install red hat storage ceph osd
   dnf:
     name: "{{ item }}"
-    state: latest
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   with_items:
     - ceph
     - ceph-osd
@@ -94,7 +94,7 @@
 - name: install rados gateway
   yum:
     name: ceph-radosgw
-    state: latest
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     rgw_group_name in group_names and
     ansible_pkg_mgr == "yum"
@@ -102,7 +102,7 @@
 - name: install rados gateway
   dnf:
     name: ceph-radosgw
-    state: latest
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     rgw_group_name in group_names and
     ansible_pkg_mgr == "dnf"

--- a/rolling_update.yml
+++ b/rolling_update.yml
@@ -16,6 +16,8 @@
 - hosts: mons
   serial: 1
   sudo: True
+  vars:
+    upgrade_ceph_packages: True
 
   pre_tasks:
     - name: Compress the store as much as possible
@@ -74,6 +76,8 @@
 - hosts: osds
   serial: 1
   sudo: True
+  vars:
+    upgrade_ceph_packages: True
 
   pre_tasks:
     - name: Set OSD flags
@@ -133,6 +137,8 @@
 - hosts: mdss
   serial: 1
   sudo: True
+  vars:
+    upgrade_ceph_packages: True
 
   roles:
     - ceph-common
@@ -167,6 +173,8 @@
 - hosts: rgws
   serial: 1
   sudo: True
+  vars:
+    upgrade_ceph_packages: True
 
   roles:
     - ceph-common


### PR DESCRIPTION
Currently, all the ceph package installation resources use
"state=latest", which means subsequent runs of the ceph playbooks
could result in ceph being upgraded if there are package updates
available in the selected repo.

This commit adds a new variable to ceph-common called
'upgrade_ceph_packages' which defaults to False.  This variable is used
in the package installation resources for ceph packages to determine if
the resource should use "state=present" or "state=latest".  If the
variable gets set to True, "state=latest" will be used.

Additionally, we update rolling_update.yml to override
upgrade_ceph_packages to true to permit package upgrades in this
context specifically.

Closes issue #506