### PR TITLE
ceph-common: use a generic way to create uuid

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -64,7 +64,7 @@
   run_once: true
 
 - name: generate cluster uuid
-  local_action: shell uuidgen | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
+  local_action: shell python -c 'import uuid; print str(uuid.uuid4())' | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
     creates="{{ fetch_directory }}/ceph_cluster_uuid.conf"
   register: cluster_uuid
   sudo: false


### PR DESCRIPTION
as reported in #510 some systems don't have uuidgen installed so we
better use a more global way to generate it. It sounds like python
should be available in case uuidgen is not.
Otherwise we will have to find another way :)

closes #510

Signed-off-by: Sébastien Han <seb@redhat.com>