### PR TITLE
Refact code using `set_fact` to handle 'legacy' versions

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -45,6 +45,54 @@
 - set_fact:
     is_ceph_infernalis={{ (ceph_stable and ceph_stable_release not in ceph_stable_releases) or (ceph_stable_rh_storage and (rh_storage_version.stdout | version_compare('0.94', '>'))) }}
 
+- set_fact:
+    dir_owner: ceph
+    dir_group: ceph
+    dir_mode: 0755
+  when: is_ceph_infernalis
+
+- set_fact:
+    dir_owner: root
+    dir_group: root
+    dir_mode: 0755
+  when: not is_ceph_infernalis
+
+- set_fact:
+    key_owner: root
+    key_group: root
+    key_mode: 0600
+  when: not is_ceph_infernalis
+
+- set_fact:
+    key_owner: ceph
+    key_group: ceph
+    key_mode: 0600
+  when: is_ceph_infernalis
+
+- set_fact:
+    activate_file_owner: ceph
+    activate_file_group: ceph
+    activate_file_mode: 0644
+  when: is_ceph_infernalis
+
+- set_fact:
+    activate_file_owner: root
+    activate_file_group: root
+    activate_file_mode: 0644
+  when: not is_ceph_infernalis
+
+- set_fact:
+    rbd_client_dir_owner: root
+    rbd_client_dir_group: root
+    rbd_client_dir_mode: 0644
+  when: not is_ceph_infernalis
+
+- set_fact:
+    rbd_client_dir_owner: ceph
+    rbd_client_dir_group: ceph
+    rbd_client_dir_mode: 0770
+  when: is_ceph_infernalis
+
 - name: check for a ceph socket
   shell: "stat /var/run/ceph/*.asok > /dev/null 2>&1"
   changed_when: false
@@ -108,21 +156,10 @@
     - restart ceph rgws on red hat
     - restart ceph rgws with systemd
 
-- name: create rbd client directory (before infernalis)
+- name: create rbd client directory
   file:
     path: "{{ rbd_client_admin_socket_path }}"
     state: directory
-    owner: root
-    group: root
-    mode: 0644
-  when: not is_ceph_infernalis
-
-- name: create rbd client directory (for infernalis or after)
-  file:
-    path: "{{ rbd_client_admin_socket_path }}"
-    state: directory
-    owner: ceph
-    group: ceph
-    mode: 0770
-  when: is_ceph_infernalis
-
+    owner: "{{ rbd_client_dir_owner }}"
+    group: "{{ rbd_client_dir_group }}"
+    mode: "{{ rbd_client_dir_mode }}"

--- a/roles/ceph-mds/tasks/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/pre_requisite.yml
@@ -1,57 +1,27 @@
 ---
-- name: create bootstrap-mds directory (for or after infernalis release)
+- name: create bootstrap-mds directory
   file:
     path: /var/lib/ceph/bootstrap-mds/
     state: directory
-    owner: ceph
-    group: ceph
-    mode: 0755
-  when: is_ceph_infernalis
+    owner: "{{ dir_owner }}"
+    group: "{{ dir_group }}"
+    mode: "{{ dir_mode }}"
 
-- name: create bootstrap-mds directory (before infernalis release)
-  file:
-    path: /var/lib/ceph/bootstrap-mds/
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-  when: not is_ceph_infernalis
-
-- name: copy mds bootstrap key (for or after infernalis release)
+- name: copy mds bootstrap key
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-mds/ceph.keyring"
     dest: /var/lib/ceph/bootstrap-mds/ceph.keyring
-    owner: ceph
-    group: ceph
-    mode: 0600
-  when: is_ceph_infernalis
+    owner: "{{ key_owner }}"
+    group: "{{ key_group }}"
+    mode: "{{ key_mode }}"
 
-- name: copy mds bootstrap key (before infernalis release)
-  copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-mds/ceph.keyring"
-    dest: /var/lib/ceph/bootstrap-mds/ceph.keyring
-    owner: root
-    group: root
-    mode: 0600
-  when: not is_ceph_infernalis
-
-- name: create mds directory (for or after infernalis release)
+- name: create mds directory
   file:
     path: /var/lib/ceph/mds/ceph-{{ ansible_hostname }}
     state: directory
-    owner: ceph
-    group: ceph
-    mode: 0755
-  when: is_ceph_infernalis
-
-- name: create mds directory (before infernalis release)
-  file:
-    path: /var/lib/ceph/mds/ceph-{{ ansible_hostname }}
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-  when: not is_ceph_infernalis
+    owner: "{{ dir_owner }}"
+    group: "{{ dir_group }}"
+    mode: "{{ dir_mode }}"
 
 - name: create mds keyring
   command: ceph --cluster ceph --name client.bootstrap-mds --keyring /var/lib/ceph/bootstrap-mds/ceph.keyring auth get-or-create mds.{{ ansible_hostname }} osd 'allow rwx' mds 'allow' mon 'allow profile mds' -o /var/lib/ceph/mds/ceph-{{ ansible_hostname }}/keyring
@@ -60,85 +30,40 @@
   changed_when: false
   when: cephx
 
-- name: set mds key permissions (for or after infernalis release)
+- name: set mds key permissions
   file:
     path: /var/lib/ceph/mds/ceph-{{ ansible_hostname }}/keyring
-    mode: 0600
-    owner: ceph
-    group: ceph
-  when:
-    cephx and
-    is_ceph_infernalis
+    mode: "{{ key_mode }}"
+    owner: "{{ key_owner }}"
+    group: "{{ key_group }}"
+  when: cephx
 
-- name: set mds key permissions (before infernalis)
-  file:
-    path: /var/lib/ceph/mds/ceph-{{ ansible_hostname }}/keyring
-    mode: 0600
-    owner: root
-    group: root
-  when:
-    cephx and
-    not is_ceph_infernalis
 
-- name: activate metadata server with upstart (for or after infernalis release)
+- name: activate metadata server with upstart
   file:
     path: /var/lib/ceph/mds/ceph-{{ ansible_hostname }}/{{ item }}
     state: touch
-    owner: ceph
-    group: ceph
-    mode: 0600
+    owner: "{{ activate_file_owner }}"
+    group: "{{ activate_file_group }}"
+    mode: "{{ activate_file_mode }}"
   with_items:
     - done
     - upstart
   changed_when: false
-  when:
-    ansible_distribution == "Ubuntu" and
-    is_ceph_infernalis
+  when: ansible_distribution == "Ubuntu"
 
-- name: activate metadata server with upstart (before infernalis release)
+- name: activate metadata server with sysvinit
   file:
     path: /var/lib/ceph/mds/ceph-{{ ansible_hostname }}/{{ item }}
     state: touch
-    owner: root
-    group: root
-    mode: 0644
-  with_items:
-    - done
-    - upstart
-  changed_when: false
-  when:
-    ansible_distribution == "Ubuntu" and
-    not is_ceph_infernalis
-
-- name: activate metadata server with sysvinit (for or after infernalis release)
-  file:
-    path: /var/lib/ceph/mds/ceph-{{ ansible_hostname }}/{{ item }}
-    state: touch
-    owner: ceph
-    group: ceph
-    mode: 0644
+    owner: "{{ activate_file_owner }}"
+    group: "{{ activate_file_group }}"
+    mode: "{{ activate_file_mode }}"
   with_items:
     - done
     - sysvinit
   changed_when: false
-  when:
-    ansible_distribution != "Ubuntu" and
-    is_ceph_infernalis
-
-- name: activate metadata server with sysvinit (before infernalis release)
-  file:
-    path: /var/lib/ceph/mds/ceph-{{ ansible_hostname }}/{{ item }}
-    state: touch
-    owner: root
-    group: root
-    mode: 0644
-  with_items:
-    - done
-    - sysvinit
-  changed_when: false
-  when:
-    ansible_distribution != "Ubuntu" and
-    not is_ceph_infernalis
+  when: ansible_distribution != "Ubuntu"
 
 - name: start and add that the metadata service to the init sequence (ubuntu)
   service:

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -17,39 +17,20 @@
   args:
     creates: /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
 
-- name: set initial monitor key permissions (for or after infernalis release)
+- name: set initial monitor key permissions
   file:
     path: /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
-    mode: 0600
-    owner: ceph
-    group: ceph
-  when: is_ceph_infernalis
+    mode: "{{ key_mode }}"
+    owner: "{{ key_owner }}"
+    group: "{{ key_group }}"
 
-- name: set initial monitor key permissions (before infernalis release)
-  file:
-    path: /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
-    mode: 0600
-    owner: root
-    group: root
-  when: not is_ceph_infernalis
-
-- name: create monitor directory (for or after infernalis release)
+- name: create monitor directory
   file:
     path: /var/lib/ceph/mon/ceph-{{ ansible_hostname }}
     state: directory
-    owner: ceph
-    group: ceph
-    mode: 0755
-  when: is_ceph_infernalis
-
-- name: create monitor directory (before infernalis release)
-  file:
-    path: /var/lib/ceph/mon/ceph-{{ ansible_hostname }}
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-  when: not is_ceph_infernalis
+    owner: "{{ dir_owner }}"
+    group: "{{ dir_group }}"
+    mode: "{{ dir_mode }}"
 
 - name: ceph monitor mkfs (for or after infernalis release)
   command: ceph-mon --setuser ceph --setgroup ceph --mkfs -i {{ ansible_hostname }} --fsid {{ fsid }} --keyring /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -1,33 +1,16 @@
 ---
-- name: activate monitor with upstart for or after infernalis release
+- name: activate monitor with upstart
   file:
     path: /var/lib/ceph/mon/ceph-{{ ansible_hostname }}/{{ item }}
     state: touch
-    owner: ceph
-    group: ceph
-    mode: 0600
+    owner: "{{ activate_file_owner }}"
+    group: "{{ activate_file_group }}"
+    mode: "{{ activate_file_mode }}"
   changed_when: false
   with_items:
     - done
     - upstart
-  when:
-    ansible_distribution == "Ubuntu" and
-    is_ceph_infernalis
-
-- name: activate monitor with upstart before infernalis release
-  file:
-    path: /var/lib/ceph/mon/ceph-{{ ansible_hostname }}/{{ item }}
-    state: touch
-    owner: root
-    group: root
-    mode: 0600
-  changed_when: false
-  with_items:
-    - done
-    - upstart
-  when:
-    ansible_distribution == "Ubuntu" and
-    not is_ceph_infernalis
+  when: ansible_distribution == "Ubuntu"
 
 - name: start and add that the monitor service to the init sequence (ubuntu)
   service:

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - include: pre_requisite.yml
   when: not osd_containerized_deployment
 

--- a/roles/ceph-osd/tasks/scenarios/osd_directory.yml
+++ b/roles/ceph-osd/tasks/scenarios/osd_directory.yml
@@ -8,8 +8,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: root
-    group: root
+    owner: "{{ dir_owner }}"
+    group: "{{ dir_group }}"
   with_items: osd_directories
 
 # NOTE (leseb): the prepare process must be parallelized somehow...

--- a/roles/ceph-restapi/tasks/pre_requisite.yml
+++ b/roles/ceph-restapi/tasks/pre_requisite.yml
@@ -1,101 +1,45 @@
 ---
-- name: create ceph rest api directory (for or after infernalis release)
+- name: create ceph rest api directory
   file:
     path: /var/lib/ceph/restapi/ceph-restapi
     state: directory
-    owner: ceph
-    group: ceph
-    mode: 0755
-  when: is_ceph_infernalis
+    owner: "{{ dir_owner }}"
+    group: "{{ dir_group }}"
+    mode: "{{ dir_mode }}"
 
-- name: create ceph rest api directory (before infernalis release)
-  file:
-    path: /var/lib/ceph/restapi/ceph-restapi
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-  when: not is_ceph_infernalis
-
-- name: copy ceph rest api keyring (for or after infernalis release)
+- name: copy ceph rest api keyring
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/ceph.client.restapi.keyring"
     dest: "/var/lib/ceph/restapi/ceph-restapi/keyring"
-    owner: ceph
-    group: ceph
-    mode: 0600
-  when:
-    cephx and
-    is_ceph_infernalis
+    owner: "{{ key_owner }}"
+    group: "{{ key_group }}"
+    mode: "{{ key_mode }}"
+  when: cephx
 
-- name: copy ceph rest api keyring (before infernalis release)
-  copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/ceph.client.restapi.keyring"
-    dest: "/var/lib/ceph/restapi/ceph-restapi/keyring"
-    owner: root
-    group: root
-    mode: 600
-  when:
-    cephx and
-    not is_ceph_infernalis
-
-- name: activate ceph rest api with upstart (for or after infernalis release)
+- name: activate ceph rest api with upstart
   file:
     path: /var/lib/ceph/restapi/{{ item }}
     state: touch
-    owner: ceph
-    group: ceph
-    mode: 0600
+    owner: "{{ activate_file_owner }}"
+    group: "{{ activate_file_group }}"
+    mode: "{{ activate_file_mode }}"
   with_items:
     - done
     - upstart
   changed_when: false
-  when:
-    ansible_distribution == "Ubuntu" and
-    is_ceph_infernalis
+  when: ansible_distribution == "Ubuntu"
 
-- name: activate ceph rest api with upstart (before infernalis release)
+- name: activate ceph rest api with sysvinit
   file:
     path: /var/lib/ceph/restapi/{{ item }}
     state: touch
-    owner: root
-    group: root
-    mode: 0600
-  with_items:
-    - done
-    - upstart
-  changed_when: false
-  when:
-    ansible_distribution == "Ubuntu" and
-    not is_ceph_infernalis
-
-- name: activate ceph rest api with sysvinit (for or after infernalis release))
-  file:
-    path: /var/lib/ceph/restapi/{{ item }}
-    state: touch
-    owner: ceph
-    group: ceph
-    mode: 0600
+    owner: "{{ activate_file_owner }}"
+    group: "{{ activate_file_group }}"
+    mode: "{{ activate_file_mode }}"
   with_items:
     - done
     - sysvinit
-  when:
-    ansible_distribution != "Ubuntu" and
-    is_ceph_infernalis
-
-- name: activate ceph rest api with sysvinit (before infernalis release))
-  file:
-    path: /var/lib/ceph/restapi/{{ item }}
-    state: touch
-    owner: root
-    group: root
-    mode: 0600
-  with_items:
-    - done
-    - sysvinit
-  when:
-    ansible_distribution != "Ubuntu" and
-    not is_ceph_infernalis
+  when: ansible_distribution != "Ubuntu"
 
 # NOTE (leseb): will uncomment this when this https://github.com/ceph/ceph/pull/4144 lands
 #- name: start and add that the Ceph REST API service to the init sequence (Ubuntu)

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -1,49 +1,23 @@
 ---
-- name: create rados gateway directories (for or after infernalis release)
+- name: create rados gateway directories
   file:
     path: "{{ item }}"
     state: directory
-    owner: ceph
-    group: ceph
-    mode: 0755
+    owner: "{{ dir_owner }}"
+    group: "{{ dir_group }}"
+    mode: "{{ dir_mode }}"
   with_items:
     - /var/lib/ceph/bootstrap-rgw
     - /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}
-  when: is_ceph_infernalis
 
-- name: create rados gateway directories (before infernalis release)
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-  with_items:
-    - /var/lib/ceph/bootstrap-rgw
-    - /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}
-  when: not is_ceph_infernalis
-
-- name: copy rados gateway bootstrap key (for or after infernalis release)
+- name: copy rados gateway bootstrap key
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-rgw/ceph.keyring"
     dest: /var/lib/ceph/bootstrap-rgw/ceph.keyring
-    owner: ceph
-    group: ceph
-    mode: 0600
-  when:
-    cephx and
-    is_ceph_infernalis
-
-- name: copy rados gateway bootstrap key (before infernalis release)
-  copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-rgw/ceph.keyring"
-    dest: /var/lib/ceph/bootstrap-rgw/ceph.keyring
-    owner: root
-    group: root
-    mode: 0600
-  when:
-    cephx and
-    not is_ceph_infernalis
+    owner: "{{ key_owner }}"
+    group: "{{ key_group }}"
+    mode: "{{ key_mode }}"
+  when: cephx
 
 - name: create rados gateway keyring
   command: ceph --cluster ceph --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/ceph.keyring auth get-or-create client.rgw.{{ ansible_hostname }} osd 'allow rwx' mon 'allow rw' -o /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/keyring
@@ -55,22 +29,10 @@
 - name: set rados gateway key permissions (for or after the infernalis release)
   file:
     path: /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/keyring
-    mode: 0600
-    owner: ceph
-    group: ceph
-  when:
-    cephx and
-    is_ceph_infernalis
-
-- name: set rados gateway key permissions (before infernalis release)
-  file:
-    path: /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/keyring
-    mode: 0600
-    owner: root
-    group: root
-  when:
-    cephx and
-    not is_ceph_infernalis
+    mode: "{{ key_mode }}"
+    owner: "{{ key_owner }}"
+    group: "{{ key_group }}"
+  when: cephx
 
 - name: activate rados gateway with upstart (for or after infernalis release)
   file:
@@ -87,50 +49,31 @@
     ansible_distribution == "Ubuntu" and
     is_ceph_infernalis
 
-- name: activate rados gateway with upstart (before infernalis release)
+- name: activate rados gateway with upstart
   file:
     path: /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/{{ item }}
     state: touch
-    owner: root
-    group: root
-    mode: 0644
+    owner: "{{ activate_file_owner }}"
+    group: "{{ activate_file_group }}"
+    mode: "{{ activate_file_mode }}"
   with_items:
     - done
     - upstart
   changed_when: false
-  when:
-    ansible_distribution == "Ubuntu" and
-    not is_ceph_infernalis
+  when: ansible_distribution == "Ubuntu"
 
-- name: activate rados gateway with sysvinit (for or after infernalis release)
+- name: activate rados gateway with sysvinit
   file:
     path: /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/{{ item }}
     state: touch
-    owner: ceph
-    group: ceph
-    mode: 0644
+    owner: "{{ activate_file_owner }}"
+    group: "{{ activate_file_group }}"
+    mode: "{{ activate_file_mode }}"
   with_items:
     - done
     - sysvinit
   changed_when: false
-  when:
-    ansible_distribution != "Ubuntu" and
-    is_ceph_infernalis
-
-- name: activate rados gateway with sysvinit (before infernalis release)
-  file:
-    path: /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/{{ item }}
-    state: touch
-    owner: root
-    group: root
-    mode: 0644
-  with_items:
-    - done
-    - sysvinit
-  changed_when: false
-  when:
-    ansible_distribution != "Ubuntu" and
-    not is_ceph_infernalis
+  when: ansible_distribution != "Ubuntu"
 
 - name: generate rados gateway sudoers file
   template:


### PR DESCRIPTION
At the moment, all the tasks using the file module are duplicated to have differents ownerships depending on the fact `is_ceph_infernalis`.
The goal of this commit is to have a new logic for this:
- First set facts depending on the `is_ceph_infernalis` fact
- Create the files or directories using the setted facts as ownerships.

There will be less evaluations of the concerned tasks.