### PR TITLE
Adds a package-install tag to all installation tasks

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -10,34 +10,48 @@
 
 - include: ./pre_requisites/prerequisite_ice.yml
   when: ceph_stable_ice
+  tags:
+    - package-install
 
 - include: ./pre_requisites/prerequisite_rh_storage_iso_install.yml
   when:
     ceph_stable_rh_storage and
     ceph_stable_rh_storage_iso_install
+  tags:
+    - package-install
 
 - include: ./pre_requisites/prerequisite_rh_storage_cdn_install.yml
   when:
     ceph_stable_rh_storage and
     ceph_stable_rh_storage_cdn_install
+  tags:
+    - package-install
 
 - include: ./installs/install_on_redhat.yml
   when: ansible_os_family == 'RedHat'
+  tags:
+    - package-install
 
 - include: ./installs/install_on_debian.yml
   when: ansible_os_family == 'Debian'
+  tags:
+    - package-install
 
 - include: ./installs/install_rgw_on_redhat.yml
   when:
     ansible_os_family == 'RedHat' and
     radosgw_frontend == 'apache' and
     rgw_group_name in group_names
+  tags:
+    - package-install
 
 - include: ./installs/install_rgw_on_debian.yml
   when:
     ansible_os_family == 'Debian' and
     radosgw_frontend == 'apache' and
     rgw_group_name in group_names
+  tags:
+    - package-install
 
 # NOTE (leseb): be careful with the following
 # somehow the YAML syntax using "is_ceph_infernalis: {{"


### PR DESCRIPTION
We have a requirement to install the packages first without
configuration. These tags should allow us to target the tasks need to do
that.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>