### PR TITLE
ceph-common: replace 'sudo' by 'become'

### DIFF
--- a/roles/ceph-common/tasks/checks/check_system.yml
+++ b/roles/ceph-common/tasks/checks/check_system.yml
@@ -24,7 +24,7 @@
 - name: check ansible version
   local_action: shell ansible --version | awk '/[0-9].[0-9].[0-9]/ {print $2}'
   changed_when: false
-  sudo: false
+  become: false
   register: ansible__version
 
 - name: fail on unsupported ansible version

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -74,21 +74,21 @@
 - name: create a local fetch directory if it does not exist
   local_action: file path={{ fetch_directory }} state=directory
   changed_when: false
-  sudo: false
+  become: false
   run_once: true
 
 - name: generate cluster uuid
   local_action: shell python -c 'import uuid; print str(uuid.uuid4())' | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
     creates="{{ fetch_directory }}/ceph_cluster_uuid.conf"
   register: cluster_uuid
-  sudo: false
+  become: false
 
 - name: read cluster uuid if it already exists
   local_action: command cat {{ fetch_directory }}/ceph_cluster_uuid.conf
     removes="{{ fetch_directory }}/ceph_cluster_uuid.conf"
   changed_when: false
   register: cluster_uuid
-  sudo: false
+  become: false
 
 - name: create ceph conf directory
   file:

--- a/roles/ceph-mds/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-mds/tasks/docker/fetch_configs.yml
@@ -12,7 +12,7 @@
   local_action: stat path={{ item }}
   with_items: ceph_config_keys
   changed_when: false
-  sudo: false
+  become: false
   failed_when: false
   register: statconfig
 

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -3,14 +3,14 @@
   local_action: shell python -c "import os ; import struct ; import time; import base64 ; key = os.urandom(16) ; header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ; print base64.b64encode(header + key)" | tee {{ fetch_directory }}/monitor_keyring.conf
     creates={{ fetch_directory }}/monitor_keyring.conf
   register: monitor_keyring
-  sudo: false
+  become: false
 
 - name: read monitor initial keyring if it already exists
   local_action: command cat {{ fetch_directory }}/monitor_keyring.conf
     removes={{ fetch_directory }}/monitor_keyring.conf
   changed_when: false
   register: monitor_keyring
-  sudo: false
+  become: false
 
 - name: create monitor initial keyring
   command: ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} --create-keyring --name=mon. --add-key={{ monitor_secret }} --cap mon 'allow *'

--- a/roles/ceph-mon/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-mon/tasks/docker/fetch_configs.yml
@@ -14,7 +14,7 @@
   local_action: stat path={{ item }}
   with_items: ceph_config_keys
   changed_when: false
-  sudo: false
+  become: false
   failed_when: false
   register: statconfig
 

--- a/roles/ceph-osd/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-osd/tasks/docker/fetch_configs.yml
@@ -9,7 +9,7 @@
   local_action: stat path={{ item }}
   with_items: ceph_config_keys
   changed_when: false
-  sudo: false
+  become: false
   failed_when: false
   register: statconfig
 

--- a/roles/ceph-restapi/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-restapi/tasks/docker/fetch_configs.yml
@@ -9,7 +9,7 @@
   local_action: stat path={{ item }}
   with_items: ceph_config_keys
   changed_when: false
-  sudo: false
+  become: false
   ignore_errors: true
   register: statconfig
 

--- a/roles/ceph-rgw/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-rgw/tasks/docker/fetch_configs.yml
@@ -9,7 +9,7 @@
   local_action: stat path={{ item }}
   with_items: ceph_config_keys
   changed_when: false
-  sudo: false
+  become: false
   ignore_errors: true
   register: statconfig
 

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -2,27 +2,27 @@
 # Defines deployment design and assigns role to server groups
 
 - hosts: mons
-  sudo: True
+  become: True
   roles:
   - ceph-mon
   #serial: 1 # ENABLE THIS WHEN DEPLOYING MONITORS ON DOCKER CONTAINERS
 
 - hosts: osds
-  sudo: True
+  become: True
   roles:
   - ceph-osd
 
 - hosts: mdss
-  sudo: True
+  become: True
   roles:
   - ceph-mds
 
 - hosts: rgws
-  sudo: True
+  become: True
   roles:
   - ceph-rgw
 
 - hosts: restapis
-  sudo: True
+  become: True
   roles:
   - ceph-restapi


### PR DESCRIPTION
to avoid warning from ansible v2. works for both `1.9.4` and `2.0.0.2`.

Signed-off-by: Sébastien Han <seb@redhat.com>