### PR TITLE
ceph-ansible: allow to run containerized daemons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ group_vars/rgws
 group_vars/restapis
 *.DS_Store
 site.yml
+site-docker.yml
 *.pyc

--- a/roles/ceph-mds/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-mds/tasks/docker/fetch_configs.yml
@@ -9,7 +9,7 @@
       - /var/lib/ceph/bootstrap-mds/ceph.keyring
 
 - name: stat for ceph config and keys
-  local_action: stat path={{ item }}
+  local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
   with_items: ceph_config_keys
   changed_when: false
   become: false

--- a/roles/ceph-mds/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/docker/pre_requisite.yml
@@ -7,24 +7,45 @@
     - /etc/ceph/
     - /var/lib/ceph/bootstrap-mds
 
-- name: install pip on debian
+- name: install pip and docker on ubuntu
   apt:
-    name: python-pip
+    name: "{{ item }}"
     state: present
-  when: ansible_os_family == 'Debian'
+    update_cache: yes
+  with_items:
+    - python-pip
+    - docker
+    - docker.io
+  when: ansible_distribution == 'Ubuntu'
 
-- name: install pip on redhat
-  yum:
-    name: python-pip
+- name: install pip and docker on debian
+  apt:
+    name: "{{ item }}"
     state: present
+    update_cache: yes
+  with_items:
+    - python-pip
+    - docker-engine
+  when: ansible_distribution == 'Debian'
+
+- name: install pip and docker on redhat
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python-pip
+    - docker-engine
   when:
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "yum"
 
-- name: install pip on redhat
+- name: install pip and docker on redhat
   dnf:
-    name: python-pip
+    name: "{{ item }}"
     state: present
+  with_items:
+    - python-pip
+    - docker-engine
   when:
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "dnf"

--- a/roles/ceph-mon/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-mon/tasks/docker/fetch_configs.yml
@@ -11,7 +11,7 @@
       - /var/lib/ceph/bootstrap-mds/ceph.keyring
 
 - name: stat for ceph config and keys
-  local_action: stat path={{ item }}
+  local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
   with_items: ceph_config_keys
   changed_when: false
   become: false

--- a/roles/ceph-mon/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-mon/tasks/docker/pre_requisite.yml
@@ -9,24 +9,45 @@
     - /var/lib/ceph/bootstrap-mds
     - /var/lib/ceph/bootstrap-rgw
 
-- name: install pip on debian
+- name: install pip and docker on ubuntu
   apt:
-    name: python-pip
+    name: "{{ item }}"
     state: present
-  when: ansible_os_family == 'Debian'
+    update_cache: yes
+  with_items:
+    - python-pip
+    - docker
+    - docker.io
+  when: ansible_distribution == 'Ubuntu'
 
-- name: install pip on redhat
-  yum:
-    name: python-pip
+- name: install pip and docker on debian
+  apt:
+    name: "{{ item }}"
     state: present
+    update_cache: yes
+  with_items:
+    - python-pip
+    - docker-engine
+  when: ansible_distribution == 'Debian'
+
+- name: install pip and docker on redhat
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python-pip
+    - docker-engine
   when:
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "yum"
 
-- name: install pip on redhat
+- name: install pip and docker on redhat
   dnf:
-    name: python-pip
+    name: "{{ item }}"
     state: present
+  with_items:
+    - python-pip
+    - docker-engine
   when:
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "dnf"

--- a/roles/ceph-osd/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-osd/tasks/docker/fetch_configs.yml
@@ -6,7 +6,7 @@
       - /var/lib/ceph/bootstrap-osd/ceph.keyring
 
 - name: stat for ceph config and keys
-  local_action: stat path={{ item }}
+  local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
   with_items: ceph_config_keys
   changed_when: false
   become: false

--- a/roles/ceph-osd/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/docker/pre_requisite.yml
@@ -7,24 +7,45 @@
     - /etc/ceph/
     - /var/lib/ceph/bootstrap-osd
 
-- name: install pip on debian
+- name: install pip and docker on ubuntu
   apt:
-    name: python-pip
+    name: "{{ item }}"
     state: present
-  when: ansible_os_family == 'Debian'
+    update_cache: yes
+  with_items:
+    - python-pip
+    - docker
+    - docker.io
+  when: ansible_distribution == 'Ubuntu'
 
-- name: install pip on redhat
-  yum:
-    name: python-pip
+- name: install pip and docker on debian
+  apt:
+    name: "{{ item }}"
     state: present
+    update_cache: yes
+  with_items:
+    - python-pip
+    - docker-engine
+  when: ansible_distribution == 'Debian'
+
+- name: install pip and docker on redhat
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python-pip
+    - docker-engine
   when:
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "yum"
 
-- name: install pip on redhat
+- name: install pip and docker on redhat
   dnf:
-    name: python-pip
+    name: "{{ item }}"
     state: present
+  with_items:
+    - python-pip
+    - docker-engine
   when:
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "dnf"

--- a/roles/ceph-restapi/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-restapi/tasks/docker/fetch_configs.yml
@@ -6,7 +6,7 @@
       - /etc/ceph/ceph.client.admin.keyring
 
 - name: stat for ceph config and keys
-  local_action: stat path={{ item }}
+  local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
   with_items: ceph_config_keys
   changed_when: false
   become: false

--- a/roles/ceph-restapi/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-restapi/tasks/docker/pre_requisite.yml
@@ -1,22 +1,43 @@
 ---
-- name: install pip on debian
+- name: install pip and docker on ubuntu
   apt:
-    name: python-pip
+    name: "{{ item }}"
     state: present
-  when: ansible_os_family == 'Debian'
+    update_cache: yes
+  with_items:
+    - python-pip
+    - docker
+    - docker.io
+  when: ansible_distribution == 'Ubuntu'
 
-- name: install pip on redhat
-  yum:
-    name: python-pip
+- name: install pip and docker on debian
+  apt:
+    name: "{{ item }}"
     state: present
+    update_cache: yes
+  with_items:
+    - python-pip
+    - docker-engine
+  when: ansible_distribution == 'Debian'
+
+- name: install pip and docker on redhat
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python-pip
+    - docker-engine
   when:
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "yum"
 
-- name: install pip on redhat
+- name: install pip and docker on redhat
   dnf:
-    name: python-pip
+    name: "{{ item }}"
     state: present
+  with_items:
+    - python-pip
+    - docker-engine
   when:
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "dnf"

--- a/roles/ceph-rgw/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-rgw/tasks/docker/fetch_configs.yml
@@ -6,7 +6,7 @@
       - /var/lib/ceph/bootstrap-rgw/ceph.keyring
 
 - name: stat for ceph config and keys
-  local_action: stat path={{ item }}
+  local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
   with_items: ceph_config_keys
   changed_when: false
   become: false

--- a/roles/ceph-rgw/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/docker/pre_requisite.yml
@@ -7,24 +7,45 @@
     - /etc/ceph/
     - /var/lib/ceph/bootstrap-rgw
 
-- name: install pip on debian
+ name: install pip and docker on ubuntu
   apt:
-    name: python-pip
+    name: "{{ item }}"
     state: present
-  when: ansible_os_family == 'Debian'
+    update_cache: yes
+  with_items:
+    - python-pip
+    - docker
+    - docker.io
+  when: ansible_distribution == 'Ubuntu'
 
-- name: install pip on redhat
-  yum:
-    name: python-pip
+- name: install pip and docker on debian
+  apt:
+    name: "{{ item }}"
     state: present
+    update_cache: yes
+  with_items:
+    - python-pip
+    - docker-engine
+  when: ansible_distribution == 'Debian'
+
+- name: install pip and docker on redhat
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python-pip
+    - docker-engine
   when:
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "yum"
 
-- name: install pip on redhat
+- name: install pip and docker on redhat
   dnf:
-    name: python-pip
+    name: "{{ item }}"
     state: present
+  with_items:
+    - python-pip
+    - docker-engine
   when:
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "dnf"

--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -5,6 +5,7 @@
   become: True
   roles:
   - ceph-mon
+  serial: 1 # MUST be '1' WHEN DEPLOYING MONITORS ON DOCKER CONTAINERS
 
 - hosts: osds
   become: True

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -1,5 +1,8 @@
 ---
 
+# DEPLOY CONTAINERIZED DAEMONS
+docker: false
+
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 3
 osd_vms: 3


### PR DESCRIPTION
run containerized daemons in virtual machines.
to enable it simply do:

`cp site-docker.yml.sample site-docker.yml`

and set `docker: true` in `vagrant_variables.yml`

Signed-off-by: Sébastien Han <seb@redhat.com>