### PR TITLE
ceph-rgw: fix docker typo

### DIFF
--- a/roles/ceph-rgw/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/docker/pre_requisite.yml
@@ -7,7 +7,7 @@
     - /etc/ceph/
     - /var/lib/ceph/bootstrap-rgw
 
- name: install pip and docker on ubuntu
+- name: install pip and docker on ubuntu
   apt:
     name: "{{ item }}"
     state: present


### PR DESCRIPTION
Signed-off-by: Sébastien Han <seb@redhat.com>