### PR TITLE
Change modes to string values

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -62,49 +62,49 @@
 - set_fact:
     dir_owner: ceph
     dir_group: ceph
-    dir_mode: 0755
+    dir_mode: "0755"
   when: is_ceph_infernalis
 
 - set_fact:
     dir_owner: root
     dir_group: root
-    dir_mode: 0755
+    dir_mode: "0755"
   when: not is_ceph_infernalis
 
 - set_fact:
     key_owner: root
     key_group: root
-    key_mode: 0600
+    key_mode: "0600"
   when: not is_ceph_infernalis
 
 - set_fact:
     key_owner: ceph
     key_group: ceph
-    key_mode: 0600
+    key_mode: "0600"
   when: is_ceph_infernalis
 
 - set_fact:
     activate_file_owner: ceph
     activate_file_group: ceph
-    activate_file_mode: 0644
+    activate_file_mode: "0644"
   when: is_ceph_infernalis
 
 - set_fact:
     activate_file_owner: root
     activate_file_group: root
-    activate_file_mode: 0644
+    activate_file_mode: "0644"
   when: not is_ceph_infernalis
 
 - set_fact:
     rbd_client_dir_owner: root
     rbd_client_dir_group: root
-    rbd_client_dir_mode: 0644
+    rbd_client_dir_mode: "0644"
   when: not is_ceph_infernalis
 
 - set_fact:
     rbd_client_dir_owner: ceph
     rbd_client_dir_group: ceph
-    rbd_client_dir_mode: 0770
+    rbd_client_dir_mode: "0770"
   when: is_ceph_infernalis
 
 - name: check for a ceph socket


### PR DESCRIPTION
Currently deploying a MON fails with "bad symbolic permission for mode"
errors due to the file/directory modes not being interpreted as octal
values.  This commit updates roles/ceph-common/tasks/main.yml to set
the file/directory modes to strings so they can be interpreted
correctly.

Closes issue #525