### PR TITLE
make sure /etc/fstab is always valid at boot time no matter what

### DIFF
--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_iso_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_iso_install.yml
@@ -33,4 +33,4 @@
     name: "{{ ceph_stable_rh_storage_mount_path }}"
     src: "{{ ceph_stable_rh_storage_iso_path }}"
     fstype: iso9660
-    state: absent
+    state: unmounted

--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_iso_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_iso_install.yml
@@ -12,11 +12,15 @@
     src: "{{ ceph_stable_rh_storage_iso_path }}"
     dest: "{{ ceph_stable_rh_storage_iso_path }}"
 
+# assumption: ceph_stable_rh_storage_mount_path does not specify directory
+
 - name: mount red hat storage iso file
   mount:
     name: "{{ ceph_stable_rh_storage_mount_path }}"
     src: "{{ ceph_stable_rh_storage_iso_path }}"
     fstype: iso9660
+    opts: ro,loop,noauto
+    passno: 2
     state: mounted
 
 - name: copy red hat storage iso content
@@ -24,9 +28,9 @@
   args:
     creates: "{{ ceph_stable_rh_storage_repository_path }}/README"
 
-- name: mount red hat storage iso file
+- name: unmount red hat storage iso file
   mount:
     name: "{{ ceph_stable_rh_storage_mount_path }}"
     src: "{{ ceph_stable_rh_storage_iso_path }}"
     fstype: iso9660
-    state: unmounted
+    state: absent


### PR DESCRIPTION
For .iso-based install only.

Ensure that contents of /etc/fstab are ALWAYS valid at boot time, no matter what.  Otherwise Linux will not boot at all.  I discovered this the hard way.  The ansible mount module left an entry in fstab even after I unmounted, and that mount option did not work at boot time.  I had to PXEboot to rescue mode to figure out why - Linux hung immediately after the grub entry was selected.  Only explanation I had was that the "passno" field of /etc/fstab record was set to 0, and apparently it tried to mount the .iso before root fs was mounted, very strange but legal. So this fix has multiple defenses against this kind of thing ever happening again.  We make mount entry "noauto" so it won't even attempt mount at boot time.  We make "passno" field 2 instead of 0 (why isn't this default in Ansible mount module?) so that it wouldn't attempt mount until after root fs was mounted.   And in the unmount step, we use the state "absent" to indicate that it should remove the entry from /etc/fstab.   I know all this seems excessive and paranoid ;-) That's me I guess.

I inserted a comment about the ceph_stable_rh_storage_iso_path because I did not see how it would work if a directory path was included - we don't know if the directory exists.

Do most folks use subscription manager now so none of this matters to them?

I'm sorry but I haven't been able to test this in a while, can someone else try it?  It's a very small change.  I don't have any hardware to try it with today, wanted to get this in for comment at least.