### PR TITLE
config_template: Add interpreter line

### DIFF
--- a/plugins/actions/config_template.py
+++ b/plugins/actions/config_template.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # (c) 2015, Kevin Carter <kevin.carter@rackspace.com>
 #
 # This file is part of Ansible


### PR DESCRIPTION
Fixes the error: "module is missing interpreter line"

Signed-off-by: Zack Cerza <zack@redhat.com>