### PR TITLE
ceph-osd: docker: fix type

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,7 +49,7 @@ ansible_provision = proc do |ansible|
       ceph_mon_docker_interface: ETH,
       ceph_mon_docker_subnet: "#{SUBNET}.0/24",
       ceph_osd_docker_extra_env: "CEPH_DAEMON=OSD_CEPH_DISK,OSD_JOURNAL_SIZE=100",
-      ceph_osd_docker_device: settings['disks'],
+      ceph_osd_docker_devices: settings['disks'],
       ceph_rgw_civetweb_port: 8080
     }
   else

--- a/group_vars/osds.sample
+++ b/group_vars/osds.sample
@@ -117,5 +117,5 @@ osd_crush_location: "'root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} host
 #ceph_osd_docker_username: ceph
 #ceph_osd_docker_imagename: daemon
 #ceph_osd_docker_extra_env: "CEPH_DAEMON=OSD_CEPH_DISK" # comma separated variables
-#ceph_osd_docker_device:
+#ceph_osd_docker_devices:
 # - /dev/sdb

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -112,5 +112,5 @@ osd_containerized_deployment: false
 ceph_osd_docker_username: ceph
 ceph_osd_docker_imagename: daemon
 ceph_osd_docker_extra_env: "CEPH_DAEMON=OSD_CEPH_DISK" # comma separated variables
-#ceph_osd_docker_device:
+#ceph_osd_docker_devices:
 # - /dev/sdb


### PR DESCRIPTION
use ceph_osd_docker_devices and not ceph_osd_docker_device

Signed-off-by: Sébastien Han <seb@redhat.com>