### PR TITLE
Allow RGW and client VMs together

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,7 +108,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   (0..NRGWS - 1).each do |i|
     config.vm.define "rgw#{i}" do |rgw|
       rgw.vm.hostname = "ceph-rgw#{i}"
-      rgw.vm.network :private_network, ip: "#{SUBNET}.4#{i}"
+      rgw.vm.network :private_network, ip: "#{SUBNET}.5#{i}"
 
       # Virtualbox
       rgw.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
RGW and Client VMs were sharing a network range, causing vagrant
failure.  Bump the RGW range to the next value.

Note that this needs to be applied to the docker branch as well.