### PR TITLE
ceph-osd: fix the auto discovery scenario

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -4,7 +4,7 @@
 - name: activate osd(s) when device is a disk
   command: ceph-disk activate {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
   with_together:
-    - ispartition.results
+    - combined_ispartition_results.results
     - devices
   changed_when: false
   failed_when: false
@@ -14,7 +14,7 @@
 - name: activate osd(s) when device is a partition
   command: "ceph-disk activate {{ item.1 }}"
   with_together:
-    - ispartition.results
+    - combined_ispartition_results.results
     - devices
   changed_when: false
   failed_when: false

--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -11,7 +11,7 @@
 # for SSD journals.
 
 - name: check if the device is a partition
-  shell: "echo '{{ item }}' | egrep '/dev/(sd[a-z]{1,2}|hd[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p)[0-9]{1,2}$'"
+  shell: "echo '{{ item }}' | egrep '/dev/({h,s,v}d[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p)[0-9]{1,2}$'"
   with_items: devices
   changed_when: false
   failed_when: false
@@ -19,7 +19,7 @@
   when: not osd_auto_discovery
 
 - name: check if the device is a partition (autodiscover disks)
-  shell: "echo '/dev/{{ item.key }}' | egrep '/dev/(sd[a-z]{1,2}|hd[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p)[0-9]{1,2}$'"
+  shell: "echo '/dev/{{ item.key }}' | egrep '/dev/({h,s,v}d[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p)[0-9]{1,2}$'"
   with_dict: ansible_devices
   changed_when: false
   failed_when: false

--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -16,6 +16,18 @@
   changed_when: false
   failed_when: false
   register: ispartition
+  when: not osd_auto_discovery
+
+- name: check if the device is a partition (autodiscover disks)
+  shell: "echo '/dev/{{ item.key }}' | egrep '/dev/(sd[a-z]{1,2}|hd[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p)[0-9]{1,2}$'"
+  with_dict: ansible_devices
+  changed_when: false
+  failed_when: false
+  register: ispartition
+  when:
+    ansible_devices is defined and
+    item.value.removable == "0" and
+    osd_auto_discovery
 
 - name: check the partition status of the osd disks
   shell: "parted --script {{ item }} print > /dev/null 2>&1"
@@ -25,7 +37,22 @@
   register: osd_partition_status
   when:
     journal_collocation or
-    raw_multi_journal
+    raw_multi_journal and
+    not osd_auto_discovery
+
+- name: check the partition status of the osd disks (autodiscover disks)
+  shell: "parted --script /dev/{{ item.key }} print > /dev/null 2>&1"
+  with_dict: ansible_devices
+  changed_when: false
+  failed_when: false
+  register: osd_partition_status
+  when:
+    journal_collocation or
+    raw_multi_journal and
+    ansible_devices is defined and
+    item.value.removable == "0" and
+    item.value.partitions|count == 0 and
+    osd_auto_discovery
 
 - name: check the partition status of the journal devices
   shell: "parted --script {{ item }} print > /dev/null 2>&1"
@@ -41,7 +68,24 @@
     - osd_partition_status.results
     - devices
   changed_when: false
-  when: (journal_collocation or raw_multi_journal) and item.0.rc != 0
+  when:
+    (journal_collocation or raw_multi_journal) and not
+    osd_auto_discovery and
+    item.0.rc != 0
+
+- name: fix partitions gpt header or labels of the osd disks (autodiscover disks)
+  shell: sgdisk --zap-all --clear --mbrtogpt -g -- "/dev/{{ item.1.key }}"
+  with_together:
+    - osd_partition_status.results
+    - ansible_devices
+  changed_when: false
+  when:
+    journal_collocation and
+    osd_auto_discovery and
+    ansible_devices is defined and
+    item.value.removable == "0" and
+    item.value.partitions|count == 0 and
+    item.0.rc != 0
 
 - name: fix partitions gpt header or labels of the journal devices
   shell: sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }}
@@ -49,11 +93,25 @@
     - journal_partition_status.results
     - raw_journal_devices
   changed_when: false
-  when: raw_multi_journal and item.0.rc != 0
+  when:
+    raw_multi_journal and
+    item.0.rc != 0
 
-- name: if partition named 'ceph' exists
+- name: check if a partition named 'ceph' exists
   shell: "parted --script {{ item }} print | egrep -sq '^ 1.*ceph'"
   with_items: devices
   changed_when: false
   failed_when: false
   register: parted
+  when: not osd_auto_discovery
+
+- name: check if a partition named 'ceph' exists (autodiscover disks)
+  shell: "parted --script {{ item }} print | egrep -sq '^ 1.*ceph'"
+  with_dict: ansible_devices
+  changed_when: false
+  failed_when: false
+  register: parted
+  when:
+    ansible_devices is defined and
+    item.value.removable == "0" and
+    osd_auto_discovery

--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -23,11 +23,17 @@
   with_dict: ansible_devices
   changed_when: false
   failed_when: false
-  register: ispartition
+  register: ispartition_autodiscover
   when:
     ansible_devices is defined and
     item.value.removable == "0" and
     osd_auto_discovery
+
+# NOTE (leseb): we must do this because of
+# https://github.com/ansible/ansible/issues/4297
+- name: combine ispartition results
+  set_fact:
+    combined_ispartition_results: "{{ ispartition if not osd_auto_discovery else ispartition_autodiscover }}"
 
 - name: check the partition status of the osd disks
   shell: "parted --script {{ item }} print > /dev/null 2>&1"
@@ -37,15 +43,15 @@
   register: osd_partition_status
   when:
     journal_collocation or
-    raw_multi_journal and
-    not osd_auto_discovery
+    raw_multi_journal and not
+    osd_auto_discovery
 
 - name: check the partition status of the osd disks (autodiscover disks)
   shell: "parted --script /dev/{{ item.key }} print > /dev/null 2>&1"
   with_dict: ansible_devices
   changed_when: false
   failed_when: false
-  register: osd_partition_status
+  register: osd_partition_status_autodiscover
   when:
     journal_collocation or
     raw_multi_journal and
@@ -53,6 +59,12 @@
     item.value.removable == "0" and
     item.value.partitions|count == 0 and
     osd_auto_discovery
+
+# NOTE (leseb): we must do this because of
+# https://github.com/ansible/ansible/issues/4297
+- name: combine osd_partition_status results
+  set_fact:
+    combined_osd_partition_status_results: "{{ osd_partition_status if not osd_auto_discovery else osd_partition_status_autodiscover }}"
 
 - name: check the partition status of the journal devices
   shell: "parted --script {{ item }} print > /dev/null 2>&1"
@@ -65,7 +77,7 @@
 - name: fix partitions gpt header or labels of the osd disks
   shell: sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }}
   with_together:
-    - osd_partition_status.results
+    - combined_osd_partition_status_results.results
     - devices
   changed_when: false
   when:
@@ -76,7 +88,7 @@
 - name: fix partitions gpt header or labels of the osd disks (autodiscover disks)
   shell: sgdisk --zap-all --clear --mbrtogpt -g -- "/dev/{{ item.1.key }}"
   with_together:
-    - osd_partition_status.results
+    - combined_osd_partition_status_results.results
     - ansible_devices
   changed_when: false
   when:
@@ -106,12 +118,19 @@
   when: not osd_auto_discovery
 
 - name: check if a partition named 'ceph' exists (autodiscover disks)
-  shell: "parted --script {{ item }} print | egrep -sq '^ 1.*ceph'"
+  shell: "parted --script /dev/{{ item }} print | egrep -sq '^ 1.*ceph'"
   with_dict: ansible_devices
   changed_when: false
   failed_when: false
-  register: parted
+  register: parted_autodiscover
   when:
     ansible_devices is defined and
     item.value.removable == "0" and
+    item.value.partitions|count != 0 and
     osd_auto_discovery
+
+# NOTE (leseb): we must do this because of
+# https://github.com/ansible/ansible/issues/4297
+- name: combine parted results
+  set_fact:
+    combined_parted_results: "{{ parted if not osd_auto_discovery else parted_autodiscover }}"

--- a/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
+++ b/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
@@ -21,7 +21,7 @@
     journal_collocation and
     osd_auto_discovery
 
-- name: manually Prepare osd disk(s)
+- name: manually prepare osd disk(s)
   command: "ceph-disk prepare {{ item.2 }}"
   ignore_errors: true
   with_together:

--- a/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
+++ b/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
@@ -25,8 +25,8 @@
   command: "ceph-disk prepare {{ item.2 }}"
   ignore_errors: true
   with_together:
-    - parted.results
-    - ispartition.results
+    - combined_parted_results.results
+    - combined_ispartition_results.results
     - devices
   when:
     item.0.rc != 0 and

--- a/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
+++ b/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
@@ -12,8 +12,8 @@
 - name: prepare osd disk(s)
   command: "ceph-disk prepare {{ item.2 }} {{ item.3 }}"
   with_together:
-    - parted.results
-    - ispartition.results
+    - combined_parted_results.results
+    - combined_ispartition_results.results
     - devices
     - raw_journal_devices
   changed_when: false
@@ -21,6 +21,7 @@
   when:
     item.0.rc != 0 and
     item.1.rc != 0 and
-    raw_multi_journal
+    raw_multi_journal and
+    not osd_auto_discovery
 
 - include: ../activate_osds.yml


### PR DESCRIPTION
While this is not widly used (AFAIK :p) the feature was broken. Thanks
to @zmc for reporting it. You can now set `osd_auto_discovery` to
true in your group_vars/osd and it will go through all the devices
available and will make them OSDs.

Signed-off-by: Sébastien Han <seb@redhat.com>