### PR TITLE
ceph-common: use explicit action syntax for config_template

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -147,7 +147,8 @@
     mode: "{{ conf_directory_mode }}"
 
 - name: generate ceph configuration file
-  config_template:
+  action: config_template
+  args:
     src: ceph.conf.j2
     dest: /etc/ceph/ceph.conf
     owner: "{{ conf_file_owner }}"


### PR DESCRIPTION
This fails for me with "ERROR! no action detected in task" otherwise.

```
ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.

The error appears to have been in '/etc/ansible/include/ceph-ansible/roles/ceph-common/tasks/main.yml': line 149, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: generate ceph configuration file
  ^ here
```