### PR TITLE
ceph-common: calculate vm.min_free_kbytes

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -283,4 +283,4 @@ dummy:
 #  - { name: fs.file-max, value: 26234859 }
 #  - { name: vm.zone_reclaim_mode, value: 0 }
 #  - { name: vm.vfs_cache_pressure, value: 50 }
-#  - { name: vm.min_free_kbytes, value: 4194303 }
+#  - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -295,7 +295,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
   - { name: vm.zone_reclaim_mode, value: 0 }
   - { name: vm.vfs_cache_pressure, value: 50 }
-  - { name: vm.min_free_kbytes, value: 4194303 }
+  - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }
 
 
 ##########

--- a/roles/ceph-common/tasks/misc/system_tuning.yml
+++ b/roles/ceph-common/tasks/misc/system_tuning.yml
@@ -16,9 +16,13 @@
   failed_when: false
   when: disable_swap
 
+- name: get default vm.min_free_kbytes
+  command: sysctl -b vm.min_free_kbytes
+  register: default_vm_min_free_kbytes
+
 - name: calculate vm.min_free_kbytes
   set_fact:
-    vm_min_free_kbytes: "{{ 4194303 if ansible_memtotal_mb >= 49152 else (ansible_memtotal_mb * 1024 / 100)|int }}"
+    vm_min_free_kbytes: "{{ 4194303 if ansible_memtotal_mb >= 49152 else default_vm_min_free_kbytes|int }}"
 
 - name: apply operating system tuning
   sysctl:

--- a/roles/ceph-common/tasks/misc/system_tuning.yml
+++ b/roles/ceph-common/tasks/misc/system_tuning.yml
@@ -16,6 +16,10 @@
   failed_when: false
   when: disable_swap
 
+- name: calculate vm.min_free_kbytes
+  set_fact:
+    vm_min_free_kbytes: "{{ 4194303 if ansible_memtotal_mb >= 49152 else (ansible_memtotal_mb * 1024 / 100)|int }}"
+
 - name: apply operating system tuning
   sysctl:
     name: "{{ item.name }}"

--- a/roles/ceph-common/tasks/misc/system_tuning.yml
+++ b/roles/ceph-common/tasks/misc/system_tuning.yml
@@ -20,9 +20,9 @@
   command: sysctl -b vm.min_free_kbytes
   register: default_vm_min_free_kbytes
 
-- name: calculate vm.min_free_kbytes
+- name: define vm.min_free_kbytes
   set_fact:
-    vm_min_free_kbytes: "{{ 4194303 if ansible_memtotal_mb >= 49152 else default_vm_min_free_kbytes|int }}"
+    vm_min_free_kbytes: "{{ 4194303 if ansible_memtotal_mb >= 49152 else default_vm_min_free_kbytes.stdout }}"
 
 - name: apply operating system tuning
   sysctl:


### PR DESCRIPTION
based on the os memory we calculate the value for vm.min_free_kbytes
we don't go over 4GB of memory, even for systems with more than 48GB of RAM.

Signed-off-by: Sébastien Han <seb@redhat.com>