### PR TITLE
separate the agent so it doesn't break standard installs

### DIFF
--- a/site.yml.sample
+++ b/site.yml.sample
@@ -7,6 +7,11 @@
   - ceph-mon
   - ceph-agent
 
+- hosts: agents
+  become: True
+  roles:
+  - ceph-agent
+
 - hosts: osds
   become: True
   roles:

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -5,7 +5,6 @@
   become: True
   roles:
   - ceph-mon
-  - ceph-agent
 
 - hosts: agents
   become: True


### PR DESCRIPTION
Mainly because some packages are still not there for upstream which will cause
it to break installs that would otherwise would succeed

Should fix issue #545 