### PR TITLE
adds some more --package-install tags; make check_mandatory_vars more specific

### DIFF
--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -5,6 +5,8 @@
   when:
     ceph_origin != 'upstream' and
     ceph_origin != 'distro'
+  tags:
+    - package-install
 
 - name: make sure an installation source was chosen
   fail:
@@ -15,6 +17,8 @@
     not ceph_dev and
     not ceph_stable_ice and
     not ceph_stable_rh_storage
+  tags:
+    - package-install
 
 - name: verify that a method was chosen for red hat storage
   fail:
@@ -23,6 +27,8 @@
     ceph_stable_rh_storage and
     not ceph_stable_rh_storage_cdn_install and
     not ceph_stable_rh_storage_iso_install
+  tags:
+    - package-install
 
 - name: make sure journal_size configured
   fail:

--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -33,22 +33,30 @@
 - name: make sure journal_size configured
   fail:
     msg: "journal_size must be configured. See http://ceph.com/docs/master/rados/configuration/osd-config-ref/"
-  when: journal_size|int == 0
+  when:
+    journal_size|int == 0 and
+    osd_group_name in group_names
 
 - name: make sure monitor_interface configured
   fail:
     msg: "monitor_interface must be configured. Interface for the monitor to listen on"
-  when: monitor_interface == 'interface'
+  when:
+    monitor_interface == 'interface' and
+    mon_group_name in group_names
 
 - name: make sure cluster_network configured
   fail:
     msg: "cluster_network must be configured. Ceph replication network"
-  when: cluster_network == '0.0.0.0/0'
+  when:
+    cluster_network == '0.0.0.0/0' and
+    osd_group_name in group_names
 
 - name: make sure public_network configured
   fail:
     msg: "public_network must be configured. Ceph public network"
-  when: public_network == '0.0.0.0/0'
+  when:
+    public_network == '0.0.0.0/0' and
+    osd_group_name in group_names
 
 - name: make sure an osd scenario was chosen
   fail:


### PR DESCRIPTION
We have a use case where we won't be configuring mons and osds in the same call, so we want to allow the playbook to run and only check for variables when absolutely necessary. For example, there is no need to check ``journal_size`` when only configuring a mon.