### PR TITLE
Use object map for xattrs with ext4

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -186,6 +186,13 @@ dummy:
 # Object backend
 #osd_objectstore: filestore
 
+# xattrs. by default, 'filestore xattr use omap' is set to 'true' if
+# 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can
+# be set to 'true' or 'false' to explicitly override those
+# defaults. Leave it 'null' to use the default for your chosen mkfs
+# type.
+# filestore_xattr_use_omap: null
+
 # Performance tuning
 #filestore_merge_threshold: 40
 #filestore_split_multiple: 8

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -198,6 +198,13 @@ osd_crush_update_on_start: "true"
 # Object backend
 osd_objectstore: filestore
 
+# xattrs. by default, 'filestore xattr use omap' is set to 'true' if
+# 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can
+# be set to 'true' or 'false' to explicitly override those
+# defaults. Leave it 'null' to use the default for your chosen mkfs
+# type.
+filestore_xattr_use_omap: null
+
 # Performance tuning
 filestore_merge_threshold: 40
 filestore_split_multiple: 8

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -114,6 +114,12 @@ filestore split multiple = {{ filestore_split_multiple }}
 osd op threads = {{ osd_op_threads }}
 filestore op threads = {{ filestore_op_threads }}
 filestore max sync interval = {{ filestore_max_sync_interval }}
+{% if filestore_xattr_use_omap != None %}
+filestore xattr use omap = {{ filestore_xattr_use_omap }}
+{% elif osd_mkfs_type == "ext4" %}
+filestore xattr use omap = true
+{# else, default is false #}
+{% endif %}
 osd max scrubs = {{ osd_max_scrubs }}
 {% if ceph_stable_release not in ['argonaut','bobtail','cuttlefish','dumpling','emperor','firefly','giant'] %}
 osd scrub begin hour = {{ osd_scrub_begin_hour }}


### PR DESCRIPTION
These three commits add a number of useful tunables for the ceph.conf template.