### PR TITLE
Improve firewall checks

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -34,6 +34,12 @@ dummy:
 #mds_group_name: mdss
 #restapi_group_name: restapis
 
+# If check_firewall is true, then ansible will try to determine if the
+# Ceph ports are blocked by a firewall. If the machine running ansible
+# cannot reach the Ceph ports for some other reason, you may need or
+# want to set this to False to skip those checks.
+#check_firewall: True
+
 # This variable determines if ceph packages can be updated.  If False, the
 # package resources will use "state=present".  If True, they will use
 # "state=latest".

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -31,6 +31,12 @@ rgw_group_name: rgws
 mds_group_name: mdss
 restapi_group_name: restapis
 
+# If check_firewall is true, then ansible will try to determine if the
+# Ceph ports are blocked by a firewall. If the machine running ansible
+# cannot reach the Ceph ports for some other reason, you may need or
+# want to set this to False to skip those checks.
+check_firewall: True
+
 # This variable determines if ceph packages can be updated.  If False, the
 # package resources will use "state=present".  If True, they will use
 # "state=latest".

--- a/roles/ceph-common/tasks/checks/check_firewall.yml
+++ b/roles/ceph-common/tasks/checks/check_firewall.yml
@@ -4,19 +4,23 @@
   changed_when: false
   failed_when: false
   register: nmapexist
+  when: check_firewall
 
 - name: inform that nmap is not present
   debug:
       msg: "nmap is not installed, can not test if ceph ports are allowed :("
-  when: nmapexist.rc != 0
+  when:
+    check_firewall and
+    nmapexist.rc != 0
 
 - name: check if monitor port is not filtered
-  local_action: shell nmap -p 6789 {{ item }} {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] }} | grep -sqo filtered
+  local_action: shell set -o pipefail && nmap -p 6789 {{ item }} {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
   with_items: groups.{{ mon_group_name }}
   register: monportstate
   when:
+    check_firewall and
     mon_group_name in group_names and
     nmapexist.rc == 0
 
@@ -25,18 +29,20 @@
       msg: "Please allow port 6789 on your firewall"
   with_items: monportstate.results
   when:
+    check_firewall and
     item.rc == 0 and
     mon_group_name is defined and
     mon_group_name in group_names and
     nmapexist.rc == 0
 
 - name: check if osd and mds range is not filtered
-  local_action: shell nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
+  local_action: shell set -o pipefail && nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
   with_items: groups.{{ osd_group_name }}
   register: osdrangestate
   when:
+    check_firewall and
     osd_group_name in group_names and
     nmapexist.rc == 0
 
@@ -45,18 +51,20 @@
       msg: "Please allow range from 6800 to 7300 on your firewall"
   with_items: osdrangestate.results
   when:
+    check_firewall and
     item.rc == 0 and
     osd_group_name is defined and
     osd_group_name in group_names and
     nmapexist.rc == 0
 
 - name: check if osd and mds range is not filtered
-  local_action: shell nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
+  local_action: shell set -o pipefail && nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
   with_items: groups.{{ mds_group_name }}
   register: mdsrangestate
   when:
+    check_firewall and
     mds_group_name in group_names and
     nmapexist.rc == 0
 
@@ -65,18 +73,20 @@
       msg: "Please allow range from 6800 to 7300 on your firewall"
   with_items: mdsrangestate.results
   when:
+    check_firewall and
     item.rc == 0 and
     mds_group_name is defined and
     mds_group_name in group_names and
     nmapexist.rc == 0
 
 - name: check if rados gateway port is not filtered
-  local_action: shell nmap -p {{ radosgw_civetweb_port }} {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
+  local_action: shell set -o pipefail && nmap -p {{ radosgw_civetweb_port }} {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
   with_items: groups.rgws
   register: rgwportstate
   when:
+    check_firewall and
     rgw_group_name in group_names and
     nmapexist.rc == 0
 
@@ -85,6 +95,7 @@
       msg: "Please allow port {{ radosgw_civetweb_port }} on your firewall"
   with_items: rgwportstate.results
   when:
+    check_firewall and
     item.rc == 0 and
     rgw_group_name is defined and
     rgw_group_name in group_names and


### PR DESCRIPTION
The firewall checks can fail for any number of reasons -- e.g., the
ceph cluster hostnames are unresolvable from the ansible host, or the
ports are filtered by some intermediate hop, etc. Make two changes to
make those checks better:

* Set pipefail when running the checks, so if nmap itself fails the
  command will be marked as 'failed'. Specifically, this fixes the
  case where the hostnames cannot be resolved.
* Add a new variable, check_firewall, which can be used to disable
  checks entirely. Specifically, this fixes the case where some
  intermediate firewall filters the ports, so nmap returns "filtered".