### PR TITLE
Do not prepare skipped disks

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -1,6 +1,18 @@
 ---
 # NOTE (leseb) : this task is for disk devices only because of the explicit use of the first
 # partition.
+
+- name: automatically activate osd disk(s) without partitions
+  command: ceph-disk activate "/dev/{{ item.key }}"
+  ignore_errors: true
+  with_dict: ansible_devices
+  when:
+    ansible_devices is defined and
+    item.value.removable == "0" and
+    item.value.partitions|count == 0 and
+    journal_collocation and
+    osd_auto_discovery
+
 - name: activate osd(s) when device is a disk
   command: ceph-disk activate {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
   with_together:
@@ -10,7 +22,8 @@
   failed_when: false
   when:
     not item.0.get("skipped") and
-    item.0.get("rc", 0) != 0
+    item.0.get("rc", 0) != 0 and
+    not osd_auto_discovery
 
 # NOTE (leseb): this task is for partitions because we don't explicitly use a partition.
 - name: activate osd(s) when device is a partition
@@ -22,7 +35,8 @@
   failed_when: false
   when:
     not item.0.get("skipped") and
-    item.0.get("rc", 0) == 0
+    item.0.get("rc", 0) != 0 and
+    not osd_auto_discovery
 
 - include: osd_fragment.yml
   when: crush_location

--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -8,7 +8,9 @@
     - devices
   changed_when: false
   failed_when: false
-  when: item.0.rc != 0
+  when:
+    not item.0.get("skipped") and
+    item.0.get("rc", 0) != 0
 
 # NOTE (leseb): this task is for partitions because we don't explicitly use a partition.
 - name: activate osd(s) when device is a partition
@@ -18,7 +20,9 @@
     - devices
   changed_when: false
   failed_when: false
-  when: item.0.rc == 0
+  when:
+    not item.0.get("skipped") and
+    item.0.get("rc", 0) == 0
 
 - include: osd_fragment.yml
   when: crush_location

--- a/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
+++ b/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
@@ -29,8 +29,10 @@
     - combined_ispartition_results.results
     - devices
   when:
-    item.0.rc != 0 and
-    item.1.rc != 0 and
+    not item.0.get("skipped") and
+    not item.1.get("skipped") and
+    item.0.get("rc", 0) != 0 and
+    item.1.get("rc", 0) != 0 and
     journal_collocation and not
     osd_auto_discovery
 

--- a/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
+++ b/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
@@ -19,8 +19,10 @@
   changed_when: false
   ignore_errors: true
   when:
-    item.0.rc != 0 and
-    item.1.rc != 0 and
+    not item.0.get("skipped") and
+    not item.1.get("skipped") and
+    item.0.get("rc", 0) != 0 and
+    item.1.get("rc", 0) != 0 and
     raw_multi_journal and
     not osd_auto_discovery
 


### PR DESCRIPTION
When autodiscovering disks, disks can be skipped if either they are
removable, or if they have partitions on them. Skipped actions have no
'rc' attribute, though, so the 'ceph prepare' conditional fails unless
we first check to ensure that the results were not skipped before
checking the return value.