### PR TITLE
Make /etc/ceph.conf 755 instead of 644

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -14,7 +14,7 @@ fetch_directory: fetch/
 # Permissions for /etc/ceph configuration directory
 conf_directory_owner: root
 conf_directory_group: root
-conf_directory_mode: 644
+conf_directory_mode: 755
 
 # Permissions for /etc/ceph/ceph.conf configuration file
 conf_file_owner: root


### PR DESCRIPTION
Otherwise, the 644 permissions on ceph.conf don't actually allow
non-root to read the file.

Signed-off-by: Zack Cerza <zack@redhat.com>