### PR TITLE
ceph-: abitlity to copy admin on all the nodes

### DIFF
--- a/group_vars/mdss.sample
+++ b/group_vars/mdss.sample
@@ -10,6 +10,11 @@ dummy:
 
 #fetch_directory: fetch/
 
+# Even though MDS nodes should not have the admin key
+# at their disposal, some people might want to have it
+# distributed on MDS nodes. Setting 'copy_admin_key' to 'true'
+# will copy the admin key to the /etc/ceph/ directory
+# copy_admin_key: false
 
 ##########
 # DOCKER #

--- a/group_vars/osds.sample
+++ b/group_vars/osds.sample
@@ -11,6 +11,12 @@ dummy:
 
 #fetch_directory: fetch/
 
+# Even though OSD nodes should not have the admin key
+# at their disposal, some people might want to have it
+# distributed on OSD nodes. Setting 'copy_admin_key' to 'true'
+# will copy the admin key to the /etc/ceph/ directory
+#copy_admin_key: false
+
 ####################
 # OSD CRUSH LOCATION
 ####################

--- a/group_vars/rgws.sample
+++ b/group_vars/rgws.sample
@@ -9,6 +9,12 @@ dummy:
 #
 #cephx: true
 
+# Even though RGW nodes should not have the admin key
+# at their disposal, some people might want to have it
+# distributed on RGW nodes. Setting 'copy_admin_key' to 'true'
+# will copy the admin key to the /etc/ceph/ directory
+# copy_admin_key: false
+
 # Used for the sudo exception while starting the radosgw process
 # a new entry /etc/sudoers.d/ceph will be created
 # allowing root to not require tty

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -7,6 +7,12 @@
 
 fetch_directory: fetch/
 
+# Even though MDS nodes should not have the admin key
+# at their disposal, some people might want to have it
+# distributed on MDS nodes. Setting 'copy_admin_key' to 'true'
+# will copy the admin key to the /etc/ceph/ directory
+copy_admin_key: false
+
 cephx: true
 
 

--- a/roles/ceph-mds/tasks/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/pre_requisite.yml
@@ -9,11 +9,17 @@
 
 - name: copy mds bootstrap key
   copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-mds/ceph.keyring"
-    dest: /var/lib/ceph/bootstrap-mds/ceph.keyring
+    src: "{{ fetch_directory }}/{{ fsid }}{{ item.name }}"
+    dest: "{{ item }}"
     owner: "{{ key_owner }}"
     group: "{{ key_group }}"
     mode: "{{ key_mode }}"
+  with_items:
+    - { name: /var/lib/ceph/bootstrap-mds/ceph.keyring, copy: true }
+    - { name: /etc/ceph/client.admin.keyring, "{{ copy_admin_key }}" }
+  when:
+    cephx and
+    item.copy is true
 
 - name: create mds directory
   file:

--- a/roles/ceph-mds/tasks/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/pre_requisite.yml
@@ -10,16 +10,16 @@
 - name: copy mds bootstrap key
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}{{ item.name }}"
-    dest: "{{ item }}"
+    dest: "{{ item.name }}"
     owner: "{{ key_owner }}"
     group: "{{ key_group }}"
     mode: "{{ key_mode }}"
   with_items:
-    - { name: /var/lib/ceph/bootstrap-mds/ceph.keyring, copy: true }
-    - { name: /etc/ceph/client.admin.keyring, "{{ copy_admin_key }}" }
+    - { name: /var/lib/ceph/bootstrap-mds/ceph.keyring, copy_key: true }
+    - { name: /etc/ceph/ceph.client.admin.keyring, copy_key: "{{ copy_admin_key }}" }
   when:
     cephx and
-    item.copy is true
+    item.copy_key|bool
 
 - name: create mds directory
   file:

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -8,6 +8,12 @@
 
 fetch_directory: fetch/
 
+# Even though OSD nodes should not have the admin key
+# at their disposal, some people might want to have it
+# distributed on OSD nodes. Setting 'copy_admin_key' to 'true'
+# will copy the admin key to the /etc/ceph/ directory
+copy_admin_key: false
+
 ####################
 # OSD CRUSH LOCATION
 ####################

--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -24,13 +24,13 @@
 - name: copy osd bootstrap key
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}{{ item.name }}"
-    dest: "{{ item }}"
+    dest: "{{ item.name }}"
     owner: "{{ key_owner }}"
     group: "{{ key_group }}"
     mode: "{{ key_mode }}"
   with_items:
-    - { name: /var/lib/ceph/bootstrap-osd/ceph.keyring, copy: true }
-    - { name: /etc/ceph/client.admin.keyring, "{{ copy_admin_key }}" }
+    - { name: /var/lib/ceph/bootstrap-osd/ceph.keyring, copy_key: true }
+    - { name: /etc/ceph/ceph.client.admin.keyring, copy_key: "{{ copy_admin_key }}" }
   when:
     cephx and
-    item.copy is true
+    item.copy_key|bool

--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -23,10 +23,14 @@
 
 - name: copy osd bootstrap key
   copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-osd/ceph.keyring"
-    dest: /var/lib/ceph/bootstrap-osd/ceph.keyring
+    src: "{{ fetch_directory }}/{{ fsid }}{{ item.name }}"
+    dest: "{{ item }}"
     owner: "{{ key_owner }}"
     group: "{{ key_group }}"
     mode: "{{ key_mode }}"
+  with_items:
+    - { name: /var/lib/ceph/bootstrap-osd/ceph.keyring, copy: true }
+    - { name: /etc/ceph/client.admin.keyring, "{{ copy_admin_key }}" }
   when:
-    cephx
+    cephx and
+    item.copy is true

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -7,6 +7,12 @@
 
 fetch_directory: fetch/
 
+# Even though RGW nodes should not have the admin key
+# at their disposal, some people might want to have it
+# distributed on RGW nodes. Setting 'copy_admin_key' to 'true'
+# will copy the admin key to the /etc/ceph/ directory
+copy_admin_key: false
+
 ## Ceph options
 #
 cephx: true

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -12,12 +12,17 @@
 
 - name: copy rados gateway bootstrap key
   copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-rgw/ceph.keyring"
-    dest: /var/lib/ceph/bootstrap-rgw/ceph.keyring
+    src: "{{ fetch_directory }}/{{ fsid }}{{ item.name }}"
+    dest: "{{ item }}"
     owner: "{{ key_owner }}"
     group: "{{ key_group }}"
     mode: "{{ key_mode }}"
-  when: cephx
+  with_items:
+    - { name: /var/lib/ceph/bootstrap-rgw/ceph.keyring, copy: true }
+    - { name: /etc/ceph/client.admin.keyring, "{{ copy_admin_key }}" }
+  when:
+    cephx and
+    item.copy is true
 
 - name: create rados gateway keyring
   command: ceph --cluster ceph --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/ceph.keyring auth get-or-create client.rgw.{{ ansible_hostname }} osd 'allow rwx' mon 'allow rw' -o /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/keyring

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -13,16 +13,16 @@
 - name: copy rados gateway bootstrap key
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}{{ item.name }}"
-    dest: "{{ item }}"
+    dest: "{{ item.name }}"
     owner: "{{ key_owner }}"
     group: "{{ key_group }}"
     mode: "{{ key_mode }}"
   with_items:
-    - { name: /var/lib/ceph/bootstrap-rgw/ceph.keyring, copy: true }
-    - { name: /etc/ceph/client.admin.keyring, "{{ copy_admin_key }}" }
+    - { name: /var/lib/ceph/bootstrap-rgw/ceph.keyring, copy_key: true }
+    - { name: /etc/ceph/ceph.client.admin.keyring, copy_key: "{{ copy_admin_key }}" }
   when:
     cephx and
-    item.copy is true
+    item.copy_key|bool
 
 - name: create rados gateway keyring
   command: ceph --cluster ceph --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/ceph.keyring auth get-or-create client.rgw.{{ ansible_hostname }} osd 'allow rwx' mon 'allow rw' -o /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/keyring


### PR DESCRIPTION
This commit allows you to set a new variable to 'true' if you want to
have ceph admin key copied over different kind of hosts such as MDS,
OSD, RGW. To enable this just set `copy_admin_key` to true.

Closes: #555

Signed-off-by: Sébastien Han <seb@redhat.com>