### PR TITLE
Skip keyring tasks when cephx is disabled

### DIFF
--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -4,6 +4,7 @@
     creates={{ fetch_directory }}/monitor_keyring.conf
   register: monitor_keyring
   become: false
+  when: cephx
 
 - name: read monitor initial keyring if it already exists
   local_action: command cat {{ fetch_directory }}/monitor_keyring.conf
@@ -11,11 +12,13 @@
   changed_when: false
   register: monitor_keyring
   become: false
+  when: cephx
 
 - name: create monitor initial keyring
   command: ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }} --create-keyring --name=mon. --add-key={{ monitor_secret }} --cap mon 'allow *'
   args:
     creates: /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
+  when: cephx
 
 - name: set initial monitor key permissions
   file:
@@ -23,6 +26,7 @@
     mode: "{{ key_mode }}"
     owner: "{{ key_owner }}"
     group: "{{ key_group }}"
+  when: cephx
 
 - name: create monitor directory
   file:
@@ -32,14 +36,34 @@
     group: "{{ dir_group }}"
     mode: "{{ dir_mode }}"
 
-- name: ceph monitor mkfs (for or after infernalis release)
+- name: ceph monitor mkfs with keyring (for or after infernalis release)
   command: ceph-mon --setuser ceph --setgroup ceph --mkfs -i {{ ansible_hostname }} --fsid {{ fsid }} --keyring /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
   args:
     creates: /var/lib/ceph/mon/ceph-{{ ansible_hostname }}/keyring
-  when: is_ceph_infernalis
+  when:
+    cephx and
+    is_ceph_infernalis
 
-- name: ceph monitor mkfs (before infernalis release)
+- name: ceph monitor mkfs without keyring (for or after infernalis release)
+  command: ceph-mon --setuser ceph --setgroup ceph --mkfs -i {{ ansible_hostname }} --fsid {{ fsid }}
+  args:
+    creates: /var/lib/ceph/mon/ceph-{{ ansible_hostname }}/store.db
+  when:
+    not cephx and
+    is_ceph_infernalis
+
+- name: ceph monitor mkfs with keyring (before infernalis release)
   command: ceph-mon --mkfs -i {{ ansible_hostname }} --fsid {{ fsid }} --keyring /var/lib/ceph/tmp/keyring.mon.{{ ansible_hostname }}
   args:
     creates: /var/lib/ceph/mon/ceph-{{ ansible_hostname }}/keyring
-  when: not is_ceph_infernalis
+  when:
+    cephx and
+    not is_ceph_infernalis
+
+- name: ceph monitor mkfs without keyring (before infernalis release)
+  command: ceph-mon --mkfs -i {{ ansible_hostname }} --fsid {{ fsid }}
+  args:
+    creates: /var/lib/ceph/mon/ceph-{{ ansible_hostname }}/store.db
+  when:
+    not cephx and
+    not is_ceph_infernalis

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -54,6 +54,7 @@
   command: ceph-create-keys --id {{ ansible_hostname }}
   changed_when: false
   failed_when:  false
+  when: cephx
 
 - name: get ceph monitor version
   shell: ceph daemon mon."{{ ansible_hostname }}" version | cut -d '"' -f 4 | cut -f 1,2 -d '.'


### PR DESCRIPTION
Skip a number of ceph keyring-related tasks (or remove the keyring
portion of some tasks) when cephx is disabled. Specifically, avoid
generating the initial keyring, which only clutters up the ansible
repo if cephx is not in use.