### PR TITLE
Add option to skip generating fsid

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -144,7 +144,15 @@ dummy:
 
 ## Ceph options
 #
+# Each cluster requires a unique, consistent filesystem ID. By
+# default, the playbook generates one for you and stores it in a file
+# in `fetch_directory`. If you want to customize how the fsid is
+# generated, you may find it useful to disable fsid generation to
+# avoid cluttering up your ansible repo. If you set `generate_fsid` to
+# false, you *must* generate `fsid` in another way.
 #fsid: "{{ cluster_uuid.stdout }}"
+#generate_fsid: true
+
 #cephx: true
 #cephx_require_signatures: true # Kernel RBD does NOT support signatures!
 #cephx_cluster_require_signatures: true

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -146,7 +146,15 @@ ceph_dev_redhat_distro: centos7
 
 ## Ceph options
 #
+# Each cluster requires a unique, consistent filesystem ID. By
+# default, the playbook generates one for you and stores it in a file
+# in `fetch_directory`. If you want to customize how the fsid is
+# generated, you may find it useful to disable fsid generation to
+# avoid cluttering up your ansible repo. If you set `generate_fsid` to
+# false, you *must* generate `fsid` in another way.
 fsid: "{{ cluster_uuid.stdout }}"
+generate_fsid: true
+
 cephx: true
 cephx_require_signatures: true # Kernel RBD does NOT support signatures for Kernels < 3.18!
 cephx_cluster_require_signatures: true

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -124,12 +124,16 @@
   changed_when: false
   become: false
   run_once: true
+  when:
+    cephx or
+    generate_fsid
 
 - name: generate cluster uuid
   local_action: shell python -c 'import uuid; print str(uuid.uuid4())' | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
     creates="{{ fetch_directory }}/ceph_cluster_uuid.conf"
   register: cluster_uuid
   become: false
+  when: generate_fsid
 
 - name: read cluster uuid if it already exists
   local_action: command cat {{ fetch_directory }}/ceph_cluster_uuid.conf
@@ -137,6 +141,7 @@
   changed_when: false
   register: cluster_uuid
   become: false
+  when: generate_fsid
 
 - name: create ceph conf directory
   file:


### PR DESCRIPTION
If using another method to generate a consistent fsid, then we can
skip creation of an (unused) cluster UUID file. If cephx is disabled
as well, we can skip creation of the fetch directory entirely.

Skipping fetch directory creation when cephx is disabled requires #568 to be merged as well.