### PR TITLE
Use saner defaults for config dir/files mode

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -17,12 +17,12 @@ dummy:
 # Permissions for /etc/ceph configuration directory
 #conf_directory_owner: root
 #conf_directory_group: root
-#conf_directory_mode: 644
+#conf_directory_mode: 0755
 
 # Permissions for /etc/ceph/ceph.conf configuration file
 #conf_file_owner: root
 #conf_file_group: root
-#conf_file_mode: 644
+#conf_file_mode: 0644
 
 #########
 # INSTALL

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -14,12 +14,12 @@ fetch_directory: fetch/
 # Permissions for /etc/ceph configuration directory
 conf_directory_owner: root
 conf_directory_group: root
-conf_directory_mode: 644
+conf_directory_mode: 0755
 
 # Permissions for /etc/ceph/ceph.conf configuration file
 conf_file_owner: root
 conf_file_group: root
-conf_file_mode: 644
+conf_file_mode: 0644
 
 ###########
 # INSTALL #


### PR DESCRIPTION
The mode argument requires octal (prefixed with 0) values to properly
work.