### PR TITLE
Fix openstack config skipping

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -15,9 +15,7 @@
     groups[restapi_group_name] is defined
 
 - include: openstack_config.yml
-  when:
-    openstack_config and
-    cephx
+  when: openstack_config
 
 - name: find ceph keys
   shell: ls -1 /etc/ceph/*.keyring

--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -15,3 +15,4 @@
     creates: /etc/ceph/ceph.{{ item.name }}.keyring
   with_items: openstack_keys
   changed_when: false
+  when: cephx


### PR DESCRIPTION
Previously, creating pools was skipped if cephx was disabled; instead,
we should only skip key creation if cephx is disabled, and create
pools any time openstack_config is true.