### PR TITLE
help RGW install from RHCS .iso

### DIFF
--- a/roles/ceph-common/templates/redhat_storage_repo.j2
+++ b/roles/ceph-common/templates/redhat_storage_repo.j2
@@ -17,6 +17,15 @@ type=rpm-md
 priority=1
 gpgkey=file://{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release
 
+[rh_storage_tools]
+name=Red Hat Storage Ceph - assorted tools
+baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/Tools
+enabled=1
+gpgcheck=1
+type=rpm-md
+priority=1
+gpgkey=file://{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release
+
 [rh_storage_calamari]
 name=Red Hat Storage Ceph - local packages for Ceph
 baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/Calamari


### PR DESCRIPTION
While doing RGW install using ceph-ansible with RHCS .iso image, I saw that ceph-radosgw RPM install step was failing, it is packaged in this Tools subdirectory of the .iso image.   This change adds the Tools subdirectory into /etc/yum.repos.d/ceph.repo.