### PR TITLE
extend to handle rgws, read in ceph-common defaults

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -7,7 +7,12 @@
     - mons
     - osds
     - mdss
+    - rgws
+
   become: yes
+
+  roles:
+    - ceph-common
 
   vars:
 # When set to true both groups of packages are purged.
@@ -21,6 +26,7 @@
       - ceph-fuse
       - ceph-mds
       - ceph-release
+      - ceph-radosgw
 
     ceph_remaining_packages:
       - libcephfs1


### PR DESCRIPTION
purge-cluster.yml blows up for me on expression "osd_group_name in group_names".  This seems to be because it isn't reading roles/ceph-common/defaults/main.yml which defines osd_group_name.  By explicitly calling out ceph-common role I was able to work around this, but how does site.yml work then?

Also, it ignores rgws role so I tried to add that in, it gets farther but does not yet remove RPMs from rgws hosts, probably doesn't shut down services.

If you need one of these two fixes but not the other, let me know and I'll push separate PR.