### PR TITLE
ceph-common: use saner defaults for ceph dir

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -10,20 +10,6 @@ dummy:
 
 #fetch_directory: fetch/
 
-###############
-# PERMISSIONS #
-###############
-
-# Permissions for /etc/ceph configuration directory
-#conf_directory_owner: root
-#conf_directory_group: root
-#conf_directory_mode: 644
-
-# Permissions for /etc/ceph/ceph.conf configuration file
-#conf_file_owner: root
-#conf_file_group: root
-#conf_file_mode: 644
-
 #########
 # INSTALL
 #########

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -7,20 +7,6 @@
 
 fetch_directory: fetch/
 
-###############
-# PERMISSIONS #
-###############
-
-# Permissions for /etc/ceph configuration directory
-conf_directory_owner: root
-conf_directory_group: root
-conf_directory_mode: 644
-
-# Permissions for /etc/ceph/ceph.conf configuration file
-conf_file_owner: root
-conf_file_group: root
-conf_file_mode: 644
-
 ###########
 # INSTALL #
 ###########

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -142,18 +142,18 @@
   file:
     path: /etc/ceph
     state: directory
-    owner: "{{ conf_directory_owner }}"
-    group: "{{ conf_directory_group }}"
-    mode: "{{ conf_directory_mode }}"
+    owner: "{{ dir_owner }}"
+    group: "{{ dir_group }}"
+    mode: "{{ dir_mode }}"
 
 - name: generate ceph configuration file
   action: config_template
   args:
     src: ceph.conf.j2
     dest: /etc/ceph/ceph.conf
-    owner: "{{ conf_file_owner }}"
-    group: "{{ conf_file_group }}"
-    mode: "{{ conf_file_mode }}"
+    owner: "{{ dir_owner }}"
+    group: "{{ dir_group }}"
+    mode: "{{ activate_file_mode }}"
     config_overrides: "{{ ceph_conf_overrides }}"
     config_type: ini
   notify:


### PR DESCRIPTION
re-use the logic introduced in #512 for the ceph directory and the
`ceph.conf` file.

Signed-off-by: Sébastien Han <seb@redhat.com>