### PR TITLE
Fix pre-infernalis RBD client directory mode

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -98,7 +98,7 @@
 - set_fact:
     rbd_client_dir_owner: root
     rbd_client_dir_group: root
-    rbd_client_dir_mode: "0644"
+    rbd_client_dir_mode: "1777"
   when: not is_ceph_infernalis
 
 - set_fact:


### PR DESCRIPTION
0644 should never be a directory mode. 1777 makes it so that any user
can create a ceph client, not just root. (This is helpful if, for
instance, nova-compute is running as non-root.)

I'm not entirely sure this is the right fix, but it works for me, and 0644 is plainly wrong.