### PR TITLE
Optionally install ceph-test

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -43,6 +43,9 @@ redhat_package_dependencies:
   - ntp
   - python-setuptools
 
+# Whether or not to install the ceph-test package.
+ceph_test: False
+
 ## Configure package origin
 #
 ceph_origin: 'upstream' # or 'distro'

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -24,6 +24,13 @@
     - ceph-mds       #|--> they don't get update so we need to force them
     - libcephfs1     #|
 
+- name: install ceph-test
+  apt:
+    pkg: ceph-test
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+    default_release: "{{ ansible_distribution_release }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
+  when: ceph_test
+
 - name: install rados gateway
   apt:
     pkg: radosgw

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -71,6 +71,22 @@
     osd_group_name in group_names and
     ansible_pkg_mgr == "dnf"
 
+- name: install ceph-test
+  yum:
+    name: ceph-test
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    ceph_test and
+    ansible_pkg_mgr == "yum"
+
+- name: install ceph-test
+  dnf:
+    name: ceph-test
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    ceph_test and
+    ansible_pkg_mgr == "dnf"
+
 - name: install Inktank Ceph Enterprise RBD Kernel modules
   yum:
     name: "{{ item }}"


### PR DESCRIPTION
We want this to enable testing with existing teuthology jobs.

https://github.com/ceph/teuthology

Signed-off-by: Zack Cerza <zack@redhat.com>