### PR TITLE
ceph-fetch-keys: add dependencies flag to galaxy

### DIFF
--- a/roles/ceph-fetch-keys/meta/main.yml
+++ b/roles/ceph-fetch-keys/meta/main.yml
@@ -13,3 +13,4 @@ galaxy_info:
         - 7
   categories:
     - system
+dependencies: []


### PR DESCRIPTION
Signed-off-by: Sébastien Han <seb@redhat.com>