### PR TITLE
ceph-rgw: install libnss3-tools for keystone

### DIFF
--- a/roles/ceph-rgw/tasks/openstack-keystone.yml
+++ b/roles/ceph-rgw/tasks/openstack-keystone.yml
@@ -1,4 +1,22 @@
 ---
+- name: install libnss3-tools on redhat
+  yum:
+    name: libnss3-tools
+    state: present
+  when: ansible_pkg_mgr == "yum"
+
+- name: install libnss3-tools on redhat
+  dnf:
+    name: libnss3-tools
+    state: present
+  when: ansible_pkg_mgr == "dnf"
+
+- name: install libnss3-tools on debian
+  apt:
+    name: libnss3-tools
+    state: present
+  when: ansible_pkg_mgr == 'apt'
+
 - name: create nss directory for keystone certificates
   file:
     path: "{{ radosgw_nss_db_path }}"


### PR DESCRIPTION
closes: #598

Signed-off-by: Sébastien Han <seb@redhat.com>