### PR TITLE
fix purge-request.yml so non-OSD hosts will not fail

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -43,7 +43,7 @@
 
   tasks:
   - name: get osd numbers
-    shell: ls /var/lib/ceph/osd | cut -d "-" -f 2
+    shell: "if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | cut -d '-' -f 2 ; fi"
     register: osd_ids
     changed_when: false
 

--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -46,8 +46,6 @@
     shell: ls /var/lib/ceph/osd | cut -d "-" -f 2
     register: osd_ids
     changed_when: false
-    when:
-     osd_group_name in group_names
 
 # Infernalis
   - name: stop ceph.target with systemd


### PR DESCRIPTION
The problem with only doing "get osd numbers" task for OSD hosts is that subsequent tasks iterating on the "osd_ids" register variable will fail for non-OSD hosts, such as task "stop ceph-osd with systemd".  You would think that the when clause would be sufficient to prevent this problem, but it does not.  By defining "osd_ids" for all hosts (empty for non-OSD hosts), we avoid this problem.

The "ls" command will fail for non-OSD hosts (or for OSD hosts that have already been purged), but it's ok, return status from entire command is zero.