### PR TITLE
fixes for installing / configuring red hat ceph storage

### DIFF
--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -26,7 +26,8 @@
   when:
     ceph_stable_rh_storage and
     not ceph_stable_rh_storage_cdn_install and
-    not ceph_stable_rh_storage_iso_install
+    not ceph_stable_rh_storage_iso_install and
+    ceph_origin == "upstream"
   tags:
     - package-install
 

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -147,10 +147,3 @@
    - rbd_client_log_path
    - rbd_client_admin_socket_path
   when: rbd_client_directories
-
-- name: get ceph rhcs version
-  shell: rpm -q --qf "%{version}\n" ceph-common | cut -f1,2 -d '.'
-  changed_when: false
-  failed_when: false
-  register: rh_storage_version
-  when: ceph_stable_rh_storage

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -53,6 +53,13 @@
   tags:
     - package-install
 
+- name: get ceph rhcs version
+  shell: rpm -q --qf "%{version}\n" ceph-common | cut -f1,2 -d '.'
+  changed_when: false
+  failed_when: false
+  register: rh_storage_version
+  when: ceph_stable_rh_storage
+
 # NOTE (leseb): be careful with the following
 # somehow the YAML syntax using "is_ceph_infernalis: {{"
 # does NOT work, so we keep this syntax styling...


### PR DESCRIPTION
Make the checks pass when you want to do a 'distro' install of RHCS.

Move ``get_rc_ceph_version`` into ``ceph-common/tasks/main.yml`` so it won't be skipped if you're wanting to configure a RHCS node without installing packages. Meaning you've passed ``--skip-tags package-install`` to your ansible-playbook command.