### PR TITLE
Use ceph.target if available

### DIFF
--- a/roles/ceph-osd/tasks/scenarios/osd_directory.yml
+++ b/roles/ceph-osd/tasks/scenarios/osd_directory.yml
@@ -31,3 +31,11 @@
     name: ceph
     state: started
     enabled: yes
+  when: ansible_service_mgr != "systemd"
+
+- name: start and add the OSD target to the systemd sequence
+  service:
+    name: ceph.target
+    state: started
+    enabled: yes
+  when: ansible_service_mgr == "systemd"


### PR DESCRIPTION
On systems with systemd enabled, "systemctl start ceph" does not work. It instead needs to be "systemctl start ceph.target". This takes that into account.