### PR TITLE
support for the jewel version of red hat ceph storage on ubuntu

### DIFF
--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
@@ -9,21 +9,15 @@
 
 - name: install red hat storage ceph mon
   apt:
-    name: "{{ item }}"
+    name: ceph-mon
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  with_items:
-    - ceph
-    - ceph-mon
   when:
     mon_group_name in group_names
 
 - name: install red hat storage ceph osd
   apt:
-    name: "{{ item }}"
+    name: ceph-osd
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  with_items:
-    - ceph
-    - ceph-osd
   when:
     osd_group_name in group_names
 

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
@@ -1,4 +1,9 @@
 ---
+- name: add the red hat storage apt-key
+  apt_key:
+    url: "https://www.redhat.com/security/fd431d51.txt"
+    state: present
+
 - name: install dependencies
   apt:
     pkg: "{{ item }}"

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
@@ -1,0 +1,35 @@
+---
+- name: install dependencies
+  apt:
+    pkg: "{{ item }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+  with_items: debian_package_dependencies
+
+- name: install red hat storage ceph mon
+  apt:
+    name: "{{ item }}"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  with_items:
+    - ceph
+    - ceph-mon
+  when:
+    mon_group_name in group_names
+
+- name: install red hat storage ceph osd
+  apt:
+    name: "{{ item }}"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  with_items:
+    - ceph
+    - ceph-osd
+  when:
+    osd_group_name in group_names
+
+- name: install ceph-test
+  apt:
+    name: ceph-test
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    ceph_test

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -35,7 +35,16 @@
     - package-install
 
 - include: ./installs/install_on_debian.yml
-  when: ansible_os_family == 'Debian'
+  when:
+    ansible_os_family == 'Debian' and
+    not ceph_stable_rh_storage
+  tags:
+    - package-install
+
+- include: ./installs/install_rh_storage_on_debian.yml
+  when:
+    ansible_os_family == 'Debian' and
+    ceph_stable_rh_storage
   tags:
     - package-install
 
@@ -67,6 +76,12 @@
 # does NOT work, so we keep this syntax styling...
 - set_fact:
     is_ceph_infernalis={{ (ceph_stable and ceph_stable_release not in ceph_stable_releases) or (ceph_dev) or (ceph_stable_rh_storage and (rh_storage_version.stdout | version_compare('0.94', '>'))) }}
+
+- set_fact:
+    is_ceph_infernalis=True
+  when:
+    ansible_os_family == 'Debian' and
+    ceph_stable_rh_storage
 
 - set_fact:
     dir_owner: ceph

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -16,14 +16,16 @@
 - include: ./pre_requisites/prerequisite_rh_storage_iso_install.yml
   when:
     ceph_stable_rh_storage and
-    ceph_stable_rh_storage_iso_install
+    ceph_stable_rh_storage_iso_install and
+    ansible_os_family == "RedHat"
   tags:
     - package-install
 
 - include: ./pre_requisites/prerequisite_rh_storage_cdn_install.yml
   when:
     ceph_stable_rh_storage and
-    ceph_stable_rh_storage_cdn_install
+    ceph_stable_rh_storage_cdn_install and
+    ansible_os_family == "RedHat"
   tags:
     - package-install
 


### PR DESCRIPTION
The packages aren't released yet, but this enables us to install them on Ubuntu when they are released.