### PR TITLE
ceph-rgw: remove leftover for service activation

### DIFF
--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -39,21 +39,6 @@
     group: "{{ key_group }}"
   when: cephx
 
-- name: activate rados gateway with upstart (for or after infernalis release)
-  file:
-    path: /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/{{ item }}
-    state: touch
-    owner: ceph
-    group: ceph
-    mode: 0644
-  with_items:
-    - done
-    - upstart
-  changed_when: false
-  when:
-    ansible_distribution == "Ubuntu" and
-    is_ceph_infernalis
-
 - name: activate rados gateway with upstart
   file:
     path: /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}/{{ item }}


### PR DESCRIPTION
this is handled by the task after.

Signed-off-by: Sébastien Han <seb@redhat.com>