### PR TITLE
Allow to install the calamari-server on monitors

### DIFF
--- a/group_vars/mons.sample
+++ b/group_vars/mons.sample
@@ -40,6 +40,8 @@ dummy:
 #  - nodelete
 #  - nosizechange
 
+# Enable the Calamari-backed REST API on a Monitor
+#calamari: false
 
 #############
 # OPENSTACK #

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -32,6 +32,8 @@ secure_cluster_flags:
   - nodelete
   - nosizechange
 
+# Enable the Calamari-backed REST API on a Monitor
+calamari: false
 
 #############
 # OPENSTACK #

--- a/roles/ceph-mon/tasks/calamari.yml
+++ b/roles/ceph-mon/tasks/calamari.yml
@@ -1,0 +1,19 @@
+---
+- name: install calamari server
+  apt:
+    pkg: calamari-server
+    state: present
+  when: ansible_os_family == 'Debian'
+  tags:
+    - package-install
+
+- name: install calamari server
+  yum:
+    pkg: calamari-server
+    state: present
+  when: ansible_os_family == 'RedHat'
+  tags:
+    - package-install
+
+- name: initialize the calamari server api
+  command: calamari-ctl initialize

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -20,3 +20,6 @@
 
 - include: ./docker/main.yml
   when: mon_containerized_deployment
+
+- include: calamari.yml
+  when: calamari


### PR DESCRIPTION
This enables monitors to have the "rest api" provided by `calamari-server`. It lives in the `ceph-mon` role because it requires to live where the monitors are.

Reference BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1305259