### PR TITLE
ceph-osd: Set selinux to permissive

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -41,6 +41,16 @@
 - include: osd_fragment.yml
   when: crush_location
 
+- name: set selinux to permissive and make it persistent
+  selinux:
+    policy: targeted
+    state: permissive
+  when:
+    ansible_selinux != false and
+    ansible_selinux['status'] == 'enabled' and
+    ansible_selinux['config_mode'] != 'disabled' and
+    not is_ceph_infernalis
+
 - name: start and add that the osd service(s) to the init sequence (before infernalis)
   service:
     name: ceph


### PR DESCRIPTION
Currently we don't yet support runnings OSDs w/ selinux in
enforcing mode. Thus its better to ensure that ceph-ansible
explicitly makes selinux permissive. This should help in
scenarios such as hyperconverged where OSDs are colocated
with VMs on compute nodes which needs selinux enforcing, but
OSDs don't.

Signed-off-by: Deepak C Shetty <deepakcs@redhat.com>