### PR TITLE
add libselinux-python as dependency pkg for centos

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -50,6 +50,7 @@ dummy:
 #  - epel-release
 #  - ntp
 #  - python-setuptools
+#  - libselinux-python
 
 #redhat_package_dependencies:
 #  - python-pycurl

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -42,6 +42,7 @@ centos_package_dependencies:
   - epel-release
   - ntp
   - python-setuptools
+  - libselinux-python
 
 redhat_package_dependencies:
   - python-pycurl


### PR DESCRIPTION
closes: #631

Signed-off-by: Sébastien Han <seb@redhat.com>