### PR TITLE
Address issue #632 with systemd unit rename

### DIFF
--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -35,7 +35,7 @@
 
 - name: start rgw on red hat (after infernalis)
   service:
-    name: ceph-radosgw@{{ ansible_hostname }}
+    name: ceph-radosgw@rgw.{{ ansible_hostname }}
     state: started
     enabled: yes
   when:


### PR DESCRIPTION
* the client-name is actually `rgw.{{ ansible_hostname }}` instead
  of just `{{ ansible_hostname }}`
* it matches the directory created under `/var/lib/ceph/radosgw`
* and, it matches the client-name used to create the keyring in
  `pre_requisite.yml`