### PR TITLE
Create the directory used for rbd-clients sockets

### DIFF
--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -9,6 +9,7 @@
   with_items:
     - /var/lib/ceph/bootstrap-rgw
     - /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}
+    - "{{ rbd_client_admin_socket_path }}"
 
 - name: copy rados gateway bootstrap key
   copy:


### PR DESCRIPTION
* `/var/run/ceph/rbd-clients` is not created automatically
* because it is missing, ceph-rgw complains about missing client
  socket on start up; it is because the containing directory is
  not there
* so we just add it to the list of directory pre-requisite