### PR TITLE
ceph-osd: fix activate for osd on partitions

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -35,7 +35,7 @@
   failed_when: false
   when:
     not item.0.get("skipped") and
-    item.0.get("rc", 0) != 0 and
+    item.0.get("rc", 0) == 0 and
     not osd_auto_discovery
 
 - include: osd_fragment.yml


### PR DESCRIPTION
Since we want to activate the OSD when it's a partition we are looking
for a return code that is equal to 0 which means the device is a
  partition.

Thanks @dvusboy
closes: #636

Signed-off-by: Sébastien Han <seb@redhat.com>