### PR TITLE
Ensure purge-cluster doesn't call install tasks

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -12,7 +12,7 @@
   become: yes
 
   roles:
-    - ceph-common
+    - { role: ceph-common, purge_cluster: true }
 
   vars:
 # When set to true both groups of packages are purged.

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -7,6 +7,12 @@
 
 fetch_directory: fetch/
 
+#############
+# UNINSTALL #
+#############
+
+purge_cluster: false
+
 ###########
 # INSTALL #
 ###########

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -9,7 +9,9 @@
   when: osd_group_name in group_names
 
 - include: ./pre_requisites/prerequisite_ice.yml
-  when: ceph_stable_ice
+  when:
+    ceph_stable_ice and
+    not purge_cluster
   tags:
     - package-install
 
@@ -17,7 +19,8 @@
   when:
     ceph_stable_rh_storage and
     ceph_stable_rh_storage_iso_install and
-    ansible_os_family == "RedHat"
+    ansible_os_family == "RedHat" and
+    not purge_cluster
   tags:
     - package-install
 
@@ -25,26 +28,31 @@
   when:
     ceph_stable_rh_storage and
     ceph_stable_rh_storage_cdn_install and
-    ansible_os_family == "RedHat"
+    ansible_os_family == "RedHat" and
+    not purge_cluster
   tags:
     - package-install
 
 - include: ./installs/install_on_redhat.yml
-  when: ansible_os_family == 'RedHat'
+  when:
+    ansible_os_family == 'RedHat' and
+    not purge_cluster
   tags:
     - package-install
 
 - include: ./installs/install_on_debian.yml
   when:
     ansible_os_family == 'Debian' and
-    not ceph_stable_rh_storage
+    not ceph_stable_rh_storage and
+    not purge_cluster
   tags:
     - package-install
 
 - include: ./installs/install_rh_storage_on_debian.yml
   when:
     ansible_os_family == 'Debian' and
-    ceph_stable_rh_storage
+    ceph_stable_rh_storage and
+    not purge_cluster
   tags:
     - package-install
 
@@ -52,7 +60,8 @@
   when:
     ansible_os_family == 'RedHat' and
     radosgw_frontend == 'apache' and
-    rgw_group_name in group_names
+    rgw_group_name in group_names and
+    not purge_cluster
   tags:
     - package-install
 
@@ -60,7 +69,8 @@
   when:
     ansible_os_family == 'Debian' and
     radosgw_frontend == 'apache' and
-    rgw_group_name in group_names
+    rgw_group_name in group_names and
+    not purge_cluster
   tags:
     - package-install
 


### PR DESCRIPTION
Currently calling purge-cluster calls ceph-common role
which ends up installing common ceph deps. This isn't
correct as we are in the process of purging the cluster.

Add a new purge_cluster var and ensure all the tasks tagged
with package-install are skipped if purge_cluster is true.
Default value of purge_cluster is false.

A better way to fix this would be to use --skip-tags, but
unfortunately there is no way to embed skip-tags inside a
playbook, thus falling back to this method.

Signed-off-by: Deepak C Shetty <deepakcs@redhat.com>