### PR TITLE
Provide the ability to provide monitor_address instead of an interface

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -191,6 +191,8 @@ dummy:
 
 ## Monitor options
 #
+# You must define either monitor_interface or monitor_address. Preference
+# will go to monitor_interface if both are defined.
 #monitor_interface: interface
 #monitor_address: 0.0.0.0
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf

--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -192,6 +192,7 @@ dummy:
 ## Monitor options
 #
 #monitor_interface: interface
+#monitor_address: 0.0.0.0
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 #mon_osd_down_out_interval: 600
 #mon_osd_min_down_reporters: 7 # number of OSDs per host + 1
@@ -286,6 +287,7 @@ dummy:
 ## REST API options
 #
 #restapi_interface: "{{ monitor_interface }}"
+#restapi_address: "{{ monitor_address }}"
 #restapi_port: 5000
 #restapi_base_url: /api/v0.1
 #restapi_log_level: warning # available level are: critical, error, warning, info, debug

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -183,6 +183,8 @@ rbd_default_format: 2
 
 ## Monitor options
 #
+# You must define either monitor_interface or monitor_address. Preference
+# will go to monitor_interface if both are defined.
 monitor_interface: interface
 monitor_address: 0.0.0.0
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -184,6 +184,7 @@ rbd_default_format: 2
 ## Monitor options
 #
 monitor_interface: interface
+monitor_address: 0.0.0.0
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 mon_osd_down_out_interval: 600
 mon_osd_min_down_reporters: 7 # number of OSDs per host + 1
@@ -278,6 +279,7 @@ email_address: foo@bar.com
 ## REST API options
 #
 restapi_interface: "{{ monitor_interface }}"
+restapi_address: "{{ monitor_address }}"
 restapi_port: 5000
 restapi_base_url: /api/v0.1
 restapi_log_level: warning # available level are: critical, error, warning, info, debug

--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -38,11 +38,12 @@
     journal_size|int == 0 and
     osd_group_name in group_names
 
-- name: make sure monitor_interface configured
+- name: make sure monitor_interface or monitor_address is configured
   fail:
-    msg: "monitor_interface must be configured. Interface for the monitor to listen on"
+    msg: "monitor_interface or monitor_address must be configured. Interface for the monitor to listen on or IP address of that interface"
   when:
     monitor_interface == 'interface' and
+    monitor_address == '0.0.0.0' and
     mon_group_name in group_names
 
 - name: make sure cluster_network configured

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -92,11 +92,14 @@ debug auth = {{ debug_mon_level }}
 {% if hostvars[host]['ansible_fqdn'] is defined and mon_use_fqdn %}
 [mon.{{ hostvars[host]['ansible_fqdn'] }}]
 host = {{ hostvars[host]['ansible_fqdn'] }}
-mon addr = {{ hostvars[host]['ansible_' + (hostvars[host]['monitor_interface'] if hostvars[host]['monitor_interface'] is defined else monitor_interface) ]['ipv4']['address'] }}
 {% elif hostvars[host]['ansible_hostname'] is defined %}
 [mon.{{ hostvars[host]['ansible_hostname'] }}]
 host = {{ hostvars[host]['ansible_hostname'] }}
-mon addr = {{ hostvars[host]['ansible_' + (hostvars[host]['monitor_interface'] if hostvars[host]['monitor_interface'] is defined else monitor_interface) ]['ipv4']['address'] }}
+{% endif %}
+{% if monitor_interface != "interface" %}
+{% include 'mon_addr_interface.j2' %}
+{% else %}
+{% include 'mon_addr_address.j2' %}
 {% endif %}
 {% endfor %}
 
@@ -198,7 +201,11 @@ nss db path = {{ radosgw_nss_db_path }}
 
 {% if groups[restapi_group_name] is defined %}
 [client.restapi]
-public addr = {{ hostvars[inventory_hostname]['ansible_' + restapi_interface]['ipv4']['address'] }}:{{ restapi_port }}
+{% if restapi_interface != "interface" %}
+{% include 'client_restapi_interface.j2' %}
+{% else %}
+{% include 'client_restapi_address.j2' %}
+{% endif %}
 restapi base url = {{ restapi_base_url }}
 restapi log level = {{ restapi_log_level }}
 keyring = /var/lib/ceph/restapi/ceph-restapi/keyring

--- a/roles/ceph-common/templates/client_restapi_address.j2
+++ b/roles/ceph-common/templates/client_restapi_address.j2
@@ -1,0 +1,2 @@
+public addr = {{ hostvars[inventory_hostname]['restapi_address'] if hostvars[inventory_hostname]['restapi_address'] is defined else restapi_address }}:{{ restapi_port }}
+

--- a/roles/ceph-common/templates/client_restapi_interface.j2
+++ b/roles/ceph-common/templates/client_restapi_interface.j2
@@ -1,0 +1,2 @@
+public addr = {{ hostvars[inventory_hostname]['ansible_' + restapi_interface]['ipv4']['address'] }}:{{ restapi_port }}
+

--- a/roles/ceph-common/templates/mon_addr_address.j2
+++ b/roles/ceph-common/templates/mon_addr_address.j2
@@ -1,0 +1,2 @@
+mon addr = {{ hostvars[host]['monitor_address'] if hostvars[host]['monitor_address'] is defined else monitor_address }}
+

--- a/roles/ceph-common/templates/mon_addr_interface.j2
+++ b/roles/ceph-common/templates/mon_addr_interface.j2
@@ -1,0 +1,2 @@
+mon addr = {{ hostvars[host]['ansible_' + (hostvars[host]['monitor_interface'] if hostvars[host]['monitor_interface'] is defined else monitor_interface) ]['ipv4']['address'] }}
+


### PR DESCRIPTION
This would allow users who don't know what interface to provide to
give an IP address to use for the monitor instead.

Note: the includes are needed in ceph.conf.j2 because without them
jinja2 can not properly evaluate the template and will complain about a
missing 'ansible_interface' variable. The includes allow the template to
be evaluated correctly and then the correct include will be used during
render time.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>