### PR TITLE
Make RBD client directory owner/group configurable

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -181,7 +181,9 @@ dummy:
 #rbd_cache: "true"
 #rbd_cache_writethrough_until_flush: "true"
 #rbd_concurrent_management_ops: 20
-#rbd_client_directories: false # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions, this WON'T work if libvirt and kvm are installed
+#rbd_client_directories: false # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions
+#rbd_client_directory_user: qemu
+#rbd_client_directory_group: libvirtd
 #rbd_client_log_file: /var/log/rbd-clients/qemu-guest-$pid.log # must be writable by QEMU and allowed by SELinux or AppArmor
 #rbd_client_log_path: /var/log/rbd-clients/
 #rbd_client_admin_socket_path: /var/run/ceph/rbd-clients # must be writable by QEMU and allowed by SELinux or AppArmor

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -173,7 +173,9 @@ debug_mds_level: 20
 rbd_cache: "true"
 rbd_cache_writethrough_until_flush: "true"
 rbd_concurrent_management_ops: 20
-rbd_client_directories: false # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions, this WON'T work if libvirt and kvm are installed
+rbd_client_directories: false # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions
+rbd_client_directory_user: qemu
+rbd_client_directory_group: libvirtd
 rbd_client_log_file: /var/log/rbd-clients/qemu-guest-$pid.log # must be writable by QEMU and allowed by SELinux or AppArmor
 rbd_client_log_path: /var/log/rbd-clients/
 rbd_client_admin_socket_path: /var/run/ceph/rbd-clients # must be writable by QEMU and allowed by SELinux or AppArmor

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -148,8 +148,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: qemu
-    group: libvirtd
+    owner: "{{ rbd_client_directory_user }}"
+    group: "{{ rbd_client_directory_group }}"
     mode: 0755
   with_items:
    - rbd_client_log_path


### PR DESCRIPTION
Some versions (?) of libvirt provide a 'libvirt' group instead of
'libvirtd'. (Observed with libvirt-daemon-1.2.17-13.el7_2.2.x86_64.)
This makes the RBD client directory owner and group configurable to
allow for this.