### PR TITLE
Simplification and correction of when clauses for yum install

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -58,7 +58,7 @@
     - ceph-mon
   when:
     mon_group_name in group_names and
-    ansible_pkg_mgr == "dnf" and
+    ansible_pkg_mgr == "dnf"
 
 - name: install distro or red hat storage ceph osd
   yum:
@@ -69,7 +69,7 @@
     - ceph-osd
   when:
     osd_group_name in group_names and
-    ansible_pkg_mgr == "yum" and
+    ansible_pkg_mgr == "yum"
 
 - name: install distro or red hat storage ceph osd
   dnf:
@@ -80,7 +80,7 @@
     - ceph-osd
   when:
     osd_group_name in group_names and
-    ansible_pkg_mgr == "dnf" and
+    ansible_pkg_mgr == "dnf"
 
 - name: install ceph-test
   yum:

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -34,7 +34,9 @@
   yum:
     name: ceph
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when: not ceph_stable_rh_storage
+  when: 
+    not ceph_stable_rh_storage and
+    ansible_pkg_mgr == "yum"
 
 - name: install distro or red hat storage ceph mon
   yum:
@@ -44,11 +46,8 @@
     - ceph
     - ceph-mon
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage) and
     mon_group_name in group_names and
-    ansible_pkg_mgr == "yum" and
-    ceph_stable and
-    ceph_stable_release not in ceph_stable_releases
+    ansible_pkg_mgr == "yum"
 
 - name: install distro or red hat storage ceph mon
   dnf:
@@ -58,11 +57,8 @@
     - ceph
     - ceph-mon
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage) and
     mon_group_name in group_names and
     ansible_pkg_mgr == "dnf" and
-    ceph_stable and
-    ceph_stable_release not in ceph_stable_releases
 
 - name: install distro or red hat storage ceph osd
   yum:
@@ -72,11 +68,8 @@
     - ceph
     - ceph-osd
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage) and
     osd_group_name in group_names and
     ansible_pkg_mgr == "yum" and
-    ceph_stable and
-    ceph_stable_release not in ceph_stable_releases
 
 - name: install distro or red hat storage ceph osd
   dnf:
@@ -86,11 +79,8 @@
     - ceph
     - ceph-osd
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage) and
     osd_group_name in group_names and
     ansible_pkg_mgr == "dnf" and
-    ceph_stable and
-    ceph_stable_release not in ceph_stable_releases
 
 - name: install ceph-test
   yum:

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -67,7 +67,6 @@
 - name: get ceph rhcs version
   shell: rpm -q --qf "%{version}\n" ceph-common | cut -f1,2 -d '.'
   changed_when: false
-  failed_when: false
   register: rh_storage_version
   when: ceph_stable_rh_storage
 


### PR DESCRIPTION
This is following up on discussion in issue 641, where you suggested a pull request like this.

The first commit is just trying to simplify and correct when clauses.  There are 4 distro types you have to support, but for these steps I don't think the decision tree is any different.  The existing when clause is wrong because it evaluates "ceph_stable_rh_storage and ceph_stable" but they are never both true, right?  I  I think the logic in the PR is cleaner and easier to understand unless I'm missing something, plz review. 

The 2nd commit is just to fail early where it's easy to understand what went wrong, rather than failing way into some complicated logic path where it's much harder to determine what went wrong.

