### PR TITLE
ceph-common: Fix for issue no. 652

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -340,3 +340,7 @@ dummy:
 
 #docker: false
 
+# Do not comment the variable mon_containerized_deployment_with_kv here. This variable is being used
+# by ceph.conf.j2 template. so it should always be defined
+#mon_containerized_deployment_with_kv: false
+

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -331,3 +331,7 @@ os_tuning_params:
 ##########
 
 docker: false
+
+# Do not comment the variable mon_containerized_deployment_with_kv here. This variable is being used
+# by ceph.conf.j2 template. so it should always be defined
+mon_containerized_deployment_with_kv: false


### PR DESCRIPTION
ceph.conf file generation task in ceph-common role was getting failed
because it ansible cant find defination of varriable mon_containerized_deployment_with_kv
This fix declare mon_containerized_deployment_with_kv under ceph-common/defaults/main.yml which fixes this issue

Signed-off-by: ksingh7 <karan.singh731987@gmail.com>