### PR TITLE
if user created OSD directories, don't zap disks

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -237,7 +237,8 @@
     shell: ceph-disk zap "{{ item }}"
     with_items: devices
     when:
-     osd_group_name in group_names
+     osd_group_name in group_names and
+     not osd_directory
 
   - name: zap journal devices
     shell: ceph-disk zap "{{ item }}"


### PR DESCRIPTION
If the user is specifying osd_directory: true in group_vars/osds, then this is an indication that the user is taking responsibility for creating, and purging, OSD directories, so we don't want to do something as radical as zapping OSD block devices.    I tried commenting out the devices: variable in group_vars/osds -- when I do this, the task "check for a device list" fails.  If I supply a devices: variable that is empty, then this effectively disables disk zapping as well.   But it's not obvious that this is what you have to do.  It seems safer to do it this way.
