### PR TITLE
ceph-common: use variable rgw_group_name instead of hard coded group name 'rgws'

### DIFF
--- a/roles/ceph-common/tasks/checks/check_firewall.yml
+++ b/roles/ceph-common/tasks/checks/check_firewall.yml
@@ -83,7 +83,7 @@
   local_action: shell set -o pipefail && nmap -p {{ radosgw_civetweb_port }} {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
-  with_items: groups.rgws
+  with_items: groups.{{ rgw_group_name }}
   register: rgwportstate
   when:
     check_firewall and


### PR DESCRIPTION
ceph-common: use variable rgw_group_name instead of hard coded group name `rgws` when checking rgw port.

Signed-off-by: runsisi <runsisi@hust.edu.cn>