### PR TITLE
ceph-common: Newline separation in ceph.conf.j2

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -15,7 +15,9 @@ auth service required = none
 auth client required = none
 auth supported = none
 {% endif %}
-{% if not mon_containerized_deployment_with_kv %}fsid = {{ fsid }}{% endif %}
+{% if not mon_containerized_deployment_with_kv %}
+fsid = {{ fsid }}
+{% endif %}
 max open files = {{ max_open_files }}
 osd pool default pg num = {{ pool_default_pg_num }}
 osd pool default pgp num = {{ pool_default_pgp_num }}


### PR DESCRIPTION
ceph.conf.j2 template requires a new line between mon_containerized_deployment_with_kv and fsid variables. With this commit , i have added a new line for better readablity