### PR TITLE
ceph-rgw: fix rgw enable with systemd

### DIFF
--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -8,6 +8,7 @@
     mode: "{{ dir_mode }}"
   with_items:
     - /var/lib/ceph/bootstrap-rgw
+    - /var/lib/ceph/radosgw
     - /var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}
     - "{{ rbd_client_admin_socket_path }}"
 

--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -33,6 +33,17 @@
     ansible_os_family == 'RedHat' and
     not is_ceph_infernalis
 
+- name: enable systemd unit file for rgw instance (for or after infernalis)
+  file:
+    src: /usr/lib/systemd/system/ceph-radosgw@.service
+    dest: /etc/systemd/system/multi-user.target.wants/ceph-radosgw@rgw.{{ ansible_hostname }}.service
+    state: link
+  changed_when: false
+  failed_when: false
+  when:
+    ansible_distribution != "Ubuntu" and
+    is_ceph_infernalis
+
 - name: start rgw on red hat (after infernalis)
   service:
     name: ceph-radosgw@rgw.{{ ansible_hostname }}


### PR DESCRIPTION
now rgw can be enabled.

closes: #642 #261

Signed-off-by: Sébastien Han <seb@redhat.com>