### PR TITLE
Added when: cephx to prevent waiting on keyring with cephx: false

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -4,6 +4,7 @@
 - name: wait for client.admin key exists
   wait_for:
     path: /etc/ceph/{{ cluster }}.client.admin.keyring
+  when: cephx
 
 - name: create ceph rest api keyring when mon is not containerized
   command: ceph --cluster {{ cluster }} auth get-or-create client.restapi osd 'allow *' mon 'allow *' -o /etc/ceph/{{ cluster }}.client.restapi.keyring


### PR DESCRIPTION
We unnecessarily wait for `/etc/ceph/{{ cluster }}.client.admin.keyring` to be created when `cephx: false` is set in `group_vars/all ` which causes this task to timeout resulting in an abort. 

Adding a `when: cephx` clause fixes this.

