### PR TITLE
ceph-mon: fix ceph keys permissions

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -27,9 +27,9 @@
 - name: set keys permissions
   file:
     path: "{{ item }}"
-    mode: 0600
-    owner: root
-    group: root
+    mode: "{{ key_mode }}"
+    owner: "{{ key_owner }}"
+    group: "{{ key_group }}"
   with_items:
     - "{{ ceph_keys.stdout_lines }}"
   when: cephx


### PR DESCRIPTION
Certain daemons will not start because of the wrong permissions.

Signed-off-by: Sébastien Han <seb@redhat.com>