### PR TITLE
misc: add a script for vm test env

### DIFF
--- a/ceph-aio-no-vagrant.sh
+++ b/ceph-aio-no-vagrant.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# This script will install Ansible and then deploy a simple Ceph cluster.
+# The script relies on the auto osd discovery feature, so we at least expect 2 raw devices
+# to work properly.
+set -e
+
+if [[ -z $1 ]]; then
+  CEPH_BRANCH_DEFAULT=master
+else
+  CEPH_BRANCH_DEFAULT=$1
+fi
+CEPH_BRANCH=${CEPH_BRANCH:-$CEPH_BRANCH_DEFAULT}
+SUBNET=$(ip r | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/[0-9]\{1,2\}' | head -1)
+MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
+
+if [[ $EUID -ne 0 ]]; then
+    echo "You are NOT running this script as root."
+    echo "You should."
+    echo "Really."
+    echo "PLEASE RUN IT WITH SUDO ONLY :)"
+    exit 1
+fi
+
+sudo bash install-ansible.sh
+
+ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+cat $HOME/.ssh/id_rsa.pub >> $HOME/.ssh/authorized_keys
+cp group_vars/all.sample group_vars/all
+cp group_vars/osds.sample group_vars/osds
+
+sed -i "s/#osd_auto_discovery: false/osd_auto_discovery: true/" group_vars/osds
+sed -i "s/#journal_collocation: false/journal_collocation: true/" group_vars/osds
+sed -i "s/#ceph_dev: false/ceph_dev: true/" group_vars/all
+sed -i "s/#monitor_address: 0.0.0.0/monitor_address: ${MON_IP}/" group_vars/all
+sed -i "s/#journal_size: 0/journal_size: 100/" group_vars/all
+sed -i "s|#public_network: 0.0.0.0\/0|public_network: ${SUBNET}|" group_vars/all
+sed -i "s/#common_single_host_mode: true/common_single_host_mode: true/" group_vars/all
+sed -i "s|#ceph_dev_branch: master|ceph_dev_branch: ${CEPH_BRANCH}|" group_vars/all
+
+cat > /etc/ansible/hosts <<EOF
+[mons]
+localhost
+[osds]
+localhost
+[mdss]
+localhost
+[rgws]
+localhost
+EOF
+
+cp site.yml.sample site.yml
+ansible all -m ping
+ansible-playbook site.yml

--- a/install-ansible.sh
+++ b/install-ansible.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # THIS SCRIPT INSTALLS ANSIBLE
+set -e
 
 if [[ $EUID -ne 0 ]]; then
     echo "You are NOT running this script as root."
@@ -14,14 +15,14 @@ if [[ -x $(which lsb_release 2>/dev/null) ]]; then
   os_VERSION=$(lsb_release -c -s)
   if [[ "Debian" =~ $os_VENDOR ]]; then
     apt-get update
-    apt-get install python-pip python-dev git build-essential -y
+    apt-get install -y python-pip python-dev git build-essential
     pip install PyYAML jinja2 paramiko
     git clone https://github.com/ansible/ansible.git
     cd ansible
     make install
     mkdir /etc/ansible
   elif [[ "Ubuntu" =~ $os_VENDOR ]]; then
-    add-apt-repository ppa:ansible/ansible
+    add-apt-repository -y ppa:ansible/ansible
     apt-get update
     apt-get install -y ansible
   elif [[ "RedHatEnterpriseServer" =~ $os_VENDOR ]]; then


### PR DESCRIPTION
Vagrant will not always be available everywhere, sometimes we want to
bootstrap a ceph on a virtual machine. This script will help you
bootstrapping a ceph cluster from a development branch only.

So you can run it like this: ./ceph-aio-no-vagrant.sh v10.1.0
To get the v10.1.0 version installed. If the first argument ($1) is
empty then master will be used in consequence.

Signed-off-by: Sébastien Han <seb@redhat.com>