### PR TITLE
ceph-common: let ceph handle pool_default_min_size

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -216,7 +216,7 @@ dummy:
 #pool_default_pg_num: 128
 #pool_default_pgp_num: 128
 #pool_default_size: 3
-#pool_default_min_size: 1
+#pool_default_min_size: 0 # 0 means no specific default; ceph will use (pool_default_size)-(pool_default_size/2) so 2 if pool_default_size=3
 #public_network: 0.0.0.0/0
 #cluster_network: "{{ public_network }}"
 #osd_mkfs_type: xfs

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -208,7 +208,7 @@ journal_size: 0
 pool_default_pg_num: 128
 pool_default_pgp_num: 128
 pool_default_size: 3
-pool_default_min_size: 1
+pool_default_min_size: 0 # 0 means no specific default; ceph will use (pool_default_size)-(pool_default_size/2) so 2 if pool_default_size=3
 public_network: 0.0.0.0/0
 cluster_network: "{{ public_network }}"
 osd_mkfs_type: xfs


### PR DESCRIPTION
We now set the value to 0, which means no specific default; ceph will
use size-size/2

Signed-off-by: Sébastien Han <seb@redhat.com>