### PR TITLE
Fix mis-use of config_template in docker tasks

### DIFF
--- a/roles/ceph-mon/tasks/docker/create_configs.yml
+++ b/roles/ceph-mon/tasks/docker/create_configs.yml
@@ -8,7 +8,8 @@
       mode: 0644
 
 - name: generate ceph configuration file
-  config_template:
+  action: config_template
+  args:
     src: "{{ playbook_dir }}/roles/ceph-common/templates/ceph.conf.j2"
     dest: /etc/ceph/ceph.conf
     owner: "root"


### PR DESCRIPTION
As written, generating the config file for ceph-mon in Docker yielded:

ERROR: config_template is not a legal parameter in an Ansible task or
handler

This fixes that error condition.