### PR TITLE
fix when clauses for installation of ceph RPM

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -36,6 +36,13 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when: not ceph_stable_rh_storage
 
+# include Infernalis in the set of releases that do not have
+# a separate ceph-mon package or ceph-osd package
+# Note: Red Hat Ceph Storage is different, DOES separate them even in hammer
+
+- set_fact: > 
+    ceph_stable_rel_pkg="{{ ceph_stable_releases | union([ 'infernalis' ]) }}"
+
 - name: install distro or red hat storage ceph mon
   yum:
     name: "{{ item }}"
@@ -45,7 +52,7 @@
     - ceph-mon
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
-     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
+     (ceph_stable and ceph_stable_release not in ceph_stable_rel_pkg)) and
     mon_group_name in group_names and
     ansible_pkg_mgr == "yum"
 
@@ -58,7 +65,7 @@
     - ceph-mon
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
-     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
+     (ceph_stable and ceph_stable_release not in ceph_stable_rel_pkg)) and
     mon_group_name in group_names and
     ansible_pkg_mgr == "dnf"
 
@@ -71,7 +78,7 @@
     - ceph-osd
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
-     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
+     (ceph_stable and ceph_stable_release not in ceph_stable_rel_pkg)) and
     osd_group_name in group_names and
     ansible_pkg_mgr == "yum"
 
@@ -84,7 +91,7 @@
     - ceph-osd
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
-     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
+     (ceph_stable and ceph_stable_release not in ceph_stable_rel_pkg)) and
     osd_group_name in group_names and
     ansible_pkg_mgr == "dnf"
 

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -44,11 +44,10 @@
     - ceph
     - ceph-mon
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage) and
+    (ceph_origin == "distro" or ceph_stable_rh_storage or
+     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     mon_group_name in group_names and
-    ansible_pkg_mgr == "yum" and
-    ceph_stable and
-    ceph_stable_release not in ceph_stable_releases
+    ansible_pkg_mgr == "yum"
 
 - name: install distro or red hat storage ceph mon
   dnf:
@@ -58,11 +57,10 @@
     - ceph
     - ceph-mon
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage) and
+    (ceph_origin == "distro" or ceph_stable_rh_storage or
+     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     mon_group_name in group_names and
-    ansible_pkg_mgr == "dnf" and
-    ceph_stable and
-    ceph_stable_release not in ceph_stable_releases
+    ansible_pkg_mgr == "dnf"
 
 - name: install distro or red hat storage ceph osd
   yum:
@@ -72,11 +70,10 @@
     - ceph
     - ceph-osd
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage) and
+    (ceph_origin == "distro" or ceph_stable_rh_storage or
+     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     osd_group_name in group_names and
-    ansible_pkg_mgr == "yum" and
-    ceph_stable and
-    ceph_stable_release not in ceph_stable_releases
+    ansible_pkg_mgr == "yum"
 
 - name: install distro or red hat storage ceph osd
   dnf:
@@ -86,11 +83,10 @@
     - ceph
     - ceph-osd
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage) and
+    (ceph_origin == "distro" or ceph_stable_rh_storage or
+     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     osd_group_name in group_names and
-    ansible_pkg_mgr == "dnf" and
-    ceph_stable and
-    ceph_stable_release not in ceph_stable_releases
+    ansible_pkg_mgr == "dnf"
 
 - name: install ceph-test
   yum:


### PR DESCRIPTION
This pull request is a cleaner (I hope!) commit for the issues discussed in PR 651, which should be closed.    The important thing is that the old code was in effect evaluating "ceph_stable_rh_storage and ceph_stable" but these should not both be true.  The new code changes the "and" to an "or".  This code was tested by installing with RHCS 1.3.1 .iso and 1.3.2 .iso.    It would be nice if there was a way to factor out the common when clause expression used here, but other than "set_fact" I can't think of one.