### PR TITLE
create /etc/sysconfig/ceph if it doesn't already exist

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -212,6 +212,7 @@
   lineinfile:
     dest: /etc/sysconfig/ceph
     insertafter: EOF
+    create: yes
     line: "CLUSTER={{ cluster }}"
   when:
     ansible_os_family == "RedHat"
@@ -220,6 +221,7 @@
   lineinfile:
     dest: /etc/default/ceph/ceph
     insertafter: EOF
+    create: yes
     line: "CLUSTER={{ cluster }}"
   when:
     ansible_os_family == "Debian"


### PR DESCRIPTION
This change deals with case where /etc/sysconfig/ceph doesn't already exist.  I ran into this while installing RHCS 1.3.1 iso image.  Perhaps later RPM versions create this file for you?  But the install errored out because of this.