### PR TITLE
Deduplicate RBD client directory creation

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -182,11 +182,41 @@ dummy:
 #rbd_cache: "true"
 #rbd_cache_writethrough_until_flush: "true"
 #rbd_concurrent_management_ops: 20
+
 #rbd_client_directories: false # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions
-#rbd_client_directory_user: qemu
-#rbd_client_directory_group: libvirtd
-#rbd_client_log_file: /var/log/rbd-clients/qemu-guest-$pid.log # must be writable by QEMU and allowed by SELinux or AppArmor
+
+# Permissions for the rbd_client_log_path and
+# rbd_client_admin_socket_path. Depending on your use case for Ceph
+# you may want to change these values. The default, which is used if
+# any of the variables are unset or set to a false value (like `null`
+# or `false`) is to automatically determine what is appropriate for
+# the Ceph version with non-OpenStack workloads -- ceph:ceph and 0770
+# for infernalis releases, and root:root and 1777 for pre-infernalis
+# releases.
+#
+# For other use cases, including running Ceph with OpenStack, you'll
+# want to set these differently:
+#
+# For OpenStack on RHEL, you'll want:
+#   rbd_client_directory_owner: "qemu"
+#   rbd_client_directory_group: "libvirtd" (or "libvirt", depending on your version of libvirt)
+#   rbd_client_directory_mode: "0755"
+#
+# For OpenStack on Ubuntu or Debian, set:
+#    rbd_client_directory_owner: "libvirt-qemu"
+#    rbd_client_directory_group: "kvm"
+#    rbd_client_directory_mode: "0755"
+#
+# If you set rbd_client_directory_mode, you must use a string (e.g.,
+# 'rbd_client_directory_mode: "0755"', *not*
+# 'rbd_client_directory_mode: 0755', or Ansible will complain: mode
+# must be in octal or symbolic form
+#rbd_client_directory_owner: null
+#rbd_client_directory_group: null
+#rbd_client_directory_mode: null
+
 #rbd_client_log_path: /var/log/rbd-clients/
+#rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor
 #rbd_client_admin_socket_path: /var/run/ceph/rbd-clients # must be writable by QEMU and allowed by SELinux or AppArmor
 #rbd_default_features: 3
 #rbd_default_map_options: rw

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -174,11 +174,41 @@ debug_mds_level: 20
 rbd_cache: "true"
 rbd_cache_writethrough_until_flush: "true"
 rbd_concurrent_management_ops: 20
+
 rbd_client_directories: false # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions
-rbd_client_directory_user: qemu
-rbd_client_directory_group: libvirtd
-rbd_client_log_file: /var/log/rbd-clients/qemu-guest-$pid.log # must be writable by QEMU and allowed by SELinux or AppArmor
+
+# Permissions for the rbd_client_log_path and
+# rbd_client_admin_socket_path. Depending on your use case for Ceph
+# you may want to change these values. The default, which is used if
+# any of the variables are unset or set to a false value (like `null`
+# or `false`) is to automatically determine what is appropriate for
+# the Ceph version with non-OpenStack workloads -- ceph:ceph and 0770
+# for infernalis releases, and root:root and 1777 for pre-infernalis
+# releases.
+#
+# For other use cases, including running Ceph with OpenStack, you'll
+# want to set these differently:
+#
+# For OpenStack on RHEL, you'll want:
+#   rbd_client_directory_owner: "qemu"
+#   rbd_client_directory_group: "libvirtd" (or "libvirt", depending on your version of libvirt)
+#   rbd_client_directory_mode: "0755"
+#
+# For OpenStack on Ubuntu or Debian, set:
+#    rbd_client_directory_owner: "libvirt-qemu"
+#    rbd_client_directory_group: "kvm"
+#    rbd_client_directory_mode: "0755"
+#
+# If you set rbd_client_directory_mode, you must use a string (e.g.,
+# 'rbd_client_directory_mode: "0755"', *not*
+# 'rbd_client_directory_mode: 0755', or Ansible will complain: mode
+# must be in octal or symbolic form
+rbd_client_directory_owner: null
+rbd_client_directory_group: null
+rbd_client_directory_mode: null
+
 rbd_client_log_path: /var/log/rbd-clients/
+rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor
 rbd_client_admin_socket_path: /var/run/ceph/rbd-clients # must be writable by QEMU and allowed by SELinux or AppArmor
 rbd_default_features: 3
 rbd_default_map_options: rw

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -45,15 +45,3 @@
     default_release: "{{ ansible_distribution_release }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
   when:
     mds_group_name in group_names
-
-- name: configure rbd clients directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: libvirt-qemu
-    group: kvm
-    mode: 0755
-  with_items:
-   - rbd_client_log_path
-   - rbd_client_admin_socket_path
-  when: rbd_client_directories

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -143,15 +143,3 @@
   when:
     rgw_group_name in group_names and
     ansible_pkg_mgr == "dnf"
-
-- name: configure rbd clients directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: "{{ rbd_client_directory_user }}"
-    group: "{{ rbd_client_directory_group }}"
-    mode: 0755
-  with_items:
-   - rbd_client_log_path
-   - rbd_client_admin_socket_path
-  when: rbd_client_directories

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -120,16 +120,46 @@
   when: not is_ceph_infernalis
 
 - set_fact:
-    rbd_client_dir_owner: root
-    rbd_client_dir_group: root
-    rbd_client_dir_mode: "1777"
-  when: not is_ceph_infernalis
+    rbd_client_directory_owner: root
+  when:
+    not is_ceph_infernalis and
+    (rbd_client_directory_owner is not defined or
+     not rbd_client_directory_owner)
 
 - set_fact:
-    rbd_client_dir_owner: ceph
-    rbd_client_dir_group: ceph
-    rbd_client_dir_mode: "0770"
-  when: is_ceph_infernalis
+    rbd_client_directory_owner: ceph
+  when:
+    is_ceph_infernalis and
+    (rbd_client_directory_owner is not defined or
+     not rbd_client_directory_owner)
+
+- set_fact:
+    rbd_client_directory_group: root
+  when:
+    not is_ceph_infernalis and
+    (rbd_client_directory_group is not defined or
+     not rbd_client_directory_group)
+
+- set_fact:
+    rbd_client_directory_group: ceph
+  when:
+    is_ceph_infernalis and
+    (rbd_client_directory_group is not defined or
+     not rbd_client_directory_group)
+
+- set_fact:
+    rbd_client_directory_mode: "1777"
+  when:
+    not is_ceph_infernalis and
+    (rbd_client_directory_mode is not defined or
+     not rbd_client_directory_mode)
+
+- set_fact:
+    rbd_client_directory_mode: "0770"
+  when:
+    is_ceph_infernalis and
+    (rbd_client_directory_mode is not defined or
+     not rbd_client_directory_mode)
 
 - name: check for a ceph socket
   shell: "stat /var/run/ceph/*.asok > /dev/null 2>&1"
@@ -202,11 +232,15 @@
 
 - name: create rbd client directory
   file:
-    path: "{{ rbd_client_admin_socket_path }}"
+    path: "{{ item }}"
     state: directory
-    owner: "{{ rbd_client_dir_owner }}"
-    group: "{{ rbd_client_dir_group }}"
-    mode: "{{ rbd_client_dir_mode }}"
+    owner: "{{ rbd_client_directory_owner }}"
+    group: "{{ rbd_client_directory_group }}"
+    mode: "{{ rbd_client_directory_mode }}"
+  with_items:
+    - rbd_client_admin_socket_path
+    - rbd_client_log_path
+  when: rbd_client_directories
 
 - name: configure cluster name
   lineinfile:


### PR DESCRIPTION
Instead of creating the RBD client socket path three different places
in three different ways, this creates it once. Ceph on OpenStack users
have the option to customize the permissions of the RBD client
directories.

Fixes #687