### PR TITLE
sysvinit changes to rolling update playbook 

### DIFF
--- a/rolling_update.yml
+++ b/rolling_update.yml
@@ -30,7 +30,8 @@
   post_tasks:
     - name: Check if sysvinit
       stat: >
-        path=/var/lib/ceph/mon/ceph-{{ ansible_hostname }}/sysvinit
+        path=/etc/rc?.d/S??ceph
+        follow=yes
       register: monsysvinit
 
     - name: Check if upstart
@@ -49,7 +50,6 @@
       service: >
         name=ceph
         state=restarted
-        args=mon
       when: monsysvinit.stat.exists == True
 
     - name: restart monitor(s)
@@ -57,6 +57,13 @@
         name=ceph
         state=restarted
         args=mon
+      when: not ansible_os_family == "RedHat"
+
+    - name: restart monitor(s)
+      service: >
+        name=ceph
+        state=restarted
+      when: ansible_os_family == "RedHat"
 
     - name: select a running monitor
       set_fact: mon_host={{ item }}
@@ -113,7 +120,6 @@
       service: >
         name=ceph
         state=restarted
-        args=osd
       when: osdsysvinit.rc == 0
 
     - name: Waiting for clean PGs...


### PR DESCRIPTION
This update has the following changes for the rolling update playbook.

1. Change how sysvinit ceph is determined to be enabled

For mons, the playbook checks if sysvinit is enabled by trying to
stat /var/lib/ceph/mon/ceph-{{ ansible_hostname }}/sysvinit [1].
However, that file is not created when a monitor is configured to
use sysvinit, instead, Ansible's service module is used [2]. Ansible
2.0 can verify if a service is enabled and does this by checking for
a glob, in this context it would be '/etc/rc?.d/S??ceph' [3]. Because
Ansible 1.9 does not support this feature, this change updates
rolling_update.yml by checking if sysvinit is enabled by having stat
glob for the same pattern and following the symlink. This is done only
for the mons.

2. Change how sysvinit ceph is restarted

The playbook passes the argument "mon" to the sysv init script
but, the init script does not necessarily take that argument and
it failed when tested on a RHEL7 system. However, dropping the
argument and just using Ansible's service module for state=restarted
worked so this change does not have this line for when
monsysvinit.stat.exists. A similar change is in this pull request
for the OSD restart (removing args=osd).

A second ceph mon restart command is run regardless of any conditions
being met. I am not sure why the service is restarted in the case of
upstart or sysvinit and then restarted again. I am going to assume
there is a subtle reason for this and not touch this second run but I
added a condition so that when ansible_os_family is Red Hat, then mon
is not passed as an argument, otherwise it is restarted as was already
in place.

[1] https://github.com/ceph/ceph-ansible/blob/v1.0.3/rolling_update.yml#L32-L33
[2] https://github.com/ceph/ceph-ansible/blob/v1.0.3/roles/ceph-mon/tasks/start_monitor.yml#L42-L45
[3] https://github.com/ansible/ansible-modules-core/blob/stable-2.0/system/service.py#L492-L493