### PR TITLE
look at monitor_interface in hostvars when choosing interface or address

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -99,7 +99,7 @@ host = {{ hostvars[host]['ansible_fqdn'] }}
 [mon.{{ hostvars[host]['ansible_hostname'] }}]
 host = {{ hostvars[host]['ansible_hostname'] }}
 {% endif %}
-{% if monitor_interface != "interface" %}
+{% if hostvars[host]['monitor_interface'] != "interface" %}
 {% include 'mon_addr_interface.j2' %}
 {% else %}
 {% include 'mon_addr_address.j2' %}


### PR DESCRIPTION
This fixes a bug where monitor_interface might be set in your inventory
file and not by using group_vars or --extra-vars causing the template to
use the default address of 0.0.0.0 instead of the defined
monitor_interface.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>