### PR TITLE
if ceph-disk fails to activate an OSD then bubble up the error

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -20,10 +20,18 @@
     - devices
   changed_when: false
   failed_when: false
+  register: activate_osd_disk
   when:
     not item.0.get("skipped") and
     item.0.get("rc", 0) != 0 and
     not osd_auto_discovery
+
+- name: fail if ceph-disk cannot create an OSD
+  fail:
+    msg: "ceph-disk failed to create an OSD"
+  when:
+    " 'ceph-disk: Error: ceph osd create failed' in item.get('stderr', '') "
+  with_items: "{{activate_osd_disk.results}}"
 
 # NOTE (leseb): this task is for partitions because we don't explicitly use a partition.
 - name: activate osd(s) when device is a partition


### PR DESCRIPTION
Fixes issue #670 