### PR TITLE
Balance tags on <your_host

### DIFF
--- a/cluster-maintenance.yml
+++ b/cluster-maintenance.yml
@@ -27,7 +27,7 @@
 
   - name: Wait for the server to come up
     local_action: >
-      wait_for host=<your_host
+      wait_for host=<your_host>
       port=22
       delay=10
       timeout=3600


### PR DESCRIPTION
In cluster-maintenance.yml, the third of occurrence of &lt;your_host&gt; didn't have a closing tag. This is a tiny change to add the the missing '&gt;'. 

This will let people quickly update this file with sed. For example: `sed s/\<your_host\>/192.168.1.41/g -i cluster-maintenance.yml`.