### PR TITLE
Update the config_template plugin

### DIFF
--- a/plugins/actions/_v1_config_template.py
+++ b/plugins/actions/_v1_config_template.py
@@ -263,7 +263,7 @@ class ActionModule(object):
         if isinstance(value, set):
             config.set(str(section), str(key), value)
         elif isinstance(value, list):
-            config.set(str(section), str(key), ','.join(value))
+            config.set(str(section), str(key), ','.join(str(i) for i in value))
         else:
             config.set(str(section), str(key), str(value))
 

--- a/plugins/actions/_v2_config_template.py
+++ b/plugins/actions/_v2_config_template.py
@@ -303,17 +303,8 @@ class ActionModule(ActionBase):
                 except (ConfigParser.DuplicateSectionError, ValueError):
                     pass
                 for key, value in items.items():
-                    if isinstance(value, list):
-                        items = ','.join(_convert_2_string(value))
-                    else:
-                        items = _convert_2_string(value)
                     try:
-                        self._option_write(
-                            config,
-                            str(section),
-                            str(key),
-                            items
-                        )
+                        self._option_write(config, section, key, value)
                     except ConfigParser.NoSectionError as exp:
                         error_msg = str(exp)
                         error_msg += (
@@ -340,11 +331,11 @@ class ActionModule(ActionBase):
         except AttributeError:
             pass
         if isinstance(value, set):
-            config.set(section, key, value)
+            config.set(str(section), str(key), value)
         elif isinstance(value, list):
-            config.set(section, key, ','.join(value))
+            config.set(str(section), str(key), ','.join(str(i) for i in value))
         else:
-            config.set(section, key, value)
+            config.set(str(section), str(key), str(value))
 
     def return_config_overrides_json(self, config_overrides, resultant):
         """Returns config json


### PR DESCRIPTION
These changes address 2 issues:

* The config template plugin in v1 mode was not respecting a list
  of integers and would cause a stacktrace because the ConfigParese
  module expects everything written to be a string.
* The config template plugin in v2 mode was not properly handingly
  the multi-string-op type due to an oversight in the ``_option_write``
  method.

With these updates the config template is now able to better support
all of the potential options that could be thrown at it when writing
an INI config file.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>