### PR TITLE
purge-cluster - fix osd_auto_discovery check

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -96,6 +96,7 @@
     fail:
       msg: "OSD automatic discovery was detected, purge cluster does not support this scenario. If you want to purge the cluster, manually provide the list of devices in group_vars/osds using the devices variable."
     when:
+      osd_group_name in group_names and
       devices is not defined and
       osd_auto_discovery
 


### PR DESCRIPTION
The task "check for a device list" causes non-OSD hosts to be skipped by purge-cluster.yml.  This task is making sure that purge-cluster is not applied in the case of osd_auto_discovery: true without devices var being defined.  The problem is that the when clause can only be evaluated in the context of the OSD role, since "devices" and "osd_auto_discovery" vars are defined in group_vars/osds .  This change restricts the task to only operate in the OSD role.  I tested with both my 8-host cluster and with a CI-like single-node cluster running ceph_stable Infernalis.

It would be nice if the fail action could apply to all hosts, since this seems to be the intent, but I don't know how to do that.  At least the user can now re-run the purge-cluster.yml after correcting the vars as requested, since it is idempotent now.

Here's what happens without the change on my 8-node cluster - the osd hosts are skipped correctly, but the non-OSD hosts fail and do not perform any subsequent tasks.

[root@ceph-cbt ceph-ansible]# ap -v --step purge-cluster.yml
Are you sure you want to purge the cluster? [no]: yes
 ...
Perform task: check for a device list (y/n/c): y

Perform task: check for a device list (y/n/c):  ******************************* 
fatal: [cephmon2] => error while evaluating conditional: devices is not defined and osd_auto_discovery
skipping: [gprfs041]
skipping: [gprfs044]
skipping: [gprfs042]
skipping: [gprfs043]
fatal: [gprfc074] => error while evaluating conditional: devices is not defined and osd_auto_discovery
fatal: [gprfc075] => error while evaluating conditional: devices is not defined and osd_auto_discovery
fatal: [gprfc073] => error while evaluating conditional: devices is not defined and osd_auto_discovery
fatal: [gprfc076] => error while evaluating conditional: devices is not defined and osd_auto_discovery
Perform task: get osd numbers (y/n/c): ^CERROR: interrupted

