### PR TITLE
Check to see if hostvars[host]['monitor_interface'] is defined

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -99,7 +99,7 @@ host = {{ hostvars[host]['ansible_fqdn'] }}
 [mon.{{ hostvars[host]['ansible_hostname'] }}]
 host = {{ hostvars[host]['ansible_hostname'] }}
 {% endif %}
-{% if hostvars[host]['monitor_interface'] != "interface" %}
+{% if hostvars[host]['monitor_interface'] is defined and hostvars[host]['monitor_interface'] != "interface" %}
 {% include 'mon_addr_interface.j2' %}
 {% else %}
 {% include 'mon_addr_address.j2' %}


### PR DESCRIPTION
This fixes https://github.com/ceph/ceph-ansible/issues/711

Signed-off-by: Andrew Schoen <aschoen@redhat.com>