### PR TITLE
Fix for #718

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -236,10 +236,11 @@
       ansible_distribution == 'Ubuntu' and
       rbdmirror_group_name in group_names
 
-  - name: check for anything running ceph
-    shell: "ps awux | grep -v grep | grep -q -- ceph-"
-    register: check_for_running_ceph
-    failed_when: check_for_running_ceph.rc == 0
+  - name: Kill Ceph processes that are still running
+    shell: "pkill -9 ceph"
+    failed_when: false
+    register: kill_running_ceph_processes
+    changed_when: kill_running_ceph_processes.rc == 0
 
   - name: see if ceph-disk-created data partitions are present
     shell: "ls /dev/disk/by-partlabel | grep -q 'ceph\\\\x20data'"


### PR DESCRIPTION
Problem: Task that check for running Ceph processes fails against some nodes.
Due to that the failed node does not purges completely.

With this fix i have replaced that task with a new one "pkill -9 ceph" where it kills all running
ceph processes. The change has been tested and works fine than before

Signed-off-by: karan singh <karasing@redhat.com>