### PR TITLE
correctly set mon addr when monitor_interface is defined in group_vars

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -99,7 +99,8 @@ host = {{ hostvars[host]['ansible_fqdn'] }}
 [mon.{{ hostvars[host]['ansible_hostname'] }}]
 host = {{ hostvars[host]['ansible_hostname'] }}
 {% endif %}
-{% if hostvars[host]['monitor_interface'] is defined and hostvars[host]['monitor_interface'] != "interface" %}
+# we need to check if monitor_interface is defined in the inventory per host or if it's set in a group_vars file
+{% if (hostvars[host]['monitor_interface'] is defined and hostvars[host]['monitor_interface'] != "interface") or monitor_interface != "interface" %}
 {% include 'mon_addr_interface.j2' %}
 {% else %}
 {% include 'mon_addr_address.j2' %}


### PR DESCRIPTION
This fixes the ceph.conf template so that it will look for an inventory
defined value for monitor_interface or for monitor_interface defined in
a group_vars file.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>