### PR TITLE
change defaults for rbd_client_directories and rbd_client_admin_socket_path

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -219,7 +219,7 @@ dummy:
 
 #rbd_client_log_path: /var/log/rbd-clients/
 #rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor
-#rbd_client_admin_socket_path: /var/run/ceph/rbd-clients # must be writable by QEMU and allowed by SELinux or AppArmor
+#rbd_client_admin_socket_path: /var/run/ceph # must be writable by QEMU and allowed by SELinux or AppArmor
 #rbd_default_features: 3
 #rbd_default_map_options: rw
 #rbd_default_format: 2

--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -217,7 +217,7 @@ dummy:
 #rbd_client_directory_group: null
 #rbd_client_directory_mode: null
 
-#rbd_client_log_path: /var/log/rbd-clients/
+#rbd_client_log_path: /var/log/ceph
 #rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor
 #rbd_client_admin_socket_path: /var/run/ceph # must be writable by QEMU and allowed by SELinux or AppArmor
 #rbd_default_features: 3

--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -185,7 +185,7 @@ dummy:
 #rbd_cache_writethrough_until_flush: "true"
 #rbd_concurrent_management_ops: 20
 
-#rbd_client_directories: false # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions
+#rbd_client_directories: true # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions
 
 # Permissions for the rbd_client_log_path and
 # rbd_client_admin_socket_path. Depending on your use case for Ceph

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -177,7 +177,7 @@ rbd_cache: "true"
 rbd_cache_writethrough_until_flush: "true"
 rbd_concurrent_management_ops: 20
 
-rbd_client_directories: false # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions
+rbd_client_directories: true # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions
 
 # Permissions for the rbd_client_log_path and
 # rbd_client_admin_socket_path. Depending on your use case for Ceph

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -211,7 +211,7 @@ rbd_client_directory_mode: null
 
 rbd_client_log_path: /var/log/rbd-clients/
 rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor
-rbd_client_admin_socket_path: /var/run/ceph/rbd-clients # must be writable by QEMU and allowed by SELinux or AppArmor
+rbd_client_admin_socket_path: /var/run/ceph # must be writable by QEMU and allowed by SELinux or AppArmor
 rbd_default_features: 3
 rbd_default_map_options: rw
 rbd_default_format: 2

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -209,7 +209,7 @@ rbd_client_directory_owner: null
 rbd_client_directory_group: null
 rbd_client_directory_mode: null
 
-rbd_client_log_path: /var/log/rbd-clients/
+rbd_client_log_path: /var/log/ceph
 rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor
 rbd_client_admin_socket_path: /var/run/ceph # must be writable by QEMU and allowed by SELinux or AppArmor
 rbd_default_features: 3


### PR DESCRIPTION
Changing these defaults will ensure that the rbd_client_directories are being created by default and will avoid the following warning when running ceph commands:

2016-04-19 15:20:05.128327 7fc0e4033700 -1 asok(0x7fc0dc001680)
    AdminSocketConfigObs::init: failed: AdminSocket::bind_and_listen:
    failed to bind the UNIX domain socket to
    '/var/run/ceph/rbd-clients/ceph-client.admin.20455.140466301441968.asok':
    (2) No such file or directory

See: https://bugzilla.redhat.com/show_bug.cgi?id=1328594

Signed-off-by: Andrew Schoen <aschoen@redhat.com>