### PR TITLE
docker: ensures conf/var folders exist and copy files directly without stat

### DIFF
--- a/roles/ceph-mds/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-mds/tasks/docker/fetch_configs.yml
@@ -8,23 +8,17 @@
       - /etc/ceph/ceph.client.admin.keyring
       - /var/lib/ceph/bootstrap-mds/ceph.keyring
 
-- name: stat for ceph config and keys
-  local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
-  with_items: ceph_config_keys
-  changed_when: false
-  become: false
-  failed_when: false
-  register: statconfig
+- name: ensure conf dirs exist
+  file: path={{ item }} state=directory
+  with_items:
+  - /etc/ceph
+  - /var/lib/ceph/bootstrap-mds/
 
-- name: try to fetch ceph config and keys
+- name: copy ceph config and keys
   copy:
-    src: "{{ fetch_directory }}/docker_mon_files/{{ item.0 }}"
-    dest: "{{ item.0 }}"
+    src: "{{ playbook_dir }}/{{ fetch_directory }}/docker_mon_files/{{ item }}"
+    dest: "{{ item }}"
     owner: root
     group: root
     mode: 0644
-  changed_when: false
-  with_together:
-    - ceph_config_keys
-    - statconfig.results
-  when: item.1.stat.exists == true
+  with_items: ceph_config_keys

--- a/roles/ceph-mon/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-mon/tasks/docker/fetch_configs.yml
@@ -10,23 +10,19 @@
       - /var/lib/ceph/bootstrap-rgw/ceph.keyring
       - /var/lib/ceph/bootstrap-mds/ceph.keyring
 
-- name: stat for ceph config and keys
-  local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
-  with_items: ceph_config_keys
-  changed_when: false
-  become: false
-  failed_when: false
-  register: statconfig
+- name: ensure conf dirs exist
+  file: path={{ item }} state=directory
+  with_items:
+  - /etc/ceph
+  - /var/lib/ceph/bootstrap-mds/
+  - /var/lib/ceph/bootstrap-osd/
+  - /var/lib/ceph/bootstrap-rgw/
 
-- name: try to fetch ceph config and keys
+- name: copy ceph config and keys
   copy:
-    src: "{{ playbook_dir }}/{{ fetch_directory }}/docker_mon_files/{{ item.0 }}"
-    dest: "{{ item.0 }}"
+    src: "{{ playbook_dir }}/{{ fetch_directory }}/docker_mon_files/{{ item }}"
+    dest: "{{ item }}"
     owner: root
     group: root
     mode: 0644
-  changed_when: false
-  with_together:
-    - ceph_config_keys
-    - statconfig.results
-  when: item.1.stat.exists == true
+  with_items: ceph_config_keys

--- a/roles/ceph-osd/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-osd/tasks/docker/fetch_configs.yml
@@ -5,29 +5,18 @@
       - /etc/ceph/ceph.conf
       - /var/lib/ceph/bootstrap-osd/ceph.keyring
 
-- name: wait for ceph.conf and keys
-  local_action: >
-    wait_for
-    path="{{ playbook_dir }}/{{ fetch_directory }}/docker_mon_files/{{ item.0 }}"
-  become: false
-  with_together:
-      - ceph_config_keys
-
-- name: stat for ceph config and keys
-  local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
-  with_items: ceph_config_keys
-  changed_when: false
-  become: false
-  failed_when: false
-  register: statconfig
+- name: ensure conf dirs exist
+  file: path={{ item }} state=directory
+  with_items:
+  - /etc/ceph
+  - /var/lib/ceph/bootstrap-osd/
 
 - name: try to copy ceph config and keys
   copy:
-    src: "{{ playbook_dir }}/{{ fetch_directory }}/docker_mon_files/{{ item.0 }}"
-    dest: "{{ item.0 }}"
+    src: "{{ playbook_dir }}/{{ fetch_directory }}/docker_mon_files/{{ item }}"
+    dest: "{{ item }}"
     owner: root
     group: root
     mode: 0644
   changed_when: false
-  with_together:
-    - ceph_config_keys
+  with_items: ceph_config_keys

--- a/roles/ceph-restapi/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-restapi/tasks/docker/fetch_configs.yml
@@ -5,23 +5,17 @@
       - /etc/ceph/ceph.conf
       - /etc/ceph/ceph.client.admin.keyring
 
-- name: stat for ceph config and keys
-  local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
-  with_items: ceph_config_keys
-  changed_when: false
-  become: false
-  ignore_errors: true
-  register: statconfig
+- name: ensure conf dirs exist
+  file: path={{ item }} state=directory
+  with_items:
+  - /etc/ceph
 
-- name: try to fetch ceph config and keys
+- name: try to copy ceph config and keys
   copy:
-    src: "{{ playbook_dir }}/{{ fetch_directory }}/docker_mon_files/{{ item.0 }}"
-    dest: "{{ item.0 }}"
+    src: "{{ playbook_dir }}/{{ fetch_directory }}/docker_mon_files/{{ item }}"
+    dest: "{{ item }}"
     owner: root
     group: root
     mode: 0644
   changed_when: false
-  with_together:
-    - ceph_config_keys
-    - statconfig.results
-  when: item.1.stat.exists == true
+  with_items: ceph_config_keys

--- a/roles/ceph-rgw/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-rgw/tasks/docker/fetch_configs.yml
@@ -5,23 +5,18 @@
       - /etc/ceph/ceph.conf
       - /var/lib/ceph/bootstrap-rgw/ceph.keyring
 
-- name: stat for ceph config and keys
-  local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
-  with_items: ceph_config_keys
-  changed_when: false
-  become: false
-  ignore_errors: true
-  register: statconfig
+- name: ensure conf dirs exist
+  file: path={{ item }} state=directory
+  with_items:
+  - /etc/ceph
+  - /var/lib/ceph/bootstrap-rgw/
 
-- name: try to fetch ceph config and keys
+- name: try to copy ceph config and keys
   copy:
-    src: "{{ playbook_dir }}/{{ fetch_directory }}/docker_mon_files/{{ item.0 }}"
-    dest: "{{ item.0 }}"
+    src: "{{ playbook_dir }}/{{ fetch_directory }}/docker_mon_files/{{ item }}"
+    dest: "{{ item }}"
     owner: root
     group: root
     mode: 0644
   changed_when: false
-  with_together:
-    - ceph_config_keys
-    - statconfig.results
-  when: item.1.stat.exists == true
+  with_items: ceph_config_keys


### PR DESCRIPTION
For docker deployments, this ensures that the `/etc/ceph` and `/var/lib/ceph` folders exist on the host. Also this copies directly without having to `stat` them first (if a file doesn't exist an error is thrown).

Fixes #725 