### PR TITLE
docker: use ceph_docker_osd_devices variable for purging docker cluster

### DIFF
--- a/purge-docker-cluster.yml
+++ b/purge-docker-cluster.yml
@@ -8,8 +8,13 @@
 
   tasks:
 
+  - name: install the latest version of gdisk
+    package:
+      name: gdisk
+      state: present
+
   - name: collect ceph containers
-    shell: "docker ps | awk '/ceph.daemon/ {print $10}'"
+    shell: docker ps -aq --filter="ancestor=ceph/daemon"
     register: containers
 
   - name: delete ceph containers
@@ -17,27 +22,22 @@
     with_items: containers.stdout_lines
 
   - name: purge ceph directories
-    shell: rm -rf {{ item }}
+    file:
+      path: {{ item }}
+      state: absent
     with_items:
-      - /etc/ceph/*
-      - /var/lib/ceph/*
-    failed_when: false
+      - /etc/ceph/
+      - /var/lib/ceph/
 
 - hosts:
   - osds
 
-  vars:
-    devices: [ '/dev/sdb', '/dev/sdc', '/dev/sdd', '/dev/sde', '/dev/sdf' ]
-    partitions: [ '1', '2', '3' ]
-
   tasks:
 
   - name: disk zap
-    command: /usr/sbin/sgdisk --zap-all --clear --mbrtogpt -g -- {{ item }}
-    with_items: devices
-    failed_when: false
+    command: sgdisk --zap-all --clear --mbrtogpt -g -- {{ item }}
+    with_items: ceph_osd_docker_devices
 
   - name: disk zap again
-    command: /usr/sbin/sgdisk --zap-all --clear --mbrtogpt -g -- {{ item }}
-    with_items: devices
-    failed_when: false
+    command: sgdisk --zap-all --clear --mbrtogpt -g -- {{ item }}
+    with_items: ceph_osd_docker_devices


### PR DESCRIPTION
Also checks for the existence of gdisk and installs if necessary. fixes #727 