### PR TITLE
docker: fixes for OpenStack VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,8 @@ ansible_provision = proc do |ansible|
       ceph_mon_docker_subnet: "#{SUBNET}.0/24",
       ceph_osd_docker_extra_env: "CEPH_DAEMON=OSD_CEPH_DISK,OSD_JOURNAL_SIZE=100",
       ceph_osd_docker_devices: settings['disks'],
+      # Note that OSVM is defaulted to false above
+      ceph_docker_on_openstack: OSVM,
       ceph_rgw_civetweb_port: 8080
     }
   else

--- a/roles/ceph-osd/tasks/docker/main.yml
+++ b/roles/ceph-osd/tasks/docker/main.yml
@@ -20,10 +20,12 @@
 
 - include: pre_requisite.yml
 
+# NOTE (jimcurtis): dirs_permissions.yml must precede fetch_configs.yml 
+# because it creats the directories needed by the latter.
+- include: dirs_permissions.yml
+
 - include: fetch_configs.yml
   when: not osd_containerized_deployment_with_kv
-
-- include: dirs_permissions.yml
 
 - include: selinux.yml
   when: ansible_os_family == 'RedHat'

--- a/roles/ceph-osd/tasks/docker/main.yml
+++ b/roles/ceph-osd/tasks/docker/main.yml
@@ -21,7 +21,7 @@
 - include: pre_requisite.yml
 
 # NOTE (jimcurtis): dirs_permissions.yml must precede fetch_configs.yml 
-# because it creats the directories needed by the latter.
+# because it creates the directories needed by the latter.
 - include: dirs_permissions.yml
 
 - include: fetch_configs.yml

--- a/roles/ceph-restapi/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-restapi/tasks/docker/dirs_permissions.yml
@@ -9,12 +9,7 @@
 - set_fact:
     after_hamer=True
   when:
-    ceph_version not in (firefly or giant or hammer)
-
-- set_fact:
-    after_hamer=False
-  when:
-    ceph_version in (firefly or giant or hammer)
+    ceph_version.stdout not in ['firefly','giant', 'hammer']
 
 - name: create bootstrap directories (for or before hammer)
   file:

--- a/roles/ceph-rgw/tasks/docker/main.yml
+++ b/roles/ceph-rgw/tasks/docker/main.yml
@@ -9,8 +9,10 @@
   when: ceph_health.rc != 0
 
 - include: pre_requisite.yml
-- include: fetch_configs.yml
 - include: dirs_permissions.yml
+# NOTE (jimcurtis): dirs_permissions.yml must precede fetch_configs.yml
+# because it creates the directories needed by the latter.
+- include: fetch_configs.yml
 
 - include: selinux.yml
   when: ansible_os_family == 'RedHat'

--- a/vagrant_variables.yml.openstack
+++ b/vagrant_variables.yml.openstack
@@ -1,5 +1,8 @@
 ---
 
+# DEPLOY CONTAINERIZED DAEMONS
+docker: true
+
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 1
 osd_vms: 1


### PR DESCRIPTION
These were the changes I had to make to get things to work on my OpenStack VMs with the rhcs docker image.   In the case of the Vagrantfile change, there is already a conditional that sets OSVM based on the box and that defaults to false so I am using OSVM to set the ceph_docker_on_openstack variable.  In the case of the roles/ceph-osd/tasks/docker/main.yml, this change is necessary in new VM creation cases to make sure that dirs_permisssions.yml is run before the fetch because dirs_permissions creates the directories that we are copying into as part of the fetch.  The roles/ceph-restapi/tasks/docker/dirs_permissions.yml change is to use the same logic to set the ceph version fact as we do in all the other roles.  The logic that was there did not work for me.