### PR TITLE
cleanup /tmp/rh-storage-repo so newer repos are actually installed

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -412,6 +412,9 @@
     when:
       ansible_pkg_mgr == 'dnf'
 
+  - name: purge RPM cache in /tmp
+    file: path=/tmp/rh-storage-repo state=absent
+
   - name: clean apt
     shell: apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
     when:

--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -413,7 +413,9 @@
       ansible_pkg_mgr == 'dnf'
 
   - name: purge RPM cache in /tmp
-    file: path=/tmp/rh-storage-repo state=absent
+    file:
+      path: /tmp/rh-storage-repo
+      state: absent
 
   - name: clean apt
     shell: apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
I got burned when I upgraded to RHCS 1.3.2 .iso image because old image still remained in /tmp/rh-storage-repo and so ceph-ansible skipped the step of copying from the (new) .iso image to /tmp/rh-storage-repo.   This fix clears out the old contents of /tmp/rh-storage-repo to ensure that new .iso image really gets used.