### PR TITLE
do not install the 'ceph' package on rpm systems for jewel

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -63,6 +63,13 @@ ceph_origin: 'upstream' # or 'distro'
 #
 ceph_use_distro_backports: false # DEBIAN ONLY
 
+ceph_mon_packages:
+  - ceph
+  - ceph-mon
+
+ceph_osd_packages:
+  - ceph
+  - ceph-osd
 
 # STABLE
 ########

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -40,9 +40,7 @@
   yum:
     name: "{{ item }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  with_items:
-    - ceph
-    - ceph-mon
+  with: ceph_mon_packages
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
@@ -53,9 +51,7 @@
   dnf:
     name: "{{ item }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  with_items:
-    - ceph
-    - ceph-mon
+  with: ceph_mon_packages
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
@@ -66,9 +62,7 @@
   yum:
     name: "{{ item }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  with_items:
-    - ceph
-    - ceph-osd
+  with: ceph_osd_packages
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
@@ -79,9 +73,7 @@
   dnf:
     name: "{{ item }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  with_items:
-    - ceph
-    - ceph-osd
+  with: ceph_osd_packages
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+
+- include_vars: ./vars/after_infernalis_vars.yml
+  when: is_after_infernalis
+
 - include: ./checks/check_system.yml
 
 - include: ./checks/check_mandatory_vars.yml

--- a/roles/ceph-common/tasks/vars/after_infernalis_vars.yml
+++ b/roles/ceph-common/tasks/vars/after_infernalis_vars.yml
@@ -1,0 +1,7 @@
+---
+
+ceph_mon_packages:
+  - ceph-mon
+
+ceph_osd_packages:
+  - ceph-osd


### PR DESCRIPTION
Starting with jewel we will no longer want to install the ceph package,
because it is a meta package that installs all ceph packages. We only
need to install the specific packages for the type of node being
configured, either a MON or OSD.

This depends on https://github.com/ceph/ceph-ansible/pull/737