### PR TITLE
Adds a use_server_package_split var

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -38,6 +38,10 @@ dummy:
 # "state=latest".
 #upgrade_ceph_packages: False
 
+# If this is false then the 'ceph' package will be installed on rpm systems, which
+# is not needed for versions after infernalis.
+#use_server_package_split: true
+
 # /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_dev /!\
 
 #debian_package_dependencies:

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -30,6 +30,10 @@ check_firewall: True
 # "state=latest".
 upgrade_ceph_packages: False
 
+# If this is false then the 'ceph' package will be installed on rpm systems, which
+# is not needed for versions after infernalis.
+use_server_package_split: true
+
 # /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_dev /!\
 
 debian_package_dependencies:
@@ -369,3 +373,4 @@ docker: false
 # Do not comment the variable mon_containerized_deployment_with_kv here. This variable is being used
 # by ceph.conf.j2 template. so it should always be defined
 mon_containerized_deployment_with_kv: false
+

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -34,15 +34,12 @@
   yum:
     name: ceph
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when: not ceph_stable_rh_storage
+  when: not use_server_package_split
 
 - name: install distro or red hat storage ceph mon
   yum:
-    name: "{{ item }}"
+    name: "ceph-mon"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  with_items:
-    - ceph
-    - ceph-mon
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
@@ -51,11 +48,8 @@
 
 - name: install distro or red hat storage ceph mon
   dnf:
-    name: "{{ item }}"
+    name: "ceph-mon"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  with_items:
-    - ceph
-    - ceph-mon
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
@@ -64,11 +58,8 @@
 
 - name: install distro or red hat storage ceph osd
   yum:
-    name: "{{ item }}"
+    name: "ceph-osd"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  with_items:
-    - ceph
-    - ceph-osd
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
@@ -77,11 +68,8 @@
 
 - name: install distro or red hat storage ceph osd
   dnf:
-    name: "{{ item }}"
+    name: "ceph-osd"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  with_items:
-    - ceph
-    - ceph-osd
   when:
     (ceph_origin == "distro" or ceph_stable_rh_storage or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and


### PR DESCRIPTION
This will allow a user to conditionally install the ceph package on rpm
based systems. Installing this package is not required or wanted in
versions passed infernalis.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>