### PR TITLE
Allow RESTAPI to be optional

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ NMONS      = settings['mon_vms']
 NOSDS      = settings['osd_vms']
 NMDSS      = settings['mds_vms']
 NRGWS      = settings['rgw_vms']
+RESTAPI    = settings['restapi']
 CLIENTS    = settings['client_vms']
 SUBNET     = settings['subnet']
 BOX        = settings['vagrant_box']
@@ -42,12 +43,16 @@ ansible_provision = proc do |ansible|
   # https://github.com/mitchellh/vagrant/issues/3539
   ansible.groups = {
     'mons'        => (0..NMONS - 1).map { |j| "mon#{j}" },
-    'restapis'    => (0..NMONS - 1).map { |j| "mon#{j}" },
     'osds'        => (0..NOSDS - 1).map { |j| "osd#{j}" },
     'mdss'        => (0..NMDSS - 1).map { |j| "mds#{j}" },
     'rgws'        => (0..NRGWS - 1).map { |j| "rgw#{j}" },
     'clients'     => (0..CLIENTS - 1).map { |j| "client#{j}" }
   }
+
+  if RESTAPI then
+    ansible.groups['restapis'] = (0..NMONS - 1).map { |j| "mon#{j}" }
+  end
+
 
   # In a production deployment, these should be secret
   if DOCKER then

--- a/vagrant_variables.yml.atomic
+++ b/vagrant_variables.yml.atomic
@@ -9,6 +9,9 @@ mds_vms: 0
 rgw_vms: 0
 client_vms: 0
 
+# Deploy RESTAPI on each of the Monitors
+#restapi: false
+
 # SUBNET TO USE FOR THE VMS
 subnet: 192.168.0
 

--- a/vagrant_variables.yml.openstack
+++ b/vagrant_variables.yml.openstack
@@ -10,6 +10,9 @@ mds_vms: 0
 rgw_vms: 0
 client_vms: 0
 
+# Deploy RESTAPI on each of the Monitors
+#restapi: false
+
 # SUBNET TO USE FOR THE VMS
 # Use whatever private subnet your Openstack VMs are given
 subnet: 172.17.72 

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -10,6 +10,9 @@ mds_vms: 0
 rgw_vms: 0
 client_vms: 0
 
+# Deploy RESTAPI on each of the Monitors
+restapi: true
+
 # INSTALL SOURCE OF CEPH
 # valid values are 'stable' and 'dev'
 ceph_install_source: stable


### PR DESCRIPTION
When running via Vagrant, rather than always starting RESTAPI on each
monitor, make it optional via a configuration option in
vagrant_variables.yml.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>