### PR TITLE
ceph-common: install ceph-mon/osd for ceph dev

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -41,7 +41,7 @@
     name: "ceph-mon"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage or
+    (ceph_origin == "distro" or ceph_stable_rh_storage or ceph_dev or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     mon_group_name in group_names and
     ansible_pkg_mgr == "yum"
@@ -51,7 +51,7 @@
     name: "ceph-mon"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage or
+    (ceph_origin == "distro" or ceph_stable_rh_storage or ceph_dev or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     mon_group_name in group_names and
     ansible_pkg_mgr == "dnf"
@@ -61,7 +61,7 @@
     name: "ceph-osd"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage or
+    (ceph_origin == "distro" or ceph_stable_rh_storage or ceph_dev or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     osd_group_name in group_names and
     ansible_pkg_mgr == "yum"
@@ -71,7 +71,7 @@
     name: "ceph-osd"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage or
+    (ceph_origin == "distro" or ceph_stable_rh_storage or ceph_dev or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     osd_group_name in group_names and
     ansible_pkg_mgr == "dnf"


### PR DESCRIPTION
Since developement versions of Ceph are after infernalis a package split
happened. So basically ceph-mon, ceph-osd, ceph-mds need to be
installed.

Signed-off-by: Sébastien Han <seb@redhat.com>