### PR TITLE
Add support for install from Ubuntu Cloud Archive

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -42,7 +42,7 @@ dummy:
 # is not needed for versions after infernalis.
 #use_server_package_split: true
 
-# /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_dev /!\
+# /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_stable_uca OR ceph_dev /!\
 
 #debian_package_dependencies:
 #  - python-pycurl
@@ -137,6 +137,16 @@ dummy:
 #ceph_stable_rh_storage_iso_path:
 #ceph_stable_rh_storage_mount_path: /tmp/rh-storage-mount
 #ceph_stable_rh_storage_repository_path: /tmp/rh-storage-repo # where to copy iso's content
+
+
+# UBUNTU CLOUD ARCHIVE
+# This allows the install of Ceph from the Ubuntu Cloud Archive.  The Ubuntu Cloud Archive
+# usually has newer Ceph releases than the normal distro repository.
+#
+#ceph_stable_uca: false
+#ceph_stable_repo_uca: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
+#ceph_stable_openstack_release_uca: liberty
+#ceph_stable_release_uca: "{{ansible_lsb.codename}}-updates/{{ceph_stable_openstack_release_uca}}"
 
 # DEV
 # ###

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -34,7 +34,7 @@ upgrade_ceph_packages: False
 # is not needed for versions after infernalis.
 use_server_package_split: true
 
-# /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_dev /!\
+# /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_stable_uca OR ceph_dev /!\
 
 debian_package_dependencies:
   - python-pycurl
@@ -129,6 +129,16 @@ ceph_stable_rh_storage_iso_install: false # usually used when nodes don't have a
 #ceph_stable_rh_storage_iso_path:
 ceph_stable_rh_storage_mount_path: /tmp/rh-storage-mount
 ceph_stable_rh_storage_repository_path: /tmp/rh-storage-repo # where to copy iso's content
+
+
+# UBUNTU CLOUD ARCHIVE
+# This allows the install of Ceph from the Ubuntu Cloud Archive.  The Ubuntu Cloud Archive
+# usually has newer Ceph releases than the normal distro repository.
+#
+ceph_stable_uca: false
+#ceph_stable_repo_uca: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
+#ceph_stable_openstack_release_uca: liberty
+#ceph_stable_release_uca: "{{ansible_lsb.codename}}-updates/{{ceph_stable_openstack_release_uca}}"
 
 # DEV
 # ###

--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -16,7 +16,8 @@
     not ceph_stable and
     not ceph_dev and
     not ceph_stable_ice and
-    not ceph_stable_rh_storage
+    not ceph_stable_rh_storage and
+    not ceph_stable_uca
   tags:
     - package-install
 

--- a/roles/ceph-common/tasks/checks/check_system.yml
+++ b/roles/ceph-common/tasks/checks/check_system.yml
@@ -21,6 +21,13 @@
     ceph_stable_rh_storage and
     {{ ansible_distribution_version | version_compare('7.1', '<') }}
 
+- name: fail on unsupported distribution for ubuntu cloud archive
+  fail:
+    msg: "Distribution not supported by Ubuntu Cloud Archive: {{ ansible_distribution }}"
+  when:
+    ceph_stable_uca and
+    '{{ ansible_distribution }}' not in ['Ubuntu']
+
 - name: fail on unsupported ansible version
   fail:
     msg: "Ansible version must be >= 1.9, please update!"

--- a/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
@@ -38,3 +38,15 @@
     state: present
   changed_when: false
   when: ceph_stable_ice
+
+- name: add ubuntu cloud archive key package
+  apt:
+    pkg: ubuntu-cloud-keyring
+  when: ceph_stable_uca
+
+- name: add ubuntu cloud archive repository
+  apt_repository:
+    repo: "deb {{ ceph_stable_repo_uca }} {{ ceph_stable_release_uca}} main"
+    state: present
+  changed_when: false
+  when: ceph_stable_uca

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -15,7 +15,7 @@
   apt:
     pkg: "{{ item }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ansible_distribution_release }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
+    default_release: "{{ ceph_stable_release_uca | default(ansible_distribution_release) }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
   with_items:
     - ceph
     - ceph-common    #|
@@ -27,7 +27,7 @@
   apt:
     pkg: ceph-test
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ansible_distribution_release }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
+    default_release: "{{ ceph_stable_release_uca | default(ansible_distribution_release) }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
   when: ceph_test
 
 - name: install rados gateway
@@ -42,6 +42,6 @@
   apt:
     pkg: ceph-mds
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ansible_distribution_release }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
+    default_release: "{{ ceph_stable_release_uca | default(ansible_distribution_release) }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
   when:
     mds_group_name in group_names


### PR DESCRIPTION
This adds support to allow the install of Ceph from the
Ubuntu Cloud Archive.  The Ubuntu Cloud Archive provides newer
release of Ceph than the normal Ubuntu distro repository.

Signed-off-by: Samuel Matzek <smatzek@us.ibm.com>