### PR TITLE
Get the correct OSD ID when the cluster name includes numbers

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -69,7 +69,7 @@
     is_before_infernalis
 
 - name: get osd id (for or after infernalis)
-  shell: "ls /var/lib/ceph/osd/ |grep -oh '[0-9]*'"
+  shell: "ls /var/lib/ceph/osd/ | grep '-' | cut -d '-' -f 2"
   changed_when: false
   failed_when: false
   register: osd_id


### PR DESCRIPTION
If the ceph cluster name includes numbers, the grep used to find the OSD
IDs from /var/lib/ceph/osd/ would also return the numbers that were in
the cluster name.

For example, if the cluster was named 'mine123' and there was only one
OSD on the node, then the task that finds the OSD IDs would return
'123' and '0'.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>