### PR TITLE
Set init_system fact and reference in ceph-osd role

### DIFF
--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -8,6 +8,15 @@
 - set_fact:
     ceph_version: "{{ ceph_version.stdout.split(' ')[2] }}"
 
+# NOTE(mattt): On ansible 2.x we can use ansible_service_mgr instead
+- name: check init system
+  slurp:
+    src: /proc/1/comm
+  register: init_system
+
+- set_fact:
+    init_system={{ init_system.content | b64decode }}
+
 # NOTE (leseb/jsaintrocc): You are supposed to quote variables
 # that follow colons to avoid confusion with dicts but this
 # causes issues with the boolean, so we keep this syntax styling...

--- a/roles/ceph-osd/tasks/scenarios/osd_directory.yml
+++ b/roles/ceph-osd/tasks/scenarios/osd_directory.yml
@@ -31,11 +31,11 @@
     name: ceph
     state: started
     enabled: yes
-  when: ansible_service_mgr != "systemd"
+  when: init_system != "systemd"
 
 - name: start and add the OSD target to the systemd sequence
   service:
     name: ceph.target
     state: started
     enabled: yes
-  when: ansible_service_mgr == "systemd"
+  when: init_system == "systemd"


### PR DESCRIPTION
The ceph-osd role currently uses ansible_service_mgr, which is a fact
only available on ansible 2.x and greater.  This commit sets a similar
fact called init_system which will store the contents of /proc/1/comm
(systemd, init, etc.) and then references it ceph-osd instead.

Closes #741