### PR TITLE
ceph-common: fix ceph default file path ubuntu

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -236,7 +236,7 @@
 
 - name: configure cluster name
   lineinfile:
-    dest: /etc/default/ceph/ceph
+    dest: /etc/default/ceph
     insertafter: EOF
     create: yes
     line: "CLUSTER={{ cluster }}"


### PR DESCRIPTION
Signed-off-by: Sébastien Han <seb@redhat.com>