### PR TITLE
Adds an use_systemd fact

### DIFF
--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -17,7 +17,7 @@
       state: restarted
   when:
     socket.rc == 0 and
-    ansible_distribution != 'Ubuntu' and
+    use_systemd and
     mon_group_name in group_names and
     is_after_hammer
 
@@ -26,6 +26,7 @@
   when:
     socket.rc == 0 and
     ansible_distribution == 'Ubuntu' and
+    not use_systemd and
     mon_group_name in group_names
 
 - name: restart ceph osds
@@ -45,7 +46,7 @@
     state: restarted
   when:
     socket.rc == 0 and
-    ansible_distribution != 'Ubuntu' and
+    use_systemd and
     osd_group_name in group_names and
     is_after_hammer
 
@@ -57,6 +58,7 @@
   when:
     socket.rc == 0 and
     ansible_distribution == 'Ubuntu' and
+    not use_systemd and
     osd_group_name in group_names
 
 - name: restart ceph mdss on ubuntu
@@ -64,6 +66,7 @@
   when:
     socket.rc == 0 and
     ansible_distribution == 'Ubuntu' and
+    not use_systemd and
     mds_group_name in group_names
 
 - name: restart ceph mdss
@@ -71,6 +74,7 @@
   when:
     socket.rc == 0 and
     ansible_distribution != 'Ubuntu' and
+    not use_systemd and
     mds_group_name in group_names and
     ceph_stable and
     ceph_stable_release in ceph_stable_releases
@@ -81,7 +85,7 @@
       state: restarted
   when:
     socket.rc == 0 and
-    ansible_distribution != 'Ubuntu' and
+    use_systemd and
     mds_group_name in group_names and
     ceph_stable and
     ceph_stable_release not in ceph_stable_releases
@@ -91,6 +95,7 @@
   when:
     socketrgw.rc == 0 and
     ansible_distribution == 'Ubuntu' and
+    not use_systemd and
     rgw_group_name in group_names
 
 - name: restart ceph rgws
@@ -115,7 +120,7 @@
     state: restarted
   when:
     socketrgw.rc == 0 and
-    ansible_distribution != 'Ubuntu' and
+    use_systemd and
     rgw_group_name in group_names and
     is_after_hammer
 

--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -74,10 +74,9 @@
   when:
     socket.rc == 0 and
     ansible_distribution != 'Ubuntu' and
-    not use_systemd and
+    use_systemd and
     mds_group_name in group_names and
-    ceph_stable and
-    ceph_stable_release in ceph_stable_releases
+    is_before_infernalis
 
 - name: restart ceph mdss with systemd
   service:
@@ -87,8 +86,7 @@
     socket.rc == 0 and
     use_systemd and
     mds_group_name in group_names and
-    ceph_stable and
-    ceph_stable_release not in ceph_stable_releases
+    is_after_hammer
 
 - name: restart ceph rgws on ubuntu
   command: initctl restart radosgw cluster={{ cluster }} id=rgw.{{ ansible_hostname }}

--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -17,6 +17,9 @@
 - set_fact:
     init_system={{ init_system.content | b64decode }}
 
+- set_fact:
+    use_systemd={{ init_system == 'systemd\n' }}
+
 # NOTE (leseb/jsaintrocc): You are supposed to quote variables
 # that follow colons to avoid confusion with dicts but this
 # causes issues with the boolean, so we keep this syntax styling...

--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -18,7 +18,7 @@
     init_system={{ init_system.content | b64decode }}
 
 - set_fact:
-    use_systemd={{ init_system == 'systemd\n' }}
+    use_systemd={{ init_system.strip() == 'systemd' }}
 
 # NOTE (leseb/jsaintrocc): You are supposed to quote variables
 # that follow colons to avoid confusion with dicts but this

--- a/roles/ceph-mds/tasks/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/pre_requisite.yml
@@ -63,7 +63,7 @@
     - done
     - upstart
   changed_when: false
-  when: ansible_distribution == "Ubuntu"
+  when: not use_systemd
 
 - name: activate metadata server with sysvinit
   file:
@@ -76,7 +76,7 @@
     - done
     - sysvinit
   changed_when: false
-  when: ansible_distribution != "Ubuntu"
+  when: use_systemd
 
 - name: enable systemd unit file for mds instance (for or after infernalis)
   file:
@@ -86,16 +86,16 @@
   changed_when: false
   failed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_after_hammer
 
-- name: start and add that the metadata service to the init sequence (ubuntu)
+- name: start and add that the metadata service to the init sequence (upstart)
   command: initctl emit ceph-mds cluster={{ cluster }} id={{ mds_name }}
   changed_when: false
   failed_when: false
-  when: ansible_distribution == "Ubuntu"
+  when: not use_systemd
 
-- name: start and add that the metadata service to the init sequence (before infernalis)
+- name: start and add that the metadata service to the init sequence (systemd before infernalis)
   service:
     name: ceph
     state: started
@@ -103,15 +103,15 @@
     args: mds.{{ mds_name }}
   changed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_before_infernalis
 
-- name: start and add that the metadata service to the init sequence (for or after infernalis)
+- name: start and add that the metadata service to the init sequence (systemd after hammer)
   service:
     name: ceph-mds@{{ mds_name }}
     state: started
     enabled: yes
   changed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_after_hammer

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -10,13 +10,13 @@
   with_items:
     - done
     - upstart
-  when: ansible_distribution == "Ubuntu"
+  when: not use_systemd
 
 - name: start and add that the monitor service to the init sequence (ubuntu)
   command: initctl emit ceph-mon cluster={{ cluster }} id={{ monitor_name }}
   changed_when: false
   failed_when: false
-  when: ansible_distribution == "Ubuntu"
+  when: not use_systemd
 
 # NOTE (leseb): somehow the service ansible module is messing things up
 # as a safety measure we run the raw command
@@ -35,7 +35,7 @@
   changed_when: false
   failed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_after_hammer
 
 - name: start and add that the monitor service to the init sequence (for or after infernalis)
@@ -45,7 +45,7 @@
       enabled: yes
   changed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_after_hammer
 
 - name: collect admin and bootstrap keys

--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -74,7 +74,7 @@
   failed_when: false
   register: osd_id
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_after_hammer
 
 - name: enable osd service instance(s) (for or after infernalis)
@@ -85,7 +85,7 @@
   with_items: osd_id.stdout_lines
   failed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_after_hammer
 
 - name: start and add that the osd service(s) to the init sequence (for or after infernalis)
@@ -96,5 +96,5 @@
   with_items: osd_id.stdout_lines
   changed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_after_hammer

--- a/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
@@ -1,20 +1,20 @@
 ---
-- name: start and add that the rbd mirror service to the init sequence (ubuntu)
+- name: start and add that the rbd mirror service to the init sequence (upstart)
   command: initctl emit ceph-rbd-mirror cluster={{ cluster }} id={{ ansible_hostname }}
   changed_when: false
   failed_when: false
-  when: ansible_distribution == "Ubuntu"
+  when: not use_systemd
 
 # NOTE (leseb): somehow the service ansible module is messing things up
 # as a safety measure we run the raw command
-- name: start and add that the rbd mirror service to the init sequence
+- name: start and add that the rbd mirror service to the init sequence (systemd before infernalis)
   command: service ceph start ceph-rbd-mirror
   changed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_before_infernalis
 
-- name: enable systemd unit file for the rbd mirror service (for or after infernalis)
+- name: enable systemd unit file for the rbd mirror service (systemd after hammer)
   file:
     src: /usr/lib/systemd/system/ceph-rbd-mirror@.service
     dest: "/etc/systemd/system/multi-user.target.wants/ceph-rbd-mirror@{{ ceph_rbd_mirror_local_user }}.service"
@@ -22,15 +22,15 @@
   changed_when: false
   failed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_after_hammer
 
-- name: start and add that the rbd mirror service to the init sequence (for or after infernalis)
+- name: start and add that the rbd mirror service to the init sequence (systemd after hammer)
   service:
       name: "ceph-rbd-mirror@{{ ceph_rbd_mirror_local_user }}"
       state: started
       enabled: yes
   changed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_after_hammer

--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -10,13 +10,14 @@
   when:
     rgwstatus.rc != 0 and
     ansible_distribution != "Ubuntu" and
-    ansible_os_family != 'RedHat'
+    ansible_os_family != 'RedHat' and
+    not use_systemd
 
 - name: start and add that the rados gateway service to the init sequence (ubuntu)
   command: initctl emit radosgw cluster={{ cluster }} id=rgw.{{ ansible_hostname }}
   changed_when: false
   failed_when: false
-  when: ansible_distribution == 'Ubuntu'
+  when: not use_systemd
 
 - name: start rgw on red hat (before or on infernalis)
   service:
@@ -35,14 +36,14 @@
   changed_when: false
   failed_when: false
   when:
-    ansible_distribution != "Ubuntu" and
+    use_systemd and
     is_after_hammer
 
-- name: start rgw on red hat (after infernalis)
+- name: start rgw with systemd (for or after infernalis)
   service:
     name: ceph-radosgw@rgw.{{ ansible_hostname }}
     state: started
     enabled: yes
   when:
-    ansible_os_family == 'RedHat' and
+    use_systemd and
     is_after_hammer

--- a/tests/inventories/single-machine.yml
+++ b/tests/inventories/single-machine.yml
@@ -6,3 +6,6 @@ localhost
 
 [rgws]
 localhost
+
+[mdss]
+localhost


### PR DESCRIPTION
This adds a helper fact that uses the ``init_system`` fact to determine if we should be using systemd to control services or not.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>