### PR TITLE
install: remove epel

### DIFF
--- a/install-ansible.sh
+++ b/install-ansible.sh
@@ -27,6 +27,7 @@ elif [[ "Ubuntu" =~ $os_VENDOR ]]; then
 elif [[ "RedHatEnterpriseServer" =~ $os_VENDOR || "CentOS" =~ $os_VENDOR || -r /etc/redhat-release ]]; then
   rpm -q epel-release-* || rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   yum install -y ansible
+  yum remove -y $(rpm -q epel-release-*)
 else
   if [[ ! -x $(which lsb_release 2>/dev/null) ]]; then
     echo "lsb_release is not installed"


### PR DESCRIPTION
We just add epel to conviently install Ansible. However we don't keep it
as it could disrupt ceph's installation and dependancies.

Signed-off-by: Sébastien Han <seb@redhat.com>