### PR TITLE
ceph-common: install ceph-mds package

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -76,6 +76,26 @@
     osd_group_name in group_names and
     ansible_pkg_mgr == "dnf"
 
+- name: install distro or red hat storage ceph mds
+  yum:
+    name: "ceph-mds"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    (ceph_origin == "distro" or ceph_stable_rh_storage or ceph_dev or
+     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
+    mds_group_name in group_names and
+    ansible_pkg_mgr == "yum"
+
+- name: install distro or red hat storage ceph mds
+  dnf:
+    name: "ceph-mds"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    (ceph_origin == "distro" or ceph_stable_rh_storage or ceph_dev or
+     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
+    mds_group_name in group_names and
+    ansible_pkg_mgr == "dnf"
+
 - name: install ceph-test
   yum:
     name: ceph-test


### PR DESCRIPTION
We kinda ommitted this package, now Jewel is out and the metadata server
is considered as stable.

Signed-off-by: Sébastien Han <seb@redhat.com>