### PR TITLE
Make install-ansible.sh work with Linux Mint and enable swap by default but decrease vm.swappiness

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -314,7 +314,6 @@ dummy:
 ## MDS options
 #
 #mds_use_fqdn: false # if set to true, the MDS name used will be the fqdn in the ceph.conf
-#mds_name: "{{ ansible_hostname }}"
 
 ## Rados Gateway options
 #
@@ -374,12 +373,13 @@ dummy:
 #############
 
 #disable_transparent_hugepage: true
-#disable_swap: true
+#disable_swap: false
 #os_tuning_params:
 #  - { name: kernel.pid_max, value: 4194303 }
 #  - { name: fs.file-max, value: 26234859 }
 #  - { name: vm.zone_reclaim_mode, value: 0 }
 #  - { name: vm.vfs_cache_pressure, value: 50 }
+#  - { name: vm.swappiness, value: 10 }
 #  - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }
 
 

--- a/install-ansible.sh
+++ b/install-ansible.sh
@@ -20,7 +20,7 @@ if [[ "Debian" =~ $os_VENDOR ]]; then
   cd ansible
   make install
   mkdir /etc/ansible
-elif [[ "Ubuntu" =~ $os_VENDOR ]]; then
+elif [[ "Ubuntu" =~ $os_VENDOR || "LinuxMint" =~ $os_VENDOR ]]; then
   add-apt-repository -y ppa:ansible/ansible
   apt-get update
   apt-get install -y ansible

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -365,12 +365,13 @@ ceph_conf_overrides: {}
 #############
 
 disable_transparent_hugepage: true
-disable_swap: true
+disable_swap: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
   - { name: vm.zone_reclaim_mode, value: 0 }
   - { name: vm.vfs_cache_pressure, value: 50 }
+  - { name: vm.swappiness, value: 10 }
   - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }
 
 


### PR DESCRIPTION
1. Just a small one to make it work with Linux Mint
2. I would like to see the swap enabled by default to guarantee a better resilience. Instead of turning swap completely of the way to go for better performance is to decrease vm.swappiness