### PR TITLE
Add Debian ppc64le support

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -64,6 +64,17 @@ dummy:
 #  - ntp
 #  - python-setuptools
 
+
+# The list of ceph packages needed for debian.
+# This variable should only be changed if packages are not available from a given
+# install source or architecture.
+#debian_ceph_packages:
+#  - ceph
+#  - ceph-common    #|
+#  - ceph-fs-common #|--> yes, they are already all dependencies from 'ceph'
+#  - ceph-fuse      #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
+#  - libcephfs1     #|--> they don't get update so we need to force them
+
 # Whether or not to install the ceph-test package.
 #ceph_test: False
 

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -56,6 +56,17 @@ redhat_package_dependencies:
   - ntp
   - python-setuptools
 
+
+# The list of ceph packages needed for debian.
+# This variable should only be changed if packages are not available from a given
+# install source or architecture.
+debian_ceph_packages:
+  - ceph
+  - ceph-common    #|
+  - ceph-fs-common #|--> yes, they are already all dependencies from 'ceph'
+  - ceph-fuse      #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
+  - libcephfs1     #|--> they don't get update so we need to force them
+
 # Whether or not to install the ceph-test package.
 ceph_test: False
 

--- a/roles/ceph-common/tasks/checks/check_system.yml
+++ b/roles/ceph-common/tasks/checks/check_system.yml
@@ -7,7 +7,7 @@
 - name: fail on unsupported architecture
   fail:
     msg: "Architecture not supported {{ ansible_architecture }}"
-  when: "'{{ ansible_architecture }}' not in ['x86_64']"
+  when: "'{{ ansible_architecture }}' not in ['x86_64', 'ppc64le']"
 
 - name: fail on unsupported distribution
   fail:

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -16,12 +16,7 @@
     pkg: "{{ item }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default(ansible_distribution_release) }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-  with_items:
-    - ceph
-    - ceph-common    #|
-    - ceph-fs-common #|--> yes, they are already all dependencies from 'ceph'
-    - ceph-fuse      #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
-    - libcephfs1     #|--> they don't get update so we need to force them
+  with_items: debian_ceph_packages
 
 - name: install ceph-test
   apt:


### PR DESCRIPTION
Add support to allow ceph-ansible to install and
configure Ceph on Debian on the ppc64le architecture.

Canonical has ppc64le Debian packages in Ubuntu distros
and on Ubuntu Cloud Archive.  Both of which can be installed
and configured using the 'distro' or 'uca' options in
ceph-ansible when this patch is used.

Signed-off-by: Samuel Matzek <smatzek@us.ibm.com>