### PR TITLE
Do not create symlinks for systemd manually

### DIFF
--- a/roles/ceph-mds/tasks/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/pre_requisite.yml
@@ -71,10 +71,7 @@
   when: not use_systemd
 
 - name: enable systemd unit file for mds instance (for or after infernalis)
-  file:
-    src: /usr/lib/systemd/system/ceph-mds@.service
-    dest: /etc/systemd/system/multi-user.target.wants/ceph-mds@{{ mds_name }}.service
-    state: link
+  command: systemctl enable ceph-mds@{{ mds_name }}
   changed_when: false
   failed_when: false
   when:

--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -77,13 +77,11 @@
     - use_systemd
     - is_after_hammer
 
-- name: enable osd service instance(s) (for or after infernalis)
-  file:
-    src:  /usr/lib/systemd/system/ceph-osd@.service
-    dest: /etc/systemd/system/multi-user.target.wants/ceph-osd@{{ item }}.service
-    state: link
-  with_items: osd_id.stdout_lines
+- name: enable the osd service (for or after infernalis)
+  command: systemctl enable ceph-osd@{{ item }}
+  changed_when: false
   failed_when: false
+  with_items: osd_id.stdout_lines
   when:
     - use_systemd
     - is_after_hammer

--- a/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
@@ -15,10 +15,7 @@
     - is_before_infernalis
 
 - name: enable systemd unit file for the rbd mirror service (systemd after hammer)
-  file:
-    src: /usr/lib/systemd/system/ceph-rbd-mirror@.service
-    dest: "/etc/systemd/system/multi-user.target.wants/ceph-rbd-mirror@{{ ceph_rbd_mirror_local_user }}.service"
-    state: link
+  command: systemctl enable ceph-rbd-mirror@{{ ceph_rbd_mirror_local_user }}
   changed_when: false
   failed_when: false
   when:

--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -29,10 +29,7 @@
     - is_before_infernalis
 
 - name: enable systemd unit file for rgw instance (for or after infernalis)
-  file:
-    src: /usr/lib/systemd/system/ceph-radosgw@.service
-    dest: /etc/systemd/system/multi-user.target.wants/ceph-radosgw@rgw.{{ ansible_hostname }}.service
-    state: link
+  command: systemctl enable ceph-radosgw@rgw.{{ ansible_hostname }}
   changed_when: false
   failed_when: false
   when:


### PR DESCRIPTION
Instead use 'systemctl enable' to create the symlinks.

This fixes: https://github.com/ceph/ceph-ansible/issues/779

Signed-off-by: Andrew Schoen <aschoen@redhat.com>