### PR TITLE
fix the /etc/default/ceph path on debian when setting cluster name

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -233,7 +233,7 @@
 
 - name: configure cluster name
   lineinfile:
-    dest: /etc/default/ceph/ceph
+    dest: /etc/default/ceph
     insertafter: EOF
     create: yes
     line: "CLUSTER={{ cluster }}"


### PR DESCRIPTION
In ceph version 10.2.1 a bug was fixed that corrects the path:

https://github.com/ceph/ceph/commit/791eba81a5467dd5de4f1680ed0deb647eb3fb8b

Signed-off-by: Andrew Schoen <aschoen@redhat.com>