### PR TITLE
ceph-common: fix ceph options default path again

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -236,6 +236,11 @@
 # The following commit https://github.com/ceph/ceph/commit/791eba81a5467dd5de4f1680ed0deb647eb3fb8b
 # fixed a package issue where the path was the wrong.
 # This bug is not yet on all the distros package so we are working around it
+# Impacted versions:
+# - Jewel from UCA: https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/1582773
+# - Jewel from latest Canonical 16.04 distro
+# - All previous versions from Canonical
+# - Infernalis from ceph.com
 - name: check /etc/default/ceph exist
   stat:
     path: /etc/default/ceph

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -231,10 +231,30 @@
     line: "CLUSTER={{ cluster }}"
   when: ansible_os_family == "RedHat"
 
+- name: check /etc/default/ceph exist
+  stat:
+    path: /etc/default/ceph
+  register: etc_default_ceph
+  when: ansible_os_family == "Debian"
+
 - name: configure cluster name
   lineinfile:
     dest: /etc/default/ceph
     insertafter: EOF
     create: yes
     line: "CLUSTER={{ cluster }}"
-  when: ansible_os_family == "Debian"
+  when:
+    - ansible_os_family == "Debian"
+    - etc_default_ceph.stat.exists
+    - not etc_default_ceph.stat.isdir
+
+- name: configure cluster name
+  lineinfile:
+    dest: /etc/default/ceph/ceph
+    insertafter: EOF
+    create: yes
+    line: "CLUSTER={{ cluster }}"
+  when:
+    - ansible_os_family == "Debian"
+    - etc_default_ceph.stat.exists
+    - etc_default_ceph.stat.isdir

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -231,6 +231,11 @@
     line: "CLUSTER={{ cluster }}"
   when: ansible_os_family == "RedHat"
 
+# NOTE(leseb): we are performing the following check
+# to ensure any Jewel installation will not fail.
+# The following commit https://github.com/ceph/ceph/commit/791eba81a5467dd5de4f1680ed0deb647eb3fb8b
+# fixed a package issue where the path was the wrong.
+# This bug is not yet on all the distros package so we are working around it
 - name: check /etc/default/ceph exist
   stat:
     path: /etc/default/ceph


### PR DESCRIPTION
closes: #788

Signed-off-by: Sébastien Han <seb@redhat.com>