### PR TITLE
ceph-rgw: implement keystonve api version and ssl verify options

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -26,6 +26,7 @@ dummy:
 #mds_group_name: mdss
 #restapi_group_name: restapis
 #rbdmirror_group_name: rbdmirrors
+#client_group_name: clients
 
 # If check_firewall is true, then ansible will try to determine if the
 # Ceph ports are blocked by a firewall. If the machine running ansible
@@ -270,9 +271,11 @@ dummy:
 #radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
 #radosgw_keystone_admin_token: password
+#radosgw_keystone_api_version: 2 # version of Keystone API to use (2 or 3)
 #radosgw_keystone_accepted_roles: Member, _member_, admin
 #radosgw_keystone_token_cache_size: 10000
 #radosgw_keystone_revocation_internal: 900
+#radosgw_keystone_verify_ssl: true # should try to verify keystone's ssl (true or false)
 #radosgw_s3_auth_use_keystone: "true"
 #radosgw_nss_db_path: /var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_hostname }}/nss
 # Toggle 100-continue support for Apache and FastCGI

--- a/group_vars/clients.sample
+++ b/group_vars/clients.sample
@@ -16,7 +16,9 @@ dummy:
 #user_config: false
 #pools:
 #  - { name: test, pgs: "{{ pool_default_pg_num }}" }
+#  - { name: test2, pgs: "{{ pool_default_pg_num }}" }
 
 #keys:
-#  - { name: client.test, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool={{ pools.name }}'" }
+#  - { name: client.test, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=test'" }
+#  - { name: client.test2, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=test2'" }
 

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -263,9 +263,11 @@ radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4 }}"
 radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
 radosgw_keystone_admin_token: password
+radosgw_keystone_api_version: 2 # version of Keystone API to use (2 or 3)
 radosgw_keystone_accepted_roles: Member, _member_, admin
 radosgw_keystone_token_cache_size: 10000
 radosgw_keystone_revocation_internal: 900
+radosgw_keystone_verify_ssl: true # should try to verify keystone's ssl (true or false)
 radosgw_s3_auth_use_keystone: "true"
 radosgw_nss_db_path: /var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_hostname }}/nss
 # Toggle 100-continue support for Apache and FastCGI

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -86,9 +86,11 @@ rgw frontends = civetweb port={{ radosgw_civetweb_bind_ip }}:{{ radosgw_civetweb
 {% if radosgw_keystone %}
 rgw keystone url = {{ radosgw_keystone_url }}
 rgw keystone admin token = {{ radosgw_keystone_admin_token }}
+rgw keystone api version = {{ radosgw_keystone_api_version }}
 rgw keystone accepted roles = {{ radosgw_keystone_accepted_roles }}
 rgw keystone token cache size = {{ radosgw_keystone_token_cache_size }}
 rgw keystone revocation interval = {{ radosgw_keystone_revocation_internal }}
+rgw keystone verify ssl = {{ radosgw_keystone_verify_ssl }}
 rgw s3 auth use keystone = {{ radosgw_s3_auth_use_keystone }}
 nss db path = {{ radosgw_nss_db_path }}
 {% endif %}


### PR DESCRIPTION
Jewel introduced rgw support for keystone v3 and ssl verfication.
This change enable this options on the ceph.conf file.

Signed-off-by: Flávio Ramalho <flaviosr@lsd.ufcg.edu.br>