### PR TITLE
ceph-osd: fail when ceph-disk fails to prepare an OSD

### DIFF
--- a/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
+++ b/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
@@ -18,6 +18,7 @@
     - raw_journal_devices
   changed_when: false
   ignore_errors: true
+  register: prepare_osd_disk
   when:
     - not item.0.get("skipped")
     - not item.1.get("skipped")
@@ -25,5 +26,14 @@
     - item.1.get("rc", 0) != 0
     - raw_multi_journal
     - not osd_auto_discovery
+
+- name: fail if ceph-disk cannot prepare an OSD
+  fail:
+    msg: "ceph-disk failed to prepare an OSD"
+  when:
+    - " 'ceph-disk: Error:' in item.get('stderr', '') "
+    - " 'Failed to add' in item.get('stderr', '') "
+    - item.get("rc") != 0
+  with_items: "{{prepare_osd_disk.results}}"
 
 - include: ../activate_osds.yml


### PR DESCRIPTION
Fixes issue #780 

Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=1335938