### PR TITLE
ceph-common: remove RedHat-only constraint for RH ISO install

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -17,7 +17,6 @@
   when:
     - ceph_stable_rh_storage
     - ceph_stable_rh_storage_iso_install
-    - ansible_os_family == "RedHat"
   tags:
     - package-install
 


### PR DESCRIPTION
Should fix https://bugzilla.redhat.com/show_bug.cgi?id=1337320 that tries to install RH storage ISO on Ubuntu