### PR TITLE
fix the radosgw_civetweb_bind_ip default value

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -266,7 +266,7 @@ dummy:
 #radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
 #radosgw_frontend: civetweb # supported options are 'apache' or 'civetweb', also edit roles/ceph-rgw/defaults/main.yml
 #radosgw_civetweb_port: 8080 # on Infernalis we get: "set_ports_option: cannot bind to 80: 13 (Permission denied)"
-#radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4 }}"
+#radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4.address }}"
 #radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
 #radosgw_keystone_admin_token: password

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -259,7 +259,7 @@ mds_use_fqdn: false # if set to true, the MDS name used will be the fqdn in the 
 #radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
 radosgw_frontend: civetweb # supported options are 'apache' or 'civetweb', also edit roles/ceph-rgw/defaults/main.yml
 radosgw_civetweb_port: 8080 # on Infernalis we get: "set_ports_option: cannot bind to 80: 13 (Permission denied)"
-radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4 }}"
+radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4.address }}"
 radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
 radosgw_keystone_admin_token: password


### PR DESCRIPTION
We want just the address for ansible_default_ipv4, not the entire
dictionary in ceph.conf.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>