### PR TITLE
ceph-common: on rh storage on debian add the repositories and keys (ISO)

### DIFF
--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
@@ -29,6 +29,7 @@
   apt_key:
     url: "https://www.redhat.com/security/fd431d51.txt"
     state: present
+  when: not ceph_stable_rh_storage_iso_install
 
 - name: install dependencies
   apt:

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
@@ -1,4 +1,30 @@
 ---
+# NOTE: this assumes that the ISO will always have a MON directory. Current
+# ISOs have MON, OSD, Tools, and Agent. If ISOs change the layout or provide
+# certain repos depending on the type of node this task will require a more
+# intelligent way to determine the location of the key.
+- name: install the rh ceph storage repository key
+  apt_key:
+    data: "{{ ceph_stable_rh_storage_repository_path }}/MON/release.asc"
+    state: present
+  when:
+    - ceph_stable_rh_storage
+    - ceph_stable_rh_storage_iso_install
+
+- name: add rh ceph storage repositories
+  apt_repository:
+    repo: "deb file://{{ ceph_stable_rh_storage_repository_path }}/{{ item }}/ {{ ansible_lsb.codename }} main"
+    state: present
+  changed_when: false
+  with_items:
+    - "MON"
+    - "OSD"
+    - "Tools"
+    - "Agent"
+  when:
+    - ceph_stable_rh_storage
+    - ceph_stable_rh_storage_iso_install
+
 - name: add the red hat storage apt-key
   apt_key:
     url: "https://www.redhat.com/security/fd431d51.txt"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1337320