### PR TITLE
ceph-osd: fix typo when calling sgdisk second time around

### DIFF
--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -103,7 +103,7 @@
     - item.0.rc != 0
 
 - name: fix partitions gpt header or labels of the journal devices
-  shell: "sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }} || shell: sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }}"
+  shell: "sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }} || sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }}"
   with_together:
     - journal_partition_status.results
     - raw_journal_devices


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>