### PR TITLE
ceph-common: redhat repo template: remove the Calamari reference

### DIFF
--- a/roles/ceph-common/templates/redhat_storage_repo.j2
+++ b/roles/ceph-common/templates/redhat_storage_repo.j2
@@ -26,15 +26,6 @@ type=rpm-md
 priority=1
 gpgkey=file://{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release
 
-[rh_storage_calamari]
-name=Red Hat Storage Ceph - local packages for Ceph
-baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/Calamari
-enabled=1
-gpgcheck=1
-type=rpm-md
-priority=1
-gpgkey=file://{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release
-
 [rh_storage_installer]
 name=Red Hat Storage Ceph - local packages for Ceph
 baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/Installer


### PR DESCRIPTION
It is no longer a distinct repo in RH Storage.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1337305