### PR TITLE
Allow running on local dev docker images

### DIFF
--- a/group_vars/all.docker.sample
+++ b/group_vars/all.docker.sample
@@ -1,6 +1,11 @@
 ---
 dummy:
 
+##########
+# GLOBAL #
+##########
+#ceph_docker_dev_image: false
+
 #######
 # MON #
 #######

--- a/roles/ceph-common/tasks/docker/fetch_image.yml
+++ b/roles/ceph-common/tasks/docker/fetch_image.yml
@@ -1,0 +1,27 @@
+---
+# Normal case - pull image from registry
+- name: pull ceph daemon image
+  command: "docker pull {{ ceph_docker_username }}/{{ ceph_docker_imagename }}"
+  changed_when: false
+  failed_when: false
+  when: ceph_docker_dev_image is undefined or not ceph_docker_dev_image
+
+# Dev case - export local dev image and send it across
+- name: export local ceph dev image
+  local_action: command docker save -o "/tmp/{{ ceph_docker_username }}-{{ ceph_docker_imagename }}.tar" "{{ ceph_docker_username }}/{{ ceph_docker_imagename }}"
+  when: ceph_docker_dev_image is defined and ceph_docker_dev_image
+  run_once: true
+
+- name: copy ceph dev image file
+  copy:
+    src: "/tmp/{{ ceph_docker_username }}-{{ ceph_docker_imagename }}.tar"
+    dest: "/tmp/{{ ceph_docker_username }}-{{ ceph_docker_imagename }}.tar"
+  when: ceph_docker_dev_image is defined and ceph_docker_dev_image
+
+- name: load ceph dev image
+  command: "docker load -i /tmp/{{ ceph_docker_username }}-{{ ceph_docker_imagename }}.tar"
+  when: ceph_docker_dev_image is defined and ceph_docker_dev_image
+
+- name: remove tmp ceph dev image file
+  command: "rm /tmp/{{ ceph_docker_username }}-{{ ceph_docker_imagename }}.tar"
+  when: ceph_docker_dev_image is defined and ceph_docker_dev_image

--- a/roles/ceph-mds/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-mds/tasks/docker/dirs_permissions.yml
@@ -1,9 +1,4 @@
 ---
-- name: pull ceph daemon image
-  shell: "docker pull {{ ceph_mds_docker_username }}/{{ ceph_mds_docker_imagename }}"
-  changed_when: false
-  failed_when: false
-
 # NOTE (leseb): we can not use docker inspect with 'format filed' because of
 # https://github.com/ansible/ansible/issues/10156
 - name: inspect ceph version

--- a/roles/ceph-mds/tasks/docker/main.yml
+++ b/roles/ceph-mds/tasks/docker/main.yml
@@ -9,6 +9,10 @@
   when: ceph_health.rc != 0
 
 - include: pre_requisite.yml
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
+  vars:
+    ceph_docker_username: '{{ ceph_mds_docker_username}}'
+    ceph_docker_imagename: '{{ ceph_mds_docker_imagename}}'
 - include: dirs_permissions.yml
 - include: fetch_configs.yml
 

--- a/roles/ceph-mon/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-mon/tasks/docker/dirs_permissions.yml
@@ -1,9 +1,4 @@
 ---
-- name: pull ceph daemon image
-  shell: "docker pull {{ ceph_mon_docker_username }}/{{ ceph_mon_docker_imagename }}"
-  changed_when: false
-  failed_when: false
-
 # NOTE (leseb): we can not use docker inspect with 'format filed' because of
 # https://github.com/ansible/ansible/issues/10156
 - name: inspect ceph version

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: check if a cluster is already running
-  shell: "docker ps | grep -sq 'ceph/daemon'"
+  shell: "docker ps | grep -sq '{{ceph_mon_docker_username}}/{{ceph_mon_docker_imagename}}'"
   register: ceph_health
   changed_when: false
   failed_when: false
@@ -19,6 +19,11 @@
     - not mon_containerized_deployment_with_kv
 
 - include: pre_requisite.yml
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
+  vars:
+    ceph_docker_username: '{{ ceph_mon_docker_username}}'
+    ceph_docker_imagename: '{{ ceph_mon_docker_imagename}}'
 
 - include: dirs_permissions.yml
 

--- a/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
+++ b/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
@@ -90,7 +90,7 @@
     net: "host"
     state: "running"
     privileged: "{{ mon_docker_privileged }}"
-    env: "MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface]['ipv4']['address'] }},CEPH_DAEMON=MON,CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }},{{ ceph_mon_extra_envs }}"
+    env: "MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface]['ipv4']['address'] }},CEPH_DAEMON=MON,CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }},CEPH_FSID={{ fsid }},{{ ceph_mon_extra_envs }}"
     volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph"
   when:
     - not is_atomic

--- a/roles/ceph-osd/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-osd/tasks/docker/dirs_permissions.yml
@@ -1,9 +1,4 @@
 ---
-- name: pull ceph daemon image
-  shell: "docker pull {{ ceph_osd_docker_username }}/{{ ceph_osd_docker_imagename }}"
-  changed_when: false
-  failed_when: false
-
 # NOTE (leseb): we can not use docker inspect with 'format filed' because of
 # https://github.com/ansible/ansible/issues/10156
 - name: inspect ceph version

--- a/roles/ceph-osd/tasks/docker/main.yml
+++ b/roles/ceph-osd/tasks/docker/main.yml
@@ -20,6 +20,11 @@
 
 - include: pre_requisite.yml
 
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
+  vars:
+    ceph_docker_username: '{{ ceph_osd_docker_username}}'
+    ceph_docker_imagename: '{{ ceph_osd_docker_imagename}}'
+
 # NOTE (jimcurtis): dirs_permissions.yml must precede fetch_configs.yml
 # because it creates the directories needed by the latter.
 - include: dirs_permissions.yml

--- a/roles/ceph-restapi/tasks/docker/main.yml
+++ b/roles/ceph-restapi/tasks/docker/main.yml
@@ -1,5 +1,9 @@
 ---
 - include: pre_requisite.yml
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
+  vars:
+    ceph_docker_username: '{{ ceph_restapi_docker_username}}'
+    ceph_docker_imagename: '{{ ceph_restapi_docker_imagename}}'
 - include: dirs_permissions.yml
 - include: fetch_configs.yml
 - include: start_docker_restapi.yml

--- a/roles/ceph-rgw/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-rgw/tasks/docker/dirs_permissions.yml
@@ -1,9 +1,4 @@
 ---
-- name: pull ceph daemon image
-  shell: "docker pull {{ ceph_rgw_docker_username }}/{{ ceph_rgw_docker_imagename }}"
-  changed_when: false
-  failed_when: false
-
 # NOTE (leseb): we can not use docker inspect with 'format filed' because of
 # https://github.com/ansible/ansible/issues/10156
 - name: inspect ceph version

--- a/roles/ceph-rgw/tasks/docker/main.yml
+++ b/roles/ceph-rgw/tasks/docker/main.yml
@@ -9,6 +9,10 @@
   when: ceph_health.rc != 0
 
 - include: pre_requisite.yml
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
+  vars:
+    ceph_docker_username: '{{ ceph_rgw_docker_username}}'
+    ceph_docker_imagename: '{{ ceph_rgw_docker_imagename}}'
 - include: dirs_permissions.yml
 # NOTE (jimcurtis): dirs_permissions.yml must precede fetch_configs.yml
 # because it creates the directories needed by the latter.


### PR DESCRIPTION
Docker makes it difficult to use images that are not on signed
registries.  This is a problem for developers, who likely won't have
access to a registry with proper signed certificates.

This allows the ability to use any docker image on the machine running
vagrant/ansible.  The way it works is that the image in question is
exported locally, then sent to each target box and imported there.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>