### PR TITLE
The when conditional was improperly being checked

### DIFF
--- a/filter_plugins/ceph-ansible.py
+++ b/filter_plugins/ceph-ansible.py
@@ -1,0 +1,13 @@
+from ansible import errors
+
+def only_one_true(a, *args):
+    params = list(args)
+    params.append(a)
+    it = iter(params)
+    return any(it) and not any(it)
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'only_one_true': only_one_true
+        }

--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -79,12 +79,7 @@
   when:
     - osd_group_name is defined
     - osd_group_name in group_names
-    - (journal_collocation and raw_multi_journal)
-      or (journal_collocation and osd_directory)
-      or (raw_multi_journal and osd_directory)
-      or (bluestore and journal_collocation)
-      or (bluestore and raw_multi_journal)
-      or (bluestore and osd_directory)
+    - journal_collocation | only_one_true(raw_multi_journal, osd_directory, bluestore)
 
 - name: verify devices have been provided
   fail:


### PR DESCRIPTION
The scenarios were not being accurately compared to ensure that:
* A single scenario was choosen
* ONLY a single scenario was choosen

A custom filter can handle this job far better than extending the when
conditional any further. Additionally, it allows us to add new
scenarios in the future with greater ease.