### PR TITLE
ceph-common: there is no Installer repo, it is now the Tools repo

### DIFF
--- a/roles/ceph-common/templates/redhat_storage_repo.j2
+++ b/roles/ceph-common/templates/redhat_storage_repo.j2
@@ -25,12 +25,3 @@ gpgcheck=1
 type=rpm-md
 priority=1
 gpgkey=file://{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release
-
-[rh_storage_installer]
-name=Red Hat Storage Ceph - local packages for Ceph
-baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/Installer
-enabled=1
-gpgcheck=1
-type=rpm-md
-priority=1
-gpgkey=file://{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release


### PR DESCRIPTION
Reference Bugzilla ticket: https://bugzilla.redhat.com/show_bug.cgi?id=1338548