### PR TITLE
Include rh_storage repo/installs when specified

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -44,7 +44,6 @@
     - mon_group_name in group_names
     - ansible_pkg_mgr == "yum"
     - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
-      or ceph_stable_rh_storage
       or ceph_dev
       or ceph_origin == "distro"
 
@@ -57,7 +56,6 @@
     - ansible_pkg_mgr == "dnf"
     - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
       or ceph_origin == "distro"
-      or ceph_stable_rh_storage
       or ceph_dev
 
 - name: install distro or red hat storage ceph osd
@@ -69,7 +67,6 @@
     - ansible_pkg_mgr == "yum"
     - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
       or ceph_origin == "distro"
-      or ceph_stable_rh_storage
       or ceph_dev
 
 - name: install distro or red hat storage ceph osd
@@ -81,7 +78,6 @@
     - ansible_pkg_mgr == "dnf"
     - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
       or ceph_origin == "distro"
-      or ceph_stable_rh_storage
       or ceph_dev
 
 - name: install distro or red hat storage ceph mds
@@ -89,7 +85,7 @@
     name: "ceph-mds"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage or ceph_dev or
+    (ceph_origin == "distro" or ceph_dev or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     mds_group_name in group_names and
     ansible_pkg_mgr == "yum"
@@ -99,7 +95,7 @@
     name: "ceph-mds"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage or ceph_dev or
+    (ceph_origin == "distro" or ceph_dev or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     mds_group_name in group_names and
     ansible_pkg_mgr == "dnf"
@@ -109,7 +105,7 @@
     name: "ceph-base"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage or ceph_dev or
+    (ceph_origin == "distro" or ceph_dev or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     client_group_name in group_names and
     ansible_pkg_mgr == "yum"
@@ -119,7 +115,7 @@
     name: "ceph-base"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_stable_rh_storage or ceph_dev or
+    (ceph_origin == "distro" or ceph_dev or
      (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
     client_group_name in group_names and
     ansible_pkg_mgr == "dnf"

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_redhat.yml
@@ -1,0 +1,67 @@
+---
+- name: install red hat storage repository key
+  rpm_key:
+    key: "{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release"
+    state: present
+  when:
+    - ceph_stable_rh_storage_iso_install
+
+- name: add red hat storage repository
+  template:
+    src: ../../templates/redhat_storage_repo.j2
+    dest: /etc/yum.repos.d/rh_storage.repo
+    owner: root
+    group: root
+    mode: 0644
+  when:
+    - ceph_stable_rh_storage_iso_install
+
+- name: install dependencies
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items: redhat_package_dependencies
+  when:
+    - ansible_pkg_mgr == "yum"
+
+- name: install red hat storage ceph mon
+  yum:
+    name: "ceph-mon"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - mon_group_name in group_names
+
+- name: install red hat storage ceph osd
+  yum:
+    name: "ceph-osd"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - osd_group_name in group_names
+
+- name: install red hat storage ceph mds
+  yum:
+    name: "ceph-mds"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - mds_group_name in group_names
+
+- name: install red hat storage ceph base
+  yum:
+    name: "ceph-base"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - client_group_name in group_names
+
+- name: install ceph-test
+  yum:
+    name: ceph-test
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - ceph_test
+
+- name: install rados gateway
+  yum:
+    name: ceph-radosgw
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - rgw_group_name in group_names

--- a/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
@@ -17,14 +17,6 @@
     state: present
   when: ceph_stable_ice
 
-- name: install red hat storage repository key
-  rpm_key:
-    key: "{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release"
-    state: present
-  when:
-    - ceph_stable_rh_storage
-    - ceph_stable_rh_storage_iso_install
-
 - name: add ceph stable repository
   yum:
     name: http://download.ceph.com/rpm-{{ ceph_stable_release }}/{{ ceph_stable_redhat_distro }}/noarch/ceph-release-1-0.{{ ceph_stable_redhat_distro|replace('rhel', 'el') }}.noarch.rpm
@@ -65,14 +57,3 @@
     group: root
     mode: 0644
   when: ceph_stable_ice
-
-- name: add red hat storage repository
-  template:
-    src: ../../templates/redhat_storage_repo.j2
-    dest: /etc/yum.repos.d/rh_storage.repo
-    owner: root
-    group: root
-    mode: 0644
-  when:
-    - ceph_stable_rh_storage
-    - ceph_stable_rh_storage_iso_install

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -33,6 +33,13 @@
   tags:
     - package-install
 
+- include: ./installs/install_rh_storage_on_redhat.yml
+  when:
+    - ansible_distribution == "RedHat"
+    - ceph_stable_rh_storage
+  tags:
+    - package-install
+
 - include: ./installs/install_on_debian.yml
   when:
     - ansible_os_family == 'Debian'


### PR DESCRIPTION
Before the repo configuration for ISOs for RH Storage was in a file that would be included only when:

    - name: configure ceph yum repository
      include: redhat_ceph_repository.yml
      when: ceph_origin == 'upstream'

Which would not work for rh_storage. This PR normalizes using the same convention for install_rh_storage_on_debian to create a new install_rh_storage_on_redhat.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1339096