### PR TITLE
Ambiguous "version is only supported on RHEL 7.1"

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -132,7 +132,7 @@ dummy:
 #ceph_stable_ice_password: # htaccess password
 
 # ENTERPRISE VERSION RED HAT STORAGE (from 1.3)
-# This version is only supported on RHEL 7.1
+# This version is only supported on RHEL >= 7.1
 # As of RHEL 7.1, libceph.ko and rbd.ko are now included in Red Hat's kernel
 # packages natively. The RHEL 7.1 kernel packages are more stable and secure than
 # using these 3rd-party kmods with RHEL 7.0. Please update your systems to RHEL


### PR DESCRIPTION
Change from "only supported on RHEL 7.1" to "only supported on RHEL >= 7.1" for RHS