### PR TITLE
ceph-common: ceph-base is not part of rhstorage, remove it

### DIFF
--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
@@ -68,3 +68,9 @@
     pkg: ceph-mds
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when: mds_group_name in group_names
+
+- name: install red hat storage ceph-common
+  apt:
+    pkg: ceph-common
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when: client_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_redhat.yml
@@ -45,9 +45,9 @@
   when:
     - mds_group_name in group_names
 
-- name: install red hat storage ceph base
+- name: install red hat storage ceph-common
   yum:
-    name: "ceph-base"
+    name: "ceph-common"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - client_group_name in group_names


### PR DESCRIPTION
Solves regression when fixing https://bugzilla.redhat.com/show_bug.cgi?id=1339096