### PR TITLE
lsb_release not installed by default.

### DIFF
--- a/install-ansible.sh
+++ b/install-ansible.sh
@@ -10,8 +10,22 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ! -x $(which lsb_release 2>/dev/null) ]]; then
+  echo "ERROR: lsb_release is not installed"
+  echo "Can not evaluate the platform"
+  echo "Please install lsb_release and retry"
+  echo "Red Hat based Systems : yum install redhat-lsb-core"
+  echo "Debian based Systems : apt-get install lsb-release"
+  exit 1
+fi
+ 
+
+# GET OS VENDOR
 os_VENDOR=$(lsb_release -i -s)
-os_VERSION=$(lsb_release -c -s)
+# GET OS MAJOR VERSION
+os_VERSION=$(lsb_release  -r  -s | cut -d. -f 1)
+
+
 if [[ "Debian" =~ $os_VENDOR ]]; then
   apt-get update
   apt-get install -y python-pip python-dev git build-essential
@@ -25,15 +39,10 @@ elif [[ "Ubuntu" =~ $os_VENDOR || "LinuxMint" =~ $os_VENDOR ]]; then
   apt-get update
   apt-get install -y ansible
 elif [[ "RedHatEnterpriseServer" =~ $os_VENDOR || "CentOS" =~ $os_VENDOR || -r /etc/redhat-release ]]; then
-  rpm -q epel-release-* || rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+  rpm -q epel-release-* || rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-${os_VERSION}.noarch.rpm
   yum install -y ansible
   yum remove -y $(rpm -q epel-release-*)
 else
-  if [[ ! -x $(which lsb_release 2>/dev/null) ]]; then
-    echo "lsb_release is not installed"
-    echo "Can not evaluate the platform"
-    exit 1
-  fi
   echo "Unsupported platform ${os_VENDOR}: ${os_VERSION}"
   echo "Please send a pull-request or open an issue"
   echo "on https://github.com/ceph/ceph-ansible/"


### PR DESCRIPTION
LSB Release is not present by default on minimal OS installs (for example cloud-images). Script fails with a "command not found" error.

Checking if lsb_release is present BEFORE doing the test
Change os_VERSION to grab the major OS version instead of the distro codename
When installing EPEL, use $os_VERSION to grab the correct rpm instead of using hardcoded '7' package that would fail on other versions.
os_Version can also be use to deprecate old version on which ceph-ansible is not supported.