### PR TITLE
LSB Release is not installed by default on minimal OS installs (for e…

### DIFF
--- a/install-ansible.sh
+++ b/install-ansible.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 # THIS SCRIPT INSTALLS ANSIBLE
+# DO NOT RUN IF ANSIBLE IS ALREADY INSTALLED ON YOUR SYSTEM
+
 set -e
 
 if [[ $EUID -ne 0 ]]; then
@@ -10,8 +12,23 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ! -x $(which lsb_release 2>/dev/null) ]]; then
+  echo "ERROR: lsb_release is not installed"
+  echo "Cannot evaluate the platform"
+  echo "Please install lsb_release and retry"
+  echo "Red Hat based Systems : yum install redhat-lsb-core"
+  echo "Debian based Systems : apt-get install lsb-release"
+  exit 1
+fi
+ 
+
+# GET OS VENDOR
 os_VENDOR=$(lsb_release -i -s)
-os_VERSION=$(lsb_release -c -s)
+# GET OS MAJOR VERSION
+os_VERSION=$(lsb_release  -r  -s | cut -d. -f 1)
+
+echo "*** Detected Linux $os_VENDOR $os_VERSION ***"
+
 if [[ "Debian" =~ $os_VENDOR ]]; then
   apt-get update
   apt-get install -y python-pip python-dev git build-essential
@@ -24,18 +41,28 @@ elif [[ "Ubuntu" =~ $os_VENDOR || "LinuxMint" =~ $os_VENDOR ]]; then
   add-apt-repository -y ppa:ansible/ansible
   apt-get update
   apt-get install -y ansible
-elif [[ "RedHatEnterpriseServer" =~ $os_VENDOR || "CentOS" =~ $os_VENDOR || -r /etc/redhat-release ]]; then
-  rpm -q epel-release-* || rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-  yum install -y ansible
-  yum remove -y $(rpm -q epel-release-*)
-else
-  if [[ ! -x $(which lsb_release 2>/dev/null) ]]; then
-    echo "lsb_release is not installed"
-    echo "Can not evaluate the platform"
-    exit 1
+elif [[ "RedHatEnterpriseServer" =~ $os_VENDOR || "CentOS" =~ $os_VENDOR ]]; then
+  if ( rpm -q epel-release &> /dev/null ); then
+    echo "*** WARNING : EPEL Already installed - We won't remove it but be aware that it might conflict if you plan using other Ceph repo source ***"
+    echo "*** Installing Ansible from EPEL... ***"
+    yum install -y ansible
+  else
+    echo "*** Installing EPEL... ***"
+    rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-${os_VERSION}.noarch.rpm
+    echo "*** Installing Ansible from EPEL... ***"
+    yum install -y ansible
+    echo "*** Removing EPEL... ***"
+    yum remove -y epel-release
   fi
-  echo "Unsupported platform ${os_VENDOR}: ${os_VERSION}"
-  echo "Please send a pull-request or open an issue"
-  echo "on https://github.com/ceph/ceph-ansible/"
+else
+  echo "*** Unsupported platform ${os_VENDOR}: ${os_VERSION} ***"
+  echo "*** Please send a pull-request or open an issue ***"
+  echo "*** on https://github.com/ceph/ceph-ansible/ ***"
   exit 1
+fi
+
+if ( ansible --version &> /dev/null ); then
+  echo "*** $(ansible --version | head -n1) installed successfully ***"
+else
+  echo "Something went wrong, please have a look at the script output"
 fi


### PR DESCRIPTION
…xample cloud-images). Script fails with a "command not found" erroor.

Checking if lsb_release is present BEFORE doing the test
Change os_VERSION to grab the major OS version instead of the distro codename
When installing EPEL, use $os_VERSION to grab the correct rpm instead of using hardcoded '7' package that would fail on other versions.
os_Version can also be use to deprecate old version on which ceph-ansible is not supported.