### PR TITLE
docker: enable rgw container on Atomic host environment

### DIFF
--- a/group_vars/all.docker.sample
+++ b/group_vars/all.docker.sample
@@ -44,6 +44,9 @@ dummy:
 # RGW #
 #######
 #rgw_containerized_deployment: true
+#rgw_containerized_deployment_with_kv: false
+#kv_type: etcd
+#kv_endpoint: 127.0.0.1
 #ceph_rgw_docker_username: ceph
 #ceph_rgw_docker_imagename: daemon
 #ceph_rgw_civetweb_port: 80

--- a/group_vars/rgws.sample
+++ b/group_vars/rgws.sample
@@ -35,6 +35,9 @@ dummy:
 ##########
 
 #rgw_containerized_deployment: false
+#rgw_containerized_deployment_with_kv: false
+#kv_type: etcd
+#kv_endpoint: 127.0.0.1
 #ceph_rgw_civetweb_port: 80
 #ceph_rgw_docker_username: ceph
 #ceph_rgw_docker_imagename: daemon

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -27,6 +27,9 @@ radosgw_user: root
 ##########
 
 rgw_containerized_deployment: false
+rgw_containerized_deployment_with_kv: false
+kv_type: etcd
+kv_endpoint: 127.0.0.1
 ceph_rgw_civetweb_port: 80
 ceph_rgw_docker_username: ceph
 ceph_rgw_docker_imagename: daemon

--- a/roles/ceph-rgw/tasks/docker/main.yml
+++ b/roles/ceph-rgw/tasks/docker/main.yml
@@ -5,6 +5,14 @@
   changed_when: false
   failed_when: false
 
+- name: check if it is Atomic host
+  stat: path=/run/ostree-booted
+  register: stat_ostree
+
+- name: set fact for using Atomic host
+  set_fact:
+      is_atomic='{{ stat_ostree.stat.exists }}'
+
 - include: checks.yml
   when: ceph_health.rc != 0
 

--- a/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
+++ b/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
@@ -1,4 +1,52 @@
 ---
+# Use systemd to manage container on Atomic host
+- name: generate systemd unit file
+  become: true
+  template:
+    src: "{{ playbook_dir }}/roles/ceph-rgw/templates/ceph-rgw.service.j2"
+    dest: /var/lib/ceph/ceph-rgw@.service
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  when:
+    is_atomic or
+    ansible_os_family == 'CoreOS'
+
+- name: link systemd unit file for rgw instance
+  file:
+    src: /var/lib/ceph/ceph-rgw@.service
+    dest: /etc/systemd/system/multi-user.target.wants/ceph-rgw@{{ ansible_hostname }}.service
+    state: link
+  when:
+    is_atomic or
+    ansible_os_family == 'CoreOS'
+
+- name: enable systemd unit file for rgw instance
+  shell: systemctl enable /etc/systemd/system/multi-user.target.wants/ceph-rgw@{{ ansible_hostname }}.service
+  failed_when: false
+  changed_when: false
+  when:
+    is_atomic or
+    ansible_os_family == 'CoreOS'
+
+- name: reload systemd unit files
+  shell: systemctl daemon-reload
+  changed_when: false
+  failed_when: false
+  when:
+    is_atomic or
+    ansible_os_family == 'CoreOS'
+
+- name: systemd start rgw container
+  service:
+    name: ceph-rgw@{{ ansible_hostname }}
+    state: started
+    enabled: yes
+  changed_when: false
+  when:
+    is_atomic or
+    ansible_os_family == 'CoreOS'
+
 - name: run the rados gateway docker image
   docker:
     image: "{{ ceph_rgw_docker_username }}/{{ ceph_rgw_docker_imagename }}"
@@ -8,3 +56,6 @@
     state: running
     env: "CEPH_DAEMON=RGW,{{ ceph_rgw_docker_extra_env }}"
     volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph"
+  when:
+    not is_atomic and
+    ansible_os_family != 'CoreOS'

--- a/roles/ceph-rgw/templates/ceph-rgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-rgw.service.j2
@@ -1,0 +1,28 @@
+[Unit]
+Description=Ceph RGW
+After=docker.service
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStartPre=-/usr/bin/docker stop {{ ansible_hostname }}
+ExecStartPre=-/usr/bin/docker rm {{ ansible_hostname }}
+ExecStart=/usr/bin/docker run --rm --net=host \
+   {% if not rgw_containerized_deployment_with_kv -%}
+   -v /var/lib/ceph:/var/lib/ceph \
+   -v /etc/ceph:/etc/ceph \
+   {% else -%}
+   -e KV_TYPE={{kv_type}} \
+   -e KV_IP={{kv_endpoint}} \
+   {% endif -%}
+   --privileged \
+   -e CEPH_DAEMON=RGW \
+   --name={{ ansible_hostname }} \
+   {{ ceph_rgw_docker_username }}/{{ ceph_rgw_docker_imagename }}
+ExecStopPost=-/usr/bin/docker stop {{ ansible_hostname }}
+Restart=always
+RestartSec=10s
+TimeoutStartSec=120
+TimeoutStopSec=15
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This will allow RGW to be started by systemd when it is an Atomic host environment.  This is what is done for OSD and MON.