### PR TITLE
ceph-common: uniformize template path calls

### DIFF
--- a/roles/ceph-common/tasks/installs/install_rgw_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rgw_on_debian.yml
@@ -104,7 +104,7 @@
 
 - name: install default httpd.conf
   template:
-    src: ../../templates/httpd.conf
+    src: "{{ role_path }}/templates/httpd.conf"
     dest: /etc/apache2/httpd.conf
     owner: root
     group: root
@@ -118,7 +118,7 @@
 
 - name: install rados gateway vhost
   template:
-    src: ../../templates/rgw.conf
+    src: "{{ role_path }}/templates/rgw.conf"
     dest: /etc/apache2/sites-available/rgw.conf
     owner: root
     group: root
@@ -135,7 +135,7 @@
 
 - name: install s3gw.fcgi script
   template:
-    src: ../../templates/s3gw.fcgi.j2
+    src: "{{ role_path }}/templates/s3gw.fcgi.j2"
     dest: /var/www/s3gw.fcgi
     mode: 0555
     owner: root

--- a/roles/ceph-common/tasks/installs/install_rgw_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_rgw_on_redhat.yml
@@ -1,7 +1,7 @@
 ---
 - name: add ceph extra
   template:
-    src: ../../templates/ceph-extra.repo
+    src: "{{ role_path }}/templates/ceph-extra.repo"
     dest: /etc/yum.repos.d
     owner: root
     group: root
@@ -36,14 +36,14 @@
 
 - name: install rados gateway vhost
   template:
-    src: ../../templates/rgw.conf
+    src: "{{ role_path }}/templates/rgw.conf"
     dest: /etc/httpd/conf.d/rgw.conf
     owner: root
     group: root
 
 - name: install s3gw.fcgi script
   template:
-    src: ../../templates/s3gw.fcgi.j2
+    src: "{{ role_path }}/templates/s3gw.fcgi.j2"
     dest: /var/www/s3gw.fcgi
     mode: 0555
     owner: root

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_redhat.yml
@@ -8,7 +8,7 @@
 
 - name: add red hat storage repository
   template:
-    src: ../../templates/redhat_storage_repo.j2
+    src: "{{ role_path }}/templates/redhat_storage_repo.j2"
     dest: /etc/yum.repos.d/rh_storage.repo
     owner: root
     group: root

--- a/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
@@ -51,7 +51,7 @@
 
 - name: add inktank ceph enterprise repository
   template:
-    src: redhat_ice_repo.j2
+    src: "{{ role_path }}/templates/redhat_ice_repo.j2"
     dest: /etc/yum.repos.d/ice.repo
     owner: root
     group: root

--- a/roles/ceph-mon/tasks/docker/create_configs.yml
+++ b/roles/ceph-mon/tasks/docker/create_configs.yml
@@ -2,7 +2,7 @@
 - name: generate ceph configuration file
   action: config_template
   args:
-    src: "{{ playbook_dir }}/roles/ceph-common/templates/ceph.conf.j2"
+    src: "{{ role_path }}/templates/ceph.conf.j2"
     dest: /etc/ceph/ceph.conf
     owner: "root"
     group: "root"

--- a/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
+++ b/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
@@ -44,7 +44,7 @@
 - name: generate systemd unit file
   become: true
   template:
-    src: "{{ playbook_dir }}/roles/ceph-mon/templates/ceph-mon.service.j2"
+    src: "{{ role_path }}/templates/ceph-mon.service.j2"
     dest: /var/lib/ceph/ceph-mon@.service
     owner: "root"
     group: "root"

--- a/roles/ceph-osd/tasks/docker/start_docker_osd.yml
+++ b/roles/ceph-osd/tasks/docker/start_docker_osd.yml
@@ -104,7 +104,7 @@
 - name: generate systemd unit file
   become: true
   template:
-    src: "{{ playbook_dir }}/roles/ceph-osd/templates/ceph-osd.service.j2"
+    src: "{{ role_path }}/templates/ceph-osd.service.j2"
     dest: /var/lib/ceph/ceph-osd@.service
     owner: "root"
     group: "root"


### PR DESCRIPTION
In order to align all Ansible versions, we now use the full path for the
template. We rely on `role_path` variable. Now all the tasks using
the template module have a uniform syntax.

Might fix issue raised in #483

Signed-off-by: Sébastien Han <seb@redhat.com>