### PR TITLE
Fix for #819

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,7 @@
 [defaults]
 ansible_managed = Please do not change this file directly since it is managed by Ansible and will be overwritten
 action_plugins = plugins/actions
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /etc/ansible/fact_cache
+fact_caching_timeout = 31536000

--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -421,3 +421,11 @@
     shell: apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
     when:
       ansible_pkg_mgr == 'apt'
+
+  - name: purge rh_storage.repo file in /etc/yum.repos.d
+    file:
+      path: /etc/yum.repos.d/rh_storage.repo
+      state: absent
+    when:
+      ansible_os_family == 'RedHat' and
+      ceph_stable_rh_storage_iso_install


### PR DESCRIPTION
This commit removes /etc/yum.repos.d/rh_storage.repo file
for RedHat OS with RHCS ISO install during cluster purge