### PR TITLE
Remove Centos7 dependency yum-plugin-priorities

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -339,3 +339,17 @@ dummy:
 #mon_containerized_deployment_with_kv: false
 
 
+##################
+# Temporary Vars #
+##################
+# NOTE(SamYaple): These vars are set here to they are defined before use. They
+# should be removed after a refactor has properly seperated all the checks into
+# the appropriate roles.
+
+#journal_collocation: False
+#raw_multi_journal: False
+#osd_directory: False
+#bluestore: False
+
+#osd_auto_discovery: False
+

--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -53,7 +53,6 @@ dummy:
 #centos_package_dependencies:
 #  - python-pycurl
 #  - hdparm
-#  - yum-plugin-priorities.noarch
 #  - epel-release
 #  - ntp
 #  - python-setuptools

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -123,7 +123,7 @@ ceph_stable_ice_kmod: 3.10-0.1.20140702gitdc9ac62.el7.x86_64
 #ceph_stable_ice_password: # htaccess password
 
 # ENTERPRISE VERSION RED HAT STORAGE (from 1.3)
-# This version is only supported on RHEL 7.1
+# This version is only supported on RHEL >= 7.1
 # As of RHEL 7.1, libceph.ko and rbd.ko are now included in Red Hat's kernel
 # packages natively. The RHEL 7.1 kernel packages are more stable and secure than
 # using these 3rd-party kmods with RHEL 7.0. Please update your systems to RHEL
@@ -234,7 +234,7 @@ mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the 
 
 ## OSD options
 #
-journal_size: 0
+journal_size: 0 # OSD journal size in MB
 public_network: 0.0.0.0/0
 cluster_network: "{{ public_network }}"
 osd_mkfs_type: xfs

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -45,7 +45,6 @@ debian_package_dependencies:
 centos_package_dependencies:
   - python-pycurl
   - hdparm
-  - yum-plugin-priorities.noarch
   - epel-release
   - ntp
   - python-setuptools


### PR DESCRIPTION
Currently, the ceph-ansible scripts fail when targeting Centos7 machines, due to the installation of yum-plugin-priorities, which forces older package dependencies (provided by default distribution repositories) to take precedence over newer ceph packages as provided by the ceph-release-{version}.noarch.rpm.  This is true even when setting the ceph yum repo priority=1.

See this [cautionary note](https://wiki.centos.org/PackageManagement/Yum/Priorities#head-38b91468cc607d0243f463489c2334bf40bfaaee) from the upstream maintainer of yum.

The error causes newer package versions from the ceph repository to be silently ignored in favor of older package versions from the default distribution repos.  The error looks like the following, repeated many times.

```
Error: Package: 1:ceph-base-10.2.1-0.el7.x86_64 (Ceph)
           Requires: librbd1 = 1:10.2.1-0.el7
           Available: 1:librbd1-0.80.7-2.el7.x86_64 (core-0)
```
The above type of errors make ansible fail, because the correct packages cannot be installed.

Tested on

```
CentOS Linux release 7.2.1511 (Core)
ansible 2.1.0.0
```
