### PR TITLE
docker: enable mds container on Atomic host environment

### DIFF
--- a/group_vars/all.docker.sample
+++ b/group_vars/all.docker.sample
@@ -36,6 +36,9 @@ dummy:
 # MDS #
 #######
 #mds_containerized_deployment: false
+#mds_containerized_deployment_with_kv: false
+#kv_type: etcd
+#kv_endpoint: 127.0.0.1
 #ceph_mds_docker_username: ceph
 #ceph_mds_docker_imagename: daemon
 #ceph_mds_docker_extra_env: "MDS_NAME={{ ansible_hostname }}" # comma separated variables

--- a/group_vars/mdss.sample
+++ b/group_vars/mdss.sample
@@ -29,6 +29,9 @@ dummy:
 ##########
 
 #mds_containerized_deployment: false
+#mds_containerized_deployment_with_kv: false
+#kv_type: etcd
+#kv_endpoint: 127.0.0.1
 #ceph_mds_docker_username: ceph
 #ceph_mds_docker_imagename: daemon
 #ceph_mds_docker_extra_env: "MDS_NAME={{ ansible_hostname }}" # comma separated variables

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -21,6 +21,9 @@ cephx: true
 ##########
 
 mds_containerized_deployment: false
+mds_containerized_deployment_with_kv: false
+kv_type: etcd
+kv_endpoint: 127.0.0.1
 ceph_mds_docker_username: ceph
 ceph_mds_docker_imagename: daemon
 ceph_mds_docker_extra_env: "MDS_NAME={{ ansible_hostname }}" # comma separated variables

--- a/roles/ceph-mds/tasks/docker/main.yml
+++ b/roles/ceph-mds/tasks/docker/main.yml
@@ -5,6 +5,14 @@
   changed_when: false
   failed_when: false
 
+- name: check if it is Atomic host
+  stat: path=/run/ostree-booted
+  register: stat_ostree
+
+- name: set fact for using Atomic host
+  set_fact:
+      is_atomic='{{ stat_ostree.stat.exists }}'
+
 - include: checks.yml
   when: ceph_health.rc != 0
 

--- a/roles/ceph-mds/tasks/docker/start_docker_mds.yml
+++ b/roles/ceph-mds/tasks/docker/start_docker_mds.yml
@@ -1,4 +1,52 @@
 ---
+# Use systemd to manage container on Atomic host
+- name: generate systemd unit file
+  become: true
+  template:
+    src: "{{ playbook_dir }}/roles/ceph-mds/templates/ceph-mds.service.j2"
+    dest: /var/lib/ceph/ceph-mds@.service
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  when:
+    is_atomic or
+    ansible_os_family == 'CoreOS'
+
+- name: link systemd unit file for mds instance
+  file:
+    src: /var/lib/ceph/ceph-mds@.service
+    dest: /etc/systemd/system/multi-user.target.wants/ceph-mds@{{ ansible_hostname }}.service
+    state: link
+  when:
+    is_atomic or
+    ansible_os_family == 'CoreOS'
+
+- name: enable systemd unit file for mds instance
+  shell: systemctl enable /etc/systemd/system/multi-user.target.wants/ceph-mds@{{ ansible_hostname }}.service
+  failed_when: false
+  changed_when: false
+  when:
+    is_atomic or
+    ansible_os_family == 'CoreOS'
+
+- name: reload systemd unit files
+  shell: systemctl daemon-reload
+  changed_when: false
+  failed_when: false
+  when:
+    is_atomic or
+    ansible_os_family == 'CoreOS'
+
+- name: systemd start mds container
+  service:
+    name: ceph-mds@{{ ansible_hostname }}
+    state: started
+    enabled: yes
+  changed_when: false
+  when:
+    is_atomic or
+    ansible_os_family == 'CoreOS'
+
 - name: run the ceph metadata docker image
   docker:
     image: "{{ ceph_mds_docker_username }}/{{ ceph_mds_docker_imagename }}"
@@ -7,3 +55,6 @@
     state: running
     env: "CEPH_DAEMON=MDS,CEPHFS_CREATE=1,{{ ceph_mds_docker_extra_env }}"
     volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph"
+  when:
+    not is_atomic and
+    ansible_os_family != 'CoreOS'

--- a/roles/ceph-mds/tasks/docker/start_docker_mds.yml
+++ b/roles/ceph-mds/tasks/docker/start_docker_mds.yml
@@ -3,7 +3,7 @@
 - name: generate systemd unit file
   become: true
   template:
-    src: "{{ playbook_dir }}/roles/ceph-mds/templates/ceph-mds.service.j2"
+    src: "{{ role_path }}/templates/ceph-mds.service.j2"
     dest: /var/lib/ceph/ceph-mds@.service
     owner: "root"
     group: "root"

--- a/roles/ceph-mds/tasks/docker/start_docker_mds.yml
+++ b/roles/ceph-mds/tasks/docker/start_docker_mds.yml
@@ -22,7 +22,7 @@
     ansible_os_family == 'CoreOS'
 
 - name: enable systemd unit file for mds instance
-  shell: systemctl enable /etc/systemd/system/multi-user.target.wants/ceph-mds@{{ ansible_hostname }}.service
+  command: systemctl enable /etc/systemd/system/multi-user.target.wants/ceph-mds@{{ ansible_hostname }}.service
   failed_when: false
   changed_when: false
   when:
@@ -30,7 +30,7 @@
     ansible_os_family == 'CoreOS'
 
 - name: reload systemd unit files
-  shell: systemctl daemon-reload
+  command: systemctl daemon-reload
   changed_when: false
   failed_when: false
   when:

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -1,0 +1,30 @@
+[Unit]
+Description=Ceph MDS
+After=docker.service
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStartPre=-/usr/bin/docker stop {{ ansible_hostname }}
+ExecStartPre=-/usr/bin/docker rm {{ ansible_hostname }}
+ExecStart=/usr/bin/docker run --rm --net=host \
+   {% if not mds_containerized_deployment_with_kv -%}
+   -v /var/lib/ceph:/var/lib/ceph \
+   -v /etc/ceph:/etc/ceph \
+   {% else -%}
+   -e KV_TYPE={{kv_type}} \
+   -e KV_IP={{kv_endpoint}} \
+   {% endif -%}
+   --privileged \
+   -e CEPH_DAEMON=MDS \
+   -e CEPHFS_CREATE=1 \
+   -e {{ ceph_mds_docker_extra_env }} \
+   --name={{ ansible_hostname }} \
+   {{ ceph_mds_docker_username }}/{{ ceph_mds_docker_imagename }}
+ExecStopPost=-/usr/bin/docker stop {{ ansible_hostname }}
+Restart=always
+RestartSec=10s
+TimeoutStartSec=120
+TimeoutStopSec=15
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
These changes are similar to what I did for RGW to allow it to run the containter on Atomic host environment with systemd