### PR TITLE
Various fixes for check_firewall task

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -32,7 +32,7 @@ dummy:
 # Ceph ports are blocked by a firewall. If the machine running ansible
 # cannot reach the Ceph ports for some other reason, you may need or
 # want to set this to False to skip those checks.
-#check_firewall: True
+#check_firewall: False
 
 # This variable determines if ceph packages can be updated.  If False, the
 # package resources will use "state=present".  If True, they will use

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -24,7 +24,7 @@ client_group_name: clients
 # Ceph ports are blocked by a firewall. If the machine running ansible
 # cannot reach the Ceph ports for some other reason, you may need or
 # want to set this to False to skip those checks.
-check_firewall: True
+check_firewall: False
 
 # This variable determines if ceph packages can be updated.  If False, the
 # package resources will use "state=present".  If True, they will use

--- a/roles/ceph-common/tasks/checks/check_firewall.yml
+++ b/roles/ceph-common/tasks/checks/check_firewall.yml
@@ -1,6 +1,6 @@
 ---
 - name: check if nmap is installed
-  command: "command -v nmap"
+  local_action: shell command -v nmap
   changed_when: false
   failed_when: false
   register: nmapexist
@@ -17,7 +17,7 @@
   local_action: shell set -o pipefail && nmap -p 6789 {{ item }} {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
-  with_items: groups.{{ mon_group_name }}
+  with_items: "{{ groups[mon_group_name] }}"
   register: monportstate
   when:
     - check_firewall
@@ -30,16 +30,16 @@
   with_items: monportstate.results
   when:
     - check_firewall
-    - item.has_key('rc') and item.rc == 0
+    - item is defined and item.has_key('rc') and item.rc == 0
     - mon_group_name is defined
     - mon_group_name in group_names
     - nmapexist.rc == 0
 
-- name: check if osd and mds range is not filtered
+- name: check if osd and mds range is not filtered (osd hosts)
   local_action: shell set -o pipefail && nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
-  with_items: groups.{{ osd_group_name }}
+  with_items: "{{ groups[osd_group_name] }}"
   register: osdrangestate
   when:
     - check_firewall
@@ -52,16 +52,16 @@
   with_items: osdrangestate.results
   when:
     - check_firewall
-    - item.has_key('rc') and item.rc == 0
+    - item is defined and item.has_key('rc') and item.rc == 0
     - osd_group_name is defined
     - osd_group_name in group_names
     - nmapexist.rc == 0
 
-- name: check if osd and mds range is not filtered
+- name: check if osd and mds range is not filtered (mds hosts)
   local_action: shell set -o pipefail && nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
-  with_items: groups.{{ mds_group_name }}
+  with_items: "{{ groups[mds_group_name] }}"
   register: mdsrangestate
   when:
     - check_firewall
@@ -74,7 +74,7 @@
   with_items: mdsrangestate.results
   when:
     - check_firewall
-    - item.has_key('rc') and item.rc == 0
+    - item is defined and item.has_key('rc') and item.rc == 0
     - mds_group_name is defined
     - mds_group_name in group_names
     - nmapexist.rc == 0
@@ -83,7 +83,7 @@
   local_action: shell set -o pipefail && nmap -p {{ radosgw_civetweb_port }} {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
-  with_items: groups.{{ rgw_group_name }}
+  with_items: "{{ groups[rgw_group_name] }}"
   register: rgwportstate
   when:
     - check_firewall
@@ -96,7 +96,7 @@
   with_items: rgwportstate.results
   when:
     - check_firewall
-    - item.has_key('rc') and item.rc == 0
+    - item is defined and item.has_key('rc') and item.rc == 0
     - rgw_group_name is defined
     - rgw_group_name in group_names
     - nmapexist.rc == 0

--- a/roles/ceph-common/tasks/checks/check_firewall.yml
+++ b/roles/ceph-common/tasks/checks/check_firewall.yml
@@ -14,7 +14,7 @@
     - nmapexist.rc != 0
 
 - name: check if monitor port is not filtered
-  local_action: shell set -o pipefail && nmap -p 6789 {{ item }} {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] }} | grep -sqo filtered
+  local_action: shell set -o pipefail && nmap -p 6789 {{ item }} {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] if hostvars[item]['ansible_' + monitor_interface] is defined else hostvars[item][monitor_address] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
   with_items: "{{ groups[mon_group_name] }}"

--- a/roles/ceph-common/tasks/checks/check_firewall.yml
+++ b/roles/ceph-common/tasks/checks/check_firewall.yml
@@ -1,6 +1,6 @@
 ---
 - name: check if nmap is installed
-  local_action: shell command -v nmap
+  local_action: command command -v nmap
   changed_when: false
   failed_when: false
   register: nmapexist

--- a/roles/ceph-common/tasks/checks/check_firewall.yml
+++ b/roles/ceph-common/tasks/checks/check_firewall.yml
@@ -5,108 +5,78 @@
   failed_when: false
   register: nmapexist
   run_once: true
-  when: check_firewall
 
 - name: inform that nmap is not present
   debug:
       msg: "nmap is not installed, can not test if ceph ports are allowed :("
   run_once: true
   when:
-    - check_firewall
     - nmapexist.rc != 0
 
 - name: check if monitor port is not filtered
-  local_action: shell set -o pipefail && nmap -p 6789 {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] if hostvars[item]['ansible_' + monitor_interface] is defined else hostvars[item]['monitor_address'] }} | grep -sqo -e filtered -e '0 hosts up'
+  local_action: shell set -o pipefail && nmap -p 6689 {{ hostvars[inventory_hostname]['ansible_' + monitor_interface]['ipv4']['address'] if hostvars[inventory_hostname]['ansible_' + monitor_interface] is defined else hostvars[inventory_hostname]['monitor_address'] }} | grep -sqo -e filtered -e '0 hosts up'
   changed_when: false
   failed_when: false
-  with_items: "{{ groups[mon_group_name] }}"
   register: monportstate
-  run_once: true
   when:
-    - check_firewall
     - mon_group_name in group_names
     - nmapexist.rc == 0
 
 - name: fail if monitor port is filtered
   fail:
       msg: "Please allow port 6789 on your firewall"
-  with_items: monportstate.results
-  run_once: true
   when:
-    - check_firewall
-    - item is defined and item.has_key('rc') and item.rc == 0
-    - mon_group_name is defined
     - mon_group_name in group_names
+    - monportstate.rc == 0
     - nmapexist.rc == 0
 
 - name: check if osd and mds range is not filtered (osd hosts)
-  local_action: shell set -o pipefail && nmap -p 6800-7300 {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo -e filtered -e '0 hosts up'
+  local_action: shell set -o pipefail && nmap -p 6800-7300 {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }} | grep -sqo -e filtered -e '0 hosts up'
   changed_when: false
   failed_when: false
-  with_items: "{{ groups[osd_group_name] }}"
   register: osdrangestate
-  run_once: true
   when:
-    - check_firewall
     - osd_group_name in group_names
     - nmapexist.rc == 0
 
 - name: fail if osd and mds range is filtered (osd hosts)
   fail:
       msg: "Please allow range from 6800 to 7300 on your firewall"
-  with_items: osdrangestate.results
-  run_once: true
   when:
-    - check_firewall
-    - item is defined and item.has_key('rc') and item.rc == 0
-    - osd_group_name is defined
     - osd_group_name in group_names
+    - osdrangestate.rc == 0
     - nmapexist.rc == 0
 
 - name: check if osd and mds range is not filtered (mds hosts)
-  local_action: shell set -o pipefail && nmap -p 6800-7300 {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo -e filtered -e '0 hosts up'
+  local_action: shell set -o pipefail && nmap -p 6800-7300 {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }} | grep -sqo -e filtered -e '0 hosts up'
   changed_when: false
   failed_when: false
-  with_items: "{{ groups[mds_group_name] }}"
   register: mdsrangestate
-  run_once: true
   when:
-    - check_firewall
     - mds_group_name in group_names
     - nmapexist.rc == 0
 
 - name: fail if osd and mds range is filtered (mds hosts)
   fail:
       msg: "Please allow range from 6800 to 7300 on your firewall"
-  with_items: mdsrangestate.results
-  run_once: true
   when:
-    - check_firewall
-    - item is defined and item.has_key('rc') and item.rc == 0
-    - mds_group_name is defined
     - mds_group_name in group_names
+    - mdsrangestate.rc == 0
     - nmapexist.rc == 0
 
 - name: check if rados gateway port is not filtered
-  local_action: shell set -o pipefail && nmap -p {{ radosgw_civetweb_port }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo -e filtered -e '0 hosts up'
+  local_action: shell set -o pipefail && nmap -p {{ radosgw_civetweb_port }} {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }} | grep -sqo -e filtered -e '0 hosts up'
   changed_when: false
   failed_when: false
-  with_items: "{{ groups[rgw_group_name] }}"
   register: rgwportstate
-  run_once: true
   when:
-    - check_firewall
     - rgw_group_name in group_names
     - nmapexist.rc == 0
 
 - name: fail if rados gateway port is filtered
   fail:
       msg: "Please allow port {{ radosgw_civetweb_port }} on your firewall"
-  with_items: rgwportstate.results
-  run_once: true
   when:
-    - check_firewall
-    - item is defined and item.has_key('rc') and item.rc == 0
-    - rgw_group_name is defined
     - rgw_group_name in group_names
+    - rgwportstate.rc == 0
     - nmapexist.rc == 0

--- a/roles/ceph-common/tasks/checks/check_firewall.yml
+++ b/roles/ceph-common/tasks/checks/check_firewall.yml
@@ -14,7 +14,7 @@
     - nmapexist.rc != 0
 
 - name: check if monitor port is not filtered
-  local_action: shell set -o pipefail && nmap -p 6689 {{ hostvars[inventory_hostname]['ansible_' + monitor_interface]['ipv4']['address'] if hostvars[inventory_hostname]['ansible_' + monitor_interface] is defined else hostvars[inventory_hostname]['monitor_address'] }} | grep -sqo -e filtered -e '0 hosts up'
+  local_action: shell set -o pipefail && nmap -p 6789 {{ hostvars[inventory_hostname]['ansible_' + monitor_interface]['ipv4']['address'] if hostvars[inventory_hostname]['ansible_' + monitor_interface] is defined else hostvars[inventory_hostname]['monitor_address'] }} | grep -sqo -e filtered -e '0 hosts up'
   changed_when: false
   failed_when: false
   register: monportstate

--- a/roles/ceph-common/tasks/checks/check_firewall.yml
+++ b/roles/ceph-common/tasks/checks/check_firewall.yml
@@ -14,7 +14,7 @@
     - nmapexist.rc != 0
 
 - name: check if monitor port is not filtered
-  local_action: shell set -o pipefail && nmap -p 6789 {{ item }} {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] if hostvars[item]['ansible_' + monitor_interface] is defined else hostvars[item][monitor_address] }} | grep -sqo filtered
+  local_action: shell set -o pipefail && nmap -p 6789 {{ item }} {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] if hostvars[item]['ansible_' + monitor_interface] is defined else hostvars[item]['monitor_address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
   with_items: "{{ groups[mon_group_name] }}"

--- a/roles/ceph-common/tasks/checks/check_firewall.yml
+++ b/roles/ceph-common/tasks/checks/check_firewall.yml
@@ -4,21 +4,24 @@
   changed_when: false
   failed_when: false
   register: nmapexist
+  run_once: true
   when: check_firewall
 
 - name: inform that nmap is not present
   debug:
       msg: "nmap is not installed, can not test if ceph ports are allowed :("
+  run_once: true
   when:
     - check_firewall
     - nmapexist.rc != 0
 
 - name: check if monitor port is not filtered
-  local_action: shell set -o pipefail && nmap -p 6789 {{ item }} {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] if hostvars[item]['ansible_' + monitor_interface] is defined else hostvars[item]['monitor_address'] }} | grep -sqo filtered
+  local_action: shell set -o pipefail && nmap -p 6789 {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] if hostvars[item]['ansible_' + monitor_interface] is defined else hostvars[item]['monitor_address'] }} | grep -sqo -e filtered -e '0 hosts up'
   changed_when: false
   failed_when: false
   with_items: "{{ groups[mon_group_name] }}"
   register: monportstate
+  run_once: true
   when:
     - check_firewall
     - mon_group_name in group_names
@@ -28,6 +31,7 @@
   fail:
       msg: "Please allow port 6789 on your firewall"
   with_items: monportstate.results
+  run_once: true
   when:
     - check_firewall
     - item is defined and item.has_key('rc') and item.rc == 0
@@ -36,11 +40,12 @@
     - nmapexist.rc == 0
 
 - name: check if osd and mds range is not filtered (osd hosts)
-  local_action: shell set -o pipefail && nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
+  local_action: shell set -o pipefail && nmap -p 6800-7300 {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo -e filtered -e '0 hosts up'
   changed_when: false
   failed_when: false
   with_items: "{{ groups[osd_group_name] }}"
   register: osdrangestate
+  run_once: true
   when:
     - check_firewall
     - osd_group_name in group_names
@@ -50,6 +55,7 @@
   fail:
       msg: "Please allow range from 6800 to 7300 on your firewall"
   with_items: osdrangestate.results
+  run_once: true
   when:
     - check_firewall
     - item is defined and item.has_key('rc') and item.rc == 0
@@ -58,11 +64,12 @@
     - nmapexist.rc == 0
 
 - name: check if osd and mds range is not filtered (mds hosts)
-  local_action: shell set -o pipefail && nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
+  local_action: shell set -o pipefail && nmap -p 6800-7300 {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo -e filtered -e '0 hosts up'
   changed_when: false
   failed_when: false
   with_items: "{{ groups[mds_group_name] }}"
   register: mdsrangestate
+  run_once: true
   when:
     - check_firewall
     - mds_group_name in group_names
@@ -72,6 +79,7 @@
   fail:
       msg: "Please allow range from 6800 to 7300 on your firewall"
   with_items: mdsrangestate.results
+  run_once: true
   when:
     - check_firewall
     - item is defined and item.has_key('rc') and item.rc == 0
@@ -80,11 +88,12 @@
     - nmapexist.rc == 0
 
 - name: check if rados gateway port is not filtered
-  local_action: shell set -o pipefail && nmap -p {{ radosgw_civetweb_port }} {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
+  local_action: shell set -o pipefail && nmap -p {{ radosgw_civetweb_port }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo -e filtered -e '0 hosts up'
   changed_when: false
   failed_when: false
   with_items: "{{ groups[rgw_group_name] }}"
   register: rgwportstate
+  run_once: true
   when:
     - check_firewall
     - rgw_group_name in group_names
@@ -94,6 +103,7 @@
   fail:
       msg: "Please allow port {{ radosgw_civetweb_port }} on your firewall"
   with_items: rgwportstate.results
+  run_once: true
   when:
     - check_firewall
     - item is defined and item.has_key('rc') and item.rc == 0

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -4,6 +4,7 @@
 - include: ./checks/check_mandatory_vars.yml
 
 - include: ./checks/check_firewall.yml
+  when: check_firewall
 
 - include: ./misc/system_tuning.yml
   when: osd_group_name in group_names


### PR DESCRIPTION
The check to see if nmap is available was being run on the remote host, whereas the checks to see if the applicable Ceph ports were open were being run as local_actions.

Also included are various related fixes now that the above functionality has been corrected (tested on Ansible 2.x only).

Closes: https://github.com/ceph/ceph-ansible/issues/754