### PR TITLE
Put path back to playbook_dir for common template

### DIFF
--- a/roles/ceph-mon/tasks/docker/create_configs.yml
+++ b/roles/ceph-mon/tasks/docker/create_configs.yml
@@ -2,7 +2,7 @@
 - name: generate ceph configuration file
   action: config_template
   args:
-    src: "{{ role_path }}/templates/ceph.conf.j2"
+    src: "{{ playbook_dir }}/roles/ceph-common/templates/ceph.conf.j2"
     dest: /etc/ceph/ceph.conf
     owner: "root"
     group: "root"


### PR DESCRIPTION
The config template is in ceph-common, not in the individual roles, so
roles referencing it need to use playbook_dir, not role_path.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>