### PR TITLE
Add option to enable ntp

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -64,6 +64,9 @@ dummy:
 #  - ntp
 #  - python-setuptools
 
+# Enable the ntp service by default to avoid clock skew on
+# ceph nodes
+#ntp_service_enabled: true
 
 # The list of ceph packages needed for debian.
 # This variable should only be changed if packages are not available from a given

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -56,6 +56,9 @@ redhat_package_dependencies:
   - ntp
   - python-setuptools
 
+# Enable the ntp service by default to avoid clock skew on
+# ceph nodes
+ntp_service_enabled: true
 
 # The list of ceph packages needed for debian.
 # This variable should only be changed if packages are not available from a given

--- a/roles/ceph-common/tasks/checks/check_ntp_debian.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_debian.yml
@@ -1,0 +1,7 @@
+---
+- name: check ntp installation on debian
+  command: dpkg -s ntp
+  register: ntp_pkg_query
+  ignore_errors: true
+  changed_when: false
+  when: ansible_os_family == 'Debian'

--- a/roles/ceph-common/tasks/checks/check_ntp_redhat.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_redhat.yml
@@ -1,0 +1,7 @@
+---
+- name: check ntp installation on redhat
+  command: rpm -q ntp
+  register: ntp_pkg_query
+  ignore_errors: true
+  changed_when: false
+  when: ansible_os_family == 'RedHat'

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -71,6 +71,16 @@
   tags:
     - package-install
 
+- include: ./misc/ntp_redhat.yml
+  when:
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: ./misc/ntp_debian.yml
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+
 - include: facts.yml
 
 - set_fact:

--- a/roles/ceph-common/tasks/misc/ntp_debian.yml
+++ b/roles/ceph-common/tasks/misc/ntp_debian.yml
@@ -1,0 +1,11 @@
+---
+- include: ../checks/check_ntp_debian.yml
+  when: ansible_os_family == 'Debian'
+
+- name: start the ntp service
+  service:
+    name: ntp
+    enabled: yes
+    state: started
+  when:
+    - ntp_pkg_query.rc == 0

--- a/roles/ceph-common/tasks/misc/ntp_redhat.yml
+++ b/roles/ceph-common/tasks/misc/ntp_redhat.yml
@@ -1,0 +1,11 @@
+---
+- include: ../checks/check_ntp_redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+- name: start the ntp service
+  service:
+    name: ntpd
+    enabled: yes
+    state: started
+  when:
+    - ntp_pkg_query.rc == 0


### PR DESCRIPTION
This fixes: #845 only for non-containerized deployments

Signed-off-by: Ivan Font <ivan.font@redhat.com>


##### Questions/Comments

1. As it stands we install ntp on all nodes and this will enable it on all nodes as well. Is it necessary on all nodes?
2. I filed a feature idea on ansible's packaging modules in order to simplify the task of querying for the state of a package across different package managers. It would've helped simplify this code.
3. Do we want to install and enable ntp on container hosts? If so, I will enable the containerized part pending the answer to question 1.