### PR TITLE
Enable rhcs repos according to the released version

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -143,6 +143,9 @@ dummy:
 # on RHEL 7.
 #
 #ceph_stable_rh_storage: false
+# This will affect how/what repositories are enabled depending on the desired
+# version. The next version will use "2" not "2.0" which would not work.
+#ceph_stable_rh_storage_version: 1.3 # next version is 2
 #ceph_stable_rh_storage_cdn_install: false # assumes all the nodes can connect to cdn.redhat.com
 #ceph_stable_rh_storage_iso_install: false # usually used when nodes don't have access to cdn.redhat.com
 #ceph_stable_rh_storage_iso_path:

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -135,6 +135,8 @@ ceph_stable_ice_kmod: 3.10-0.1.20140702gitdc9ac62.el7.x86_64
 # on RHEL 7.
 #
 ceph_stable_rh_storage: false
+# This will affect how/what repositories are enabled depending on the desired
+# version. The next version will use "2" not "2.0" which would not work.
 ceph_stable_rh_storage_version: 1.3 # next version is 2
 ceph_stable_rh_storage_cdn_install: false # assumes all the nodes can connect to cdn.redhat.com
 ceph_stable_rh_storage_iso_install: false # usually used when nodes don't have access to cdn.redhat.com

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -135,6 +135,7 @@ ceph_stable_ice_kmod: 3.10-0.1.20140702gitdc9ac62.el7.x86_64
 # on RHEL 7.
 #
 ceph_stable_rh_storage: false
+ceph_stable_rh_storage_version: 1.3 # next version is 2
 ceph_stable_rh_storage_cdn_install: false # assumes all the nodes can connect to cdn.redhat.com
 ceph_stable_rh_storage_iso_install: false # usually used when nodes don't have access to cdn.redhat.com
 #ceph_stable_rh_storage_iso_path:

--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_cdn_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_cdn_install.yml
@@ -4,17 +4,6 @@
   register: subscription
   changed_when: false
 
-- name: check if the red hat optional repo is present
-  shell: yum --noplugins --cacheonly repolist | grep -sq rhel-7-server-optional-rpms
-  changed_when: false
-  failed_when: false
-  register: rh_optional_repo
-
-- name: enable red hat optional repository
-  command: subscription-manager repos --enable rhel-7-server-optional-rpms
-  changed_when: false
-  when: rh_optional_repo.rc != 0
-
 - name: check if the red hat storage monitor repo is already present
   shell: yum --noplugins --cacheonly repolist | grep -sq rhel-7-server-rhceph-1.3-mon-rpms
   changed_when: false

--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_cdn_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_cdn_install.yml
@@ -5,42 +5,42 @@
   changed_when: false
 
 - name: check if the red hat storage monitor repo is already present
-  shell: yum --noplugins --cacheonly repolist | grep -sq rhel-7-server-rhceph-1.3-mon-rpms
+  shell: yum --noplugins --cacheonly repolist | grep -sq rhel-7-server-rhceph-{{ ceph_stable_rh_storage_version }}-mon-rpms
   changed_when: false
   failed_when: false
   register: rh_storage_mon_repo
   when: mon_group_name in group_names
 
 - name: enable red hat storage monitor repository
-  command: subscription-manager repos --enable rhel-7-server-rhceph-1.3-mon-rpms
+  command: subscription-manager repos --enable rhel-7-server-rhceph-{{ ceph_stable_rh_storage_version }}-mon-rpms
   changed_when: false
   when:
     - mon_group_name in group_names
     - rh_storage_mon_repo.rc != 0
 
 - name: check if the red hat storage osd repo is already present
-  shell: yum --noplugins --cacheonly repolist | grep -sq rhel-7-server-rhceph-1.3-osd-rpms
+  shell: yum --noplugins --cacheonly repolist | grep -sq rhel-7-server-rhceph-{{ ceph_stable_rh_storage_version }}-osd-rpms
   changed_when: false
   failed_when: false
   register: rh_storage_osd_repo
   when: osd_group_name in group_names
 
 - name: enable red hat storage osd repository
-  command: subscription-manager repos --enable rhel-7-server-rhceph-1.3-osd-rpms
+  command: subscription-manager repos --enable rhel-7-server-rhceph-{{ ceph_stable_rh_storage_version }}-osd-rpms
   changed_when: false
   when:
     - osd_group_name in group_names
     - rh_storage_osd_repo.rc != 0
 
 - name: check if the red hat storage rados gateway repo is already present
-  shell: yum --noplugins --cacheonly repolist | grep -sq rhel-7-server-rhceph-1.3-tools-rpms
+  shell: yum --noplugins --cacheonly repolist | grep -sq rhel-7-server-rhceph-{{ ceph_stable_rh_storage_version }}-tools-rpms
   changed_when: false
   failed_when: false
   register: rh_storage_rgw_repo
   when: rgw_group_name in group_names
 
 - name: enable red hat storage rados gateway repository
-  command: subscription-manager repos --enable rhel-7-server-rhceph-1.3-tools-rpms
+  command: subscription-manager repos --enable rhel-7-server-rhceph-{{ ceph_stable_rh_storage_version }}-tools-rpms
   changed_when: false
   when:
     - rgw_group_name in group_names


### PR DESCRIPTION
Similar to what it was done for `ice` versions. This will help for the upcoming new version, enabling the repositories for the configured version (defaulting to 1.3)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1346812