### PR TITLE
ceph-agent: install the correct package for the agent in Ubuntu

### DIFF
--- a/roles/ceph-agent/tasks/pre_requisite.yml
+++ b/roles/ceph-agent/tasks/pre_requisite.yml
@@ -7,7 +7,7 @@
 
 - name: install dependencies
   apt:
-    pkg: calamari-server
+    pkg: rhscon-agent
     state: present
   when: ansible_os_family == 'Debian'
   tags:


### PR DESCRIPTION
See: https://bugzilla.redhat.com/show_bug.cgi?id=1348130