### PR TITLE
Add URL option to vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,7 @@ RESTAPI    = settings['restapi']
 CLIENTS    = settings['client_vms']
 SUBNET     = settings['subnet']
 BOX        = settings['vagrant_box']
+BOX_URL    = settings['vagrant_box_url']
 MEMORY     = settings['memory']
 STORAGECTL = settings['vagrant_storagectl']
 ETH        = settings['eth']
@@ -100,6 +101,7 @@ end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = BOX
+  config.vm.box_url = BOX_URL
   config.ssh.insert_key = false # workaround for https://github.com/mitchellh/vagrant/issues/5048
 
   # Faster bootup.  Disable if you need this for libvirt

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -33,7 +33,6 @@ eth: 'eth1'
 disks: "[ '/dev/sdb', '/dev/sdc' ]"
 
 # VAGRANT BOX
-# Fedora: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 # Ubuntu: ubuntu/trusty64 or ubuntu/wily64
 # CentOS: bento/centos-7.1 or puppetlabs/centos-7.0-64-puppet
 # libvirt CentOS: centos/7
@@ -43,6 +42,12 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: ubuntu/trusty64
+# VAGRANT URL
+# This is a URL to download an image from an alternate location.  vagrant_box
+# above should be set to the filename of the image.
+# Fedora virtualbox: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
+# Fedora libvirt: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-libvirt.box
+# vagrant_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 
 # use vagrant_storagectl: 'SATA Controller' for CentOS
 vagrant_storagectl: 'SATAController'


### PR DESCRIPTION
Vagrant has the ability to download images from an arbitraty URL.  Add
this support to the Vagrantfile and vagrant_varables.yml

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>