### PR TITLE
Add a custom yum repo ability

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -43,7 +43,7 @@ dummy:
 # is not needed for versions after infernalis.
 #use_server_package_split: true
 
-# /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_stable_uca OR ceph_dev /!\
+# /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_stable_uca OR ceph_dev OR ceph_custom /!\
 
 #debian_package_dependencies:
 #  - python-pycurl
@@ -173,6 +173,15 @@ dummy:
 # fedora19, fedora20, opensuse12, sles0. (see http://gitbuilder.ceph.com/).
 # For rhel, please pay attention to the versions: 'rhel6 3' or 'rhel 4', the fullname is _very_ important.
 #ceph_dev_redhat_distro: centos7
+
+# CUSTOM
+# ###
+
+# Use a custom repository to install ceph.  For RPM, ceph_custom_repo should be
+# a URL to the .repo file to be installed on the targets.  For deb,
+# ceph_custom_repo should be the URL to the repo base.
+#ceph_custom: false # use custom ceph repository
+#ceph_custom_repo: https://server.domain.com/ceph-custom-repo
 
 
 ######################

--- a/roles/ceph-common/README.md
+++ b/roles/ceph-common/README.md
@@ -27,6 +27,7 @@ Have a look at `defaults/main.yml`.
   * `ceph_dev`
   * `ceph_stable_ice`
   * `ceph_stable_rh_storage`
+  * `ceph_custom`
 * `journal_size`
 * `monitor_interface`
 * `public_network`

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -35,7 +35,7 @@ upgrade_ceph_packages: False
 # is not needed for versions after infernalis.
 use_server_package_split: true
 
-# /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_stable_uca OR ceph_dev /!\
+# /!\ EITHER ACTIVE ceph_stable OR ceph_stable_ice OR ceph_stable_uca OR ceph_dev OR ceph_custom /!\
 
 debian_package_dependencies:
   - python-pycurl
@@ -165,6 +165,15 @@ ceph_dev_branch: master # development branch you would like to use e.g: master, 
 # fedora19, fedora20, opensuse12, sles0. (see http://gitbuilder.ceph.com/).
 # For rhel, please pay attention to the versions: 'rhel6 3' or 'rhel 4', the fullname is _very_ important.
 ceph_dev_redhat_distro: centos7
+
+# CUSTOM
+# ###
+
+# Use a custom repository to install ceph.  For RPM, ceph_custom_repo should be
+# a URL to the .repo file to be installed on the targets.  For deb,
+# ceph_custom_repo should be the URL to the repo base.
+ceph_custom: false # use custom ceph repository
+ceph_custom_repo: https://server.domain.com/ceph-custom-repo
 
 
 ######################

--- a/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
@@ -49,3 +49,11 @@
     state: present
   changed_when: false
   when: ceph_stable_uca
+
+- name: add custom repo
+  apt_repository:
+    repo: "deb {{ ceph_custom_repo }} {{ ansible_lsb.codename }} main"
+    state: present
+  changed_when: false
+  when: ceph_custom
+

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -46,6 +46,7 @@
     - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
       or ceph_dev
       or ceph_origin == "distro"
+      or ceph_custom
 
 - name: install distro or red hat storage ceph mon
   dnf:
@@ -57,6 +58,7 @@
     - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
       or ceph_origin == "distro"
       or ceph_dev
+      or ceph_custom
 
 - name: install distro or red hat storage ceph osd
   yum:
@@ -68,6 +70,7 @@
     - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
       or ceph_origin == "distro"
       or ceph_dev
+      or ceph_custom
 
 - name: install distro or red hat storage ceph osd
   dnf:
@@ -79,46 +82,55 @@
     - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
       or ceph_origin == "distro"
       or ceph_dev
+      or ceph_custom
 
 - name: install distro or red hat storage ceph mds
   yum:
     name: "ceph-mds"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_dev or
-     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
-    mds_group_name in group_names and
-    ansible_pkg_mgr == "yum"
+    - mds_group_name in group_names
+    - ansible_pkg_mgr == "yum"
+    - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
+      or ceph_origin == "distro"
+      or ceph_dev
+      or ceph_custom
 
 - name: install distro or red hat storage ceph mds
   dnf:
     name: "ceph-mds"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_dev or
-     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
-    mds_group_name in group_names and
-    ansible_pkg_mgr == "dnf"
+    - mds_group_name in group_names
+    - ansible_pkg_mgr == "dnf"
+    - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
+      or ceph_origin == "distro"
+      or ceph_dev
+      or ceph_custom
 
 - name: install distro or red hat storage ceph base
   yum:
     name: "ceph-base"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_dev or
-     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
-    client_group_name in group_names and
-    ansible_pkg_mgr == "yum"
+    - client_group_name in group_names
+    - ansible_pkg_mgr == "yum"
+    - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
+      or ceph_origin == "distro"
+      or ceph_dev
+      or ceph_custom
 
 - name: install distro or red hat storage ceph base
   dnf:
     name: "ceph-base"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    (ceph_origin == "distro" or ceph_dev or
-     (ceph_stable and ceph_stable_release not in ceph_stable_releases)) and
-    client_group_name in group_names and
-    ansible_pkg_mgr == "dnf"
+    - client_group_name in group_names
+    - ansible_pkg_mgr == "dnf"
+    - (ceph_stable and ceph_stable_release not in ceph_stable_releases)
+      or ceph_origin == "distro"
+      or ceph_dev
+      or ceph_custom
 
 - name: install ceph-test
   yum:

--- a/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
@@ -57,3 +57,11 @@
     group: root
     mode: 0644
   when: ceph_stable_ice
+
+- name: add custom repo
+  get_url:
+    url: "{{ ceph_custom_repo }}"
+    dest: /etc/yum.repos.d
+    owner: root
+    group: root
+  when: ceph_custom


### PR DESCRIPTION
Add the ability to use a custom yum repo, rather than just upstream,
RHEL, and distro.  This allows ansible to be used for internal testing.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>