### PR TITLE
Fail when we cannot retrieve docker image

### DIFF
--- a/roles/ceph-common/tasks/docker/fetch_image.yml
+++ b/roles/ceph-common/tasks/docker/fetch_image.yml
@@ -3,7 +3,6 @@
 - name: pull ceph daemon image
   command: "docker pull {{ ceph_docker_username }}/{{ ceph_docker_imagename }}"
   changed_when: false
-  failed_when: false
   when: ceph_docker_dev_image is undefined or not ceph_docker_dev_image
 
 # Dev case - export local dev image and send it across


### PR DESCRIPTION
If the docker image cannot be retrieved we will fail this task silently and the playbook ultimately succeeds without a successful deployment. This change makes it so we fail the playbook immediately.

Signed-off-by: Ivan Font <ivan.font@redhat.com>