### PR TITLE
Fix not creating pypy_binary_directory.

### DIFF
--- a/roles/ceph-common-coreos/tasks/install_pip.yml
+++ b/roles/ceph-common-coreos/tasks/install_pip.yml
@@ -19,6 +19,9 @@
 - name: add execute permission
   raw: chmod a+x {{pypy_directory}}/pip
 
+- name: create pypy_directory 
+  raw: mkdir -p {{pypy_binary_directory}}
+
 - name: move python to binary directory
   raw: mv {{pypy_directory}}/pip {{pypy_binary_directory}}/pip
 

--- a/roles/ceph-common-coreos/tasks/install_pypy.yml
+++ b/roles/ceph-common-coreos/tasks/install_pypy.yml
@@ -2,6 +2,9 @@
 - name: download python
   raw: cd $HOME &&  wget -O - {{coreos_pypy_url}} |tar -xjf -
 
+- name: create pypy_directory 
+  raw: mkdir -p {{pypy_binary_directory}}
+
 - name: move pypy to pypy_install_directory
   raw:  mv $HOME/pypy-{{coreos_pypy_version}}-{{coreos_pypy_arch}} {{pypy_directory}}
 


### PR DESCRIPTION
Default directory is /opt/bin. On CoreOS by default there is no /opt directory.