### PR TITLE
Trim init_system var

### DIFF
--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -14,7 +14,7 @@
   register: init_system
 
 - set_fact:
-    init_system={{ init_system.content | b64decode }}
+    init_system={{ init_system.content | b64decode | trim }}
 
 - set_fact:
     use_systemd={{ init_system.strip() == 'systemd' }}
@@ -68,4 +68,3 @@
 - set_fact:
     mds_name: "{{ ansible_fqdn }}"
   when: mds_use_fqdn
-


### PR DESCRIPTION
init_system was getting the value of "systemd\n"
and was later compared to be equal to "systemd"
making the wrong scripts to be executed.

Signed-off-by: Alberto Murillo <alberto.murillo.silva@intel.com>