### PR TITLE
ceph-common: ensure that destination iso paths exist before copying

### DIFF
--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_iso_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_iso_install.yml
@@ -6,6 +6,7 @@
   with_items:
     - "{{ ceph_stable_rh_storage_mount_path }}"
     - "{{ ceph_stable_rh_storage_repository_path }}"
+    - "{{ ceph_stable_rh_storage_iso_path }}"
 
 - name: fetch the red hat storage iso from the ansible server
   copy:


### PR DESCRIPTION
Fixes issue: https://bugzilla.redhat.com/show_bug.cgi?id=1338551