### PR TITLE
ceph-common: fix "Red Hat Ceph Storage" product name

### DIFF
--- a/roles/ceph-common/tasks/checks/check_system.yml
+++ b/roles/ceph-common/tasks/checks/check_system.yml
@@ -16,7 +16,7 @@
 
 - name: fail on unsupported distribution for red hat storage
   fail:
-    msg: "Distribution not supported {{ ansible_distribution_version }} by Red Hat Storage, only RHEL 7.1"
+    msg: "Distribution not supported {{ ansible_distribution_version }} by Red Hat Ceph Storage, only RHEL 7.1"
   when:
     - ceph_stable_rh_storage
     - ansible_distribution_version | version_compare('7.1', '<')

--- a/roles/ceph-common/templates/redhat_storage_repo.j2
+++ b/roles/ceph-common/templates/redhat_storage_repo.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 [rh_storage_mon]
-name=Red Hat Storage Ceph - local packages for Ceph
+name=Red Hat Ceph Storage - local packages for Ceph
 baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/MON
 enabled=1
 gpgcheck=1
@@ -8,7 +8,7 @@ type=rpm-md
 priority=1
 
 [rh_storage_osd]
-name=Red Hat Storage Ceph - local packages for Ceph
+name=Red Hat Ceph Storage - local packages for Ceph
 baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/OSD
 enabled=1
 gpgcheck=1
@@ -16,7 +16,7 @@ type=rpm-md
 priority=1
 
 [rh_storage_tools]
-name=Red Hat Storage Ceph - assorted tools
+name=Red Hat Ceph Storage - assorted tools
 baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/Tools
 enabled=1
 gpgcheck=1


### PR DESCRIPTION
Standardize on the name "Red Hat Ceph Storage" everywhere