### PR TITLE
ceph-common: rm "type=rpm-md" from RHCS repos

### DIFF
--- a/roles/ceph-common/templates/redhat_storage_repo.j2
+++ b/roles/ceph-common/templates/redhat_storage_repo.j2
@@ -4,7 +4,6 @@ name=Red Hat Ceph Storage - local packages for Ceph monitor
 baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/MON
 enabled=1
 gpgcheck=1
-type=rpm-md
 priority=1
 
 [rh_storage_osd]
@@ -12,7 +11,6 @@ name=Red Hat Ceph Storage - local packages for Ceph OSD
 baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/OSD
 enabled=1
 gpgcheck=1
-type=rpm-md
 priority=1
 
 [rh_storage_tools]
@@ -20,5 +18,4 @@ name=Red Hat Ceph Storage - local packages for Ceph client, MDS, and RGW
 baseurl=file://{{ ceph_stable_rh_storage_repository_path }}/Tools
 enabled=1
 gpgcheck=1
-type=rpm-md
 priority=1


### PR DESCRIPTION
As far as I can tell, this is a SUSE-ism, not needed for RHCS.