### PR TITLE
ceph-osd: Use the use_systemd fact when starting directory-scenario OSDs

### DIFF
--- a/roles/ceph-osd/tasks/scenarios/osd_directory.yml
+++ b/roles/ceph-osd/tasks/scenarios/osd_directory.yml
@@ -31,11 +31,11 @@
     name: ceph
     state: started
     enabled: yes
-  when: init_system != "systemd"
+  when: not use_systemd
 
 - name: start and add the OSD target to the systemd sequence
   service:
     name: ceph.target
     state: started
     enabled: yes
-  when: init_system == "systemd"
+  when: use_systemd


### PR DESCRIPTION
Fixes an issue where the directory scenario of the ceph-osd role fails to detect systemd.

Previously, the "init_system" fact was used. In our deployments (CentOS 7), this fact contains a trailing newline. This change switches to the use_systemd fact. This appears to be more consistent with the rest of the project as well.

I believe this is the same issue as #585 