### PR TITLE
Use correct object names when zapping GPT header

### DIFF
--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -89,7 +89,7 @@
     - item.0.rc != 0
 
 - name: fix partitions gpt header or labels of the osd disks (autodiscover disks)
-  shell: "sgdisk --zap-all --clear --mbrtogpt -g -- '/dev/{{ item.1.key }}' || sgdisk --zap-all --clear --mbrtogpt -g -- '/dev/{{ item.1.key }}'"
+  shell: "sgdisk --zap-all --clear --mbrtogpt -g -- '/dev/{{ item.0.item.key }}' || sgdisk --zap-all --clear --mbrtogpt -g -- '/dev/{{ item.0.item.key }}'"
   with_together:
     - combined_osd_partition_status_results.results
     - ansible_devices
@@ -98,8 +98,8 @@
     - journal_collocation
     - osd_auto_discovery
     - ansible_devices is defined
-    - item.value.removable == "0"
-    - item.value.partitions|count == 0
+    - item.0.item.value.removable == "0"
+    - item.0.item.value.partitions|count == 0
     - item.0.rc != 0
 
 - name: fix partitions gpt header or labels of the journal devices


### PR DESCRIPTION
I'm installing Ceph on Ubuntu 16.04 with Ansible v2.0.2.0-1. OSD options include:
```
#devices:
#  - /dev/sdb
#  - /dev/sdc
osd_auto_discovery: true
journal_collocation: true
```

 The disk items in combined_osd_partition_status_results.results look like this:
```
    "item": [
        {
            "_ansible_item_result": true, 
            "_ansible_no_log": false, 
            "changed": false, 
            "cmd": "parted --script /dev/nvme6n1 print > /dev/null 2>&1", 
            "delta": "0:00:00.031631", 
            "end": "2016-07-12 09:47:48.194265", 
            "failed": false, 
            "failed_when_result": false, 
            "invocation": {
                "module_args": {
                    "_raw_params": "parted --script /dev/nvme6n1 print > /dev/null 2>&1", 
                    "_uses_shell": true, 
                    "chdir": null, 
                    "creates": null, 
                    "executable": null, 
                    "removes": null, 
                    "warn": true
                }, 
                "module_name": "command"
            }, 
            "item": {
                "key": "nvme6n1", 
                "value": {
                    "holders": [], 
                    "host": "Non-Volatile memory controller: Intel Corporation PCIe Data Center SSD (rev 01)", 
                    "model": "INTEL SSDPE2ME020T4", 
                    "partitions": {}, 
                    "removable": "0", 
                    "rotational": "0", 
                    "scheduler_mode": "", 
                    "sectors": "3907029168", 
                    "sectorsize": "512", 
                    "size": "1.82 TB", 
                    "support_discard": "512", 
                    "vendor": null
                }
            }, 
            "rc": 1, 
            "start": "2016-07-12 09:47:48.162634", 
            "stderr": "", 
            "stdout": "", 
            "stdout_lines": [], 
            "warnings": []
        }
    ], 
```

There is another "item" inside the "item", therefore I had to adjust the code to make it work with auto discovery.