### PR TITLE
ceph-common: explicitly create the directory portion of the iso path

### DIFF
--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_iso_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_rh_storage_iso_install.yml
@@ -6,7 +6,13 @@
   with_items:
     - "{{ ceph_stable_rh_storage_mount_path }}"
     - "{{ ceph_stable_rh_storage_repository_path }}"
-    - "{{ ceph_stable_rh_storage_iso_path }}"
+
+- name: ensure destination iso directory exists
+  file:
+    path: "{{ ceph_stable_rh_storage_iso_path | dirname }}"
+    state: directory
+    recurse: yes
+  when: "'{{ ceph_stable_rh_storage_iso_path | dirname }}' != '/'"
 
 - name: fetch the red hat storage iso from the ansible server
   copy:


### PR DESCRIPTION
This will help if the path to the iso exists in the originating server but not
in the remote paths. This issue is not seen if using /tmp/file.iso but does
show up when using nested paths.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1355762