### PR TITLE
Allow generating FSID for docker

### DIFF
--- a/roles/ceph-mon/tasks/docker/create_configs.yml
+++ b/roles/ceph-mon/tasks/docker/create_configs.yml
@@ -1,4 +1,26 @@
 ---
+- name: create a local fetch directory if it does not exist
+  local_action: file path={{ fetch_directory }} state=directory
+  changed_when: false
+  become: false
+  run_once: true
+  when: cephx or generate_fsid
+
+- name: generate cluster uuid
+  local_action: shell python -c 'import uuid; print(str(uuid.uuid4()))' | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
+    creates="{{ fetch_directory }}/ceph_cluster_uuid.conf"
+  register: cluster_uuid
+  become: false
+  when: generate_fsid
+
+- name: read cluster uuid if it already exists
+  local_action: command cat {{ fetch_directory }}/ceph_cluster_uuid.conf
+    removes="{{ fetch_directory }}/ceph_cluster_uuid.conf"
+  changed_when: false
+  register: cluster_uuid
+  become: false
+  when: generate_fsid
+
 - name: generate ceph configuration file
   action: config_template
   args:


### PR DESCRIPTION
The docker case wasn't able to generate an FSID, it required it to be
set.  Allow generating it.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>

The better solution (which is in my TODO list) is to factor these bits + config generation in ceph-common and have the docker case include the common case.  However, this is a downstream QE PR (https://bugzilla.redhat.com/show_bug.cgi?id=1356105) , so I'd like to get a fix in ASAP.