### PR TITLE
ceph-common: skip default installs on redhat if ISO needs to be used

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -30,7 +30,9 @@
     - package-install
 
 - include: ./installs/install_on_redhat.yml
-  when: ansible_os_family == 'RedHat'
+  when:
+    ansible_os_family == 'RedHat' and
+    not ceph_stable_rh_storage_iso_install
   tags:
     - package-install
 


### PR DESCRIPTION
Because the ISO installs would happen later in the playbook.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1357065