### PR TITLE
Fetch keys from the mons when taking over a cluster

### DIFF
--- a/take-over-existing-cluster.yml
+++ b/take-over-existing-cluster.yml
@@ -7,9 +7,17 @@
 #
 # 1. Install Ansible and add your monitors and osds hosts in it. For more detailed information you can read the [Ceph Ansible Wiki](https://github.com/ceph/ceph-ansible/wiki)
 # 2. Set  `generate_fsid: false` in `group_vars`
-# 3. Get your current cluster fsid with `ceph fsid` and set `cluster_fsid` accordingly in `group_vars`
+# 3. Get your current cluster fsid with `ceph fsid` and set `fsid` accordingly in `group_vars`
 # 4. Run the playbook called: `take-over-existing-cluster.yml` like this `ansible-playbook take-over-existing-cluster.yml`.
 # 5. Eventually run Ceph Ansible to validate everything by doing: `ansible-playbook site.yml`.
+
+- hosts: mons
+  become: True
+  vars_files:
+    - roles/ceph-common/defaults/main.yml
+    - group_vars/all
+  roles:
+    - ceph-fetch-keys
 
 - hosts: all
   become: true


### PR DESCRIPTION
This fixes a bug where mons added to a "taken over" cluster
will get a newly generated key and do not join the cluster.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>

Resolves: rhbz#1357292