### PR TITLE
Added support for --check flag in ceph-common

### DIFF
--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -2,6 +2,7 @@
 - name: get ceph version
   command: ceph --version
   changed_when: false
+  always_run: true
   register: ceph_version
 
 - set_fact:
@@ -11,6 +12,7 @@
 - name: check init system
   slurp:
     src: /proc/1/comm
+  always_run: true
   register: init_system
 
 - set_fact:

--- a/roles/ceph-common/tasks/misc/system_tuning.yml
+++ b/roles/ceph-common/tasks/misc/system_tuning.yml
@@ -20,6 +20,7 @@
   command: sysctl -b vm.min_free_kbytes
   changed_when: false
   failed_when: false
+  always_run: true
   register: default_vm_min_free_kbytes
 
 - name: define vm.min_free_kbytes


### PR DESCRIPTION
The ceph-common role fails when you run ansible with --check. Adding
always_run to a few tasks makes the check go through easier (although
it's not foolproof).