### PR TITLE
purge-cluster: remove -q flag from grep to prevent broken pipes

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -261,7 +261,7 @@
       rbdmirror_group_name in group_names
 
   - name: check for anything running ceph
-    shell: "ps awux | grep -v grep | grep -q -- ceph-"
+    shell: "ps awux | grep -- [c]eph-"
     register: check_for_running_ceph
     failed_when: check_for_running_ceph.rc == 0
 


### PR DESCRIPTION
See: https://bugzilla.redhat.com/show_bug.cgi?id=1339576
