### PR TITLE
common: set journal size to 5GB

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -258,7 +258,7 @@ dummy:
 
 ## OSD options
 #
-#journal_size: 0 # OSD journal size in MB
+#journal_size: 5120 # OSD journal size in MB
 #public_network: 0.0.0.0/0
 #cluster_network: "{{ public_network }}"
 #osd_mkfs_type: xfs

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -250,7 +250,7 @@ mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the 
 
 ## OSD options
 #
-journal_size: 0 # OSD journal size in MB
+journal_size: 5120 # OSD journal size in MB
 public_network: 0.0.0.0/0
 cluster_network: "{{ public_network }}"
 osd_mkfs_type: xfs

--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -33,10 +33,10 @@
     - package-install
 
 - name: make sure journal_size configured
-  fail:
-    msg: "journal_size must be configured. See http://ceph.com/docs/master/rados/configuration/osd-config-ref/"
+  debug:
+    msg: "WARNING: journal_size is configured to less than 5GB. This is not recommended and can lead to severe issues."
   when:
-    - journal_size|int == 0
+    - journal_size|int < 5120
     - osd_objectstore != 'bluestore'
     - osd_group_name in group_names
 


### PR DESCRIPTION
Journal size is not mandatory anymore, a default from 5GB is being
added. A simple warning message will show up if the size is set to
something below 5GB.

Signed-off-by: Sébastien Han <seb@redhat.com>