### PR TITLE
Added option to support case-insensitive keys

### DIFF
--- a/plugins/actions/_v2_config_template.py
+++ b/plugins/actions/_v2_config_template.py
@@ -277,6 +277,7 @@ class ActionModule(ActionBase):
                 allow_no_value=True,
                 dict_type=MultiKeyDict
             )
+            config.optionxform = str
         except Exception:
             config = ConfigTemplateParser(dict_type=MultiKeyDict)
 


### PR DESCRIPTION
This change allows keys in INI format to be any case.
The default ConfigParse module sets this to be lower
however in some cases keys are needed to be upper and/or
mixed.

Change-Id: I4e0dedb1b73ee596929bd425af6b0aaefd3a6c27
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>
(cherry picked from commit https://github.com/openstack/openstack-ansible-plugins/commit/f946160dd0f370efb792bf084c7c20b18cf27c98)