### PR TITLE
sgdisk: remove duplicated option `-g`

### DIFF
--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -78,7 +78,7 @@
 # keep the current flow of the task.
 # See: https://github.com/ceph/ceph-ansible/issues/759
 - name: fix partitions gpt header or labels of the osd disks
-  shell: "sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }} || sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }}"
+  shell: "sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }} || sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }}"
   with_together:
     - combined_osd_partition_status_results.results
     - devices
@@ -89,7 +89,7 @@
     - item.0.rc != 0
 
 - name: fix partitions gpt header or labels of the osd disks (autodiscover disks)
-  shell: "sgdisk --zap-all --clear --mbrtogpt -g -- '/dev/{{ item.0.item.key }}' || sgdisk --zap-all --clear --mbrtogpt -g -- '/dev/{{ item.0.item.key }}'"
+  shell: "sgdisk --zap-all --clear --mbrtogpt -- '/dev/{{ item.0.item.key }}' || sgdisk --zap-all --clear --mbrtogpt -- '/dev/{{ item.0.item.key }}'"
   with_together:
     - combined_osd_partition_status_results.results
     - ansible_devices
@@ -103,7 +103,7 @@
     - item.0.rc != 0
 
 - name: fix partitions gpt header or labels of the journal devices
-  shell: "sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }} || sgdisk --zap-all --clear --mbrtogpt -g -- {{ item.1 }}"
+  shell: "sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }} || sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }}"
   with_together:
     - journal_partition_status.results
     - raw_journal_devices


### PR DESCRIPTION
Option `-g` of sgdisk is duplicated with `--mbrtogpt`, so lets remove it.

This fix #896

Signed-off-by: Chengwei Yang <yangchengwei@qiyi.com>