### PR TITLE
Fix purge-cluster.yml fail by removing unnecessary ceph_stable_rh_storage_iso_install check.

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -451,5 +451,4 @@
       path: /etc/yum.repos.d/rh_storage.repo
       state: absent
     when:
-      ansible_os_family == 'RedHat' and
-      ceph_stable_rh_storage_iso_install
+      ansible_os_family == 'RedHat'


### PR DESCRIPTION
In the `purge rh_storage.repo file in /etc/yum.repos.d` task, there is a check for `ceph_stable_rh_storage_iso_install` which, in many cases, is undefined and will cause the playbook to fail.  Given that the task will only delete the repo if it is present there is no need to check `ceph_stable_rh_storage_iso_install`.