### PR TITLE
Fix bad civetweb port in rgw frontends

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -93,7 +93,7 @@ rgw socket path = /tmp/radosgw-{{ hostvars[host]['ansible_hostname'] }}.sock
 log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[host]['ansible_hostname'] }}.log
 rgw data = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_hostname'] }}
 {% if radosgw_frontend  == 'civetweb' %}
-rgw frontends = civetweb port={{ radosgw_civetweb_bind_ip }}:{{ radosgw_civetweb_port }} num_threads={{ radosgw_civetweb_num_threads }}
+rgw frontends = civetweb port={{ radosgw_civetweb_port }} num_threads={{ radosgw_civetweb_num_threads }}
 {% endif %}
 {% if radosgw_keystone %}
 rgw keystone url = {{ radosgw_keystone_url }}


### PR DESCRIPTION
The civetweb config the ceph.conf.j2 incorrectly added `port=host:port` instead of just `port=port`.  RadosGW only works with `port=port`.