### PR TITLE
Add option to enable ntp

### DIFF
--- a/roles/ceph-common/tasks/checks/check_ntp_atomic.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_atomic.yml
@@ -4,4 +4,3 @@
   register: ntp_pkg_query
   ignore_errors: true
   changed_when: false
-  when: ansible_os_family == 'RedHat'

--- a/roles/ceph-common/tasks/checks/check_ntp_atomic.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_atomic.yml
@@ -1,0 +1,7 @@
+---
+- name: check ntp installation on atomic
+  command: rpm -q chrony
+  register: ntp_pkg_query
+  ignore_errors: true
+  changed_when: false
+  when: ansible_os_family == 'RedHat'

--- a/roles/ceph-common/tasks/misc/ntp_atomic.yml
+++ b/roles/ceph-common/tasks/misc/ntp_atomic.yml
@@ -1,6 +1,6 @@
 ---
 - include: ../checks/check_ntp_atomic.yml
-  when: ansible_os_family == 'RedHat'
+  when: is_atomic
 
 - name: start the ntp service
   service:

--- a/roles/ceph-common/tasks/misc/ntp_atomic.yml
+++ b/roles/ceph-common/tasks/misc/ntp_atomic.yml
@@ -1,0 +1,11 @@
+---
+- include: ../checks/check_ntp_atomic.yml
+  when: ansible_os_family == 'RedHat'
+
+- name: start the ntp service
+  service:
+    name: chronyd
+    enabled: yes
+    state: started
+  when:
+    - ntp_pkg_query.rc == 0

--- a/roles/ceph-mds/tasks/docker/main.yml
+++ b/roles/ceph-mds/tasks/docker/main.yml
@@ -17,6 +17,24 @@
   when: ceph_health.rc != 0
 
 - include: pre_requisite.yml
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_atomic.yml"
+  when:
+    - is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_redhat.yml"
+  when:
+    - not is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_debian.yml"
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+
 - include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
   vars:
     ceph_docker_username: "{{ ceph_mds_docker_username }}"

--- a/roles/ceph-mds/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/docker/pre_requisite.yml
@@ -116,7 +116,7 @@
   tags:
     with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '<')
- 
+
 - name: install docker-py
   pip:
     name: docker-py
@@ -125,3 +125,34 @@
     with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '>=')
 
+- name: install ntp on redhat using yum
+  yum:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'yum'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on redhat using dnf
+  dnf:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'dnf'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on debian
+  apt:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+  tags:
+    with_pkg

--- a/roles/ceph-mds/tasks/docker/start_docker_mds.yml
+++ b/roles/ceph-mds/tasks/docker/start_docker_mds.yml
@@ -44,5 +44,5 @@
     net: host
     state: running
     env: "CEPH_DAEMON=MDS,CEPHFS_CREATE=1,{{ ceph_mds_docker_extra_env }}"
-    volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph"
+    volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph,/etc/localtime:/etc/localtime:ro"
   when: ansible_os_family != 'RedHat' and ansible_os_family != 'CoreOS'

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}} \
    {% endif -%}
+   -v /etc/localtime:/etc/localtime:ro \
    --privileged \
    -e CEPH_DAEMON=MDS \
    -e CEPHFS_CREATE=1 \

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -20,6 +20,23 @@
 
 - include: pre_requisite.yml
 
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_atomic.yml"
+  when:
+    - is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_redhat.yml"
+  when:
+    - not is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_debian.yml"
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+
 - include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
   vars:
     ceph_docker_username: "{{ ceph_mon_docker_username }}"

--- a/roles/ceph-mon/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-mon/tasks/docker/pre_requisite.yml
@@ -126,3 +126,35 @@
   tags:
     with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '>=')
+
+- name: install ntp on redhat using yum
+  yum:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'yum'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on redhat using dnf
+  dnf:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'dnf'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on debian
+  apt:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+  tags:
+    with_pkg

--- a/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
+++ b/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
@@ -85,7 +85,7 @@
     state: "running"
     privileged: "{{ mon_docker_privileged }}"
     env: "MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface]['ipv4']['address'] }},CEPH_DAEMON=MON,CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }},CEPH_FSID={{ fsid }},{{ ceph_mon_extra_envs }}"
-    volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph"
+    volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph,/etc/localtime:/etc/localtime:ro"
   when:
     - ansible_os_family != 'RedHat'
     - ansible_os_family != 'CoreOS'
@@ -99,6 +99,7 @@
     state: "running"
     privileged: "{{ mon_docker_privileged }}"
     env: "KV_TYPE={{kv_type}},KV_IP={{kv_endpoint}},MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface]['ipv4']['address'] }},CEPH_DAEMON=MON,CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }},{{ ceph_mon_extra_envs }}"
+    volumes: "/etc/localtime:/etc/localtime:ro"
   when:
     - ansible_os_family != 'RedHat'
     - ansible_os_family != 'CoreOS'

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -15,6 +15,7 @@ ExecStart=/usr/bin/docker run --rm --name %i --net=host \
    -e KV_IP={{kv_endpoint}}\
    -e KV_PORT={{kv_port}} \
    {% endif -%}
+   -v /etc/localtime:/etc/localtime:ro \
    {% if mon_docker_privileged -%}
    --privileged \
    {% endif -%}

--- a/roles/ceph-nfs/tasks/docker/main.yml
+++ b/roles/ceph-nfs/tasks/docker/main.yml
@@ -20,6 +20,23 @@
 
 - include: pre_requisite.yml
 
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_atomic.yml"
+  when:
+    - is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_redhat.yml"
+  when:
+    - not is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_debian.yml"
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+
 - include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
   vars:
     ceph_docker_username: "{{ ceph_nfs_docker_username }}"

--- a/roles/ceph-nfs/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-nfs/tasks/docker/pre_requisite.yml
@@ -97,3 +97,35 @@
     enabled: yes
   tags:
     with_pkg
+
+- name: install ntp on redhat using yum
+  yum:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'yum'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on redhat using dnf
+  dnf:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'dnf'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on debian
+  apt:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+  tags:
+    with_pkg

--- a/roles/ceph-nfs/tasks/docker/start_docker_nfs.yml
+++ b/roles/ceph-nfs/tasks/docker/start_docker_nfs.yml
@@ -61,7 +61,7 @@
     privileged: true
     ports: "{{ ceph_nfs_port }}:{{ ceph_nfs_port }},111:111"
     env: "CEPH_DAEMON=NFS,CEPH_PUBLIC_NETWORK={{ ceph_nfs_docker_subnet }},{{ ceph_nfs_extra_envs }}"
-    volumes: "/etc/ceph:/etc/ceph,/etc/ganesha:/etc/ganesha"
+    volumes: "/etc/ceph:/etc/ceph,/etc/ganesha:/etc/ganesha,/etc/localtime:/etc/localtime:ro"
   when:
     not is_atomic and
     ansible_os_family != 'CoreOS' and
@@ -75,7 +75,7 @@
     state: "running"
     privileged: true
     env: "CEPH_DAEMON=NFS,CEPH_PUBLIC_NETWORK={{ ceph_nfs_docker_subnet }},{{ ceph_nfs_extra_envs }}"
-    volumes: "/etc/ganesha:/etc/ganesha"
+    volumes: "/etc/ganesha:/etc/ganesha,/etc/localtime:/etc/localtime:ro"
   when:
     not is_atomic and
     ansible_os_family != 'CoreOS' and

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -15,6 +15,7 @@ ExecStart=/usr/bin/docker run --rm --name %i --net=host \
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}}\
    {% endif -%}
+   -v /etc/localtime:/etc/localtime:ro \
    --privileged \
    -e CEPH_DAEMON=NFS \
    -e CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }} \

--- a/roles/ceph-osd/tasks/docker/main.yml
+++ b/roles/ceph-osd/tasks/docker/main.yml
@@ -20,6 +20,23 @@
 
 - include: pre_requisite.yml
 
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_atomic.yml"
+  when:
+    - is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_redhat.yml"
+  when:
+    - not is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_debian.yml"
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+
 - include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
   vars:
     ceph_docker_username: '{{ ceph_osd_docker_username }}'

--- a/roles/ceph-osd/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/docker/pre_requisite.yml
@@ -125,3 +125,35 @@
   tags:
     with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '>=')
+
+- name: install ntp on redhat using yum
+  yum:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'yum'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on redhat using dnf
+  dnf:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'dnf'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on debian
+  apt:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+  tags:
+    with_pkg

--- a/roles/ceph-osd/tasks/docker/start_docker_osd.yml
+++ b/roles/ceph-osd/tasks/docker/start_docker_osd.yml
@@ -28,6 +28,7 @@
     -v /etc/ceph:/etc/ceph \
     -v /var/lib/ceph/:/var/lib/ceph/ \
     -v /dev:/dev \
+    -v /etc/localtime:/etc/localtime:ro \
     -e "OSD_DEVICE={{ item.0 }}" \
     -e "{{ ceph_osd_docker_prepare_env }}" \
     "{{ ceph_osd_docker_username }}/{{ ceph_osd_docker_imagename }}:{{ ceph_osd_docker_image_tag }}" \
@@ -48,6 +49,7 @@
     --name="{{ ansible_hostname }}-osd-prepare-{{ item.0 |
     regex_replace('/', '') }}" \
     -v /dev:/dev \
+    -v /etc/localtime:/etc/localtime:ro \
     -e "OSD_DEVICE={{ item.0 }}" \
     -e "{{ ceph_osd_docker_prepare_env }}" \
     -e CEPH_DAEMON=osd_ceph_disk_prepare \
@@ -106,7 +108,7 @@
     state: started
     privileged: yes
     env: "OSD_DEVICE={{ item }},{{ ceph_osd_docker_extra_env }}"
-    volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph,/dev:/dev,/run:/run"
+    volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph,/etc/localtime:/etc/localtime:ro,/dev:/dev,/run:/run"
   with_items: ceph_osd_docker_devices
   when:
     - ansible_os_family != 'RedHat'
@@ -122,7 +124,7 @@
     state: running
     privileged: yes
     env: "KV_TYPE={{kv_type}},KV_IP={{kv_endpoint}},OSD_DEVICE={{ item }},{{ ceph_osd_docker_extra_env }}"
-    volumes: "/dev/:/dev/"
+    volumes: "/etc/localtime:/etc/localtime:ro,/dev/:/dev/"
   with_items: ceph_osd_docker_devices
   when:
    - ansible_os_family != 'RedHat'

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -15,6 +15,7 @@ ExecStart=/usr/bin/docker run --rm --net=host --pid=host\
    -e KV_IP={{kv_endpoint}} \
    -e KV_PORT={{kv_port}} \
    {% endif -%}
+   -v /etc/localtime:/etc/localtime:ro \
    -v /dev:/dev \
    --privileged \
    -e CEPH_DAEMON=OSD_CEPH_DISK_ACTIVATE \

--- a/roles/ceph-rbd-mirror/tasks/docker/main.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/main.yml
@@ -17,6 +17,24 @@
   when: ceph_health.rc != 0
 
 - include: pre_requisite.yml
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_atomic.yml"
+  when:
+    - is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_redhat.yml"
+  when:
+    - not is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_debian.yml"
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+
 - include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
   vars:
     ceph_docker_username: "{{ ceph_rbd_mirror_docker_username }}"

--- a/roles/ceph-rbd-mirror/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/pre_requisite.yml
@@ -124,3 +124,35 @@
   tags:
     with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '>=')
+
+- name: install ntp on redhat using yum
+  yum:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'yum'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on redhat using dnf
+  dnf:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'dnf'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on debian
+  apt:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+  tags:
+    with_pkg

--- a/roles/ceph-rbd-mirror/tasks/docker/start_docker_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/start_docker_rbd_mirror.yml
@@ -43,5 +43,5 @@
     name: ceph-{{ ansible_hostname }}-rbd-mirror
     net: host
     state: running
-    volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph"
+    volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph,/etc/localtime:/etc/localtime:ro"
   when: ansible_os_family != 'RedHat' and ansible_os_family != 'CoreOS'

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}} \
    {% endif -%}
+   -v /etc/localtime:/etc/localtime:ro \
    --privileged \
    -e CEPH_DAEMON=RBD_MIRROR \
    --name={{ ansible_hostname }} \

--- a/roles/ceph-restapi/tasks/docker/main.yml
+++ b/roles/ceph-restapi/tasks/docker/main.yml
@@ -1,5 +1,31 @@
 ---
+- name: check if it is Atomic host
+  stat: path=/run/ostree-booted
+  register: stat_ostree
+
+- name: set fact for using Atomic host
+  set_fact:
+      is_atomic: '{{ stat_ostree.stat.exists }}'
+
 - include: pre_requisite.yml
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_atomic.yml"
+  when:
+    - is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_redhat.yml"
+  when:
+    - not is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_debian.yml"
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+
 - include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
   vars:
     ceph_docker_username: "{{ ceph_restapi_docker_username }}"

--- a/roles/ceph-restapi/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-restapi/tasks/docker/pre_requisite.yml
@@ -122,3 +122,35 @@
     enabled: yes
   tags:
     with_pkg
+
+- name: install ntp on redhat using yum
+  yum:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'yum'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on redhat using dnf
+  dnf:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'dnf'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on debian
+  apt:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+  tags:
+    with_pkg

--- a/roles/ceph-restapi/tasks/docker/start_docker_restapi.yml
+++ b/roles/ceph-restapi/tasks/docker/start_docker_restapi.yml
@@ -7,4 +7,4 @@
     expose: "{{ ceph_restapi_port }}"
     state: running
     env: "RESTAPI_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_restapi_docker_interface]['ipv4']['address'] }},CEPH_DAEMON=RESTAPI,{{ ceph_restapi_docker_extra_env }}"
-    volumes: "/etc/ceph:/etc/ceph"
+    volumes: "/etc/ceph:/etc/ceph,/etc/localtime:/etc/localtime:ro"

--- a/roles/ceph-rgw/tasks/docker/main.yml
+++ b/roles/ceph-rgw/tasks/docker/main.yml
@@ -17,6 +17,24 @@
   when: ceph_health.rc != 0
 
 - include: pre_requisite.yml
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_atomic.yml"
+  when:
+    - is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_redhat.yml"
+  when:
+    - not is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_service_enabled
+
+- include: "{{ playbook_dir }}/roles/ceph-common/tasks/misc/ntp_debian.yml"
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+
 - include: "{{ playbook_dir }}/roles/ceph-common/tasks/docker/fetch_image.yml"
   vars:
     ceph_docker_username: "{{ ceph_rgw_docker_username }}"

--- a/roles/ceph-rgw/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/docker/pre_requisite.yml
@@ -110,3 +110,35 @@
     enabled: yes
   tags:
     with_pkg
+
+- name: install ntp on redhat using yum
+  yum:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'yum'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on redhat using dnf
+  dnf:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_pkg_mgr == 'dnf'
+    - ntp_service_enabled
+  tags:
+    with_pkg
+
+- name: install ntp on debian
+  apt:
+    name: ntp
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+  tags:
+    with_pkg

--- a/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
+++ b/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
@@ -45,5 +45,5 @@
     ports: "{{ ceph_rgw_civetweb_port }}:{{ ceph_rgw_civetweb_port }}"
     state: running
     env: "CEPH_DAEMON=RGW,{{ ceph_rgw_docker_extra_env }}"
-    volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph"
+    volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph,/etc/localtime:/etc/localtime:ro"
   when: ansible_os_family != 'RedHat' and ansible_os_family != 'CoreOS'

--- a/roles/ceph-rgw/templates/ceph-rgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-rgw.service.j2
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}} \
    {% endif -%}
+   -v /etc/localtime:/etc/localtime:ro \
    --privileged \
    -e CEPH_DAEMON=RGW \
    --name={{ ansible_hostname }} \


### PR DESCRIPTION
This fixes #845 for containerized deployments. We now also mount the
/etc/localtime volume in the containers in order to synchronize the host
timezone with the container timezone.

Signed-off-by: Ivan Font <ivan.font@redhat.com>