### PR TITLE
ceph-mon: fix the loop in `secure the cluster' task

### DIFF
--- a/roles/ceph-mon/tasks/secure_cluster.yml
+++ b/roles/ceph-mon/tasks/secure_cluster.yml
@@ -7,6 +7,6 @@
 - name: secure the cluster
   command: ceph --cluster {{ cluster }} osd pool set {{ item[0] }} {{ item[1] }} true
   with_nested:
-    - ceph_pools.stdout_lines
+    - "{{ ceph_pools.stdout_lines|default([]) }}"
     - secure_cluster_flags
   when: "{{ ceph_version | version_compare('0.94.0', '>=') }}"


### PR DESCRIPTION
Deployment fails when the ``secure_cluster`` is false:

TASK [ceph-mon : secure the cluster]
*******************************************
fatal: [saceph-mon.vm.ceph.asheplyakov]: FAILED! => {"failed": true, "msg": "'dict object' has no attribute 'stdout_lines'"}
fatal: [saceph-mon2.vm.ceph.asheplyakov]: FAILED! => {"failed": true, "msg": "'dict object' has no attribute 'stdout_lines'"}
fatal: [saceph-mon3.vm.ceph.asheplyakov]: FAILED! => {"failed": true, "msg": "'dict object' has no attribute 'stdout_lines'"}

A conditional include evaluates all included tasks with the (additional)
conditional applied to every task [1]. Thus all tasks from `secure_cluster.yml'
are always evaluated (with an additional 'when: secure_cluster' condition).
The `secure the cluster' task iterates over ``ceph_pools.stdout_lines``
even if ``secure_cluster`` is false: in loops ansible applies conditional
to every item (by design) [2]. However the `collect all the pools' task
is skipped if the very same condition evaluates to false, which leaves
the ``ceph_pools`` undefined, so the `secure the cluster' task fails:

Provide the default (empty) list to avoid the problem.

[1] http://docs.ansible.com/ansible/playbooks_conditionals.html#applying-when-to-roles-and-includes
[2] http://docs.ansible.com/ansible/playbooks_conditionals.html#loops-and-conditionals

Closes: #913

Signed-off-by: Alexey Sheplyakov <asheplyakov@mirantis.com>