### PR TITLE
ceph-common: client settings are for libvirt

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -15,7 +15,7 @@ max open files = {{ max_open_files }}
 {% if common_single_host_mode is defined %}
 osd crush chooseleaf type = 0
 {% endif %}
-[client]
+[client.libvirt]
 admin socket = {{ rbd_client_admin_socket_path }}/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
 log file = {{ rbd_client_log_file }} # must be writable by QEMU and allowed by SELinux or AppArmor
 


### PR DESCRIPTION
Prior to this change, each ceph cluster node would end up with several `qemu-client-$pid.log` files owned by root. The `[client]` section would capture *all* client activity (for example the "`ceph health`" command, etc), not just librbd-in-qemu.

Restrict this section to libvirt clients only so that we don't generate these spurious log files for other Ceph client traffic.