### PR TITLE
Fix purge yum cache

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -426,11 +426,6 @@
     notify:
       - remove data
 
-  - name: purge yum cache
-    command: yum clean all
-    when:
-      ansible_pkg_mgr == 'yum'
-
   - name: purge dnf cache
     command: dnf clean all
     when:

--- a/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
@@ -50,3 +50,9 @@
     owner: root
     group: root
   when: ceph_custom
+
+# Remove yum caches so yum doesn't get confused if we are reinstalling a different ceph version
+- name: purge yum cache
+  command: yum clean all
+  when:
+    ansible_pkg_mgr == 'yum'


### PR DESCRIPTION
The "purge yum cache" task that is in purge-cluster.yml doesn't work as designed.  `yum clean all` will only clean caches for installed repos.  Since purge-cluster.yml removes the repo before purging the cache, it does not remove the `Ceph` repo cache.  I tested putting the task before the yum erase that removes the repo, but yum rebuilds the cache just before removing the repo.  The only way to purge the yum cache for the `Ceph` repo is to move it to the install.yml so it purges the cache just after installing the repo but before it uses it.

I verified this worked correctly by purging and reinstalling several different versions of ceph on the same hardware.  Without the change the install will fail trying to install a chached version of ceph rpm's that don't exist in the currently installed repo.