### PR TITLE
Changes to allow for flexible rsync directory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,7 @@ CLIENTS        = settings['client_vms']
 SUBNET         = settings['subnet']
 BOX            = settings['vagrant_box']
 BOX_URL        = settings['vagrant_box_url']
+SYNC_DIR       = settings['vagrant_sync_dir']
 MEMORY         = settings['memory']
 STORAGECTL     = settings['vagrant_storagectl']
 ETH            = settings['eth']
@@ -112,7 +113,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Faster bootup.  Disable if you need this for libvirt
   config.vm.provider :libvirt do |v,override|
-    override.vm.synced_folder '.', '/home/vagrant/sync', disabled: true
+    override.vm.synced_folder '.', SYNC_DIR, disabled: true
   end
 
   if BOX == 'openstack'

--- a/vagrant_variables.yml.atomic
+++ b/vagrant_variables.yml.atomic
@@ -23,6 +23,9 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 
 eth: 'enp0s8'
 vagrant_box: centos/atomic-host
+# The sync directory changes based on vagrant box
+# Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
+vagrant_sync_dir: /home/vagrant/sync
 
 # if vagrant fails to attach storage controller, add the storage controller name by:
 # VBoxManage storagectl `VBoxManage list vms |grep ceph-ansible_osd0|awk '{print $1}'|tr \" ' '` --name "SATA" --add sata

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -44,6 +44,9 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: ubuntu/trusty64
+# The sync directory changes based on vagrant box
+# Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
+vagrant_sync_dir: /home/vagrant/sync
 # VAGRANT URL
 # This is a URL to download an image from an alternate location.  vagrant_box
 # above should be set to the filename of the image.


### PR DESCRIPTION
-rsync directory was hardcoded previously and did not reflect the default /vagrant rsync directory