### PR TITLE
Fix local_action Requiring Root and Various Small Fixes

### DIFF
--- a/purge-cluster.yml
+++ b/purge-cluster.yml
@@ -293,15 +293,18 @@
      osd_group_name in group_names
 
   - name: remove osd mountpoint tree
-    shell: rm -rf /var/lib/ceph/osd
+    file:
+      path: /var/lib/ceph/osd/
+      state: absent
     register: remove_osd_mountpoints
-    failed_when: false
+    ignore_errors: true
     when:
       osd_group_name in group_names
 
   - name: remove monitor store and bootstrap keys
-    shell: rm -rf /var/lib/ceph/
-    failed_when: false
+    file:
+      path: /var/lib/ceph/
+      state: absent
     when:
       mon_group_name in group_names
 
@@ -313,7 +316,7 @@
       - remove data
     when:
       osd_group_name in group_names and
-      remove_osd_mountpoints.rc != 0
+      remove_osd_mountpoints.failed is defined
 
   - name: see if ceph-disk is installed
     shell: "which ceph-disk"
@@ -322,7 +325,7 @@
 
   - name: zap osd disks
     shell: ceph-disk zap "{{ item }}"
-    with_items: devices
+    with_items: "{{ devices | default([]) }}"
     when:
      osd_group_name in group_names and
      ceph_disk_present.rc == 0 and
@@ -423,6 +426,7 @@
 
   - name: request data removal
     local_action: shell echo requesting data removal
+    become: false
     notify:
       - remove data
 


### PR DESCRIPTION
In purge-cluster.yml the `request data removal` task has a local_action that tries to run as root (At least on OS X).  Fixed by hard coding `become: false`.

Other fixes while I was in the file:
- fixed some ansible2 variable warnings
- replaced shell `rm` with ansible `file/absent` module