### PR TITLE
osd: fix collocation spelling and declare dmcrypt variables

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -352,6 +352,8 @@ dummy:
 #raw_multi_journal: False
 #osd_directory: False
 #bluestore: False
+#dmcrypt_journal_collocation: False
+#dmcrypt_dedicated_journal: False
 
 #osd_auto_discovery: False
 

--- a/group_vars/osds.sample
+++ b/group_vars/osds.sample
@@ -121,7 +121,7 @@ dummy:
 # Keys are stored into the monitors k/v store
 # Use 'true' to enable this scenario
 # Both journal and data are stored on the same dm-crypt encrypted device
-#dmcrypt_journal_colocation: false
+#dmcrypt_journal_collocation: false
 
 
 # VI. Encrypt osd data and/or journal devices with dm-crypt.

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -344,5 +344,7 @@ journal_collocation: False
 raw_multi_journal: False
 osd_directory: False
 bluestore: False
+dmcrypt_journal_collocation: False
+dmcrypt_dedicated_journal: False
 
 osd_auto_discovery: False

--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -71,7 +71,7 @@
     - not raw_multi_journal
     - not osd_directory
     - not bluestore
-    - not dmcrypt_journal_colocation
+    - not dmcrypt_journal_collocation
     - not dmcrypt_dedicated_journal
 
 - name: verify only one osd scenario was chosen
@@ -86,14 +86,15 @@
       or (raw_multi_journal and osd_directory)
       or (raw_multi_journal and bluestore)
       or (osd_directory and bluestore)
-      or (dmcrypt_journal_colocation and journal_collocation)
-      or (dmcrypt_journal_colocation and raw_multi_journal)
-      or (dmcrypt_journal_colocation and osd_directory)
-      or (dmcrypt_journal_colocation and bluestore)
+      or (dmcrypt_journal_collocation and journal_collocation)
+      or (dmcrypt_journal_collocation and raw_multi_journal)
+      or (dmcrypt_journal_collocation and osd_directory)
+      or (dmcrypt_journal_collocation and bluestore)
       or (dmcrypt_dedicated_journal and journal_collocation)
       or (dmcrypt_dedicated_journal and raw_multi_journal)
       or (dmcrypt_dedicated_journal and osd_directory)
       or (dmcrypt_dedicated_journal and bluestore)
+      or (dmcrypt_dedicated_journal and dmcrypt_journal_collocation)
 
 - name: verify devices have been provided
   fail:

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -113,7 +113,7 @@ bluestore: false
 # Keys are stored into the monitors k/v store
 # Use 'true' to enable this scenario
 # Both journal and data are stored on the same dm-crypt encrypted device
-dmcrypt_journal_colocation: false
+dmcrypt_journal_collocation: false
 
 
 # VI. Encrypt osd data and/or journal devices with dm-crypt.

--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -36,7 +36,7 @@
     - item.value.removable == "0"
     - item.value.partitions|count == 0
     - osd_auto_discovery
-    - dmcrypt_journal_colocation
+    - dmcrypt_journal_collocation
 
 - name: activate osd(s) when device is a disk (dmcrypt)
   command: ceph-disk activate --dmcrypt {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
@@ -56,7 +56,7 @@
 # https://github.com/ansible/ansible/issues/4297
 - name: combine ispartition results
   set_fact:
-    combined_activate_osd_disk_results: "{{ activate_osd_disk if not dmcrypt_journal_colocation else activate_osd_disk_dmcrypt }}"
+    combined_activate_osd_disk_results: "{{ activate_osd_disk if not dmcrypt_journal_collocation else activate_osd_disk_dmcrypt }}"
 
 - name: fail if ceph-disk cannot create an OSD
   fail:

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -22,9 +22,9 @@
     - osd_objectstore == 'bluestore'
     - not osd_containerized_deployment
 
-- include: ./scenarios/dmcrypt-journal-colocation.yml
+- include: ./scenarios/dmcrypt-journal-collocation.yml
   when:
-    - dmcrypt_journal_colocation
+    - dmcrypt_journal_collocation
     - not osd_containerized_deployment
 
 - include: ./scenarios/dmcrypt-dedicated-journal.yml

--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -35,7 +35,7 @@
   set_fact:
     copy_admin_key: true
   when:
-    - dmcrypt_journal_colocation or dmcrypt_dedicated_journal
+    - dmcrypt_journal_collocation or dmcrypt_dedicated_journal
 
 - name: copy osd bootstrap key
   copy:

--- a/roles/ceph-osd/tasks/scenarios/dmcrypt-journal-collocation.yml
+++ b/roles/ceph-osd/tasks/scenarios/dmcrypt-journal-collocation.yml
@@ -16,7 +16,7 @@
     - ansible_devices is defined
     - item.value.removable == "0"
     - item.value.partitions|count == 0
-    - dmcrypt_journal_colocation
+    - dmcrypt_journal_collocation
     - osd_auto_discovery
 
 - name: manually prepare osd disk(s) (dmcrypt)
@@ -30,7 +30,7 @@
     - not item.1.get("skipped")
     - item.0.get("rc", 0) != 0
     - item.1.get("rc", 0) != 0
-    - dmcrypt_journal_colocation
+    - dmcrypt_journal_collocation
     - not osd_auto_discovery
 
 - include: ../activate_osds.yml


### PR DESCRIPTION
* changed s/colocation/collocation/
* declare dmcrypt variable in ceph-common so the variables check does
not fail

Signed-off-by: Sébastien Han <seb@redhat.com>