### PR TITLE
Fix ceph.conf template for containerized deployment

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -18,12 +18,16 @@ osd crush chooseleaf type = 0
 {# NOTE (leseb): the blank lines in-between are needed otherwise we won't get any line break #}
 {% if groups[mon_group_name] is defined %}
 mon_initial_members = {% if groups[mon_group_name] is defined %}{% for host in groups[mon_group_name] %}{% if hostvars[host]['ansible_fqdn'] is defined and mon_use_fqdn %}{{ hostvars[host]['ansible_fqdn'] }}{% if not loop.last %},{% endif %}{% elif hostvars[host]['ansible_hostname'] is defined %}{{ hostvars[host]['ansible_hostname'] }}{% if not loop.last %},{% endif %}{% endif %}{% endfor %}{% endif %}
+{% endif %}
 
-mon_host = {% if groups[mon_group_name] is defined %}{% for host in groups[mon_group_name] %}{{ hostvars[host]['ansible_' + monitor_interface]['ipv4']['address'] }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+{% if not mon_containerized_deployment and not mon_containerized_deployment_with_kv %}
+{% if groups[mon_group_name] is defined %}
+mon host = {% for host in groups[mon_group_name] %}{{ hostvars[host]['ansible_' + monitor_interface]['ipv4']['address'] }}{% if not loop.last %},{% endif %}{% endfor %}
 {% elif (hostvars[host]['monitor_interface'] is defined and hostvars[host]['monitor_interface'] != "interface") or monitor_interface != "interface" %}
 {% include 'mon_addr_interface.j2' %}
 {% else %}
 {% include 'mon_addr_address.j2' %}
+{% endif %}
 {% endif %}
 {% if mon_containerized_deployment %}
 fsid = {{ fsid }}
@@ -31,7 +35,7 @@ fsid = {{ fsid }}
 {% for host in groups[mon_group_name] %}
 {% if mon_containerized_deployment %}
 {% set interface = ["ansible_",ceph_mon_docker_interface]|join %}
-mon_host = {{ hostvars[host]['ansible_' + interface]['ipv4']['address'] }}
+mon_host = {{ hostvars[host][interface]['ipv4']['address'] }}
 {% if not loop.last %},{% endif %}
 {% elif hostvars[host]['monitor_address'] is defined %}
 mon_host = {{ hostvars[host]['monitor_address'] }}


### PR DESCRIPTION
I'm not sure if this is the preferred fix, but this was blocking me on container deployments during ceph-mon's `generate ceph configuration file` task in `roles/ceph-mon/tasks/docker/create_configs.yml`. I kept getting the below error caused by #815:
> 'dict object' has no attribute u'ansible_interface'

I did see the warnings that were heeded in the conversation.  :)