### PR TITLE
Fix pre-infernalis RPM installation of ceph-radosgw

### DIFF
--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -41,6 +41,14 @@
     group: "{{ key_group }}"
   when: cephx
 
+- name: ensure ceph-radosgw systemd unit file is present
+  command: chkconfig --add ceph-radosgw
+  args:
+    creates: /var/run/systemd/generator.late/ceph-radosgw.service
+  when:
+    - ansible_os_family == "RedHat"
+    - is_before_infernalis
+
 - name: activate rados gateway with upstart
   file:
     path: /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}/{{ item }}


### PR DESCRIPTION
For pre-infernalis installation of ceph-radosgw from RPM, run 'chkconfig'
to ensure systemd's ceph-radosgw.service is created.

This fixes issue #843.