### PR TITLE
Restrict fact gathering to mons and update ceph.conf

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -32,19 +32,19 @@ mon host = {% for host in groups[mon_group_name] %}{{ hostvars[host]['ansible_' 
 {% if mon_containerized_deployment %}
 fsid = {{ fsid }}
 {% if groups[mon_group_name] is defined %}
-{% for host in groups[mon_group_name] %}
+mon host = {% for host in groups[mon_group_name] -%}
 {% if mon_containerized_deployment %}
 {% set interface = ["ansible_",ceph_mon_docker_interface]|join %}
-mon_host = {{ hostvars[host][interface]['ipv4']['address'] }}
-{% if not loop.last %},{% endif %}
+{{ hostvars[host][interface]['ipv4']['address'] }}
+{%- if not loop.last %},{% endif %}
 {% elif hostvars[host]['monitor_address'] is defined %}
-mon_host = {{ hostvars[host]['monitor_address'] }}
-{% if not loop.last %},{% endif %}
+{{ hostvars[host]['monitor_address'] }}
+{%- if not loop.last %},{% endif %}
 {% elif monitor_address != "0.0.0.0" %}
-mon_host = monitor_address
-{% if not loop.last %},{% endif %}
+monitor_address
+{%- if not loop.last %},{% endif %}
 {% endif %}
-{% endfor %}
+{%- endfor %}
 {% endif %}
 {% endif %}
 

--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -1,11 +1,12 @@
 ---
 # Defines deployment design and assigns role to server groups
 
-- hosts: all
+- hosts: mons # gather mon facts first before we process ceph-mon serially
   tasks: []
 
 - hosts: mons
   become: True
+  gather_facts: false
   roles:
   - ceph-mon
   serial: 1 # MUST be '1' WHEN DEPLOYING MONITORS ON DOCKER CONTAINERS


### PR DESCRIPTION
- Gather facts only for mons before processing ceph-mon role serially in
  containerized playbook sample
- Updated ceph.conf in order to generate a valid ceph.conf

Signed-off-by: Ivan Font <ivan.font@redhat.com>