### PR TITLE
NFS fixes

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -351,6 +351,7 @@ dummy:
 # by ceph.conf.j2 template. so it should always be defined
 #mon_containerized_deployment_with_kv: false
 #mon_containerized_deployment: false
+#mon_containerized_default_ceph_conf_with_kv: false
 
 
 ##################

--- a/group_vars/mons.sample
+++ b/group_vars/mons.sample
@@ -72,6 +72,7 @@ dummy:
 
 #mon_containerized_deployment: false
 #mon_containerized_deployment_with_kv: false
+# This is currently in ceph-common defaults because it is shared with ceph-nfs
 #mon_containerized_default_ceph_conf_with_kv: false
 #ceph_mon_docker_interface: eth0
 #ceph_mon_docker_subnet: # subnet of the ceph_mon_docker_interface

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -343,6 +343,7 @@ docker: false
 # by ceph.conf.j2 template. so it should always be defined
 mon_containerized_deployment_with_kv: false
 mon_containerized_deployment: false
+mon_containerized_default_ceph_conf_with_kv: false
 
 
 ##################

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -64,7 +64,8 @@ openstack_keys:
 
 mon_containerized_deployment: false
 mon_containerized_deployment_with_kv: false
-mon_containerized_default_ceph_conf_with_kv: false
+# This is currently in ceph-common defaults because it is shared with ceph-nfs
+#mon_containerized_default_ceph_conf_with_kv: false
 ceph_mon_docker_interface: eth0
 #ceph_mon_docker_subnet: # subnet of the ceph_mon_docker_interface
 ceph_mon_docker_username: ceph

--- a/roles/ceph-nfs/tasks/docker/create_configs.yml
+++ b/roles/ceph-nfs/tasks/docker/create_configs.yml
@@ -11,6 +11,7 @@
   docker:
     image: "{{ ceph_rgw_docker_username }}/{{ ceph_rgw_docker_imagename }}:{{ ceph_rgw_docker_image_tag }}"
     name: ceph-{{ ansible_hostname }}-rgw-user
+    hostname: "{{ ansible_hostname }}"
     expose: "{{ ceph_rgw_civetweb_port }}"
     ports: "{{ ceph_rgw_civetweb_port }}:{{ ceph_rgw_civetweb_port }}"
     state: running

--- a/roles/ceph-nfs/tasks/docker/main.yml
+++ b/roles/ceph-nfs/tasks/docker/main.yml
@@ -55,7 +55,7 @@
 - include: create_configs.yml
   when:
     inventory_hostname == groups.nfss[0] and
-    mon_containerized_default_ceph_conf_with_kv
+    not mon_containerized_default_ceph_conf_with_kv
 
 # Copy Ganesha configs to host
 - include: fetch_configs.yml

--- a/roles/ceph-rgw/tasks/docker/copy_configs.yml
+++ b/roles/ceph-rgw/tasks/docker/copy_configs.yml
@@ -25,7 +25,7 @@
 - name: push ceph files to the ansible server
   fetch:
     src: "{{ item.0 }}"
-    dest: "{{ fetch_directory }}/docker_mon_files/var/lib/ceph/radosgw/{{ ansible_hostname }}/keyring"
+    dest: "{{ fetch_directory }}/docker_mon_files/var/lib/ceph/radosgw/keyring"
     flat: yes
   with_together:
     - rgw_config_keys


### PR DESCRIPTION
- Move mon_containerized_default_ceph_conf_with_kv config from ceph-mon
  to ceph-common defaults as it's used in ceph-nfs
- Update conditional to generate ganesha config when not
  mon_containerized_default_ceph_conf_with_kv
- Revert change to store radosgw keyring using ansible_hostname on
  ansible server so that ceph-nfs can find it
- Update ceph-ceph-nfs0-rgw-user container to use ansible_hostname
  variable

Signed-off-by: Ivan Font <ivan.font@redhat.com>