### PR TITLE
ceph-disk activate must be used on the OSD partition

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -3,7 +3,7 @@
 # partition.
 
 - name: automatically activate osd disk(s) without partitions
-  command: ceph-disk activate "/dev/{{ item.key }}"
+  command: ceph-disk activate "/dev/{{ item.key }}p1"
   ignore_errors: true
   with_dict: ansible_devices
   when:


### PR DESCRIPTION
When using `journal_collocation`, the `ceph-disk activate` must activate the OSD partition, which is the first partition on the device.