### PR TITLE
rolling updates: remove mon compact command

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -60,10 +60,6 @@
     upgrade_ceph_packages: True
     mon_group_name: mons
 
-  pre_tasks:
-    - name: compress the store as much as possible
-      command: ceph tell mon.{{ ansible_hostname }} compact --cluster {{ cluster }}
-
   roles:
     - ceph-common
     - ceph-mon


### PR DESCRIPTION
Users have reported this task to hang. Since this command is not
required to perform the upgrade, we remove it.

Signed-off-by: Sébastien Han <seb@redhat.com>