### PR TITLE
ceph-osd: get full link path when testing if a partition

### DIFF
--- a/roles/ceph-osd/tasks/check_devices_auto.yml
+++ b/roles/ceph-osd/tasks/check_devices_auto.yml
@@ -1,6 +1,6 @@
 ---
 - name: check if the device is a partition (autodiscover disks)
-  shell: "echo '/dev/{{ item.key }}' | egrep '/dev/([hsv]d[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p)[0-9]{1,2}$'"
+  shell: "readlink -f /dev/{{ item.key }} | egrep '/dev/([hsv]d[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p)[0-9]{1,2}$'"
   with_dict: "{{ ansible_devices }}"
   changed_when: false
   failed_when: false

--- a/roles/ceph-osd/tasks/check_devices_static.yml
+++ b/roles/ceph-osd/tasks/check_devices_static.yml
@@ -1,6 +1,6 @@
 ---
 - name: check if the device is a partition
-  shell: "echo '{{ item }}' | egrep '/dev/([hsv]d[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p)[0-9]{1,2}$'"
+  shell: "readlink -f {{ item }} | egrep '/dev/([hsv]d[a-z]{1,2}|cciss/c[0-9]d[0-9]p|nvme[0-9]n[0-9]p)[0-9]{1,2}$'"
   with_items: "{{ devices }}"
   changed_when: false
   failed_when: false


### PR DESCRIPTION
this allows us to test devices set with persistent naming such as
/dev/disk/by-*

Signed-off-by: Sébastien Han <seb@redhat.com>