### PR TITLE
Allow deployer to customize openstack pools

### DIFF
--- a/group_vars/mons.sample
+++ b/group_vars/mons.sample
@@ -61,6 +61,12 @@ dummy:
 #  name: backups
 #  pg_num: "{{ pool_default_pg_num }}"
 
+#openstack_pools:
+#  - "{{ openstack_glance_pool }}"
+#  - "{{ openstack_cinder_pool }}"
+#  - "{{ openstack_nova_pool }}"
+#  - "{{ openstack_cinder_backup_pool }}"
+
 #openstack_keys:
 #  - { name: client.glance, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool={{ openstack_glance_pool.name }}'" }
 #  - { name: client.cinder, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool={{ openstack_cinder_pool.name }}, allow rwx pool={{ openstack_nova_pool.name }}, allow rx pool={{ openstack_glance_pool.name }}'"  }

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -53,6 +53,12 @@ openstack_cinder_backup_pool:
   name: backups
   pg_num: "{{ pool_default_pg_num }}"
 
+openstack_pools:
+  - "{{ openstack_glance_pool }}"
+  - "{{ openstack_cinder_pool }}"
+  - "{{ openstack_nova_pool }}"
+  - "{{ openstack_cinder_backup_pool }}"
+
 openstack_keys:
   - { name: client.glance, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool={{ openstack_glance_pool.name }}'" }
   - { name: client.cinder, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool={{ openstack_cinder_pool.name }}, allow rwx pool={{ openstack_nova_pool.name }}, allow rx pool={{ openstack_glance_pool.name }}'"  }

--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -1,11 +1,7 @@
 ---
 - name: create openstack pool
   command: ceph --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pg_num }}
-  with_items:
-    - "{{ openstack_glance_pool }}"
-    - "{{ openstack_cinder_pool }}"
-    - "{{ openstack_nova_pool }}"
-    - "{{ openstack_cinder_backup_pool }}"
+  with_items: "{{ openstack_pools }}"
   changed_when: false
   failed_when: false
 
@@ -13,6 +9,6 @@
   command: ceph --cluster {{ cluster }} auth get-or-create {{ item.name }} {{ item.value }} -o /etc/ceph/{{ cluster }}.{{ item.name }}.keyring
   args:
     creates: /etc/ceph/{{ cluster }}.{{ item.name }}.keyring
-  with_items: openstack_keys
+  with_items: "{{ openstack_keys }}"
   changed_when: false
   when: cephx


### PR DESCRIPTION
By overriding the openstack_pools variable introduced by this commit, the deployer may choose not to create some of the openstack pools, or to add new pools which were not foreseen by ceph-ansible, e.g. for a gnocchi storage backend.

For backwards compatibility, we keep the openstack_glance_pool, openstack_cinder_pool, openstack_nova_pool and openstack_cinder_backup_pool variables, although the user may now choose to specify the pools directly as dictionary literals inside the openstack_pools list.