### PR TITLE
vagrant: add label_prefix setting

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ DEBUG = false
 config_file=File.expand_path(File.join(File.dirname(__FILE__), 'vagrant_variables.yml'))
 settings=YAML.load_file(config_file)
 
-LABEL_PREFIX   = ""
+LABEL_PREFIX   = settings['label_prefix'] ? settings['label_prefix'] : ""
 NMONS          = settings['mon_vms']
 NOSDS          = settings['osd_vms']
 NMDSS          = settings['mds_vms']

--- a/vagrant_variables.yml.linode
+++ b/vagrant_variables.yml.linode
@@ -3,6 +3,9 @@
 vagrant_box: 'linode'
 vagrant_box_url: 'https://github.com/displague/vagrant-linode/raw/master/box/linode.box'
 
+# Set a label prefix for the machines in this cluster. (This is useful and necessary when running multiple clusters concurrently.)
+#label_prefix: 'foo'
+
 ssh_username: 'vagrant'
 ssh_private_key_path: '~/.ssh/id_rsa'
 


### PR DESCRIPTION
This enables running multiple clusters concurrently in the same Linode
account. Linode does not allow machines to have the same label.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>