### PR TITLE
group_vars: default to version 2 of RHCS

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -147,8 +147,8 @@ dummy:
 #
 #ceph_rhcs: false
 # This will affect how/what repositories are enabled depending on the desired
-# version. The next version will use "2" not "2.0" which would not work.
-#ceph_rhcs_version: 1.3 # next version is 2
+# version. The previous version was 1.3. The current version is 2.
+#ceph_rhcs_version: 2
 #ceph_rhcs_cdn_install: false # assumes all the nodes can connect to cdn.redhat.com
 #ceph_rhcs_iso_install: false # usually used when nodes don't have access to cdn.redhat.com
 #ceph_rhcs_iso_path:

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -139,8 +139,8 @@ ceph_stable_redhat_distro: el7
 #
 ceph_rhcs: false
 # This will affect how/what repositories are enabled depending on the desired
-# version. The next version will use "2" not "2.0" which would not work.
-ceph_rhcs_version: 1.3 # next version is 2
+# version. The previous version was 1.3. The current version is 2.
+ceph_rhcs_version: 2
 ceph_rhcs_cdn_install: false # assumes all the nodes can connect to cdn.redhat.com
 ceph_rhcs_iso_install: false # usually used when nodes don't have access to cdn.redhat.com
 #ceph_rhcs_iso_path:


### PR DESCRIPTION
This RHCS version is now generally available. Default to using it.

Related to https://bugzilla.redhat.com/1357631