### PR TITLE
Small fix in config template

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -56,9 +56,6 @@ public_network = {{ public_network }}
 {% if cluster_network is defined %}
 cluster_network = {{ cluster_network }}
 {% endif %}
-{% if common_single_host_mode is defined %}
-osd crush chooseleaf type = 0
-{% endif %}
 
 [client.libvirt]
 admin socket = {{ rbd_client_admin_socket_path }}/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor


### PR DESCRIPTION
1) Remove duplication of "osd crush chooseleaf type = 0"
2) Add osd_pool_default_size = 1 for a single node deployment

Signed-off-by: Proskurin Kirill <kproskurin@mirantis.com>