### PR TITLE
upgrade: add custom timeout options

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -59,6 +59,8 @@
   vars:
     upgrade_ceph_packages: True
     mon_group_name: mons
+    health_mon_check_retries: 5
+    health_mon_check_delay: 10
 
   roles:
     - ceph-common
@@ -95,8 +97,8 @@
         ceph -s  --cluster {{ cluster }} | grep monmap | sed 's/.*quorum//' | egrep -sq {{ ansible_hostname }}
       register: result
       until: result.rc == 0
-      retries: 5
-      delay: 10
+      retries: "{{ health_mon_check_retries }}"
+      delay: "{{ health_mon_check_delay }}"
       delegate_to: "{{ mon_host }}"
 
 
@@ -106,6 +108,8 @@
   vars:
     upgrade_ceph_packages: True
     osd_group_name: osds
+    health_osd_check_retries: 10
+    health_osd_check_delay: 10
 
   pre_tasks:
     - name: set osd flags
@@ -151,8 +155,8 @@
         test "$(ceph pg stat --cluster {{ cluster }} | sed 's/^.*pgs://;s/active+clean.*//;s/ //')" -eq "$(ceph pg stat --cluster {{ cluster }}  | sed 's/pgs.*//;s/^.*://;s/ //')" && ceph health --cluster {{ cluster }}  | egrep -sq "HEALTH_OK|HEALTH_WARN"
       register: result
       until: result.rc == 0
-      retries: 10
-      delay: 10
+      retries: "{{ health_osd_check_retries }}"
+      delay: "{{ health_osd_check_delay }}"
       delegate_to: "{{ groups.mons[0] }}"
 
     - name: unset osd flags


### PR DESCRIPTION
This commit introduces the ability to configure delays and retries for
cluster health checks, for both monitors and OSDs.

Signed-off-by: Sébastien Han <seb@redhat.com>