### PR TITLE
Remove dupes in raw_journal_devices in a consistent manner

### DIFF
--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -32,7 +32,7 @@
   shell: "sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }} || sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }}"
   with_together:
     - "{{ journal_partition_status.results }}"
-    - "{{ raw_journal_devices }}"
+    - "{{ raw_journal_devices|default([])|unique }}"
   changed_when: false
   when:
     - raw_multi_journal


### PR DESCRIPTION
This task was failing because the array lengths didn't match up within the two arrays under with_together because the previous task reduced the first array.

`fatal: [hpc7873.eng.fireeye.com]: FAILED! => {"failed": true, "msg": "The conditional check 'item.0.rc != 0' failed. The error was: error while evaluating conditional (item.0.rc != 0): 'None' has no attribute 'rc'\n\nThe error appears to have been in '/home/musee/automatons/ceph-poc2/roles/ceph-osd/tasks/check_devices.yml': line 31, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: fix partitions gpt header or labels of the journal devices\n  ^ here\n"}
`