### PR TITLE
Create separate subnet for public/cluster networks

### DIFF
--- a/vagrant_variables.yml.atomic
+++ b/vagrant_variables.yml.atomic
@@ -15,8 +15,9 @@ iscsi_gw_vms: 0
 # Deploy RESTAPI on each of the Monitors
 #restapi: false
 
-# SUBNET TO USE FOR THE VMS
-subnet: 192.168.0
+# SUBNETS TO USE FOR THE VMS
+public_subnet: 192.168.0
+cluster_subnet: 192.168.1
 
 # MEMORY
 memory: 1024

--- a/vagrant_variables.yml.linode
+++ b/vagrant_variables.yml.linode
@@ -17,7 +17,7 @@ memory: 2048
 
 # The private network on Linode, you probably don't want to change this.
 public_subnet: 192.168.0
-cluster_subnet: 192.168.1
+cluster_subnet: 192.168.0
 
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 3

--- a/vagrant_variables.yml.linode
+++ b/vagrant_variables.yml.linode
@@ -16,7 +16,8 @@ cloud_datacenter: 'newark'
 memory: 2048
 
 # The private network on Linode, you probably don't want to change this.
-subnet: 192.168.0
+public_subnet: 192.168.0
+cluster_subnet: 192.168.1
 
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 3

--- a/vagrant_variables.yml.openstack
+++ b/vagrant_variables.yml.openstack
@@ -17,7 +17,7 @@ client_vms: 0
 # SUBNET TO USE FOR THE VMS
 # Use whatever private subnet your Openstack VMs are given
 public_subnet: 172.17.72
-cluster_subnet: 172.17.73
+cluster_subnet: 172.17.72
 
 # For Openstack VMs, the disk will depend on what you are allocated
 disks: "[ '/dev/vdb' ]"

--- a/vagrant_variables.yml.openstack
+++ b/vagrant_variables.yml.openstack
@@ -16,7 +16,8 @@ client_vms: 0
 
 # SUBNET TO USE FOR THE VMS
 # Use whatever private subnet your Openstack VMs are given
-subnet: 172.17.72 
+public_subnet: 172.17.72
+cluster_subnet: 172.17.73
 
 # For Openstack VMs, the disk will depend on what you are allocated
 disks: "[ '/dev/vdb' ]"

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -20,8 +20,9 @@ restapi: true
 # valid values are 'stable' and 'dev'
 ceph_install_source: stable
 
-# SUBNET TO USE FOR THE VMS
-subnet: 192.168.42
+# SUBNETS TO USE FOR THE VMS
+public_subnet: 192.168.42
+cluster_subnet: 192.168.43
 
 # MEMORY
 # set 1024 for CentOS


### PR DESCRIPTION
- All Ceph instances now communication using public subnet and
  additionally OSDs communicate with each other using private cluster
  subnet
- Workaround for
  https://github.com/vagrant-libvirt/vagrant-libvirt/issues/645
- Fix for #952 to avoid concatenated MAC addresses caused by
  vagrant-libvirt bug.