### PR TITLE
Updated to use xenial by default.  Added OSD specific controller.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,6 @@ BOX            = settings['vagrant_box']
 BOX_URL        = settings['vagrant_box_url']
 SYNC_DIR       = settings['vagrant_sync_dir']
 MEMORY         = settings['memory']
-STORAGECTL     = settings['vagrant_storagectl']
 ETH            = settings['eth']
 DOCKER         = settings['docker']
 USER           = settings['ssh_username']
@@ -418,15 +417,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
       # Virtualbox
       osd.vm.provider :virtualbox do |vb|
+        # Create our own controller for consistency and to remove VM dependency
+        vb.customize ['storagectl', :id,
+                      '--name', 'OSD Controller',
+                      '--add', 'scsi']
         (0..1).each do |d|
           vb.customize ['createhd',
                         '--filename', "disk-#{i}-#{d}",
                         '--size', '11000'] unless File.exist?("disk-#{i}-#{d}.vdi")
-          # Controller names are dependent on the VM being built.
-          # It is set when the base box is made in our case ubuntu/trusty64.
-          # Be careful while changing the box.
           vb.customize ['storageattach', :id,
-                        '--storagectl', STORAGECTL,
+                        '--storagectl', 'OSD Controller',
                         '--port', 3 + d,
                         '--device', 0,
                         '--type', 'hdd',

--- a/vagrant_variables.yml.atomic
+++ b/vagrant_variables.yml.atomic
@@ -30,8 +30,4 @@ vagrant_box: centos/atomic-host
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 vagrant_sync_dir: /home/vagrant/sync
 
-# if vagrant fails to attach storage controller, add the storage controller name by:
-# VBoxManage storagectl `VBoxManage list vms |grep ceph-ansible_osd0|awk '{print $1}'|tr \" ' '` --name "SATA" --add sata
-# and "vagrant up" again
-vagrant_storagectl: 'SATA'
 skip_tags: 'with_pkg'

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -26,7 +26,7 @@ cluster_subnet: 192.168.43
 
 # MEMORY
 # set 1024 for CentOS
-memory: 256
+memory: 512
 
 # Ethernet interface name
 # use eth1 for libvirt and ubuntu, enp0s8 for CentOS
@@ -34,10 +34,11 @@ eth: 'eth1'
 
 # Disks
 # For libvirt use disks: "[ '/dev/vdb', '/dev/vdc' ]"
+# For CentOS7 use disks: "[ '/dev/sda', '/dev/sdb' ]"
 disks: "[ '/dev/sdb', '/dev/sdc' ]"
 
 # VAGRANT BOX
-# Ubuntu: ubuntu/trusty64 or ubuntu/wily64
+# Ubuntu: geerlingguy/ubuntu1604 or ubuntu/trusty64 or ubuntu/wily64
 # CentOS: bento/centos-7.1 or puppetlabs/centos-7.0-64-puppet
 # libvirt CentOS: centos/7
 # parallels Ubuntu: parallels/ubuntu-14.04
@@ -45,7 +46,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: ubuntu/trusty64
+vagrant_box: geerlingguy/ubuntu1604
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 vagrant_sync_dir: /home/vagrant/sync
@@ -55,9 +56,6 @@ vagrant_sync_dir: /home/vagrant/sync
 # Fedora virtualbox: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 # Fedora libvirt: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-libvirt.box
 # vagrant_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
-
-# use vagrant_storagectl: 'SATA Controller' for CentOS
-vagrant_storagectl: 'SATAController'
 
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -29,7 +29,7 @@ cluster_subnet: 192.168.43
 memory: 512
 
 # Ethernet interface name
-# use eth1 for libvirt and ubuntu, enp0s8 for CentOS
+# use eth1 for libvirt and ubuntu precise, enp0s8 for CentOS and ubuntu xenial
 eth: 'eth1'
 
 # Disks
@@ -38,7 +38,7 @@ eth: 'eth1'
 disks: "[ '/dev/sdb', '/dev/sdc' ]"
 
 # VAGRANT BOX
-# Ubuntu: geerlingguy/ubuntu1604 or ubuntu/trusty64 or ubuntu/wily64
+# Ubuntu: bento/ubuntu-16.04 or ubuntu/trusty64 or ubuntu/wily64
 # CentOS: bento/centos-7.1 or puppetlabs/centos-7.0-64-puppet
 # libvirt CentOS: centos/7
 # parallels Ubuntu: parallels/ubuntu-14.04
@@ -46,7 +46,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: geerlingguy/ubuntu1604
+vagrant_box: bento/ubuntu-16.04
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 vagrant_sync_dir: /home/vagrant/sync


### PR DESCRIPTION
Found a Vagrant box image for xenial that works well.  The ubuntu and bento ones don't include python by default and have other issues as well.  geerlingguy/ubuntu1604 image is the 2nd most popular one on the atlas repo with 144K downloads.  The developer looks pretty legit and has the code posted in his git repo.  @leseb is this image ok for us to use?

I've added code to create a SCSI controller as part of the vagrant provisioning.  This makes us a little less dependent on the controller the box has built in.  Also it means we can rely on the controller name being a constant.

