### PR TITLE
vagrant_variables.yml.sample: vagrant_url should be vagrant_box_url

### DIFF
--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -54,7 +54,7 @@ vagrant_sync_dir: /home/vagrant/sync
 # above should be set to the filename of the image.
 # Fedora virtualbox: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 # Fedora libvirt: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-libvirt.box
-# vagrant_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
+# vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 
 # use vagrant_storagectl: 'SATA Controller' for CentOS
 vagrant_storagectl: 'SATAController'


### PR DESCRIPTION
As per the variable in Vagrantfile and vagrant_variables.yml.linode

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>