### PR TITLE
common: backward compatibility name for rhcs

### DIFF
--- a/group_vars/all.sample
+++ b/group_vars/all.sample
@@ -143,15 +143,20 @@ dummy:
 # time. Please use ELRepo's latest upstream 4.x kernels if you want to run CephFS
 # on RHEL 7.
 #
-#ceph_rhcs: false
+#
+# Backward compatibility of variable names
+# Commit 492518a2 changed variable names of rhcs installations
+# to not break backward compatiblity we re-declare these variables
+# with the content of the new variable
+#ceph_rhcs: "{{ ceph_stable_rh_storage | default(false) }}"
 # This will affect how/what repositories are enabled depending on the desired
 # version. The previous version was 1.3. The current version is 2.
-#ceph_rhcs_version: 2
-#ceph_rhcs_cdn_install: false # assumes all the nodes can connect to cdn.redhat.com
-#ceph_rhcs_iso_install: false # usually used when nodes don't have access to cdn.redhat.com
-#ceph_rhcs_iso_path:
-#ceph_rhcs_mount_path: /tmp/rh-storage-mount
-#ceph_rhcs_repository_path: /tmp/rh-storage-repo # where to copy iso's content
+#ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(2) }}"
+#ceph_rhcs_cdn_install: "{{ ceph_stable_rh_storage_cdn_install | default(false) }}" # assumes all the nodes can connect to cdn.redhat.com
+#ceph_rhcs_iso_install: "{{ ceph_stable_rh_storage_iso_install | default(false) }}" # usually used when nodes don't have access to cdn.redhat.com
+#ceph_rhcs_iso_path: "{{ ceph_stable_rh_storage_iso_path | default('') }}"
+#ceph_rhcs_mount_path: "{{ ceph_stable_rh_storage_mount_path | default(/tmp/rh-storage-mount) }}"
+#ceph_rhcs_repository_path: "{{ ceph_stable_rh_storage_repository_path | default(/tmp/rh-storage-repo) }}" # where to copy iso's content
 
 
 # UBUNTU CLOUD ARCHIVE

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -135,15 +135,20 @@ ceph_stable_redhat_distro: el7
 # time. Please use ELRepo's latest upstream 4.x kernels if you want to run CephFS
 # on RHEL 7.
 #
-ceph_rhcs: false
+#
+# Backward compatibility of variable names
+# Commit 492518a2 changed variable names of rhcs installations
+# to not break backward compatiblity we re-declare these variables
+# with the content of the new variable
+ceph_rhcs: "{{ ceph_stable_rh_storage | default(false) }}"
 # This will affect how/what repositories are enabled depending on the desired
 # version. The previous version was 1.3. The current version is 2.
-ceph_rhcs_version: 2
-ceph_rhcs_cdn_install: false # assumes all the nodes can connect to cdn.redhat.com
-ceph_rhcs_iso_install: false # usually used when nodes don't have access to cdn.redhat.com
-#ceph_rhcs_iso_path:
-ceph_rhcs_mount_path: /tmp/rh-storage-mount
-ceph_rhcs_repository_path: /tmp/rh-storage-repo # where to copy iso's content
+ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(2) }}"
+ceph_rhcs_cdn_install: "{{ ceph_stable_rh_storage_cdn_install | default(false) }}" # assumes all the nodes can connect to cdn.redhat.com
+ceph_rhcs_iso_install: "{{ ceph_stable_rh_storage_iso_install | default(false) }}" # usually used when nodes don't have access to cdn.redhat.com
+ceph_rhcs_iso_path: "{{ ceph_stable_rh_storage_iso_path | default('') }}"
+ceph_rhcs_mount_path: "{{ ceph_stable_rh_storage_mount_path | default(/tmp/rh-storage-mount) }}"
+ceph_rhcs_repository_path: "{{ ceph_stable_rh_storage_repository_path | default(/tmp/rh-storage-repo) }}" # where to copy iso's content
 
 
 # UBUNTU CLOUD ARCHIVE


### PR DESCRIPTION
backward compatibility for ceph-ansible version running latest code but
using variables defined before commit: 492518a2

Signed-off-by: Sébastien Han seb@redhat.com
