### PR TITLE
Ensure extras repo enabled on CentOS

### DIFF
--- a/roles/ceph-mds/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/docker/pre_requisite.yml
@@ -38,6 +38,15 @@
     with_pkg
   failed_when: false
 
+- name: enable extras repo for centos
+  yum_repository:
+    name: extras
+    state: present
+    enabled: yes
+  when: ansible_distribution == 'CentOS'
+  tags:
+    with_pkg
+
 - name: install pip on redhat
   yum:
     name: "{{ item }}"

--- a/roles/ceph-mon/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-mon/tasks/docker/pre_requisite.yml
@@ -40,7 +40,6 @@
     state: present
     enabled: yes
   when:
-    - ansible_os_family == 'RedHat'
     - ansible_distribution == 'CentOS'
   tags:
     with_pkg

--- a/roles/ceph-mon/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-mon/tasks/docker/pre_requisite.yml
@@ -33,6 +33,18 @@
   tags:
     with_pkg
 
+# ensure extras enabled for docker
+- name: enable extras on centos
+  yum_repository:
+    name: extras
+    state: present
+    enabled: yes
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution == 'CentOS'
+  tags:
+    with_pkg
+
 - name: install pip on redhat
   yum:
     name: "{{ item }}"

--- a/roles/ceph-nfs/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-nfs/tasks/docker/pre_requisite.yml
@@ -24,6 +24,15 @@
   tags:
     with_pkg
 
+- name: enable extras repo for centos
+  yum_repository:
+    name: extras
+    state: present
+    enabled: yes
+  when: ansible_distribution == 'CentOS'
+  tags:
+    with_pkg
+
 - name: install pip and docker on redhat
   yum:
     name: "{{ item }}"

--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -5,6 +5,14 @@
     state: present
   when: ansible_os_family == 'Debian'
 
+- name: enable extras repo on centos
+  yum_repository:
+    name: extras
+    state: present
+    enabled: yes
+  when:
+    - ansible_distribution == 'CentOS'
+
 - name: install redhat dependencies via yum
   yum:
     name: parted

--- a/roles/ceph-rbd-mirror/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/pre_requisite.yml
@@ -38,6 +38,15 @@
     with_pkg
   failed_when: false
 
+- name: enable extras repo for centos
+  yum_repository:
+    name: extras
+    state: present
+    enabled: yes
+  when: ansible_distribution == 'CentOS'
+  tags:
+    with_pkg
+
 - name: install pip on redhat
   yum:
     name: "{{ item }}"

--- a/roles/ceph-restapi/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-restapi/tasks/docker/pre_requisite.yml
@@ -32,6 +32,15 @@
   tags:
     with_pkg
 
+- name: enable extras repo on centos
+  yum_repository:
+    name: extras
+    state: present
+    enabled: yes
+  when: ansible_distribution == 'CentOS'
+  tags:
+    with_pkg
+
 - name: install pip on redhat
   yum:
     name: "{{ item }}"

--- a/roles/ceph-rgw/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/docker/pre_requisite.yml
@@ -32,6 +32,15 @@
   tags:
     with_pkg
     
+- name: enable extras repo on centos
+  yum_repository:
+    name: extras
+    state: present
+    enabled: yes
+  when: ansible_distribution == 'CentOS'
+  tags:
+    with_pkg
+
 - name: install pip on redhat
   yum:
     name: "{{ item }}"


### PR DESCRIPTION
This is to address the problem I found in issue #1030, in cases where (for whatever reason) the CentOS `Extras` repo is not enabled.