### PR TITLE
forced an apt-get update prior to installing any packages from Ceph r…

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -14,6 +14,7 @@
 - name: install ceph
   apt:
     name: "{{ item }}"
+    update_cache: yes
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default(ansible_distribution_release) }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
   with_items: "{{debian_ceph_packages}}"


### PR DESCRIPTION
Minor change to force apt to refresh it's cache after adding the Ceph repo (otherwise you end up in dependency hell)