### PR TITLE
fixed breakage on Debian under ansible v2.0 caused by #74d73d1e65b672…

### DIFF
--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -10,8 +10,7 @@
     name: extras
     state: present
     enabled: yes
-  when:
-    - ansible_distribution == 'CentOS'
+  when: ansible_distribution == 'CentOS'
 
 - name: install redhat dependencies via yum
   yum:


### PR DESCRIPTION
https://github.com/ceph/ceph-ansible/pull/1035 broke installation on Debian with v2.0 due to syntax issues:

`TASK [ceph-osd : include] ******************************************************
task path: /tmp/ceph-ansible/roles/ceph-osd/tasks/main.yml:2
fatal: [172.16.0.101]: FAILED! => {"failed": true, "reason": "no action detected in task. This often indicates a misspelled module name, or incorrect module path.\n\nThe error appears to have been in '/tmp/ceph-ansible/roles/ceph-osd/tasks/pre_requisite.yml': line 8, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: enable extras repo on centos\n  ^ here\n\n\nThe error appears to have been in '/tmp/ceph-ansible/roles/ceph-osd/tasks/pre_requisite.yml': line 8, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: enable extras repo on centos\n  ^ here\n"}
`

Judging by [this](http://docs.ansible.com/ansible/playbooks_conditionals.html#the-when-statement), if it's a single conditional then it shouldn't be a list.