### PR TITLE
Change enabling of extras repo for CentOS to use ini_file

### DIFF
--- a/roles/ceph-mds/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/docker/pre_requisite.yml
@@ -39,10 +39,11 @@
   failed_when: false
 
 - name: enable extras repo for centos
-  yum_repository:
-    name: extras
-    state: present
-    enabled: yes
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-Base.repo
+    section: extras
+    option: enabled
+    value: 1
   when: ansible_distribution == 'CentOS'
   tags:
     with_pkg

--- a/roles/ceph-mon/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-mon/tasks/docker/pre_requisite.yml
@@ -34,13 +34,13 @@
     with_pkg
 
 # ensure extras enabled for docker
-- name: enable extras on centos
-  yum_repository:
-    name: extras
-    state: present
-    enabled: yes
-  when:
-    - ansible_distribution == 'CentOS'
+- name: enable extras repo for centos
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-Base.repo
+    section: extras
+    option: enabled
+    value: 1
+  when: ansible_distribution == 'CentOS'
   tags:
     with_pkg
 

--- a/roles/ceph-nfs/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-nfs/tasks/docker/pre_requisite.yml
@@ -25,10 +25,11 @@
     with_pkg
 
 - name: enable extras repo for centos
-  yum_repository:
-    name: extras
-    state: present
-    enabled: yes
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-Base.repo
+    section: extras
+    option: enabled
+    value: 1
   when: ansible_distribution == 'CentOS'
   tags:
     with_pkg

--- a/roles/ceph-osd/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/docker/pre_requisite.yml
@@ -44,6 +44,16 @@
   tags:
     with_pkg
 
+- name: enable extras repo for centos
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-Base.repo
+    section: extras
+    option: enabled
+    value: 1
+  when: ansible_distribution == 'CentOS'
+  tags:
+    with_pkg
+
 - name: install docker-engine on redhat
   yum:
     name: "{{ item }}"

--- a/roles/ceph-rbd-mirror/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/pre_requisite.yml
@@ -39,10 +39,11 @@
   failed_when: false
 
 - name: enable extras repo for centos
-  yum_repository:
-    name: extras
-    state: present
-    enabled: yes
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-Base.repo
+    section: extras
+    option: enabled
+    value: 1
   when: ansible_distribution == 'CentOS'
   tags:
     with_pkg

--- a/roles/ceph-restapi/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-restapi/tasks/docker/pre_requisite.yml
@@ -32,11 +32,12 @@
   tags:
     with_pkg
 
-- name: enable extras repo on centos
-  yum_repository:
-    name: extras
-    state: present
-    enabled: yes
+- name: enable extras repo for centos
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-Base.repo
+    section: extras
+    option: enabled
+    value: 1
   when: ansible_distribution == 'CentOS'
   tags:
     with_pkg

--- a/roles/ceph-rgw/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/docker/pre_requisite.yml
@@ -32,11 +32,12 @@
   tags:
     with_pkg
     
-- name: enable extras repo on centos
-  yum_repository:
-    name: extras
-    state: present
-    enabled: yes
+- name: enable extras repo for centos
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-Base.repo
+    section: extras
+    option: enabled
+    value: 1
   when: ansible_distribution == 'CentOS'
   tags:
     with_pkg


### PR DESCRIPTION
Fix the problems caused by my previous attempt to make sure the `extras` repo is enabled on `CentOS`.

Signed-off-by: Adam Huffman <bloch@verdurin.com>