### PR TITLE
vagrant: use group_vars for ceph pkg source

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,14 +64,6 @@ ansible_provision = proc do |ansible|
       journal_size: 100,
       public_network: "#{PUBLIC_SUBNET}.0/24",
   }
-  if settings['ceph_install_source'] == 'dev' then
-    ansible.extra_vars['ceph_dev'] = true
-    if settings['ceph_install_branch'] then
-      ansible.extra_vars['ceph_dev_branch'] = settings['ceph_install_branch']
-    end
-  else
-    ansible.extra_vars['ceph_stable'] = true
-  end
 
   # In a production deployment, these should be secret
   if DOCKER then

--- a/vagrant_variables.yml.linode
+++ b/vagrant_variables.yml.linode
@@ -32,11 +32,6 @@ iscsi_gw_vms: 0
 # Deploy RESTAPI on each of the Monitors
 restapi: true
 
-# INSTALL SOURCE OF CEPH
-# valid values are 'stable' and 'dev'
-ceph_install_source: 'dev'
-ceph_install_branch: 'master'
-
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 # vagrant_sync_dir: /home/vagrant/sync

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -16,10 +16,6 @@ iscsi_gw_vms: 0
 # Deploy RESTAPI on each of the Monitors
 restapi: true
 
-# INSTALL SOURCE OF CEPH
-# valid values are 'stable' and 'dev'
-ceph_install_source: stable
-
 # SUBNETS TO USE FOR THE VMS
 public_subnet: 192.168.42
 cluster_subnet: 192.168.43


### PR DESCRIPTION
This was a holdout from the Linode merge that shouldn't have been
included. The right way to set the installation source is through
group_vars.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>