### PR TITLE
Update for infrastructure-playbooks execution

### DIFF
--- a/infrastructure-playbooks/ansible.cfg
+++ b/infrastructure-playbooks/ansible.cfg
@@ -1,4 +1,4 @@
 [defaults]
 ansible_managed = Please do not change this file directly since it is managed by Ansible and will be overwritten
-action_plugins = plugins/actions
-roles_path = ./roles
+action_plugins = ../plugins/actions
+roles_path = ../roles


### PR DESCRIPTION
Fixing: https://bugzilla.redhat.com/show_bug.cgi?id=1388295
- Updates to allow running infrastructure-playbooks both from within its
  directory or root directory of ceph-ansible.

Signed-off-by: Ivan Font <ifont@redhat.com>