### PR TITLE
ceph-osd: use ini_file instead of yum_repository to enable Centos extras

### DIFF
--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -5,11 +5,12 @@
     state: present
   when: ansible_os_family == 'Debian'
 
-- name: enable extras repo on centos
-  yum_repository:
-    name: extras
-    state: present
-    enabled: yes
+- name: enable extras repo for centos
+  ini_file:
+    dest: /etc/yum.repos.d/CentOS-Base.repo
+    section: extras
+    option: enabled
+    value: 1
   when: ansible_distribution == 'CentOS'
 
 - name: install redhat dependencies via yum


### PR DESCRIPTION
Fixes issue #1041

Signed-off-by: Andrew Schoen <aschoen@redhat.com>

Resolves: issue#1041