### PR TITLE
Fix tag list throughout Docker playbooks

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -409,7 +409,7 @@
   become: true
 
   tags:
-    with_pkg
+    - with_pkg
 
   tasks:
   - name: check if it is Atomic host

--- a/roles/ceph-mds/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/docker/pre_requisite.yml
@@ -10,7 +10,7 @@
     - docker.io
   when: ansible_distribution == 'Ubuntu'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip and docker on debian
   apt:
@@ -22,7 +22,7 @@
     - docker-engine
   when: ansible_distribution == 'Debian'
   tags:
-    with_pkg
+    - with_pkg
 
 # install epel for pip
 - name: install epel on redhat
@@ -35,7 +35,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 - name: enable extras repo for centos
@@ -46,7 +46,7 @@
     value: 1
   when: ansible_distribution == 'CentOS'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip on redhat
   yum:
@@ -58,7 +58,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install docker-engine on redhat
   yum:
@@ -70,7 +70,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 # for CentOS
@@ -84,7 +84,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
   
 # docker package could be docker-enginer or docker  
@@ -99,7 +99,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "dnf"
   tags:
-    with_pkg
+    - with_pkg
 
 - name: start docker service
   service:
@@ -107,7 +107,7 @@
     state: started
     enabled: yes
   tags:
-    with_pkg
+    - with_pkg
 
 # NOTE (jimcurtis): need at least version 1.9.0 of six or we get:
 # re:NameError: global name 'DEFAULT_DOCKER_API_VERSION' is not defined
@@ -116,7 +116,7 @@
     name: six
     version: 1.9.0
   tags:
-    with_pkg
+    - with_pkg
 
 # NOTE (leseb): for version 1.1.0 because https://github.com/ansible/ansible-modules-core/issues/1227
 - name: install docker-py
@@ -124,7 +124,7 @@
     name: docker-py
     version: 1.1.0
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '<')
 
 - name: install docker-py
@@ -132,7 +132,7 @@
     name: docker-py
     state: latest
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '>=')
 
 - name: install ntp on redhat using yum
@@ -144,7 +144,7 @@
     - ansible_pkg_mgr == 'yum'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on redhat using dnf
   dnf:
@@ -155,7 +155,7 @@
     - ansible_pkg_mgr == 'dnf'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on debian
   apt:
@@ -165,4 +165,4 @@
     - ansible_os_family == 'Debian'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg

--- a/roles/ceph-mon/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-mon/tasks/docker/pre_requisite.yml
@@ -10,7 +10,7 @@
     - docker.io
   when: ansible_distribution == 'Ubuntu'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip and docker on debian
   apt:
@@ -22,7 +22,7 @@
     - docker-engine
   when: ansible_distribution == 'Debian'
   tags:
-    with_pkg
+    - with_pkg
 
 # install epel for pip
 - name: install epel-release on redhat
@@ -31,7 +31,7 @@
     state: present
   when: ansible_os_family == 'RedHat'
   tags:
-    with_pkg
+    - with_pkg
 
 # ensure extras enabled for docker
 - name: enable extras repo for centos
@@ -42,7 +42,7 @@
     value: 1
   when: ansible_distribution == 'CentOS'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip on redhat
   yum:
@@ -54,7 +54,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install docker-engine on redhat
   yum:
@@ -66,7 +66,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 # for CentOS
@@ -80,7 +80,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 - name: install pip and docker on redhat (dnf)
@@ -95,7 +95,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "dnf"
   tags:
-    with_pkg
+    - with_pkg
 
 
 # NOTE (jimcurtis): need at least version 1.9.0 of six or we get:
@@ -105,13 +105,13 @@
     name: six
     version: 1.9.0
   tags:
-    with_pkg
+    - with_pkg
 
 - name: pause after docker install before starting (on openstack vms)
   pause: seconds=5
   when: ceph_docker_on_openstack
   tags:
-    with_pkg
+    - with_pkg
 
 - name: start docker service
   service:
@@ -119,7 +119,7 @@
     state: started
     enabled: yes
   tags:
-    with_pkg
+    - with_pkg
 
 # NOTE (leseb): for version 1.1.0 because https://github.com/ansible/ansible-modules-core/issues/1227
 - name: install docker-py
@@ -127,7 +127,7 @@
     name: docker-py
     version: 1.1.0
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '<')
  
 - name: install docker-py
@@ -135,7 +135,7 @@
     name: docker-py
     state: latest
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '>=')
 
 - name: install ntp on redhat using yum
@@ -147,7 +147,7 @@
     - ansible_pkg_mgr == 'yum'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on redhat using dnf
   dnf:
@@ -158,7 +158,7 @@
     - ansible_pkg_mgr == 'dnf'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on debian
   apt:
@@ -168,4 +168,4 @@
     - ansible_os_family == 'Debian'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg

--- a/roles/ceph-nfs/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-nfs/tasks/docker/pre_requisite.yml
@@ -10,7 +10,7 @@
     - docker.io
   when: ansible_distribution == 'Ubuntu'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip and docker on debian
   apt:
@@ -22,7 +22,7 @@
     - docker-engine
   when: ansible_distribution == 'Debian'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: enable extras repo for centos
   ini_file:
@@ -32,7 +32,7 @@
     value: 1
   when: ansible_distribution == 'CentOS'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip and docker on redhat
   yum:
@@ -45,7 +45,7 @@
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip and docker on redhat
   dnf:
@@ -58,7 +58,7 @@
     ansible_os_family == 'RedHat' and
     ansible_pkg_mgr == "dnf"
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install epel-release on redhat
   yum:
@@ -66,7 +66,7 @@
     state: present
   when: ansible_os_family == 'RedHat'
   tags:
-    with_pkg
+    - with_pkg
 
 # NOTE (jimcurtis): need at least version 1.9.0 of six or we get:
 # re:NameError: global name 'DEFAULT_DOCKER_API_VERSION' is not defined
@@ -75,7 +75,7 @@
     name: six
     version: 1.9.0
   tags:
-    with_pkg
+    - with_pkg
 
 # NOTE (leseb): for version 1.1.0 because https://github.com/ansible/ansible-modules-core/issues/1227
 - name: install docker-py
@@ -83,7 +83,7 @@
     name: docker-py
     version: 1.1.0
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '<')
  
 - name: install docker-py
@@ -91,14 +91,14 @@
     name: docker-py
     state: latest
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '>=')
 
 - name: pause after docker install before starting (on openstack vms)
   pause: seconds=5
   when: ceph_docker_on_openstack
   tags:
-    with_pkg
+    - with_pkg
 
 - name: start docker service
   service:
@@ -106,7 +106,7 @@
     state: started
     enabled: yes
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on redhat using yum
   yum:
@@ -117,7 +117,7 @@
     - ansible_pkg_mgr == 'yum'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on redhat using dnf
   dnf:
@@ -128,7 +128,7 @@
     - ansible_pkg_mgr == 'dnf'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on debian
   apt:
@@ -138,4 +138,4 @@
     - ansible_os_family == 'Debian'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg

--- a/roles/ceph-osd/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/docker/pre_requisite.yml
@@ -10,7 +10,7 @@
     - docker.io
   when: ansible_distribution == 'Ubuntu'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip and docker on debian
   apt:
@@ -22,7 +22,7 @@
     - docker-engine
   when: ansible_distribution == 'Debian'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install epel-release on redhat
   yum:
@@ -30,7 +30,7 @@
     state: present
   when: ansible_os_family == 'RedHat'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip on redhat
   yum:
@@ -42,7 +42,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
 
 - name: enable extras repo for centos
   ini_file:
@@ -52,7 +52,7 @@
     value: 1
   when: ansible_distribution == 'CentOS'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install docker-engine on redhat
   yum:
@@ -64,7 +64,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 # for CentOS
@@ -78,7 +78,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 - name: install pip and docker on redhat
@@ -93,7 +93,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "dnf"
   tags:
-    with_pkg
+    - with_pkg
 
 
 # NOTE (jimcurtis): need at least version 1.9.0 of six or we get:
@@ -103,13 +103,13 @@
     name: six
     version: 1.9.0
   tags:
-    with_pkg
+    - with_pkg
 
 - name: pause after docker install before starting (on openstack vms)
   pause: seconds=5
   when: ceph_docker_on_openstack
   tags:
-    with_pkg
+    - with_pkg
 
 - name: start docker service
   service:
@@ -117,7 +117,7 @@
     state: started
     enabled: yes
   tags:
-    with_pkg
+    - with_pkg
 
 # NOTE (leseb): for version 1.1.0 because https://github.com/ansible/ansible-modules-core/issues/1227
 - name: install docker-py
@@ -125,7 +125,7 @@
     name: docker-py
     version: 1.1.0
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '<')
  
 - name: install docker-py
@@ -133,7 +133,7 @@
     name: docker-py
     state: latest
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '>=')
 
 - name: install ntp on redhat using yum
@@ -145,7 +145,7 @@
     - ansible_pkg_mgr == 'yum'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on redhat using dnf
   dnf:
@@ -156,7 +156,7 @@
     - ansible_pkg_mgr == 'dnf'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on debian
   apt:
@@ -166,4 +166,4 @@
     - ansible_os_family == 'Debian'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg

--- a/roles/ceph-rbd-mirror/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/pre_requisite.yml
@@ -10,7 +10,7 @@
     - docker.io
   when: ansible_distribution == 'Ubuntu'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip and docker on debian
   apt:
@@ -22,7 +22,7 @@
     - docker-engine
   when: ansible_distribution == 'Debian'
   tags:
-    with_pkg
+    - with_pkg
 
 # install epel for pip
 - name: install epel on redhat
@@ -35,7 +35,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 - name: enable extras repo for centos
@@ -46,7 +46,7 @@
     value: 1
   when: ansible_distribution == 'CentOS'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip on redhat
   yum:
@@ -58,7 +58,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install docker-engine on redhat
   yum:
@@ -70,7 +70,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 # for CentOS
@@ -84,7 +84,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 # docker package could be docker-enginer or docker
@@ -99,7 +99,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "dnf"
   tags:
-    with_pkg
+    - with_pkg
 
 - name: start docker service
   service:
@@ -107,7 +107,7 @@
     state: started
     enabled: yes
   tags:
-    with_pkg
+    - with_pkg
 
 # NOTE (jimcurtis): need at least version 1.9.0 of six or we get:
 # re:NameError: global name 'DEFAULT_DOCKER_API_VERSION' is not defined
@@ -116,7 +116,7 @@
     name: six
     version: 1.9.0
   tags:
-    with_pkg
+    - with_pkg
 
 # NOTE (leseb): for version 1.1.0 because https://github.com/ansible/ansible-modules-core/issues/1227
 - name: install docker-py
@@ -124,7 +124,7 @@
     name: docker-py
     version: 1.1.0
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '<')
 
 - name: install docker-py
@@ -132,7 +132,7 @@
     name: docker-py
     state: latest
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '>=')
 
 - name: install ntp on redhat using yum
@@ -144,7 +144,7 @@
     - ansible_pkg_mgr == 'yum'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on redhat using dnf
   dnf:
@@ -155,7 +155,7 @@
     - ansible_pkg_mgr == 'dnf'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on debian
   apt:
@@ -165,4 +165,4 @@
     - ansible_os_family == 'Debian'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg

--- a/roles/ceph-restapi/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-restapi/tasks/docker/pre_requisite.yml
@@ -10,7 +10,7 @@
     - docker.io
   when: ansible_distribution == 'Ubuntu'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip and docker on debian
   apt:
@@ -22,7 +22,7 @@
     - docker-engine
   when: ansible_distribution == 'Debian'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install epel-release on redhat
   yum:
@@ -30,7 +30,7 @@
     state: present
   when: ansible_os_family == 'RedHat'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: enable extras repo for centos
   ini_file:
@@ -40,7 +40,7 @@
     value: 1
   when: ansible_distribution == 'CentOS'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip on redhat
   yum:
@@ -52,7 +52,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install docker-engine on redhat
   yum:
@@ -64,7 +64,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 # for CentOS
@@ -78,7 +78,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 - name: install pip and docker on redhat
   dnf:
@@ -91,7 +91,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "dnf"
   tags:
-    with_pkg
+    - with_pkg
 
 # NOTE (jimcurtis): need at least version 1.9.0 of six or we get:
 # re:NameError: global name 'DEFAULT_DOCKER_API_VERSION' is not defined
@@ -100,7 +100,7 @@
     name: six
     version: 1.9.0
   tags:
-    with_pkg
+    - with_pkg
 
 # NOTE (leseb): for version 1.1.0 because https://github.com/ansible/ansible-modules-core/issues/1227
 - name: install docker-py
@@ -108,7 +108,7 @@
     name: docker-py
     version: 1.1.0
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '<')
  
 - name: install docker-py
@@ -116,14 +116,14 @@
     name: docker-py
     state: latest
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '>=')
 
 - name: pause after docker install before starting (on openstack vms)
   pause: seconds=5
   when: ceph_docker_on_openstack
   tags:
-    with_pkg
+    - with_pkg
 
 - name: start docker service
   service:
@@ -131,7 +131,7 @@
     state: started
     enabled: yes
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on redhat using yum
   yum:
@@ -142,7 +142,7 @@
     - ansible_pkg_mgr == 'yum'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on redhat using dnf
   dnf:
@@ -153,7 +153,7 @@
     - ansible_pkg_mgr == 'dnf'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on debian
   apt:
@@ -163,4 +163,4 @@
     - ansible_os_family == 'Debian'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg

--- a/roles/ceph-rgw/tasks/docker/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/docker/pre_requisite.yml
@@ -10,7 +10,7 @@
     - docker.io
   when: ansible_distribution == 'Ubuntu'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip and docker on debian
   apt:
@@ -22,7 +22,7 @@
     - docker-engine
   when: ansible_distribution == 'Debian'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install epel-release on redhat
   yum:
@@ -30,7 +30,7 @@
     state: present
   when: ansible_os_family == 'RedHat'
   tags:
-    with_pkg
+    - with_pkg
     
 - name: enable extras repo for centos
   ini_file:
@@ -40,7 +40,7 @@
     value: 1
   when: ansible_distribution == 'CentOS'
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install pip on redhat
   yum:
@@ -52,7 +52,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install docker-engine on redhat
   yum:
@@ -64,7 +64,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 # for CentOS
@@ -78,7 +78,7 @@
     - ansible_os_family == 'RedHat'
     - ansible_pkg_mgr == "yum"
   tags:
-    with_pkg
+    - with_pkg
   failed_when: false
 
 # NOTE (jimcurtis): need at least version 1.9.0 of six or we get:
@@ -88,7 +88,7 @@
     name: six
     version: 1.9.0
   tags:
-    with_pkg
+    - with_pkg
 
 # NOTE (leseb): for version 1.1.0 because https://github.com/ansible/ansible-modules-core/issues/1227
 - name: install docker-py
@@ -96,7 +96,7 @@
     name: docker-py
     version: 1.1.0
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '<')
  
 - name: install docker-py
@@ -104,14 +104,14 @@
     name: docker-py
     state: latest
   tags:
-    with_pkg
+    - with_pkg
   when: ansible_version['full'] | version_compare('2.1.0.0', '>=')
 
 - name: pause after docker install before starting (on openstack vms)
   pause: seconds=5
   when: ceph_docker_on_openstack
   tags:
-    with_pkg
+    - with_pkg
 
 - name: start docker service
   service:
@@ -119,7 +119,7 @@
     state: started
     enabled: yes
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on redhat using yum
   yum:
@@ -130,7 +130,7 @@
     - ansible_pkg_mgr == 'yum'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on redhat using dnf
   dnf:
@@ -141,7 +141,7 @@
     - ansible_pkg_mgr == 'dnf'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg
 
 - name: install ntp on debian
   apt:
@@ -151,4 +151,4 @@
     - ansible_os_family == 'Debian'
     - ntp_service_enabled
   tags:
-    with_pkg
+    - with_pkg


### PR DESCRIPTION
This should (finally) fix the issues with the original PR for enabling CentOS extras. Apologies for the disruption this caused.


Signed-off-by: Adam Huffman <bloch@verdurin.com>