### PR TITLE
rolling_update: define mon_group_name when upgrading the mons

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -63,6 +63,7 @@
 - name: upgrade ceph mon cluster
 
   vars:
+    mon_group_name: mons
     health_mon_check_retries: 5
     health_mon_check_delay: 10
 


### PR DESCRIPTION
see: https://bugzilla.redhat.com/show_bug.cgi?id=1389456

Signed-off-by: Andrew Schoen <aschoen@redhat.com>

Resolves: rhbz#1389456