### PR TITLE
raw_multi_journal is not required when using dmcrypt_dedicated_journal

### DIFF
--- a/roles/ceph-osd/tasks/scenarios/dmcrypt-dedicated-journal.yml
+++ b/roles/ceph-osd/tasks/scenarios/dmcrypt-dedicated-journal.yml
@@ -22,7 +22,6 @@
     - not item.1.get("skipped")
     - item.0.get("rc", 0) != 0
     - item.1.get("rc", 0) != 0
-    - raw_multi_journal
     - not osd_auto_discovery
     - dmcrypt_dedicated_journal
 


### PR DESCRIPTION
Fixes: https://github.com/ceph/ceph-ansible/issues/1054

Signed-off-by: Andrew Schoen aschoen@redhat.com
