### PR TITLE
Adjust 'devices' list check for being not defined in purge-cluster pl…

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -298,7 +298,7 @@
     fail:
       msg: "OSD automatic discovery was detected, purge cluster does not support this scenario. If you want to purge the cluster, manually provide the list of devices in group_vars/{{ osd_group_name }} using the devices variable."
     when:
-      devices is not defined and
+      devices|length == 0 and
       osd_auto_discovery
 
   - name: get osd numbers


### PR DESCRIPTION
I'm really sorry, this change should really be in PR #1024, of course.

Since we defined both `devices` and `raw_journal_devices` as empty lists in default.yml files, now this check should be also adjusted:

```diff
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -298,7 +298,7 @@
     fail:
       msg: "OSD automatic discovery was detected, purge cluster does not support this scenario. If yo
     when:                                                                                            
-      devices is not defined and
+      devices|length == 0 and
       osd_auto_discovery
```

