### PR TITLE
osd dmcrypt: add ability to check devices

### DIFF
--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -11,12 +11,16 @@
 # for SSD journals.
 
 - include: ./check_devices_static.yml
-  when: not osd_auto_discovery
+  when:
+    - not osd_auto_discovery
+    - not osd_directory
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 
 - include: ./check_devices_auto.yml
-  when: osd_auto_discovery
+  when:
+    - osd_auto_discovery
+    - not osd_directory
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 
@@ -26,7 +30,7 @@
   changed_when: false
   failed_when: false
   register: journal_partition_status
-  when: raw_multi_journal
+  when: raw_multi_journal or dmcrypt_dedicated_journal
 
 - name: fix partitions gpt header or labels of the journal devices
   shell: "sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }} || sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }}"
@@ -35,5 +39,5 @@
     - "{{ raw_journal_devices|unique }}"
   changed_when: false
   when:
-    - raw_multi_journal
+    - raw_multi_journal or dmcrypt_dedicated_journal
     - item.0.rc != 0

--- a/roles/ceph-osd/tasks/check_devices_auto.yml
+++ b/roles/ceph-osd/tasks/check_devices_auto.yml
@@ -16,7 +16,6 @@
   failed_when: false
   register: osd_partition_status_results
   when:
-    - journal_collocation or raw_multi_journal
     - ansible_devices is defined
     - item.value.removable == "0"
     - item.value.partitions|count == 0
@@ -28,7 +27,6 @@
     - "{{ ansible_devices }}"
   changed_when: false
   when:
-    - journal_collocation
     - ansible_devices is defined
     - item.0.item.value.removable == "0"
     - item.0.item.value.partitions|count == 0

--- a/roles/ceph-osd/tasks/check_devices_static.yml
+++ b/roles/ceph-osd/tasks/check_devices_static.yml
@@ -12,8 +12,6 @@
   changed_when: false
   failed_when: false
   register: osd_partition_status_results
-  when:
-    - journal_collocation or raw_multi_journal
 
 # NOTE: The following calls to sgdisk are retried because sgdisk is known to
 # fully wipe a device the first time around. There is no need to halt execution
@@ -26,9 +24,7 @@
     - "{{ osd_partition_status_results.results }}"
     - "{{ devices }}"
   changed_when: false
-  when:
-    - journal_collocation or raw_multi_journal
-    - item.0.rc != 0
+  when: item.0.rc != 0
 
 - name: check if a partition named 'ceph' exists
   shell: "parted --script {{ item }} print | egrep -sq '^ 1.*ceph'"


### PR DESCRIPTION
Even for dmcrypt we need to check the "devices" status and
"raw_journal_devices" as well so we can fix them if there is something
wrong with them.

Signed-off-by: Sébastien Han <seb@redhat.com>