### PR TITLE
Update .gitignore to ignore emacs auto-save files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ rgw-standalone.yml
 take-over-existing-cluster.yml
 osd-configure.yml
 rolling_update.yml
+*~


### PR DESCRIPTION
We're using this to deploy a ceph cluster, and it would be nice to not have git keep telling me about emacs auto-save files :-)