### PR TITLE
rolling_update: add variable to upgrade ceph

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -63,10 +63,11 @@
 - name: upgrade ceph mon cluster
 
   vars:
-    mon_group_name:       mons    
+    mon_group_name:       mons
     restapi_group_name:   restapis
     health_mon_check_retries: 5
     health_mon_check_delay: 10
+    upgrade_ceph_packages: True
 
   hosts:
     - "{{ mon_group_name }}"
@@ -130,6 +131,7 @@
     osd_group_name: osds
     health_osd_check_retries: 10
     health_osd_check_delay: 10
+    upgrade_ceph_packages: True
 
   hosts:
     - "{{ osd_group_name }}"
@@ -212,6 +214,7 @@
 
   vars:
     mds_group_name: mdss
+    upgrade_ceph_packages: True
 
   hosts:
     - "{{ mds_group_name }}"
@@ -257,6 +260,7 @@
 
   vars:
     rgw_group_name: rgws
+    upgrade_ceph_packages: True
 
   hosts:
     - "{{ rgw_group_name }}"


### PR DESCRIPTION
My stupid self removed this crucial variable here: 217ce3ca thinking it
was another hard coded variable import where this is actually the
trigger for the upgrade.

Closes: #1071

Signed-off-by: Sébastien Han <seb@redhat.com>