### PR TITLE
functional test scenarios should include a group_vars dir

### DIFF
--- a/tests/functional/ubuntu/16.04/mon/initial_members/group_vars/all
+++ b/tests/functional/ubuntu/16.04/mon/initial_members/group_vars/all
@@ -1,0 +1,6 @@
+---
+
+ceph_stable: True
+public_network: "192.168.42.0/24"
+cluster_network: "192.168.43.0/24"
+journal_size: 100

--- a/tests/functional/ubuntu/16.04/mon/initial_members/hosts
+++ b/tests/functional/ubuntu/16.04/mon/initial_members/hosts
@@ -1,4 +1,2 @@
-
 [mons]
-mon0
-
+mon0 monitor_interface=eth1

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands=
   vagrant up --no-provision --provider=virtualbox
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
-  initial-members: ansible-playbook -i {toxinidir}/tests/functional/ubuntu/16.04/mon/initial_members/hosts --extra-vars "ceph_stable=True public_network=192.168.42.0/24 cluster_network=192.168.43.0/24 journal_size=100 monitor_interface=eth1" {toxinidir}/site.yml.sample
+  ansible-playbook -i {changedir}/hosts {toxinidir}/site.yml.sample
 
   py.test -v
   vagrant destroy --force


### PR DESCRIPTION
This allows for the ansible-playbook command to be reused by each scenario in tox.ini. It's also a nicer way to define your vars than using --extra-vars, imho.