### PR TITLE
ensure there is a unique container name for RGW container

### DIFF
--- a/roles/ceph-rgw/templates/ceph-rgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-rgw.service.j2
@@ -4,8 +4,8 @@ After=docker.service
 
 [Service]
 EnvironmentFile=-/etc/environment
-ExecStartPre=-/usr/bin/docker stop {{ ansible_hostname }}
-ExecStartPre=-/usr/bin/docker rm {{ ansible_hostname }}
+ExecStartPre=-/usr/bin/docker stop {{ ansible_hostname }}-rgw
+ExecStartPre=-/usr/bin/docker rm {{ ansible_hostname }}-rgw
 ExecStart=/usr/bin/docker run --rm --net=host \
    {% if not rgw_containerized_deployment_with_kv -%}
    -v /var/lib/ceph:/var/lib/ceph \
@@ -17,9 +17,9 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    -v /etc/localtime:/etc/localtime:ro \
    --privileged \
    -e CEPH_DAEMON=RGW \
-   --name={{ ansible_hostname }} \
+   --name={{ ansible_hostname }}-rgw \
    {{ ceph_rgw_docker_username }}/{{ ceph_rgw_docker_imagename }}:{{ ceph_rgw_docker_image_tag }}
-ExecStopPost=-/usr/bin/docker stop {{ ansible_hostname }}
+ExecStopPost=-/usr/bin/docker stop {{ ansible_hostname }}-rgw
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120


### PR DESCRIPTION
Both the  monitor and RGW roles create a container with name {{ ansible_hostname}}, this will cause a clash if they are deployed on the same host.

Proposed correction is to add a unique identifier to the container name for the RGW container, alternatively the monitor container could also have a unique name appended such as {{ ansible_hostname }}-mon
