### PR TITLE
sync config_template plugin with master branch

### DIFF
--- a/plugins/actions/_v2_config_template.py
+++ b/plugins/actions/_v2_config_template.py
@@ -465,7 +465,12 @@ class ActionModule(ActionBase):
         """Run the method"""
 
         try:
-            remote_user = task_vars.get('ansible_ssh_user') or self._play_context.remote_user
+            remote_user = task_vars.get('ansible_user')
+            if not remote_user:
+                remote_user = task_vars.get('ansible_ssh_user')
+            if not remote_user:
+                remote_user = self._play_context.remote_user
+
             if not tmp:
                 tmp = self._make_tmp_path(remote_user)
         except TypeError:


### PR DESCRIPTION
ansible 2.2 deprecates first_available_file option which is used in
the config_template module by 'generate ceph configuration file' task.

This change syncs the config_module files from their master repository
in github.com/openstack/openstack/ansible-plugins which includes the fix

https://github.com/openstack/openstack-ansible-plugins/commit/2f6cac2cf6ddebf462e21c70da7f60fa334b5f1e

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>