### PR TITLE
use vagrant boxes that support libvirt and virtualbox

### DIFF
--- a/tests/functional/centos/7/mon-osd/group_vars/all
+++ b/tests/functional/centos/7/mon-osd/group_vars/all
@@ -5,8 +5,8 @@ public_network: "192.168.42.0/24"
 cluster_network: "192.168.43.0/24"
 journal_size: 100
 devices:
+  - '/dev/sda'
   - '/dev/sdb'
-  - '/dev/sdc'
 journal_collocation: True
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }

--- a/tests/functional/centos/7/mon-osd/hosts
+++ b/tests/functional/centos/7/mon-osd/hosts
@@ -1,6 +1,5 @@
 [mons]
-# centos7 uses the enp0s8 interface
-mon0 monitor_interface=enp0s8
+mon0 monitor_interface=eth1
 
 [osds]
 osd0

--- a/tests/functional/centos/7/mon-osd/vagrant_variables.yml
+++ b/tests/functional/centos/7/mon-osd/vagrant_variables.yml
@@ -46,7 +46,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: box-cutter/centos72
+vagrant_box: centos/7
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/ubuntu/16.04/mon-osd/vagrant_variables.yml
+++ b/tests/functional/ubuntu/16.04/mon-osd/vagrant_variables.yml
@@ -46,7 +46,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: geerlingguy/ubuntu1604
+vagrant_box: yk0/ubuntu-xenial
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/ubuntu/16.04/mon/vagrant_variables.yml
+++ b/tests/functional/ubuntu/16.04/mon/vagrant_variables.yml
@@ -46,7 +46,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: geerlingguy/ubuntu1604
+vagrant_box: yk0/ubuntu-xenial
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ changedir=
   xenial-mon-osd: {toxinidir}/tests/functional/ubuntu/16.04/mon-osd
   centos7-mon-osd: {toxinidir}/tests/functional/centos/7/mon-osd
 commands=
-  vagrant up --no-provision --provider=virtualbox
+  vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/site.yml.sample


### PR DESCRIPTION
Long term we'd like to build our own vagrant boxes, but these should work for now and gives us a way to test integration with the CI.

This also provides a way tell tox that we want to use libvirt in the CI with:

```
tox -- --provider=libvirt
```