### PR TITLE
Correct syntax of rgw frontends line for civetweb

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -114,7 +114,7 @@ rgw socket path = /tmp/radosgw-{{ hostvars[host]['ansible_hostname'] }}.sock
 log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[host]['ansible_hostname'] }}.log
 rgw data = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_hostname'] }}
 {% if radosgw_frontend  == 'civetweb' %}
-rgw frontends = civetweb port={{ radosgw_civetweb_bind_ip }}:{{ radosgw_civetweb_port }} num_threads={{ radosgw_civetweb_num_threads }}
+rgw frontends = "civetweb port={{ radosgw_civetweb_port }}"
 {% endif %}
 {% if radosgw_keystone %}
 rgw keystone url = {{ radosgw_keystone_url }}


### PR DESCRIPTION
The correct configuration of the civetweb port is:
rgw frontents = "civetweb port=80"

rather than ipaddress:port. Our civetwebs wouldn't work until this was
corrected.

Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>