### PR TITLE
Fix user key creation.

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -1,7 +1,7 @@
 ---
 - name: create pools
   command: ceph --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pgs }}
-  with_items: pools
+  with_items: "{{ pools }}"
   changed_when: false
   failed_when: false
 
@@ -9,6 +9,6 @@
   command: ceph --cluster {{ cluster }} auth get-or-create {{ item.name }} {{ item.value }} -o /etc/ceph/{{ cluster }}.{{ item.name }}.keyring
   args:
     creates: /etc/ceph/{{ cluster }}.{{ item.name }}.keyring
-  with_items: keys
+  with_items: "{{ keys }}"
   changed_when: false
   when: cephx


### PR DESCRIPTION
With `ansible-playbook 2.2.0.0`, user key creation fails because ansible interprets the `with_items` key as a string instead of a jinja variable. This pull request fixes that issue.

Please be aware that I'm not confident that this is backwards-compatible with older versions of `ansible-playbook`. Can someone confirm or deny this?

UPDATE:

Running `grep -r 'with_items: [^"]'` on the source tree reveals that this is a common issue. I'd fix this if desired.