### PR TITLE
ceph-rgw: add systemd condition

### DIFF
--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -46,7 +46,7 @@
   args:
     creates: /var/run/systemd/generator.late/ceph-radosgw.service
   when:
-    - ansible_os_family == "RedHat"
+    - use_systemd
     - ceph_release_num.{{ ceph_release }} < ceph_release_num.infernalis
 
 - name: activate rados gateway with upstart
@@ -60,7 +60,9 @@
     - done
     - upstart
   changed_when: false
-  when: ansible_distribution == "Ubuntu"
+  when:
+    - ansible_distribution == "Ubuntu"
+    - not use_systemd
 
 - name: activate rados gateway with sysvinit
   file:
@@ -73,7 +75,9 @@
     - done
     - sysvinit
   changed_when: false
-  when: ansible_distribution != "Ubuntu"
+  when:
+    - ansible_distribution != "Ubuntu"
+    - not use_systemd
 
 - name: generate rados gateway sudoers file
   template:


### PR DESCRIPTION
We have a fact that detects the package manager, so we can detect if
systemd is used. Radosgw was still using some old logic from Ubuntu.
Ubuntu 16.04 now has systemd so we don't need to configure rgw as it was
running on upstart.

Signed-off-by: Sébastien Han <seb@redhat.com>