### PR TITLE
ci: bump ansible version to 2.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {ansible2.1}-{xenial-conf-tests,xenial-mon-osd,xenial-cluster,centos7-mon-osd,centos7-cluster}
+envlist = {ansible2.2}-{xenial-conf-tests,xenial-mon-osd,xenial-cluster,centos7-mon-osd,centos7-cluster}
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
ceph-ansible is now fully compliant with ansible 2.2 so bumping the
ansible version to make we test the right things.

Signed-off-by: Sébastien Han <seb@redhat.com>