### PR TITLE
tests: make libvirt use the same device names as virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -444,10 +444,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       # Libvirt
-      driverletters = ('b'..'z').to_a
+      driverletters = ('a'..'z').to_a
       osd.vm.provider :libvirt do |lv|
-        (0..1).each do |d|
-          lv.storage :file, :device => "vd#{driverletters[d]}", :path => "disk-#{i}-#{d}.disk", :size => '11G'
+        # always make /dev/sd{a/b/c} so that CI can ensure that
+        # virtualbox and libvirt will have the same devices to use for OSDs
+        (0..2).each do |d|
+          lv.storage :file, :device => "hd#{driverletters[d]}", :path => "disk-#{i}-#{d}.disk", :size => '12G', :bus => "ide"
         end
         lv.memory = MEMORY
       end

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -29,7 +29,7 @@ memory: 512
 eth: 'eth1'
 
 # Disks
-# For libvirt use disks: "[ '/dev/vdb', '/dev/vdc' ]"
+# For Xenial use disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For CentOS7 use disks: "[ '/dev/sda', '/dev/sdb' ]"
 disks: "[ '/dev/sdb', '/dev/sdc' ]"
 


### PR DESCRIPTION
This makes our libvirt boxes come up with the OS on /dev/vda and
three devices added at /dev/sd{a/b/c} so that we can ensure that
the OSD devices we want to use can always be available for
both virtualbox and libvirt for both xenial and centos7.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>