### PR TITLE
Replaced Ansible 2.2 specific `check_mode: no`

### DIFF
--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -2,7 +2,7 @@
 - name: get ceph version
   command: ceph --version
   changed_when: false
-  check_mode: no
+  always_run: yes
   register: ceph_version
 
 - set_fact:
@@ -12,7 +12,7 @@
 - name: check init system
   slurp:
     src: /proc/1/comm
-  check_mode: no
+  always_run: yes
   register: init_system
 
 - set_fact:

--- a/roles/ceph-common/tasks/misc/system_tuning.yml
+++ b/roles/ceph-common/tasks/misc/system_tuning.yml
@@ -14,7 +14,7 @@
   command: sysctl -b vm.min_free_kbytes
   changed_when: false
   failed_when: false
-  check_mode: no
+  always_run: yes
   register: default_vm_min_free_kbytes
 
 - name: define vm.min_free_kbytes


### PR DESCRIPTION
Replaced Ansible 2.2 specific `check_mode: no` with backwards compatible `always_run: yes`