### PR TITLE
rolling_update: bump retries for osd_check/retries to 20 minutes

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -160,8 +160,8 @@
 
   vars:
     osd_group_name: osds
-    health_osd_check_retries: 10
-    health_osd_check_delay: 10
+    health_osd_check_retries: 40
+    health_osd_check_delay: 30
     upgrade_ceph_packages: True
 
   hosts:


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>

See: https://bugzilla.redhat.com/show_bug.cgi?id=1395073