### PR TITLE
Fix jinja defaulting syntax

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -155,8 +155,8 @@ dummy:
 #ceph_rhcs_cdn_install: "{{ ceph_stable_rh_storage_cdn_install | default(false) }}" # assumes all the nodes can connect to cdn.redhat.com
 #ceph_rhcs_iso_install: "{{ ceph_stable_rh_storage_iso_install | default(false) }}" # usually used when nodes don't have access to cdn.redhat.com
 #ceph_rhcs_iso_path: "{{ ceph_stable_rh_storage_iso_path | default('') }}"
-#ceph_rhcs_mount_path: "{{ ceph_stable_rh_storage_mount_path | default(/tmp/rh-storage-mount) }}"
-#ceph_rhcs_repository_path: "{{ ceph_stable_rh_storage_repository_path | default(/tmp/rh-storage-repo) }}" # where to copy iso's content
+#ceph_rhcs_mount_path: "{{ ceph_stable_rh_storage_mount_path | default('/tmp/rh-storage-mount') }}"
+#ceph_rhcs_repository_path: "{{ ceph_stable_rh_storage_repository_path | default('/tmp/rh-storage-repo') }}" # where to copy iso's content
 
 
 # UBUNTU CLOUD ARCHIVE
@@ -381,4 +381,3 @@ dummy:
 #nfs_file_gw: true
 # Set this to true to enable Object access via NFS. Requires an RGW role.
 #nfs_obj_gw: false
-

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -147,8 +147,8 @@ ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(2) }}"
 ceph_rhcs_cdn_install: "{{ ceph_stable_rh_storage_cdn_install | default(false) }}" # assumes all the nodes can connect to cdn.redhat.com
 ceph_rhcs_iso_install: "{{ ceph_stable_rh_storage_iso_install | default(false) }}" # usually used when nodes don't have access to cdn.redhat.com
 ceph_rhcs_iso_path: "{{ ceph_stable_rh_storage_iso_path | default('') }}"
-ceph_rhcs_mount_path: "{{ ceph_stable_rh_storage_mount_path | default(/tmp/rh-storage-mount) }}"
-ceph_rhcs_repository_path: "{{ ceph_stable_rh_storage_repository_path | default(/tmp/rh-storage-repo) }}" # where to copy iso's content
+ceph_rhcs_mount_path: "{{ ceph_stable_rh_storage_mount_path | default('/tmp/rh-storage-mount') }}"
+ceph_rhcs_repository_path: "{{ ceph_stable_rh_storage_repository_path | default('/tmp/rh-storage-repo') }}" # where to copy iso's content
 
 
 # UBUNTU CLOUD ARCHIVE


### PR DESCRIPTION
a397922 introduced a syntax error by attempting to default an unquoted
string, which causes execution failures on some ansible versions with:

Failed to template {{ ceph_rhcs_mount_path }}: Failed to template {{ ceph_stable_rh_storage_mount_path | default(/tmp/rh-storage-mount) }}: template error while templating string: unexpected '/'