### PR TITLE
add RPM packaging for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ take-over-existing-cluster.yml
 osd-configure.yml
 rolling_update.yml
 .tox
+ceph-ansible.spec

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# Makefile for constructing RPMs.
+# Try "make" (for SRPMS) or "make rpm"
+
+NAME = ceph-ansible
+VERSION := $(shell git describe --tags --abbrev=0)
+COMMIT := $(shell git rev-parse HEAD)
+SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
+RELEASE := $(shell git describe --tags --match 'v*' \
+             | sed 's/^v//' \
+             | sed 's/^[^-]*-//' \
+             | sed 's/-/./')
+ifeq ($(VERSION),$(RELEASE))
+  RELEASE = 0
+endif
+NVR := $(NAME)-$(VERSION)-$(RELEASE).el7
+
+all: srpm
+
+# Testing only
+echo:
+	echo COMMIT $(COMMIT)
+	echo VERSION $(VERSION)
+	echo RELEASE $(RELEASE)
+	echo NVR $(NVR)
+
+clean:
+	rm -rf dist/
+	rm -rf ceph-ansible-$(VERSION)-$(SHORTCOMMIT).tar.gz
+	rm -rf $(NVR).src.rpm
+
+dist:
+	git archive --format=tar.gz --prefix=ceph-ansible-$(VERSION)/ HEAD > ceph-ansible-$(VERSION)-$(SHORTCOMMIT).tar.gz
+
+spec:
+	sed ceph-ansible.spec.in \
+	  -e 's/@COMMIT@/$(COMMIT)/' \
+	  -e 's/@VERSION@/$(VERSION)/' \
+	  -e 's/@RELEASE@/$(RELEASE)/' \
+	  > ceph-ansible.spec
+
+srpm: dist spec
+	fedpkg --dist epel7 srpm
+
+rpm: dist srpm
+	mock -r epel-7-x86_64 rebuild $(NVR).src.rpm \
+	  --resultdir=. \
+	  --define "dist .el7"
+
+.PHONY: dist rpm srpm

--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -1,0 +1,47 @@
+%global commit @COMMIT@
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           ceph-ansible
+Version:        @VERSION@
+Release:        @RELEASE@%{?dist}
+Summary:        Ansible playbooks for Ceph
+# Some files have been copied from Ansible (GPLv3+). For example:
+#  library/ceph_facts
+#  plugins/actions/config_template.py
+#  roles/ceph-common/plugins/actions/config_template.py
+License:        ASL 2.0 and GPLv3+
+URL:            https://github.com/ceph/ceph-ansible
+Source0:        %{name}-%{version}-%{shortcommit}.tar.gz
+
+BuildArch:      noarch
+
+BuildRequires: ansible
+BuildRequires: python2-devel
+
+Requires: ansible
+
+%description
+Ansible playbooks for Ceph
+
+%prep
+%autosetup -p1
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_datarootdir}/ceph-ansible
+
+for f in ansible.cfg *.yml *.sample group_vars roles library plugins; do
+  cp -a $f %{buildroot}%{_datarootdir}/ceph-ansible
+done
+
+%check
+# Borrowed from upstream's .travis.yml:
+ansible-playbook -i dummy-ansible-hosts test.yml --syntax-check
+
+%files
+%doc README.md
+%license LICENSE
+%{_datarootdir}/ceph-ansible
+
+%changelog


### PR DESCRIPTION
`make rpm` will build a ceph-ansible RPM and place it in the current
working directory.

This will allow us to run this command in Jenkins for every branch.