### PR TITLE
Fix error caused by missing OSD cluster keyring

### DIFF
--- a/roles/ceph-osd/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-osd/tasks/docker/fetch_configs.yml
@@ -10,7 +10,7 @@
     wait_for
     path="{{ playbook_dir }}/{{ fetch_directory }}/docker_mon_files/{{ item.0 }}"
   become: false
-  with_together: "{{ ceph_config_keys }}"
+  with_items: "{{ ceph_config_keys }}"
 
 - name: stat for ceph config and keys
   local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
@@ -28,4 +28,4 @@
     group: root
     mode: 0644
   changed_when: false
-  with_together: "{{ ceph_config_keys }}"
+  with_items: "{{ ceph_config_keys }}"

--- a/vagrant_variables.yml.atomic
+++ b/vagrant_variables.yml.atomic
@@ -22,7 +22,7 @@ cluster_subnet: 192.168.1
 # MEMORY
 memory: 1024
 
-disks: "[ '/dev/sdb', '/dev/sdc' ]"
+disks: "[ '/dev/sda', '/dev/sdb' ]"
 
 eth: 'enp0s8'
 vagrant_box: centos/atomic-host


### PR DESCRIPTION
Ansible task was not properly fetching OSD cluster keyring causing
the keyring to be missing when we needed to authenticate. Similarly, we
were not properly waiting on the OSD keyring to be available before
continuing.

Signed-off-by: Ivan Font <ifont@redhat.com>