### PR TITLE
rolling_update: clarify "serial" usage

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -1,6 +1,10 @@
 ---
 # This playbook does a rolling update for all the Ceph services
-# Change the value of 'serial:' to adjust the number of server to be updated.
+#
+# The value of 'serial:' adjusts the number of servers to be updated simultaneously.
+# We recommend a value of 1, which means hosts of a group (e.g: monitor) will be
+# upgraded one by one. It is really crucial for the update process to happen
+# in a serialized fashion. DO NOT CHANGE THIS VALUE.
 #
 # The four roles that apply to the ceph hosts will be applied: ceph-common,
 # ceph-mon, ceph-osd and ceph-mds. So any changes to configuration, package updates, etc,


### PR DESCRIPTION
Prior to this commit the serial variable was poorly documented. Now we
are making clear that this value should be left untouched as the rolling
update mechanism should happen serially.

Solves: bz-1396742
Signed-off-by: Sébastien Han <seb@redhat.com>