### PR TITLE
Make NTP checks usable with '--check'

### DIFF
--- a/roles/ceph-common/tasks/checks/check_ntp_atomic.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_atomic.yml
@@ -3,4 +3,5 @@
   command: rpm -q chrony
   register: ntp_pkg_query
   ignore_errors: true
+  always_run: true
   changed_when: false

--- a/roles/ceph-common/tasks/checks/check_ntp_debian.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_debian.yml
@@ -3,5 +3,6 @@
   command: dpkg -s ntp
   register: ntp_pkg_query
   ignore_errors: true
+  always_run: true
   changed_when: false
   when: ansible_os_family == 'Debian'

--- a/roles/ceph-common/tasks/checks/check_ntp_redhat.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_redhat.yml
@@ -3,5 +3,6 @@
   command: rpm -q ntp
   register: ntp_pkg_query
   ignore_errors: true
+  always_run: true
   changed_when: false
   when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
As those task are only reading the installed packages and their output
is required in later tasks it is safe to run them also in check mode.