### PR TITLE
Improve --check compatibility for ceph-common, ceph-mon and ceph-rgw roles

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -169,12 +169,14 @@
   shell: "stat /var/run/ceph/*.asok > /dev/null 2>&1"
   changed_when: false
   failed_when: false
+  always_run: true
   register: socket
 
 - name: check for a rados gateway socket
   shell: "stat {{ rbd_client_admin_socket_path }}*.asok > /dev/null 2>&1"
   changed_when: false
   failed_when: false
+  always_run: true
   register: socketrgw
 
 - name: create a local fetch directory if it does not exist
@@ -197,6 +199,7 @@
   changed_when: false
   register: cluster_uuid
   become: false
+  always_run: true
   when: generate_fsid
 
 - name: create ceph conf directory

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -25,6 +25,7 @@
   shell: ls -1 /etc/ceph/*.keyring
   changed_when: false
   register: ceph_keys
+  always_run: true
   when: cephx
 
 - name: set keys permissions

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -12,6 +12,7 @@
   changed_when: false
   register: monitor_keyring
   become: false
+  always_run: true
   when: cephx
 
 - set_fact:

--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -4,6 +4,7 @@
   register: rgwstatus
   changed_when: false
   failed_when: false
+  always_run: true
 
 - name: start rgw
   command: /etc/init.d/radosgw start


### PR DESCRIPTION
Adding a few `always_run: true` lines on tasks that execute reading operations to fill variables. Making it possible to run a `ansible-playbook --check` without running into errors on undefined variables.