### PR TITLE
Add multi-cluster support to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,7 @@ MEMORY         = settings['memory']
 ETH            = settings['eth']
 DOCKER         = settings['docker']
 USER           = settings['ssh_username']
+CLUSTER_NUM    = settings['cluster_num']
 
 ASSIGN_STATIC_IP = !(BOX == 'openstack' or BOX == 'linode')
 DISABLE_SYNCED_FOLDER = settings.fetch('vagrant_disable_synced_folder', false)
@@ -184,7 +185,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       client.vm.hostname = "#{LABEL_PREFIX}ceph-client#{i}"
       if ASSIGN_STATIC_IP
         client.vm.network :private_network,
-          ip: "#{PUBLIC_SUBNET}.4#{i}"
+          ip: "#{PUBLIC_SUBNET}.#{i + 40 + (CLUSTER_NUM * 100)}"
       end
       # Virtualbox
       client.vm.provider :virtualbox do |vb|
@@ -219,7 +220,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       rgw.vm.hostname = "#{LABEL_PREFIX}ceph-rgw#{i}"
       if ASSIGN_STATIC_IP
         rgw.vm.network :private_network,
-          ip: "#{PUBLIC_SUBNET}.5#{i}"
+          ip: "#{PUBLIC_SUBNET}.#{i + 50 + (CLUSTER_NUM * 100)}"
       end
 
       # Virtualbox
@@ -255,7 +256,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       nfs.vm.hostname = "ceph-nfs#{i}"
       if ASSIGN_STATIC_IP
         nfs.vm.network :private_network,
-          ip: "#{PUBLIC_SUBNET}.6#{i}"
+          ip: "#{PUBLIC_SUBNET}.#{i + 60 + (CLUSTER_NUM * 100)}"
       end
 
       # Virtualbox
@@ -291,7 +292,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       mds.vm.hostname = "#{LABEL_PREFIX}ceph-mds#{i}"
       if ASSIGN_STATIC_IP
         mds.vm.network :private_network,
-          ip: "#{PUBLIC_SUBNET}.7#{i}"
+          ip: "#{PUBLIC_SUBNET}.#{i + 70 + (CLUSTER_NUM * 100)}"
       end
       # Virtualbox
       mds.vm.provider :virtualbox do |vb|
@@ -325,7 +326,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       rbd_mirror.vm.hostname = "#{LABEL_PREFIX}ceph-rbd-mirror#{i}"
       if ASSIGN_STATIC_IP
         rbd_mirror.vm.network :private_network,
-          ip: "#{PUBLIC_SUBNET}.8#{i}"
+          ip: "#{PUBLIC_SUBNET}.#{i + 80 + (CLUSTER_NUM * 100)}"
       end
       # Virtualbox
       rbd_mirror.vm.provider :virtualbox do |vb|
@@ -359,7 +360,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       iscsi_gw.vm.hostname = "#{LABEL_PREFIX}ceph-iscsi-gw#{i}"
       if ASSIGN_STATIC_IP
         iscsi_gw.vm.network :private_network,
-          ip: "#{PUBLIC_SUBNET}.9#{i}"
+          ip: "#{PUBLIC_SUBNET}.#{i + 90 + (CLUSTER_NUM * 100)}"
       end
       # Virtualbox
       iscsi_gw.vm.provider :virtualbox do |vb|
@@ -393,7 +394,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       mon.vm.hostname = "#{LABEL_PREFIX}ceph-mon#{i}"
       if ASSIGN_STATIC_IP
         mon.vm.network :private_network,
-          ip: "#{PUBLIC_SUBNET}.1#{i}"
+          ip: "#{PUBLIC_SUBNET}.#{i + 10 + (CLUSTER_NUM * 100)}"
       end
       # Virtualbox
       mon.vm.provider :virtualbox do |vb|
@@ -428,9 +429,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       osd.vm.hostname = "#{LABEL_PREFIX}ceph-osd#{i}"
       if ASSIGN_STATIC_IP
         osd.vm.network :private_network,
-          ip: "#{PUBLIC_SUBNET}.10#{i}"
+          ip: "#{PUBLIC_SUBNET}.#{i + 20 + (CLUSTER_NUM * 100)}"
         osd.vm.network :private_network,
-          ip: "#{CLUSTER_SUBNET}.20#{i}"
+          ip: "#{CLUSTER_SUBNET}.#{i + 30 + (CLUSTER_NUM * 100)}"
       end
       # Virtualbox
       osd.vm.provider :virtualbox do |vb|

--- a/vagrant_variables.yml.atomic
+++ b/vagrant_variables.yml.atomic
@@ -2,6 +2,10 @@
 # DEPLOY CONTAINERIZED DAEMONS
 docker: true
 
+# Cluster Number (0 or 1)
+# allows you to setup 2 clusters without conflicting IP addresses (Used to multi-cluster features in ceph)
+cluster_num: 0
+
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 1
 osd_vms: 1

--- a/vagrant_variables.yml.linode
+++ b/vagrant_variables.yml.linode
@@ -19,6 +19,10 @@ memory: 2048
 public_subnet: 192.168.0
 cluster_subnet: 192.168.0
 
+# Cluster Number (0 or 1)
+# allows you to setup 2 clusters without conflicting IP addresses (Used to multi-cluster features in ceph)
+cluster_num: 0
+
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 3
 osd_vms: 3

--- a/vagrant_variables.yml.openstack
+++ b/vagrant_variables.yml.openstack
@@ -3,6 +3,10 @@
 # DEPLOY CONTAINERIZED DAEMONS
 docker: true
 
+# Cluster Number (0 or 1)
+# allows you to setup 2 clusters without conflicting IP addresses (Used to multi-cluster features in ceph)
+cluster_num: 0
+
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 1
 osd_vms: 1

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -3,6 +3,10 @@
 # DEPLOY CONTAINERIZED DAEMONS
 docker: false
 
+# Cluster Number (0 or 1)
+# allows you to setup 2 clusters without conflicting IP addresses (Used to multi-cluster features in ceph)
+cluster_num: 0
+
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 3
 osd_vms: 3


### PR DESCRIPTION
This allows you to setup a second cluster, with non-conflicting IPs, by changing the cluster_num variable from 0 to 1.   Very useful for testing multi-cluster functionality.