### PR TITLE
add uuids for ceph-disk prepare sub command in order to seriallize osd number but run simultaneously

### DIFF
--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -58,3 +58,23 @@
   when:
     - cephx
     - item.copy_key|bool
+
+- set_fact:
+     osd_uuids: |
+      {%- set o=[] %}
+      {%- for device in  devices %}
+        {%- if o.append( ( inventory_hostname + device + "osd_uuids") | to_uuid ) %}
+        {%- endif %}
+      {%- endfor %}
+      {{ o }}
+  when: osd_uuids is not defined
+
+- set_fact:
+     journal_uuids: |
+      {%- set o=[] %}
+      {%- for device in  devices %}
+        {%- if o.append( ( inventory_hostname + device + "journal_uuids") | to_uuid ) %}
+        {%- endif %}
+      {%- endfor %}
+      {{ o }}
+  when: journal_uuids is not defined

--- a/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
+++ b/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
@@ -21,11 +21,13 @@
     - osd_auto_discovery
 
 - name: manually prepare osd disk(s)
-  command: "ceph-disk prepare --cluster {{ cluster }} {{ item.2 }}"
+  command: "ceph-disk prepare --cluster {{ cluster }} {{ item.2 }} --osd-uuid {{ item.3 }}  --journal-uuid {{ item.4 }}"
   with_together:
     - "{{ parted_results.results }}"
     - "{{ ispartition_results.results }}"
     - "{{ devices }}"
+    - "{{ osd_uuids }}"
+    - "{{ journal_uuids }}"
   when:
     - not item.0.get("skipped")
     - not item.1.get("skipped")


### PR DESCRIPTION
we can register osd id with pre-generated uuids in order and then `ceph-disk prepare devices  --osd-uuid   --journal-uuid`  simultaneously


host_vars example:
```
---
devices: ['/dev/sdb', '/dev/sdc']
osd_uuids: ['388e7ca0-b2db-11e6-8ac5-000c290e6540', '388e7fb6-b2db-11e6-8ac5-000c290e6540']
journal_uuids: ['388e7e9e-b2db-11e6-8ac5-000c290e6540', '388e80a6-b2db-11e6-8ac5-000c290e6540']
```


register osd id
```
- hosts: osds
  become: True
  serial: 1
  tasks:
    - name: register osd id  with  uuid
      command: ceph osd create {{ item }}
      delegate_to: "{{ groups['mons'][0] }}"
      with_items: "{{ osd_uuids }}"
      when:
        - osd_uuids is defined
        - journal_uuids is defined
```

prepare and activate osd
```
- hosts: osds
  become: True
  roles:
    - ceph-osd
```