### PR TITLE
contrib: It doesn't make sense to pull all tags

### DIFF
--- a/contrib/push-roles-to-ansible-galaxy.sh
+++ b/contrib/push-roles-to-ansible-galaxy.sh
@@ -23,7 +23,7 @@ function check_existing_remote {
 }
 
 function pull_origin {
-  git pull origin --tags
+  git pull origin master
 }
 
 function reset_hard_origin {


### PR DESCRIPTION
On certain git versions running: git pull origin --tags ends up with the
following error: It doesn't make sense to pull all tags; you probably
meant: git fetch --tags

So removing the --tags since later in the execution we do a git fetch
--tags

Signed-off-by: Sébastien Han <seb@redhat.com>