### PR TITLE
Use Keystone user instead of admin token for integration

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -289,7 +289,10 @@ dummy:
 #radosgw_civetweb_num_threads: 50
 #radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
-#radosgw_keystone_admin_token: password
+#radosgw_keystone_admin_token: password # should not be used in production environments. Use radosgw_keystone_admin_[user,password,tenant] instead.
+#radosgw_keystone_admin_user: # keystone user with admin rights
+#radosgw_keystone_admin_password:
+#radosgw_keystone_admin_tenant:
 #radosgw_keystone_accepted_roles: Member, _member_, admin
 #radosgw_keystone_token_cache_size: 10000
 #radosgw_keystone_revocation_internal: 900

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -116,7 +116,13 @@ rgw data = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_ho
 rgw frontends = civetweb port={{ radosgw_civetweb_bind_ip }}:{{ radosgw_civetweb_port }} num_threads={{ radosgw_civetweb_num_threads }}
 {% if radosgw_keystone %}
 rgw keystone url = {{ radosgw_keystone_url }}
+{% if radosgw_keystone_admin_user and radosgw_keystone_admin_password and radosgw_keystone_admin_tenant %}
+rgw keystone admin user = {{ radosgw_keystone_admin_user }}
+rgw keystone admin password = {{ radosgw_keystone_admin_password }}
+rgw keystone admin tenant = {{ radosgw_keystone_admin_tenant }}
+{% else %}
 rgw keystone admin token = {{ radosgw_keystone_admin_token }}
+{% endif %}
 rgw keystone accepted roles = {{ radosgw_keystone_accepted_roles }}
 rgw keystone token cache size = {{ radosgw_keystone_token_cache_size }}
 rgw keystone revocation interval = {{ radosgw_keystone_revocation_internal }}


### PR DESCRIPTION
The keystone admin token is recommended to be turned off in production
environments. This commit adds the possibility to configure a keystone
user to be used instead for keystone integration.