### PR TITLE
Add gluster nfs ganesha repo only for Ubuntu

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
@@ -52,5 +52,6 @@
     - ppa:gluster/libntirpc
     - ppa:gluster/nfs-ganesha
   changed_when: false
-  when: nfs_obj_gw or nfs_file_gw
-
+  when:
+    - (nfs_obj_gw or nfs_file_gw)
+    - not ansible_distribution == "Debian"


### PR DESCRIPTION
According to the official documentation, adding PPA is not available for Debian.