### PR TITLE
common: remove apache file

### DIFF
--- a/roles/ceph-common/templates/httpd.conf
+++ b/roles/ceph-common/templates/httpd.conf
@@ -1,3 +1,0 @@
-# {{ ansible_managed }}
-
-ServerName {{ ansible_hostname }}


### PR DESCRIPTION
we recently dropped the support for apache with rgw, so this commit
removes the last remaining file.

Signed-off-by: Sébastien Han <seb@redhat.com>