### PR TITLE
the pattern in regex_replace is not right when the pid of osd is bigger  than 9999

### DIFF
--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -100,7 +100,7 @@
 
   - set_fact: ips="{{ ip_result.results | map(attribute='ansible_facts.ip_item') | list }}"
 
-  - set_fact: real_ips="{{ ips | regex_replace(':[0-9][0-9][0-9][0-9]\/[0-9][0-9][0-9][0-9]', '') }}"
+  - set_fact: real_ips="{{ ips | regex_replace(':[0-9][0-9][0-9][0-9]\/[0-9]+', '') }}"
 
   - name: check if ceph admin key exists on the osd nodes
     stat:


### PR DESCRIPTION
when the pid of osd is bigger than 9999, just like the follow 12860. the old regex pattern ` ':[0-9][0-9][0-9][0-9]\/[0-9][0-9][0-9][0-9]'` of  regex_replace filter  process 12860 will still left 0,and the 0 will append to host ip
```
[root@onest-4 /etc/ceph]#  ceph osd find 0
{
    "osd": 0,
    "ip": "20.1.1.95:6800\/12860",
    "crush_location": {
        "host": "onest-4",
        "root": "default"
    }
}
[root@onest-4 /etc/ceph]#  ps -ef |grep ceph-osd
ceph       12860       1  0 Nov21 ?        01:09:52 /usr/bin/ceph-osd -f --cluster ceph --id 0 --setuser ceph --setgroup ceph
root      162374  159422  0 13:49 pts/0    00:00:00 grep --color=auto ceph-osd
```
the 0 append to host ip while the real host ip is `20.1.1.95`
```
failed: [172.20.255.157] (item=20.1.1.950) => {"item": "20.1.1.950", "msg": "Failed to connect to the host via ssh.", "unreachable": true}
fatal: [172.20.255.157]: UNREACHABLE! => {"changed": false, "msg": "All items completed", "results": [{"_ansible_item_result": true, "item": "20.1.1.950", "msg": "Failed to connect to the host via ssh.", "unreachable": true}, {"_ansible_item_result": true, "item": "20.1.1.950", "msg": "Failed to connect to the host via ssh.", "unreachable": true}]}
```