### PR TITLE
mon: pool creation and pgs

### DIFF
--- a/group_vars/clients.yml.sample
+++ b/group_vars/clients.yml.sample
@@ -15,8 +15,8 @@ dummy:
 
 #user_config: false
 #pools:
-#  - { name: test, pgs: "{{ pool_default_pg_num }}" }
-#  - { name: test2, pgs: "{{ pool_default_pg_num }}" }
+#  - { name: test, pgs: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}" }
+#  - { name: test2, pgs: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}" }
 
 #keys:
 #  - { name: client.test, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=test'" }

--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -23,7 +23,6 @@ dummy:
 #cephx: true
 
 # CephFS
-#pool_default_pg_num: 128
 #cephfs_data: cephfs_data
 #cephfs_metadata: cephfs_metadata
 #cephfs: cephfs
@@ -50,16 +49,16 @@ dummy:
 #openstack_config: false
 #openstack_glance_pool:
 #  name: images
-#  pg_num: "{{ pool_default_pg_num }}"
+#  pg_num: "{{ osd_pool_default_pg_num }}"
 #openstack_cinder_pool:
 #  name: volumes
-#  pg_num: "{{ pool_default_pg_num }}"
+#  pg_num: "{{ osd_pool_default_pg_num }}"
 #openstack_nova_pool:
 #  name: vms
-#  pg_num: "{{ pool_default_pg_num }}"
+#  pg_num: "{{ osd_pool_default_pg_num }}"
 #openstack_cinder_backup_pool:
 #  name: backups
-#  pg_num: "{{ pool_default_pg_num }}"
+#  pg_num: "{{ osd_pool_default_pg_num }}"
 
 #openstack_pools:
 #  - "{{ openstack_glance_pool }}"

--- a/roles/ceph-client/defaults/main.yml
+++ b/roles/ceph-client/defaults/main.yml
@@ -7,8 +7,8 @@ fetch_directory: fetch/
 
 user_config: false
 pools:
-  - { name: test, pgs: "{{ pool_default_pg_num }}" }
-  - { name: test2, pgs: "{{ pool_default_pg_num }}" }
+  - { name: test, pgs: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}" }
+  - { name: test2, pgs: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}" }
 
 keys:
   - { name: client.test, value: "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=test'" }

--- a/roles/ceph-client/tasks/main.yml
+++ b/roles/ceph-client/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
 - include: pre_requisite.yml
 - include: create_users_keys.yml
-  when: user_config
+  when:
+    - user_config
+    - ceph_conf_overrides.global.osd_pool_default_pg_num is defined

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -15,7 +15,6 @@ monitor_secret: "{{ monitor_keyring.stdout }}"
 cephx: true
 
 # CephFS
-pool_default_pg_num: 128
 cephfs_data: cephfs_data
 cephfs_metadata: cephfs_metadata
 cephfs: cephfs
@@ -42,16 +41,16 @@ calamari: false
 openstack_config: false
 openstack_glance_pool:
   name: images
-  pg_num: "{{ pool_default_pg_num }}"
+  pg_num: "{{ osd_pool_default_pg_num }}"
 openstack_cinder_pool:
   name: volumes
-  pg_num: "{{ pool_default_pg_num }}"
+  pg_num: "{{ osd_pool_default_pg_num }}"
 openstack_nova_pool:
   name: vms
-  pg_num: "{{ pool_default_pg_num }}"
+  pg_num: "{{ osd_pool_default_pg_num }}"
 openstack_cinder_backup_pool:
   name: backups
-  pg_num: "{{ pool_default_pg_num }}"
+  pg_num: "{{ osd_pool_default_pg_num }}"
 
 openstack_pools:
   - "{{ openstack_glance_pool }}"

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -43,6 +43,43 @@
     - cephx
     - groups[restapi_group_name] is defined
 
+# NOTE(leseb): we add a conditional for backward compatibility
+# so people that had 'pool_default_pg_num' declared will get
+# the same behaviour
+#
+- name: check if does global key exist in ceph_conf_overrides
+  set_fact:
+    global_in_ceph_conf_overrides: "{{ 'global' in ceph_conf_overrides }}"
+
+- name: check if ceph_conf_overrides.global.osd_pool_default_pg_num is set
+  set_fact:
+    osd_pool_default_pg_num_in_overrides: "{{ 'osd_pool_default_pg_num' in ceph_conf_overrides.global }}"
+  when: global_in_ceph_conf_overrides
+
+- name: get default value for osd_pool_default_pg_num
+  shell: |
+    ceph --cluster {{ cluster }} daemon mon.{{ monitor_name }} config get osd_pool_default_pg_num | grep -Po '(?<="osd_pool_default_pg_num": ")[^"]*'
+  failed_when: false
+  changed_when: false
+  run_once: true
+  register: default_pool_default_pg_num
+  when: (pool_default_pg_num is not defined or not global_in_ceph_conf_overrides)
+
+- set_fact:
+    osd_pool_default_pg_num: "{{ pool_default_pg_num }}"
+  when: pool_default_pg_num is defined
+
+- set_fact:
+    osd_pool_default_pg_num: "{{ default_pool_default_pg_num.stdout }}"
+  when:
+    - pool_default_pg_num is not defined
+    - default_pool_default_pg_num.rc == 0
+    - ceph_conf_overrides.global.osd_pool_default_pg_num is not defined
+
+- set_fact:
+    osd_pool_default_pg_num: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}"
+  when: ceph_conf_overrides.global.osd_pool_default_pg_num is defined
+
 - include: rbd_pool.yml
   when: ceph_conf_overrides.global.osd_pool_default_pg_num is defined
 

--- a/roles/ceph-mon/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mon/tasks/create_mds_filesystems.yml
@@ -4,7 +4,7 @@
 # the role 'ceph-common' doesn't get inherited so the condition can not be evaluate
 # since those check are performed by the ceph-common role
 - name: create filesystem pools
-  command: ceph --cluster {{ cluster }} osd pool create {{ item }} {{ pool_default_pg_num }}
+  command: ceph --cluster {{ cluster }} osd pool create {{ item }} {{ osd_pool_default_pg_num }}
   with_items:
     - cephfs_data
     - cephfs_metadata

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -14,6 +14,7 @@
   when:
     - not mon_containerized_deployment
     - groups[mds_group_name] is defined
+    - "{{ groups[mds_group_name]|length > 0 }}"
 
 - include: secure_cluster.yml
   when:

--- a/tests/functional/centos/7/cluster/group_vars/all
+++ b/tests/functional/centos/7/cluster/group_vars/all
@@ -13,3 +13,5 @@ raw_multi_journal: True
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
+user_config: True
+openstack_config: True

--- a/tests/functional/centos/7/cluster/hosts
+++ b/tests/functional/centos/7/cluster/hosts
@@ -11,3 +11,6 @@ mds0
 
 [rgws]
 rgw0
+
+[clients]
+client0

--- a/tests/functional/centos/7/cluster/vagrant_variables.yml
+++ b/tests/functional/centos/7/cluster/vagrant_variables.yml
@@ -10,7 +10,7 @@ mds_vms: 1
 rgw_vms: 1
 nfs_vms: 0
 rbd_mirror_vms: 0
-client_vms: 0
+client_vms: 1
 iscsi_gw_vms: 0
 
 # Deploy RESTAPI on each of the Monitors

--- a/tests/functional/ubuntu/16.04/cluster/hosts
+++ b/tests/functional/ubuntu/16.04/cluster/hosts
@@ -11,3 +11,6 @@ mds0
 
 [rgws]
 rgw0
+
+[clients]
+client0

--- a/tests/functional/ubuntu/16.04/cluster/vagrant_variables.yml
+++ b/tests/functional/ubuntu/16.04/cluster/vagrant_variables.yml
@@ -10,7 +10,7 @@ mds_vms: 1
 rgw_vms: 1
 nfs_vms: 0
 rbd_mirror_vms: 0
-client_vms: 0
+client_vms: 1
 iscsi_gw_vms: 0
 
 # Deploy RESTAPI on each of the Monitors


### PR DESCRIPTION
Since we introduced config_overrides we removed a lot of options from
the default template. In some cases, like mds pool, openstack pools etc
we need to know the amount of PGs required. The idea here is to skip the
task if ceph_conf_overrides.global.osd_pool_default_pg_num is not define
in your `group_vars/all.yml`.

Closes: #1145

Signed-off-by: Sébastien Han <seb@redhat.com>