### PR TITLE
take-over: use more precise ceph.conf detection

### DIFF
--- a/infrastructure-playbooks/take-over-existing-cluster.yml
+++ b/infrastructure-playbooks/take-over-existing-cluster.yml
@@ -27,7 +27,8 @@
     - include_vars: group_vars/all.yml
 
     - name: get the name of the existing ceph cluster
-      shell: "ls /etc/ceph/*.conf"
+      shell: |
+        grep -lE '\[global\]|fsid' /etc/ceph/*.conf
       changed_when: false
       register: ceph_conf
 


### PR DESCRIPTION
Prior to this patch we were just looking for any *.conf file which
sometimes could results in multiple matches. The new command looks for a
.conf file that must contain [global] and 'fsid' patterns. This will
definitely get us the ceph.conf file. We can not directly use ceph.conf
because of a different cluster name.

Signed-off-by: Sébastien Han <seb@redhat.com>