### PR TITLE
common: do not regenerate a cluster fsid if cluster exits

### DIFF
--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -5,6 +5,18 @@
   always_run: yes
   register: ceph_version
 
+- name: is ceph running already?
+  command: ceph --connect-timeout 3 --cluster {{ cluster }} fsid
+  changed_when: false
+  failed_when: false
+  always_run: yes
+  register: ceph_current_fsid
+  delegate_to: "{{ groups.mons[0] }}"
+
+- set_fact:
+    fsid: "{{ ceph_current_fsid.stdout }}"
+  when: ceph_current_fsid.rc == 0
+
 - set_fact:
     ceph_version: "{{ ceph_version.stdout.split(' ')[2] }}"
 

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -186,14 +186,22 @@
   run_once: true
   when: cephx or generate_fsid
 
-- name: generate cluster uuid
+- name: generate cluster fsid
   local_action: shell python -c 'import uuid; print(str(uuid.uuid4()))' | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
     creates="{{ fetch_directory }}/ceph_cluster_uuid.conf"
   register: cluster_uuid
   become: false
-  when: generate_fsid
+  when:
+    - generate_fsid
+    - ceph_current_fsid.rc != 0
 
-- name: read cluster uuid if it already exists
+- name: reuse cluster fsid when cluster is already running
+  local_action: shell echo {{ fsid }} | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
+    creates="{{ fetch_directory }}/ceph_cluster_uuid.conf"
+  become: false
+  when: ceph_current_fsid.rc == 0
+
+- name: read cluster fsid if it already exists
   local_action: command cat {{ fetch_directory }}/ceph_cluster_uuid.conf
     removes="{{ fetch_directory }}/ceph_cluster_uuid.conf"
   changed_when: false


### PR DESCRIPTION
This commit solves the situation where you lost your fetch directory and
you are running ansible against an existing cluster. Since no fetch
directory is present the file containing the fsid doesn't exist so we
are creating a new one. Later the ceph.conf gets updated with a wrong
fsid which causes problems for clients and ceph processes.

Closes: #1148

Signed-off-by: Sébastien Han <seb@redhat.com>