### PR TITLE
mon: remove collect keys

### DIFF
--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -60,9 +60,3 @@
   when:
     - use_systemd
     - ceph_release_num.{{ ceph_release }} > ceph_release_num.hammer
-
-- name: collect admin and bootstrap keys
-  command: ceph-create-keys --cluster {{ cluster }} --id {{ monitor_name }}
-  changed_when: false
-  failed_when:  false
-  when: cephx


### PR DESCRIPTION
Once the monitor process starts it will also trigger `ceph-create-keys`
which will collect the admin key and bootstrap keys. We used to force
this command because we were having issues on some distros like centos
7.0 and 7.1 not triggering this. This is fixed on centos 7.2 and not an
issue on ubuntu 14.04 or 16.04 so we can remove this task. If the
monitor hangs or fails to start the playbook will fail right after at
the "wait for client.admin key exists" task after 300sec.

Closes: #1161

Signed-off-by: Sébastien Han <seb@redhat.com>