### PR TITLE
Exclude non-containerized check from containerized osd

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 - include: check_mandatory_vars.yml
+  when: not osd_containerized_deployment
+  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
 
 - include: pre_requisite.yml
   when: not osd_containerized_deployment


### PR DESCRIPTION
This new check was added about a week ago but was missing the criteria to only include in non-containerized OSD.