### PR TITLE
Improve script to install Ceph AIO without Vagrant

### DIFF
--- a/ceph-aio-no-vagrant.sh
+++ b/ceph-aio-no-vagrant.sh
@@ -95,7 +95,7 @@ fi
 }
 
 function install_ansible {
-  sudo bash install-ansible.sh
+  bash install-ansible.sh
 }
 
 function ssh_setup {
@@ -159,7 +159,7 @@ EOF
 }
 
 function test_and_run {
-  ansible all -i hosts -m ping
+  ANSIBLE_HOST_KEY_CHECKING=False ansible all -i hosts -m ping
   ansible-playbook -i hosts site.yml
 }
 

--- a/ceph-aio-no-vagrant.sh
+++ b/ceph-aio-no-vagrant.sh
@@ -127,11 +127,9 @@ ceph_conf_overrides:
   global:
     mon pg warn max per osd: 0
     osd pool default size: 2
-    osd pool default min size: 2
 EOF
   fi
   sed -i "s/^    osd pool default size: .*/    osd pool default size: $CEPH_POOL_DEFAULT_SIZE/" group_vars/all.yml
-  sed -i "s/^    osd pool default min size: .*/    osd pool default min size: $CEPH_POOL_DEFAULT_SIZE/" group_vars/all.yml
 
   if [[ ${SOURCE} == 'stable' ]]; then
     sed -i "s/[#]*ceph_stable: .*/ceph_stable: true/" group_vars/all.yml

--- a/ceph-aio-no-vagrant.sh
+++ b/ceph-aio-no-vagrant.sh
@@ -120,15 +120,19 @@ function populate_vars {
   sed -i "s/[#]*journal_size: .*/journal_size: 100/" group_vars/all.yml
   sed -i "s|[#]*public_network: .*|public_network: ${SUBNET}|" group_vars/all.yml
   sed -i "s/[#]*common_single_host_mode: .*/common_single_host_mode: true/" group_vars/all.yml
-  grep -q '^[#]*osd_pool_default_size: .*' group_vars/all.yml \
-    && sed -i "s/^[#]*osd_pool_default_size: .*/osd_pool_default_size: $CEPH_POOL_DEFAULT_SIZE/" group_vars/all.yml \
-    || echo "osd_pool_default_size: $CEPH_POOL_DEFAULT_SIZE" >> group_vars/all.yml
-  grep -q '^[#]*osd_pool_default_min_size: .*' group_vars/all.yml \
-    && sed -i "s/^[#]*osd_pool_default_min_size: .*/osd_pool_default_min_size: $CEPH_POOL_DEFAULT_SIZE/" group_vars/all.yml \
-    || echo "osd_pool_default_min_size: $CEPH_POOL_DEFAULT_SIZE" >> group_vars/all.yml
-  grep -q '^[#]*mon_pg_warn_max_per_osd: .*' group_vars/all.yml \
-    && sed -i "s/^[#]*mon_pg_warn_max_per_osd: .*/mon_pg_warn_max_per_osd: 0/" group_vars/all.yml \
-    || echo "mon_pg_warn_max_per_osd: 0" >> group_vars/all.yml
+
+  if ! grep -q '^ceph_conf_overrides:' group_vars/all.yml; then
+    cat >> group_vars/all.yml <<EOF
+ceph_conf_overrides:
+  global:
+    mon pg warn max per osd: 0
+    osd pool default size: 2
+    osd pool default min size: 2
+EOF
+  fi
+  sed -i "s/^    osd pool default size: .*/    osd pool default size: $CEPH_POOL_DEFAULT_SIZE/" group_vars/all.yml
+  sed -i "s/^    osd pool default min size: .*/    osd pool default min size: $CEPH_POOL_DEFAULT_SIZE/" group_vars/all.yml
+
   if [[ ${SOURCE} == 'stable' ]]; then
     sed -i "s/[#]*ceph_stable: .*/ceph_stable: true/" group_vars/all.yml
   else

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -250,6 +250,7 @@ monitor_interface: interface
 monitor_address: 0.0.0.0
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 monitor_address_block: false
+mon_pg_warn_max_per_osd: 300
 
 ## OSD options
 #
@@ -260,6 +261,8 @@ osd_mkfs_type: xfs
 osd_mkfs_options_xfs: -f -i size=2048
 osd_mount_options_xfs: noatime,largeio,inode64,swalloc
 osd_objectstore: filestore
+osd_pool_default_size: 3
+osd_pool_default_min_size: 2
 
 # xattrs. by default, 'filestore xattr use omap' is set to 'true' if
 # 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -250,7 +250,6 @@ monitor_interface: interface
 monitor_address: 0.0.0.0
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 monitor_address_block: false
-mon_pg_warn_max_per_osd: 300
 
 ## OSD options
 #
@@ -261,8 +260,6 @@ osd_mkfs_type: xfs
 osd_mkfs_options_xfs: -f -i size=2048
 osd_mount_options_xfs: noatime,largeio,inode64,swalloc
 osd_objectstore: filestore
-osd_pool_default_size: 3
-osd_pool_default_min_size: 2
 
 # xattrs. by default, 'filestore xattr use omap' is set to 'true' if
 # 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -12,9 +12,12 @@ auth supported = none
 fsid = {{ fsid }}
 {% endif %}
 max open files = {{ max_open_files }}
-{% if common_single_host_mode is defined %}
+{% if common_single_host_mode is defined and common_single_host_mode %}
 osd crush chooseleaf type = 0
 {% endif %}
+mon pg warn max per osd = {{ mon_pg_warn_max_per_osd }}
+osd pool default size = {{ osd_pool_default_size }}
+osd pool default min size = {{ osd_pool_default_min_size }}
 {# NOTE (leseb): the blank lines in-between are needed otherwise we won't get any line break #}
 {% if groups[mon_group_name] is defined %}
 mon initial members = {% for host in groups[mon_group_name] %}

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -15,9 +15,6 @@ max open files = {{ max_open_files }}
 {% if common_single_host_mode is defined and common_single_host_mode %}
 osd crush chooseleaf type = 0
 {% endif %}
-mon pg warn max per osd = {{ mon_pg_warn_max_per_osd }}
-osd pool default size = {{ osd_pool_default_size }}
-osd pool default min size = {{ osd_pool_default_min_size }}
 {# NOTE (leseb): the blank lines in-between are needed otherwise we won't get any line break #}
 {% if groups[mon_group_name] is defined %}
 mon initial members = {% for host in groups[mon_group_name] %}


### PR DESCRIPTION
- Add mon_pg_warn_max_per_osd, osd_pool_default_size and osd_pool_default_min_size variables
- Add option to configure default pool size
- Add option not to install MDS and RGW
- Improve ssh_setup to check if file and key already exist
- Improve populate_vars for safety rerun for idempotent
- Change path of inventory file to where ansible run. So this won't pollute the system
- Remove check host key
- Remove sudo when install Ansible