### PR TITLE
common: do not regenerate initial mon keyring if cluster exists

### DIFF
--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -13,9 +13,75 @@
   register: ceph_current_fsid
   delegate_to: "{{ groups[mon_group_name][0] }}"
 
+- name: create a local fetch directory if it does not exist
+  local_action: file path={{ fetch_directory }} state=directory
+  changed_when: false
+  become: false
+  run_once: true
+  when: cephx or generate_fsid
+
 - set_fact:
     fsid: "{{ ceph_current_fsid.stdout }}"
   when: ceph_current_fsid.rc == 0
+
+- set_fact:
+    monitor_name: "{{ ansible_hostname }}"
+  when: not mon_use_fqdn
+
+- set_fact:
+    monitor_name: "{{ ansible_fqdn }}"
+  when: mon_use_fqdn
+
+# We want this check to be run only on one mon
+- name: check if {{ fetch_directory }} directory exists
+  local_action: stat path="{{ fetch_directory }}/monitor_keyring.conf"
+  register: monitor_keyring_conf
+  run_once: true
+
+- block:
+  - name: check if /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring already exists
+    stat:
+      path: /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring
+    register: initial_mon_keyring
+
+  - name: fail if /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring doesn't exist
+    fail:
+      msg: "/var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring not found"
+    when:
+      - not initial_mon_keyring.stat.exists
+      - ceph_current_fsid.rc == 0
+
+  - name: get existing initial mon keyring if it already exists but not monitor_keyring.conf in {{ fetch_directory }}
+    shell: |
+      grep key /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring | sed 's/^.*= //'
+    register: monitor_keyring
+    when:
+      - not monitor_keyring_conf.stat.exists
+      - ceph_current_fsid.rc == 0
+
+  - name: test existing initial mon keyring
+    command: ceph --connect-timeout 3 --cluster {{ cluster }} --keyring /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring -n mon. fsid
+    register: test_initial_monitor_keyring
+    ignore_errors: true
+
+  - name: fail if initial mon keyring found doesn't work
+    fail:
+      msg: "Initial mon keyring found doesn't work."
+    when: test_initial_monitor_keyring.rc != 0
+
+  - name: write initial mon keyring in {{ fetch_directory }}/monitor_keyring.conf if it doesn't exist
+    local_action: shell echo {{ monitor_keyring.stdout }} | tee {{ fetch_directory }}/monitor_keyring.conf
+    when:
+      - test_initial_monitor_keyring.rc == 0
+
+  - name: put initial mon keyring in mon kv store
+    command: ceph --cluster {{ cluster }} config-key put initial_mon_keyring {{ monitor_keyring.stdout }}
+    when: test_initial_monitor_keyring.rc == 0
+  run_once: true
+  when:
+    - not monitor_keyring_conf.stat.exists
+    - ceph_current_fsid.rc == 0
+    - mon_group_name in group_names
 
 - set_fact:
     ceph_version: "{{ ceph_version.stdout.split(' ')[2] }}"

--- a/roles/ceph-common/tasks/generate_cluster_fsid.yml
+++ b/roles/ceph-common/tasks/generate_cluster_fsid.yml
@@ -1,11 +1,4 @@
 ---
-- name: create a local fetch directory if it does not exist
-  local_action: file path={{ fetch_directory }} state=directory
-  changed_when: false
-  become: false
-  run_once: true
-  when: cephx or generate_fsid
-
 - name: generate cluster fsid
   local_action: shell python -c 'import uuid; print(str(uuid.uuid4()))' | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
     creates="{{ fetch_directory }}/ceph_cluster_uuid.conf"

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -15,14 +15,6 @@
   always_run: true
   when: cephx
 
-- set_fact:
-    monitor_name: "{{ ansible_hostname }}"
-  when: not mon_use_fqdn
-
-- set_fact:
-    monitor_name: "{{ ansible_fqdn }}"
-  when: mon_use_fqdn
-
 - name: create monitor initial keyring
   command: ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ monitor_name }} --create-keyring --name=mon. --add-key={{ monitor_secret }} --cap mon 'allow *'
   args:


### PR DESCRIPTION
This commit solves the situation where you lost your fetch directory and
you are running ansible against an existing cluster. Since no fetch
directory is present the file containing the initial mon keyring
doesn't exist so we are generating a new one.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>