### PR TITLE
Fix the mons running check to use group name var

### DIFF
--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -11,7 +11,7 @@
   failed_when: false
   always_run: yes
   register: ceph_current_fsid
-  delegate_to: "{{ groups.mons[0] }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
 
 - set_fact:
     fsid: "{{ ceph_current_fsid.stdout }}"


### PR DESCRIPTION
mon_group_name variable can be used to override mons group, but
this task assumes the group is always 'mons'. So we need to use
the var to find the group name instead.