### PR TITLE
Shaman support for `ceph_dev`

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -172,13 +172,8 @@ dummy:
 # ###
 
 #ceph_dev: false # use ceph development branch
-#ceph_dev_key: https://download.ceph.com/keys/autobuild.asc
 #ceph_dev_branch: master # development branch you would like to use e.g: master, wip-hack
-
-# supported distros are centos6, centos7, fc17, fc18, fc19, fc20, fedora17, fedora18,
-# fedora19, fedora20, opensuse12, sles0. (see http://gitbuilder.ceph.com/).
-# For rhel, please pay attention to the versions: 'rhel6 3' or 'rhel 4', the fullname is _very_ important.
-#ceph_dev_redhat_distro: centos7
+#ceph_dev_sha1: latest # distinct sha1 to use, defaults to 'latest' (as in latest built)
 
 # CUSTOM
 # ###

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -164,13 +164,8 @@ ceph_stable_uca: false
 # ###
 
 ceph_dev: false # use ceph development branch
-ceph_dev_key: https://download.ceph.com/keys/autobuild.asc
 ceph_dev_branch: master # development branch you would like to use e.g: master, wip-hack
-
-# supported distros are centos6, centos7, fc17, fc18, fc19, fc20, fedora17, fedora18,
-# fedora19, fedora20, opensuse12, sles0. (see http://gitbuilder.ceph.com/).
-# For rhel, please pay attention to the versions: 'rhel6 3' or 'rhel 4', the fullname is _very_ important.
-ceph_dev_redhat_distro: centos7
+ceph_dev_sha1: latest # distinct sha1 to use, defaults to 'latest' (as in latest built)
 
 # CUSTOM
 # ###

--- a/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
@@ -18,9 +18,17 @@
   changed_when: false
   when: ceph_stable
 
+# we must use curl instead of ansible's uri module because SNI support in
+# Python is only available in 2.7.9 and later, and most supported distributions
+# don't have that version, so a request to https fails.
+- name : fetch ceph development repository sources list file
+  command: "curl -L https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/{{ ansible_distribution | lower }}/{{ ansible_lsb.codename }}/repo"
+  register: ceph_dev_deb_repo
+  when: ceph_dev
+
 - name: add ceph development repository
   apt_repository:
-    repo: "deb http://gitbuilder.ceph.com/ceph-deb-{{ ansible_lsb.codename }}-x86_64-basic/ref/{{ ceph_dev_branch }} {{ ansible_lsb.codename }} main"
+    repo: "{{ ceph_dev_deb_repo.stdout }}"
     state: present
   changed_when: false
   when: ceph_dev

--- a/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
@@ -5,12 +5,6 @@
     state: present
   when: ceph_stable
 
-- name: install the ceph development repository key
-  rpm_key:
-    key: "{{ ceph_dev_key }}"
-    state: present
-  when: ceph_dev
-
 - name: add ceph stable repository
   package:
     name: http://download.ceph.com/rpm-{{ ceph_stable_release }}/{{ ceph_stable_redhat_distro }}/noarch/ceph-release-1-0.{{ ceph_stable_redhat_distro|replace('rhel', 'el') }}.noarch.rpm
@@ -18,11 +12,21 @@
   changed_when: false
   when: ceph_stable
 
+# we must use curl instead of ansible's uri module because SNI support in
+# Python is only available in 2.7.9 and later, and most supported distributions
+# don't have that version, so a request to https fails.
+- name: fetch ceph development repo file
+  command: 'curl -L https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/repo'
+  register: ceph_dev_yum_repo
+  when: ceph_dev
+
 - name: add ceph development repository
-  package:
-    name: http://gitbuilder.ceph.com/ceph-rpm-{{ ceph_dev_redhat_distro }}-x86_64-basic/ref/{{ ceph_dev_branch }}/noarch/ceph-release-1-0.{{ ceph_stable_redhat_distro }}.noarch.rpm
-    state: present
-  changed_when: false
+  copy:
+    content: "{{ ceph_dev_yum_repo.stdout }}"
+    dest: /etc/yum.repos.d/ceph-dev.repo
+    owner: root
+    group: root
+    backup: yes
   when: ceph_dev
 
 - name: add custom repo


### PR DESCRIPTION
Removes gitbuilder references, and uses the new shaman redirects.

Note: DEB repos will not work correctly until https://github.com/ceph/chacra/pull/217 is deployed