### PR TITLE
bump package version to libcephfs2

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -509,6 +509,7 @@
 
     ceph_remaining_packages:
       - libcephfs1
+      - libcephfs2
       - librados2
       - libradosstriper1
       - librbd1

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -66,7 +66,7 @@ debian_ceph_packages:
   - ceph-common    #|
   - ceph-fs-common #|--> yes, they are already all dependencies from 'ceph'
   - ceph-fuse      #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
-  - libcephfs1     #|--> they don't get update so we need to force them
+                   #|--> they don't get update so we need to force them
 
 # Whether or not to install the ceph-test package.
 ceph_test: False


### PR DESCRIPTION
I'm seeing some teuthology failures when trying to install ceph packages, such as this on centos (full [teuthology.log](http://qa-proxy.ceph.com/teuthology/cbodley-2016-12-08_13:02:07-rgw-wip-cbodley-testing---basic-smithi/617718/teuthology.log)):
```
Error: Package: 1:ceph-common-11.0.2-2242.gbfb49aa.el7.x86_64 (ceph)
           Requires: libcephfs2 = 1:11.0.2-2242.gbfb49aa.el7
           Installed: 1:libcephfs2-11.0.2-2336.g27f6b03.el7.x86_64 (@ceph)
               libcephfs2 = 1:11.0.2-2336.g27f6b03.el7
           Available: 1:libcephfs2-11.0.2-2242.gbfb49aa.el7.x86_64 (ceph)
               libcephfs2 = 1:11.0.2-2242.gbfb49aa.el7
```
It appears that the existing package for `libcephfs2` was not cleaned up by the ceph-ansible's `Ensure ceph packages are not present` task, which is referring to this package as `libcephfs1`.