### PR TITLE
Makefile: strip "v" from RPM versions, and improve version detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Try "make" (for SRPMS) or "make rpm"
 
 NAME = ceph-ansible
-VERSION := $(shell git describe --tags --abbrev=0 | sed 's/^v//')
+VERSION := $(shell git describe --tags --abbrev=0 --match 'v*' | sed 's/^v//')
 COMMIT := $(shell git rev-parse HEAD)
 SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
 RELEASE := $(shell git describe --tags --match 'v*' \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Try "make" (for SRPMS) or "make rpm"
 
 NAME = ceph-ansible
-VERSION := $(shell git describe --tags --abbrev=0)
+VERSION := $(shell git describe --tags --abbrev=0 | sed 's/^v//')
 COMMIT := $(shell git rev-parse HEAD)
 SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
 RELEASE := $(shell git describe --tags --match 'v*' \


### PR DESCRIPTION
Prior to this change, all RPMs would have a Version field that started with `v`, for example `ceph-ansible-v2.0.0-163.g2c98b1d.el7`

Strip the `v` out in these cases, so that the version is simply a number.

Also, ignore any tags that do not start with `v`.