### PR TITLE
RGW/Keystone integration improvements

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -285,6 +285,7 @@ dummy:
 #radosgw_civetweb_num_threads: 50
 #radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
+#radosgw_keystone_api_version: 2 # API versions 2 and 3 are supported
 #radosgw_keystone_ssl: true # Can be used to disable PKI revocation checks when other token types are used.
 # for admin_token method, define radosgw_keystone_admin_token
 # for auth_token method, define _user, _password, and _tenant
@@ -293,6 +294,7 @@ dummy:
 #radosgw_keystone_admin_user: username
 #radosgw_keystone_admin_password: password
 #radosgw_keystone_admin_tenant: tenant
+#radosgw_keystone_admin_domain: default
 #radosgw_keystone_accepted_roles: Member, _member_, admin
 #radosgw_keystone_token_cache_size: 10000
 #radosgw_keystone_revocation_internal: 900

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -285,6 +285,7 @@ dummy:
 #radosgw_civetweb_num_threads: 50
 #radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
+#radosgw_keystone_ssl: true # Can be used to disable PKI revocation checks when other token types are used.
 # for admin_token method, define radosgw_keystone_admin_token
 # for auth_token method, define _user, _password, and _tenant
 #radosgw_keystone_auth_method: admin_token

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -285,7 +285,13 @@ dummy:
 #radosgw_civetweb_num_threads: 50
 #radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
+# for admin_token method, define radosgw_keystone_admin_token
+# for auth_token method, define _user, _password, and _tenant
+#radosgw_keystone_auth_method: admin_token
 #radosgw_keystone_admin_token: password
+#radosgw_keystone_admin_user: username
+#radosgw_keystone_admin_password: password
+#radosgw_keystone_admin_tenant: tenant
 #radosgw_keystone_accepted_roles: Member, _member_, admin
 #radosgw_keystone_token_cache_size: 10000
 #radosgw_keystone_revocation_internal: 900

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -277,6 +277,7 @@ radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4.address }}"
 radosgw_civetweb_num_threads: 50
 radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
+radosgw_keystone_ssl: true # Can be used to disable PKI revocation checks when other token types are used.
 # for admin_token method, define radosgw_keystone_admin_token
 # for auth_token method, define _user, _password, and _tenant
 radosgw_keystone_auth_method: admin_token

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -277,6 +277,7 @@ radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4.address }}"
 radosgw_civetweb_num_threads: 50
 radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
+radosgw_keystone_api_version: 2 # API versions 2 and 3 are supported
 radosgw_keystone_ssl: true # Can be used to disable PKI revocation checks when other token types are used.
 # for admin_token method, define radosgw_keystone_admin_token
 # for auth_token method, define _user, _password, and _tenant
@@ -285,6 +286,7 @@ radosgw_keystone_admin_token: password
 radosgw_keystone_admin_user: username
 radosgw_keystone_admin_password: password
 radosgw_keystone_admin_tenant: tenant
+radosgw_keystone_admin_domain: default
 radosgw_keystone_accepted_roles: Member, _member_, admin
 radosgw_keystone_token_cache_size: 10000
 radosgw_keystone_revocation_internal: 900

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -277,7 +277,13 @@ radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4.address }}"
 radosgw_civetweb_num_threads: 50
 radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
+# for admin_token method, define radosgw_keystone_admin_token
+# for auth_token method, define _user, _password, and _tenant
+radosgw_keystone_auth_method: admin_token
 radosgw_keystone_admin_token: password
+radosgw_keystone_admin_user: username
+radosgw_keystone_admin_password: password
+radosgw_keystone_admin_tenant: tenant
 radosgw_keystone_accepted_roles: Member, _member_, admin
 radosgw_keystone_token_cache_size: 10000
 radosgw_keystone_revocation_internal: 900

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -114,7 +114,13 @@ rgw data = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_ho
 rgw frontends = civetweb port={{ radosgw_civetweb_bind_ip }}:{{ radosgw_civetweb_port }} num_threads={{ radosgw_civetweb_num_threads }}
 {% if radosgw_keystone %}
 rgw keystone url = {{ radosgw_keystone_url }}
+{% if radosgw_keystone_auth_method == 'admin_token' %}
 rgw keystone admin token = {{ radosgw_keystone_admin_token }}
+{% elif radosgw_keystone_auth_method == 'auth_token' %}
+rgw keystone admin user = {{ radosgw_keystone_admin_user }}
+rgw keystone admin password = {{ radosgw_keystone_admin_password }}
+rgw keystone admin tenant = {{ radosgw_keystone_admin_tenant }}
+{% endif %}
 rgw keystone accepted roles = {{ radosgw_keystone_accepted_roles }}
 rgw keystone token cache size = {{ radosgw_keystone_token_cache_size }}
 rgw keystone revocation interval = {{ radosgw_keystone_revocation_internal }}

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -125,7 +125,9 @@ rgw keystone accepted roles = {{ radosgw_keystone_accepted_roles }}
 rgw keystone token cache size = {{ radosgw_keystone_token_cache_size }}
 rgw keystone revocation interval = {{ radosgw_keystone_revocation_internal }}
 rgw s3 auth use keystone = {{ radosgw_s3_auth_use_keystone }}
+{% if radosgw_keystone_ssl | bool %}
 nss db path = {{ radosgw_nss_db_path }}
+{% endif %}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -114,12 +114,14 @@ rgw data = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_ho
 rgw frontends = civetweb port={{ radosgw_civetweb_bind_ip }}:{{ radosgw_civetweb_port }} num_threads={{ radosgw_civetweb_num_threads }}
 {% if radosgw_keystone %}
 rgw keystone url = {{ radosgw_keystone_url }}
+rgw keystone api version = {{ radosgw_keystone_api_version }}
 {% if radosgw_keystone_auth_method == 'admin_token' %}
 rgw keystone admin token = {{ radosgw_keystone_admin_token }}
 {% elif radosgw_keystone_auth_method == 'auth_token' %}
 rgw keystone admin user = {{ radosgw_keystone_admin_user }}
 rgw keystone admin password = {{ radosgw_keystone_admin_password }}
 rgw keystone admin tenant = {{ radosgw_keystone_admin_tenant }}
+rgw keystone admin domain = {{ radosgw_keystone_admin_domain }}
 {% endif %}
 rgw keystone accepted roles = {{ radosgw_keystone_accepted_roles }}
 rgw keystone token cache size = {{ radosgw_keystone_token_cache_size }}

--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -5,7 +5,9 @@
   static: False
 
 - include: openstack-keystone.yml
-  when: radosgw_keystone
+  when:
+    - radosgw_keystone|bool
+    - radosgw_keystone_ssl|bool
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 


### PR DESCRIPTION
* Add support for deploying RGW with Keystone user token authentication instead of requiring the deprecated Keystone admin token be enabled.

* Allow disabling the nss PKI database which is not applicable when PKI auth is not used in Keystone.

* Add the ability to configure RGW using the Keystone v3 API.