### PR TITLE
changes needed for ceph-installer support

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -31,7 +31,7 @@ Ansible playbooks for Ceph
 %install
 mkdir -p %{buildroot}%{_datarootdir}/ceph-ansible
 
-for f in ansible.cfg *.yml *.sample group_vars roles library plugins; do
+for f in ansible.cfg *.yml *.sample group_vars roles library plugins infrastructure-playbooks; do
   cp -a $f %{buildroot}%{_datarootdir}/ceph-ansible
 done
 

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -13,6 +13,8 @@
   - clients
   - iscsigws
   gather_facts: false
+  tags:
+    - always
   tasks:
     # If we can't get python2 installed before any module is used we will fail
     # so just try what we can to get it installed


### PR DESCRIPTION
A couple minor patches needed for https://github.com/ceph/ceph-installer

- include ``infrastructure-playbooks/`` in the rpms

- sets ``gather_facts: True`` in ``site.yml.sample`` as ``ceph-installer`` uses this playbook and requires the usage of ansible facts.