### PR TITLE
fix ceph_custom not usable

### DIFF
--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -18,6 +18,7 @@
     - not ceph_dev
     - not ceph_rhcs
     - not ceph_stable_uca
+    - not ceph_custom
   tags:
     - package-install
 


### PR DESCRIPTION
Only when ceph_origin == "upstream", install_on_redhat.yml will include
redhat_ceph_repository.yml, same as debian.

In redhat_ceph_repository.yml, ceph_custom_repo will be added.

But in check_mandatory_vars.yml, ceph_origin=="upstream" can't be combined
with ceph_custom