### PR TITLE
ceph-agent: do not check for subscription manager for agent install

### DIFF
--- a/roles/ceph-agent/tasks/pre_requisite.yml
+++ b/roles/ceph-agent/tasks/pre_requisite.yml
@@ -1,11 +1,4 @@
 ---
-- name: determine if node is registered with subscription-manager.
-  command: subscription-manager identity
-  register: subscription
-  changed_when: false
-  always_run: true
-  when: ansible_os_family == 'RedHat'
-
 - name: install dependencies
   # XXX Determine what RH repository this will belong to so that it can be
   # properly checked and errored if the repository is not enabled.


### PR DESCRIPTION
Because we shouldn't enforce where the agent is coming from as repos may be set from an ISO or local repo.

Resolves: rhbz#1403576