### PR TITLE
bump ansible testing version to 2.2.1 for the 2.2 environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,9 +36,6 @@ changedir=
   # creates a cluster, purges the cluster and then brings the cluster back up
   purge_cluster_collocated: {toxinidir}/tests/functional/centos/7/journal-collocation
 commands=
-  # install latest stable version of ansible 2.2 from github, this can be removed
-  # when there is a release > 2.2.1.0
-  ansible2.2: pip install --upgrade git+git://github.com/ansible/ansible.git@stable-2.2
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv=
 deps=
   ansible1.9: ansible==1.9.4
   ansible2.1: ansible==2.1
-  ansible2.2: ansible==2.2
+  ansible2.2: ansible==2.2.1
   -r{toxinidir}/tests/requirements.txt
 changedir=
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw xenial cluster using raw_multi_journal OSD scenario


### PR DESCRIPTION
`2.2.1` is not released yet, but this will be what we should rely on once it gets out.