### PR TITLE
common: set apt pinning with Red Hat Ceph Storage

### DIFF
--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
@@ -25,6 +25,14 @@
     - ceph_rhcs
     - ceph_rhcs_iso_install
 
+- name: set apt pinning for red hat ceph storage
+  template:
+    src: "{{ role_path }}/templates/rhcs.pref.j2"
+    dest: /etc/apt/preferences.d/rhcs.pref
+    owner: root
+    group: root
+    mode: 0644
+
 - name: add the red hat storage apt-key
   apt_key:
     data: "{{ lookup('file', role_path+'/files/cephstablerhcs.asc') }}"

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
@@ -3,15 +3,13 @@
 # ISOs have MON, OSD, Tools, and Agent. If ISOs change the layout or provide
 # certain repos depending on the type of node this task will require a more
 # intelligent way to determine the location of the key.
-- name: install the rh ceph storage repository key
+- name: install the red hat ceph storage repository key
   apt_key:
     file: "{{ ceph_rhcs_repository_path }}/MON/release.asc"
     state: present
-  when:
-    - ceph_rhcs
-    - ceph_rhcs_iso_install
+  when: ceph_rhcs_iso_install
 
-- name: add rh ceph storage repositories
+- name: add red hat ceph storage repositories
   apt_repository:
     repo: "deb file://{{ ceph_rhcs_repository_path }}/{{ item }}/ {{ ansible_lsb.codename }} main"
     state: present
@@ -21,9 +19,7 @@
     - "OSD"
     - "Tools"
     - "Agent"
-  when:
-    - ceph_rhcs
-    - ceph_rhcs_iso_install
+  when: ceph_rhcs_iso_install
 
 - name: set apt pinning for red hat ceph storage
   template:
@@ -33,7 +29,7 @@
     group: root
     mode: 0644
 
-- name: add the red hat storage apt-key
+- name: add red hat storage apt-key
   apt_key:
     data: "{{ lookup('file', role_path+'/files/cephstablerhcs.asc') }}"
     state: present
@@ -89,7 +85,7 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when: client_group_name in group_names
 
-- name: install red hat storage NFS gateway
+- name: install red hat storage nfs gateway
   apt:
     name: nfs-ganesha
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"

--- a/roles/ceph-common/templates/rhcs.pref.j2
+++ b/roles/ceph-common/templates/rhcs.pref.j2
@@ -1,0 +1,7 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+# {{ ansible_managed }}
+
+Explanation: Prefer Red Hat packages
+Package: *
+Pin: release o=/Red Hat/
+Pin-Priority: 999


### PR DESCRIPTION
When `ceph_stable_rh_storage` is True, every cluster node should have a
`/etc/apt/preferences.d/rhcs.pref` file with the following contents:

```
Explanation: Prefer Red Hat packages
Package: *
Pin: release o=/Red Hat/
Pin-Priority: 999
```

ceph-deploy already did this when used with ice-setup, and we need to do
the same thing with the ceph-ansible stack.

Closes: #1182

Signed-off-by: Sébastien Han <seb@redhat.com>