### PR TITLE
common: show which file we are waiting for

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -1,7 +1,7 @@
 ---
 # NOTE (leseb): wait for mon discovery and quorum resolution
 # the admin key is not instantaneously created so we have to wait a bit
-- name: wait for client.admin key exists
+- name: "wait for {{ cluster }}.client.admin.keyring exists"
   wait_for:
     path: /etc/ceph/{{ cluster }}.client.admin.keyring
   when: cephx

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -65,7 +65,7 @@
 # NOTE: if we don't wait we will attempt to copy config to ansible host
 # before admin key is ready, preventing future daemons e.g. ceph-mds from
 # properly retrieving key
-- name: wait for client.admin key exists
+- name: "wait for {{ cluster }}.client.admin.keyring exists"
   wait_for:
     path: /etc/ceph/{{ cluster }}.client.admin.keyring
   when: cephx


### PR DESCRIPTION
We can now see the name of the file we are waiting for, depending on the
cluster name this will change.

Signed-off-by: Sébastien Han <seb@redhat.com>