### PR TITLE
fix ceph-rest-api not using correct configure file

### DIFF
--- a/roles/ceph-restapi/tasks/start_restapi.yml
+++ b/roles/ceph-restapi/tasks/start_restapi.yml
@@ -7,6 +7,6 @@
   register: restapi_status
 
 - name: start ceph rest api
-  shell: "nohup ceph-rest-api &"
+  shell: "nohup ceph-rest-api --conf /etc/ceph/{{ cluster }}.conf &"
   changed_when: false
   when: restapi_status.rc != 0


### PR DESCRIPTION
I find when ceph-rest-api started with `--cluster xxx`, it will not read /etc/ceph/xxx.conf
So I use `--conf` here.

The ceph-rest-api is lack of a systemd service.
Maybe droping a systemd service here or ceph/ceph is better....