### PR TITLE
RGW: Add support for usage log configuration

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -300,6 +300,12 @@ dummy:
 #radosgw_keystone_revocation_internal: 900
 #radosgw_s3_auth_use_keystone: "true"
 #radosgw_nss_db_path: /var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_hostname }}/nss
+# Settings for the RGW usage logging described at http://docs.ceph.com/docs/jewel/man/8/radosgw/#usage-logging
+#radosgw_usage_log: false
+#radosgw_usage_log_tick_interval: 30
+#radosgw_usage_log_flush_threshold: 1024
+#radosgw_usage_max_shards: 32
+#radosgw_usage_max_user_shards: 1
 # Rados Gateway options
 #email_address: foo@bar.com
 

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -292,6 +292,12 @@ radosgw_keystone_token_cache_size: 10000
 radosgw_keystone_revocation_internal: 900
 radosgw_s3_auth_use_keystone: "true"
 radosgw_nss_db_path: /var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_hostname }}/nss
+# Settings for the RGW usage logging described at http://docs.ceph.com/docs/jewel/man/8/radosgw/#usage-logging
+radosgw_usage_log: false
+radosgw_usage_log_tick_interval: 30
+radosgw_usage_log_flush_threshold: 1024
+radosgw_usage_max_shards: 32
+radosgw_usage_max_user_shards: 1
 # Rados Gateway options
 email_address: foo@bar.com
 

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -131,6 +131,13 @@ rgw s3 auth use keystone = {{ radosgw_s3_auth_use_keystone }}
 nss db path = {{ radosgw_nss_db_path }}
 {% endif %}
 {% endif %}
+{% if radosgw_usage_log | bool %}
+rgw enable usage log = true
+rgw usage log tick interval = {{ radosgw_usage_log_tick_interval }}
+rgw usage log flush threshold = {{ radosgw_usage_log_flush_threshold }}
+rgw usage max shards = {{ radosgw_usage_max_shards }}
+rgw usage max user shards = {{ radosgw_usage_max_user_shards }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Adds support for configuring the RadosGW usage log described at
http://docs.ceph.com/docs/jewel/man/8/radosgw/#usage-logging.