### PR TITLE
tests: preserve newlines in ansible output when testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
+  # only available for ansible >= 2.2
+  ANSIBLE_STDOUT_CALLBACK = debug
   docker_cluster: PLAYBOOK = site-docker.yml.sample
 deps=
   ansible1.9: ansible==1.9.4


### PR DESCRIPTION
This will make the CI output in jenkins much easier to read.