### PR TITLE
rpm: require Ansible >= 2.2.0.0

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -15,10 +15,10 @@ Source0:        %{name}-%{version}-%{shortcommit}.tar.gz
 
 BuildArch:      noarch
 
-BuildRequires: ansible
+BuildRequires: ansible >= 2.2.0.0
 BuildRequires: python2-devel
 
-Requires: ansible
+Requires: ansible >= 2.2.0.0
 
 %description
 Ansible playbooks for Ceph


### PR DESCRIPTION
This is the only version that our CI uses for testing, so it's the only version we can confidently say works.

Update the RPM packaging to specifically require this version of Ansible.