### PR TITLE
Workaround for broken 'block' syntax

### DIFF
--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -39,46 +39,7 @@
   register: monitor_keyring_conf
   run_once: true
 
-- block:
-  - name: check if /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring already exists
-    stat:
-      path: /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring
-    register: initial_mon_keyring
-
-  - name: fail if /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring doesn't exist
-    fail:
-      msg: "/var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring not found"
-    when:
-      - not initial_mon_keyring.stat.exists
-      - ceph_current_fsid.rc == 0
-
-  - name: get existing initial mon keyring if it already exists but not monitor_keyring.conf in {{ fetch_directory }}
-    shell: |
-      grep key /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring | sed 's/^.*= //'
-    register: monitor_keyring
-    when:
-      - not monitor_keyring_conf.stat.exists
-      - ceph_current_fsid.rc == 0
-
-  - name: test existing initial mon keyring
-    command: ceph --connect-timeout 3 --cluster {{ cluster }} --keyring /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring -n mon. fsid
-    register: test_initial_monitor_keyring
-    ignore_errors: true
-
-  - name: fail if initial mon keyring found doesn't work
-    fail:
-      msg: "Initial mon keyring found doesn't work."
-    when: test_initial_monitor_keyring.rc != 0
-
-  - name: write initial mon keyring in {{ fetch_directory }}/monitor_keyring.conf if it doesn't exist
-    local_action: shell echo {{ monitor_keyring.stdout }} | tee {{ fetch_directory }}/monitor_keyring.conf
-    become: false
-    when:
-      - test_initial_monitor_keyring.rc == 0
-
-  - name: put initial mon keyring in mon kv store
-    command: ceph --cluster {{ cluster }} config-key put initial_mon_keyring {{ monitor_keyring.stdout }}
-    when: test_initial_monitor_keyring.rc == 0
+- include: facts_mon_fsid.yml
   run_once: true
   when:
     - not monitor_keyring_conf.stat.exists

--- a/roles/ceph-common/tasks/facts_mon_fsid.yml
+++ b/roles/ceph-common/tasks/facts_mon_fsid.yml
@@ -1,0 +1,40 @@
+---
+- name: check if /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring already exists
+  stat:
+    path: /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring
+  register: initial_mon_keyring
+
+- name: fail if /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring doesn't exist
+  fail:
+    msg: "/var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring not found"
+  when:
+    - not initial_mon_keyring.stat.exists
+    - ceph_current_fsid.rc == 0
+
+- name: get existing initial mon keyring if it already exists but not monitor_keyring.conf in {{ fetch_directory }}
+  shell: |
+    grep key /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring | sed 's/^.*= //'
+  register: monitor_keyring
+  when:
+    - not monitor_keyring_conf.stat.exists
+    - ceph_current_fsid.rc == 0
+
+- name: test existing initial mon keyring
+  command: ceph --connect-timeout 3 --cluster {{ cluster }} --keyring /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring -n mon. fsid
+  register: test_initial_monitor_keyring
+  ignore_errors: true
+
+- name: fail if initial mon keyring found doesn't work
+  fail:
+    msg: "Initial mon keyring found doesn't work."
+  when: test_initial_monitor_keyring.rc != 0
+
+- name: write initial mon keyring in {{ fetch_directory }}/monitor_keyring.conf if it doesn't exist
+  local_action: shell echo {{ monitor_keyring.stdout }} | tee {{ fetch_directory }}/monitor_keyring.conf
+  become: false
+  when:
+    - test_initial_monitor_keyring.rc == 0
+
+- name: put initial mon keyring in mon kv store
+  command: ceph --cluster {{ cluster }} config-key put initial_mon_keyring {{ monitor_keyring.stdout }}
+  when: test_initial_monitor_keyring.rc == 0


### PR DESCRIPTION
The block syntax in ansible is broken on 2.1 so we work around the
issue introduced in 471be5e by using a task file include.

Fixes #1196 