### PR TITLE
contrib: push all new stable branches to the galaxy

### DIFF
--- a/contrib/push-roles-to-ansible-galaxy.sh
+++ b/contrib/push-roles-to-ansible-galaxy.sh
@@ -29,7 +29,7 @@ function pull_origin {
 function reset_hard_origin {
   # let's bring everything back to normal
   git checkout $LOCAL_BRANCH
-  git fetch origin
+  git fetch origin --prune
   git fetch --tags
   git reset --hard origin/master
 }
@@ -63,7 +63,7 @@ for ROLE in $ROLES; do
   reset_hard_origin
   # First we filter branches by rewriting master with the content of roles/$ROLE
   # this gives us a new commit history
-  for BRANCH in $(git branch -r | egrep 'origin/master|origin/ansible-1.9|origin/stable-' | grep -v origin/HEAD | cut -d '/' -f2); do
+  for BRANCH in $(git branch --list --remotes "origin/stable-*" "origin/master" "origin/ansible-1.9" | cut -d '/' -f2); do
     git checkout -B $BRANCH origin/$BRANCH
     git filter-branch -f --prune-empty --subdirectory-filter roles/$ROLE
     git push -f $REMOTE $BRANCH

--- a/contrib/push-roles-to-ansible-galaxy.sh
+++ b/contrib/push-roles-to-ansible-galaxy.sh
@@ -63,7 +63,7 @@ for ROLE in $ROLES; do
   reset_hard_origin
   # First we filter branches by rewriting master with the content of roles/$ROLE
   # this gives us a new commit history
-  for BRANCH in $BRANCHES; do
+  for BRANCH in $(git branch -r | egrep 'origin/master|origin/ansible-1.9|origin/stable-' | grep -v origin/HEAD | cut -d '/' -f2); do
     git checkout -B $BRANCH origin/$BRANCH
     git filter-branch -f --prune-empty --subdirectory-filter roles/$ROLE
     git push -f $REMOTE $BRANCH


### PR DESCRIPTION
Prior to this patch we were only pushing 'master' and 'ansible-1.9'
branches. Each new release also introduces a new branch so we want to
push it as well.

Yes the 'grep' is a bit ugly, feel free to come up with something nicer :)

Signed-off-by: Sébastien Han <seb@redhat.com>