### PR TITLE
move monitor definition from ceph-mon back to ceph-common

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -145,3 +145,15 @@ nss db path = {{ radosgw_nss_db_path }}
 keyring = /var/lib/ceph/restapi/ceph-restapi/keyring
 log file = /var/log/ceph/ceph-restapi.log
 {% endif %}
+
+{% if groups[mon_group_name] is defined %}
+{% for host in groups[mon_group_name] %}
+{% if hostvars[host]['ansible_fqdn'] is defined and mon_use_fqdn %}
+[mon.{{ hostvars[host]['ansible_fqdn'] }}]
+host= {{ hostvars[host]['ansible_fqdn'] }}
+{% elif hostvars[host]['ansible_hostname'] is defined %}
+[mon.{{ hostvars[host]['ansible_hostname'] }}]
+host= {{ hostvars[host]['ansible_hostname'] }}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -20,19 +20,6 @@
   when:
     - not use_systemd
 
-# legacy ceph system v init scripts require a mon section in order to work
-# Not Ubuntu so we can catch old debian systems that don't use systemd or upstart
-- name: add mon section into ceph.conf for systemv init scripts
-  ini_file:
-    dest: /etc/ceph/{{ cluster }}.conf
-    section: mon.{{ monitor_name }}
-    option: host
-    value: "{{ monitor_name }}"
-    state: present
-  when:
-    - ansible_os_family != "Ubuntu"
-    - ceph_release_num.{{ ceph_stable_release }} < ceph_release_num.infernalis
- 
 # NOTE (jsaintrocc): can't use service module because we need to use the 
 # legacy systemv init for older ceph releases.  Even when the os supports systemd
 # Not Ubuntu so we can catch old debian systems that don't use systemd or upstart


### PR DESCRIPTION
ceph-common will overwrite ceph.conf on every run, so
when ceph-mon also edits the file it will cause an
unnecessary restart of ceph-mon