### PR TITLE
[rtr] Granular Multi-site PULL Variables

### DIFF
--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -30,6 +30,10 @@ dummy:
 # allowing root to not require tty
 #radosgw_user: root
 
+# Multi-site remote pull URL variables
+#rgw_pullport: "{{ radosgw_civetweb_port }}"
+#rgw_pullproto: "http"
+
 ##########
 # DOCKER #
 ##########

--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -31,8 +31,8 @@ dummy:
 #radosgw_user: root
 
 # Multi-site remote pull URL variables
-#rgw_pullport: "{{ radosgw_civetweb_port }}"
-#rgw_pullproto: "http"
+#rgw_pull_port: "{{ radosgw_civetweb_port }}"
+#rgw_pull_proto: "http"
 
 ##########
 # DOCKER #

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -22,6 +22,10 @@ cephx: true
 # allowing root to not require tty
 radosgw_user: root
 
+# Multi-site remote pull URL variables
+rgw_pullport: "{{ radosgw_civetweb_port }}"
+rgw_pullproto: "http"
+
 ##########
 # DOCKER #
 ##########

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -23,8 +23,8 @@ cephx: true
 radosgw_user: root
 
 # Multi-site remote pull URL variables
-rgw_pullport: "{{ radosgw_civetweb_port }}"
-rgw_pullproto: "http"
+rgw_pull_port: "{{ radosgw_civetweb_port }}"
+rgw_pull_proto: "http"
 
 ##########
 # DOCKER #

--- a/roles/ceph-rgw/tasks/multisite/secondary.yml
+++ b/roles/ceph-rgw/tasks/multisite/secondary.yml
@@ -1,13 +1,13 @@
 ---
 - name: fetch the realm
-  command: radosgw-admin realm pull --url={{ rgw_pullproto }}://{{ rgw_pullhost }}:{{ rgw_pullport }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}
+  command: radosgw-admin realm pull --url={{ rgw_pull_proto }}://{{ rgw_pullhost }}:{{ rgw_pull_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}
   run_once: true
   when: ("No such file or directory" in realmcheck.stderr)
   notify:
     - update period
 
 - name: fetch the period
-  command: radosgw-admin period pull --url={{ rgw_pullproto }}://{{ rgw_pullhost }}:{{ rgw_pullport }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}
+  command: radosgw-admin period pull --url={{ rgw_pull_proto }}://{{ rgw_pullhost }}:{{ rgw_pull_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}
   run_once: true
   when: ("No such file or directory" in realmcheck.stderr)
   notify:

--- a/roles/ceph-rgw/tasks/multisite/secondary.yml
+++ b/roles/ceph-rgw/tasks/multisite/secondary.yml
@@ -1,13 +1,13 @@
 ---
 - name: fetch the realm
-  command: radosgw-admin realm pull --url=http://{{ rgw_pullhost }}:{{ radosgw_civetweb_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}
+  command: radosgw-admin realm pull --url={{ rgw_pullproto }}://{{ rgw_pullhost }}:{{ rgw_pullport }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}
   run_once: true
   when: ("No such file or directory" in realmcheck.stderr)
   notify:
     - update period
 
 - name: fetch the period
-  command: radosgw-admin period pull --url=http://{{ rgw_pullhost }}:{{ radosgw_civetweb_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}
+  command: radosgw-admin period pull --url={{ rgw_pullproto }}://{{ rgw_pullhost }}:{{ rgw_pullport }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}
   run_once: true
   when: ("No such file or directory" in realmcheck.stderr)
   notify:


### PR DESCRIPTION
Allowing granular control of the pull host/port/protocol for installs where SSL/443 is used and direct civetweb access isn't necessarily available.

fixes: #1207