### PR TITLE
fix check nmapexist on debian

### DIFF
--- a/roles/ceph-common/tasks/checks/check_firewall.yml
+++ b/roles/ceph-common/tasks/checks/check_firewall.yml
@@ -1,6 +1,6 @@
 ---
 - name: check if nmap is installed
-  local_action: command command -v nmap
+  local_action: shell command -v nmap
   changed_when: false
   failed_when: false
   register: nmapexist


### PR DESCRIPTION
command is a shell-buitin, so `command -v nmap` must use shell module

Signed-off-by: Shengjing Zhu <zsj950618@gmail.com>