### PR TITLE
mon: only put mon initial key in mon kv when cephx is enabled

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -19,7 +19,9 @@
   changed_when: false
   always_run: true
   run_once: true
-  when: is_initial_mon_keyring_in_kv.rc != 0
+  when:
+    - is_initial_mon_keyring_in_kv.rc != 0
+    - cephx
 
 - name: create ceph rest api keyring when mon is not containerized
   command: ceph --cluster {{ cluster }} auth get-or-create client.restapi osd 'allow *' mon 'allow *' -o /etc/ceph/{{ cluster }}.client.restapi.keyring


### PR DESCRIPTION
Task put initial mon keyring in mon kv store from
ceph-mon/tasks/ceph_keys.yml is failing when cephx is disabled. The root
cause is that variable monitor_keyring is not populated by any task from
deploy_monitors.yml.

Fixes: #1211

Signed-off-by: Sébastien Han <seb@redhat.com>