### PR TITLE
mon: make sure osd_pool_default_size is honoured

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -20,7 +20,7 @@
 - name: test if initial mon keyring is in mon kv store
   command: ceph --cluster {{ cluster }} config-key get initial_mon_keyring
   changed_when: false
-  failed_when: false
+  ignore_errors: true
   always_run: true
   run_once: true
   register: is_initial_mon_keyring_in_kv
@@ -80,8 +80,24 @@
     osd_pool_default_pg_num: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}"
   when: ceph_conf_overrides.global.osd_pool_default_pg_num is defined
 
+- name: test if rbd exists
+  command: ceph --cluster {{ cluster }} osd pool stats rbd
+  changed_when: false
+  failed_when: false
+  register: rbd_pool_exist
+
 - include: rbd_pool.yml
-  when: ceph_conf_overrides.global.osd_pool_default_pg_num is defined
+  when: rbd_pool_exist.rc == 0
+
+- include: rbd_pool_pgs.yml
+  when:
+    - rbd_pool_exist.rc == 0
+    - ceph_conf_overrides.global.osd_pool_default_pg_num is defined
+
+- include: rbd_pool_size.yml
+  when:
+    - rbd_pool_exist.rc == 0
+    - ceph_conf_overrides.global.osd_pool_default_size is defined
 
 - include: openstack_config.yml
   when: openstack_config

--- a/roles/ceph-mon/tasks/rbd_pool.yml
+++ b/roles/ceph-mon/tasks/rbd_pool.yml
@@ -15,12 +15,3 @@
   always_run: true
   register: rbd_pool_pgs
 
-- name: destroy and recreate rbd pool if osd_pool_default_pg_num is not honoured
-  shell: |
-    ceph --connect-timeout 5 --cluster {{ cluster }} osd pool rm rbd rbd --yes-i-really-really-mean-it
-    ceph --connect-timeout 5 --cluster {{ cluster }} osd pool create rbd {{ ceph_conf_overrides.global.osd_pool_default_pg_num }}
-  changed_when: false
-  failed_when: false
-  when:
-    - rbd_pool_df.stdout == "0"
-    - rbd_pool_pgs.stdout != "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}"

--- a/roles/ceph-mon/tasks/rbd_pool_pgs.yml
+++ b/roles/ceph-mon/tasks/rbd_pool_pgs.yml
@@ -1,0 +1,10 @@
+---
+- name: destroy and recreate rbd pool if osd_pool_default_pg_num is not honoured
+  shell: |
+    ceph --connect-timeout 5 --cluster {{ cluster }} osd pool rm rbd rbd --yes-i-really-really-mean-it
+    ceph --connect-timeout 5 --cluster {{ cluster }} osd pool create rbd {{ ceph_conf_overrides.global.osd_pool_default_pg_num }}
+  changed_when: false
+  failed_when: false
+  when:
+    - rbd_pool_df.stdout == "0"
+    - rbd_pool_pgs.stdout != "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}"

--- a/roles/ceph-mon/tasks/rbd_pool_size.yml
+++ b/roles/ceph-mon/tasks/rbd_pool_size.yml
@@ -1,0 +1,16 @@
+---
+- name: check size for rbd pool
+  shell: |
+    ceph --connect-timeout 5 --cluster {{ cluster }} osd pool get rbd size | awk '{print $2}'
+  changed_when: false
+  failed_when: false
+  always_run: true
+  register: rbd_pool_size
+
+- name: change rbd pool size if osd_pool_default_size is not honoured
+  command: ceph --connect-timeout 5 --cluster {{ cluster }} osd pool set rbd size {{ ceph_conf_overrides.global.osd_pool_default_size }}
+  changed_when: false
+  failed_when: false
+  when:
+    - rbd_pool_df.stdout == "0"
+    - rbd_pool_size.stdout != "{{ ceph_conf_overrides.global.osd_pool_default_size }}"


### PR DESCRIPTION
This patch makes sure we set the proper pool size on the rbd pool.
Usually during bootstrap the rbd pool size is not honoured so we need to
add this workaround.

Signed-off-by: Sébastien Han <seb@redhat.com>