### PR TITLE
ceph-common: always include release.yml

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -4,6 +4,8 @@
 
 # Set ceph_release
 - include: ./release.yml
+  tags:
+    - always
 
 - include: ./checks/check_firewall.yml
   when: check_firewall


### PR DESCRIPTION
Prior to this change, a playbook run with `--tags` or `--skip-tags` would fail, because the ceph-common role would not include the `release.yml` task, and this file defines critical things like ceph_release.

(cherry picked from commit 63e5b5c4061c1307fa864089f198c338d77561a6)