### PR TITLE
tests: fixes for purge_cluster_collocated

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -287,8 +287,6 @@
      state: absent
 
   tasks:
-  - include_vars: roles/ceph-common/defaults/main.yml
-  - include_vars: roles/ceph-osd/defaults/main.yml
   - include_vars: group_vars/all.yml
     ignore_errors: true
   - include_vars: group_vars/{{ osd_group_name }}.yml

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ whitelist_externals =
     vagrant
     bash
     pip
+    cp
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
@@ -46,8 +47,8 @@ commands=
 
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
 
-  # use infrastructure-playbooks/purge-cluster.yml to purge the cluster
-  purge_cluster_collocated: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/infrastructure-playbooks/purge-cluster.yml --extra-vars="ireallymeanit=yes fetch_directory={changedir}/fetch"
+  purge_cluster_collocated: cp {toxinidir}/infrastructure-playbooks/purge-cluster.yml {toxinidir}/purge-cluster.yml
+  purge_cluster_collocated: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/purge-cluster.yml --extra-vars="ireallymeanit=yes fetch_directory={changedir}/fetch"
   # set up the cluster again
   purge_cluster_collocated: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars="fetch_directory={changedir}/fetch"
   # test that the cluster can be redeployed in a healthy state


### PR DESCRIPTION
I need to remove those include_vars lines because including those default vars overwrites what we have defined here: https://github.com/ceph/ceph-ansible/blob/master/tests/functional/centos/7/journal-collocation/group_vars/all

Because the defaults are being used ``devices`` is set to ``[]`` which causes this task to skip, https://github.com/ceph/ceph-ansible/blob/master/infrastructure-playbooks/purge-cluster.yml#L395, resulting in OSDs not being properly purged.