### PR TITLE
Set empty list as default for osd_directories

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -144,6 +144,7 @@ dummy:
 #osd_directories:
 #  - /var/lib/ceph/osd/mydir1
 #  - /var/lib/ceph/osd/mydir2
+#osd_directories: []
 
 
 # IV. This will partition disks for BlueStore

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -136,6 +136,7 @@ osd_directory: false
 #osd_directories:
 #  - /var/lib/ceph/osd/mydir1
 #  - /var/lib/ceph/osd/mydir2
+osd_directories: []
 
 
 # IV. This will partition disks for BlueStore


### PR DESCRIPTION
As described in issue #1224 leaving this variable undefined may
cause a problem during execution of the ceph-osd role.