### PR TITLE
Enhance RGW config options

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -289,6 +289,7 @@ dummy:
 ## Rados Gateway options
 #
 #radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
+#radosgw_resolve_cname: false # enable for radosgw to resolve DNS CNAME based bucket names
 #radosgw_civetweb_port: 8080 # on Infernalis we get: "set_ports_option: cannot bind to 80: 13 (Permission denied)"
 #radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4.address }}"
 #radosgw_civetweb_num_threads: 50

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -309,6 +309,12 @@ dummy:
 #radosgw_keystone_revocation_internal: 900
 #radosgw_s3_auth_use_keystone: "true"
 #radosgw_nss_db_path: /var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_hostname }}/nss
+# Settings for the RGW usage logging described at http://docs.ceph.com/docs/jewel/man/8/radosgw/#usage-logging
+#radosgw_usage_log: false
+#radosgw_usage_log_tick_interval: 30
+#radosgw_usage_log_flush_threshold: 1024
+#radosgw_usage_max_shards: 32
+#radosgw_usage_max_user_shards: 1
 # Rados Gateway options
 #email_address: foo@bar.com
 

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -292,6 +292,10 @@ dummy:
 #radosgw_civetweb_port: 8080 # on Infernalis we get: "set_ports_option: cannot bind to 80: 13 (Permission denied)"
 #radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4.address }}"
 #radosgw_civetweb_num_threads: 50
+# For additional civetweb configuration options available such as SSL, logging,
+# keepalive, and timeout settings, please see the civetweb docs at
+# https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md
+#radosgw_civetweb_options: "port={{ radosgw_civetweb_bind_ip }}:{{ radosgw_civetweb_port }} num_threads={{ radosgw_civetweb_num_threads }}"
 #radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
 #radosgw_keystone_api_version: 2 # API versions 2 and 3 are supported

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -319,6 +319,9 @@ dummy:
 #radosgw_usage_log_flush_threshold: 1024
 #radosgw_usage_max_shards: 32
 #radosgw_usage_max_user_shards: 1
+# Settings for static website hosting
+#radosgw_static_website: false
+#radosgw_dns_s3website_name: your.subdomain.tld # subdomain used by radosgw for website bucket hosting.
 # Rados Gateway options
 #email_address: foo@bar.com
 

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -284,6 +284,10 @@ mds_max_mds: 3
 radosgw_civetweb_port: 8080 # on Infernalis we get: "set_ports_option: cannot bind to 80: 13 (Permission denied)"
 radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4.address }}"
 radosgw_civetweb_num_threads: 50
+# For additional civetweb configuration options available such as SSL, logging,
+# keepalive, and timeout settings, please see the civetweb docs at
+# https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md
+radosgw_civetweb_options: "port={{ radosgw_civetweb_bind_ip }}:{{ radosgw_civetweb_port }} num_threads={{ radosgw_civetweb_num_threads }}"
 radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
 radosgw_keystone_api_version: 2 # API versions 2 and 3 are supported

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -301,6 +301,12 @@ radosgw_keystone_token_cache_size: 10000
 radosgw_keystone_revocation_internal: 900
 radosgw_s3_auth_use_keystone: "true"
 radosgw_nss_db_path: /var/lib/ceph/radosgw/ceph-radosgw.{{ ansible_hostname }}/nss
+# Settings for the RGW usage logging described at http://docs.ceph.com/docs/jewel/man/8/radosgw/#usage-logging
+radosgw_usage_log: false
+radosgw_usage_log_tick_interval: 30
+radosgw_usage_log_flush_threshold: 1024
+radosgw_usage_max_shards: 32
+radosgw_usage_max_user_shards: 1
 # Rados Gateway options
 email_address: foo@bar.com
 

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -311,6 +311,9 @@ radosgw_usage_log_tick_interval: 30
 radosgw_usage_log_flush_threshold: 1024
 radosgw_usage_max_shards: 32
 radosgw_usage_max_user_shards: 1
+# Settings for static website hosting
+radosgw_static_website: false
+radosgw_dns_s3website_name: your.subdomain.tld # subdomain used by radosgw for website bucket hosting.
 # Rados Gateway options
 email_address: foo@bar.com
 

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -281,6 +281,7 @@ mds_max_mds: 3
 ## Rados Gateway options
 #
 #radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
+radosgw_resolve_cname: false # enable for radosgw to resolve DNS CNAME based bucket names
 radosgw_civetweb_port: 8080 # on Infernalis we get: "set_ports_option: cannot bind to 80: 13 (Permission denied)"
 radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4.address }}"
 radosgw_civetweb_num_threads: 50

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -112,6 +112,7 @@ rgw socket path = /tmp/radosgw-{{ hostvars[host]['ansible_hostname'] }}.sock
 log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[host]['ansible_hostname'] }}.log
 rgw data = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_hostname'] }}
 rgw frontends = civetweb {{ radosgw_civetweb_options }}
+rgw resolve cname = {{ radosgw_resolve_cname | bool }}
 {% if radosgw_keystone %}
 rgw keystone url = {{ radosgw_keystone_url }}
 rgw keystone api version = {{ radosgw_keystone_api_version }}

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -138,6 +138,10 @@ rgw usage log flush threshold = {{ radosgw_usage_log_flush_threshold }}
 rgw usage max shards = {{ radosgw_usage_max_shards }}
 rgw usage max user shards = {{ radosgw_usage_max_user_shards }}
 {% endif %}
+{% if radosgw_static_website | bool %}
+rgw enable static website = {{ radosgw_static_website }}
+rgw dns s3website name = {{ radosgw_dns_s3website_name }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -111,7 +111,7 @@ keyring = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_hos
 rgw socket path = /tmp/radosgw-{{ hostvars[host]['ansible_hostname'] }}.sock
 log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[host]['ansible_hostname'] }}.log
 rgw data = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_hostname'] }}
-rgw frontends = civetweb port={{ radosgw_civetweb_bind_ip }}:{{ radosgw_civetweb_port }} num_threads={{ radosgw_civetweb_num_threads }}
+rgw frontends = civetweb {{ radosgw_civetweb_options }}
 {% if radosgw_keystone %}
 rgw keystone url = {{ radosgw_keystone_url }}
 rgw keystone api version = {{ radosgw_keystone_api_version }}

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -131,6 +131,13 @@ rgw s3 auth use keystone = {{ radosgw_s3_auth_use_keystone }}
 nss db path = {{ radosgw_nss_db_path }}
 {% endif %}
 {% endif %}
+{% if radosgw_usage_log | bool %}
+rgw enable usage log = true
+rgw usage log tick interval = {{ radosgw_usage_log_tick_interval }}
+rgw usage log flush threshold = {{ radosgw_usage_log_flush_threshold }}
+rgw usage max shards = {{ radosgw_usage_max_shards }}
+rgw usage max user shards = {{ radosgw_usage_max_user_shards }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
- Allow for enhanced configurability of the civetweb parameters
- Add switch to enable CNAME bucket resolution (ie. some.website.com.objects.example.com) where bucket name is "some.website.com"
- Ability to enable RGW usage logging and its associated configuration parameters which are detailed at http://docs.ceph.com/docs/jewel/man/8/radosgw/#usage-logging
- Add switch to enable S3-style static website hosting.