### PR TITLE
Remove libcephfs1 from group_vars sample

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -81,10 +81,9 @@ dummy:
 # install source or architecture.
 #debian_ceph_packages:
 #  - ceph
-#  - ceph-common    #|
-#  - ceph-fs-common #|--> yes, they are already all dependencies from 'ceph'
-#  - ceph-fuse      #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
-#  - libcephfs1     #|--> they don't get update so we need to force them
+#  - ceph-common    #|--> yes, they are already all dependencies from 'ceph'
+#  - ceph-fs-common #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
+#  - ceph-fuse      #|--> they don't get update so we need to force them
 
 # Whether or not to install the ceph-test package.
 #ceph_test: False

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -73,10 +73,9 @@ ntp_service_enabled: true
 # install source or architecture.
 debian_ceph_packages:
   - ceph
-  - ceph-common    #|
-  - ceph-fs-common #|--> yes, they are already all dependencies from 'ceph'
-  - ceph-fuse      #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
-                   #|--> they don't get update so we need to force them
+  - ceph-common    #|--> yes, they are already all dependencies from 'ceph'
+  - ceph-fs-common #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
+  - ceph-fuse      #|--> they don't get update so we need to force them
 
 # Whether or not to install the ceph-test package.
 ceph_test: False


### PR DESCRIPTION
The libcephfs1 package was removed from ceph-common in
cb1c06901e02a9f44c24a5d20737a9f33ac8ab2b, however it was not synced
to group_vars/all.yml.sample using the `generate_group_vars_sample.sh`
script. This fixes up the comment formatting in the ceph-common
defaults and brings the group_vars sample back into sync.