### PR TITLE
adds a ceph-docker-common role and enables custom registry usage

### DIFF
--- a/group_vars/all.docker.yml.sample
+++ b/group_vars/all.docker.yml.sample
@@ -6,6 +6,7 @@ dummy:
 ##########
 #docker: true
 #ceph_docker_dev_image: false
+#ceph_docker_registry: docker.io
 
 #######
 # MON #

--- a/roles/ceph-common/tasks/docker/fetch_image.yml
+++ b/roles/ceph-common/tasks/docker/fetch_image.yml
@@ -1,7 +1,7 @@
 ---
 # Normal case - pull image from registry
 - name: pull ceph daemon image
-  command: "docker pull {{ ceph_docker_username }}/{{ ceph_docker_imagename }}:{{ ceph_docker_image_tag }}"
+  command: "docker pull {{ ceph_docker_registry}}/{{ ceph_docker_username }}/{{ ceph_docker_imagename }}:{{ ceph_docker_image_tag }}"
   changed_when: false
   when: ceph_docker_dev_image is undefined or not ceph_docker_dev_image
 

--- a/roles/ceph-docker-common/defaults/main.yml
+++ b/roles/ceph-docker-common/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+ceph_docker_registry: docker.io

--- a/roles/ceph-mds/meta/main.yml
+++ b/roles/ceph-mds/meta/main.yml
@@ -12,3 +12,4 @@ galaxy_info:
     - system
 dependencies:
   - { role: ceph.ceph-common, when: not mds_containerized_deployment }
+  - { role: ceph.ceph-docker-common, when: mds_containerized_deployment }

--- a/roles/ceph-mds/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-mds/tasks/docker/dirs_permissions.yml
@@ -2,7 +2,7 @@
 # NOTE (leseb): we can not use docker inspect with 'format filed' because of
 # https://github.com/ansible/ansible/issues/10156
 - name: inspect ceph version
-  shell: docker inspect "docker.io/{{ ceph_mds_docker_username }}/{{ ceph_mds_docker_imagename }}:{{ ceph_mds_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
+  shell: docker inspect "{{ ceph_docker_registry }}/{{ ceph_mds_docker_username }}/{{ ceph_mds_docker_imagename }}:{{ ceph_mds_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
   changed_when: false
   failed_when: false
   run_once: true

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -20,7 +20,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    -e CEPHFS_CREATE=1 \
    {{ ceph_mds_docker_extra_env }} \
    --name={{ ansible_hostname }} \
-   {{ ceph_mds_docker_username }}/{{ ceph_mds_docker_imagename }}:{{ ceph_mds_docker_image_tag }}
+   {{ ceph_docker_registry }}/{{ ceph_mds_docker_username }}/{{ ceph_mds_docker_imagename }}:{{ ceph_mds_docker_image_tag }}
 ExecStopPost=-/usr/bin/docker stop {{ ansible_hostname }}
 Restart=always
 RestartSec=10s

--- a/roles/ceph-mon/meta/main.yml
+++ b/roles/ceph-mon/meta/main.yml
@@ -12,3 +12,4 @@ galaxy_info:
     - system
 dependencies:
   - { role: ceph.ceph-common, when: not mon_containerized_deployment }
+  - { role: ceph.ceph-docker-common, when: mon_containerized_deployment }

--- a/roles/ceph-mon/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-mon/tasks/docker/dirs_permissions.yml
@@ -2,7 +2,7 @@
 # NOTE (leseb): we can not use docker inspect with 'format filed' because of
 # https://github.com/ansible/ansible/issues/10156
 - name: inspect ceph version
-  shell: docker inspect "docker.io/{{ ceph_mon_docker_username }}/{{ ceph_mon_docker_imagename }}:{{ ceph_mon_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
+  shell: docker inspect "{{ ceph_docker_registry }}/{{ ceph_mon_docker_username }}/{{ ceph_mon_docker_imagename }}:{{ ceph_mon_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
   changed_when: false
   failed_when: false
   run_once: true

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -26,7 +26,7 @@ ExecStart=/usr/bin/docker run --rm --name %i --net=host \
    -e MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface]['ipv4']['address'] }} \
    -e CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }} \
    {{ ceph_mon_docker_extra_env }} \
-    {{ ceph_mon_docker_username }}/{{ ceph_mon_docker_imagename }}:{{ ceph_mon_docker_image_tag }}
+   {{ceph_docker_registry }}/{{ ceph_mon_docker_username }}/{{ ceph_mon_docker_imagename }}:{{ ceph_mon_docker_image_tag }}
 ExecStopPost=-/usr/bin/docker stop %i
 Restart=always
 RestartSec=10s

--- a/roles/ceph-nfs/meta/main.yml
+++ b/roles/ceph-nfs/meta/main.yml
@@ -12,3 +12,4 @@ galaxy_info:
     - system
 dependencies:
   - { role: ceph.ceph-common, when: not nfs_containerized_deployment }
+  - { role: ceph.ceph-docker-common, when: nfs_containerized_deployment }

--- a/roles/ceph-nfs/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-nfs/tasks/docker/dirs_permissions.yml
@@ -2,7 +2,7 @@
 # NOTE (leseb): we can not use docker inspect with 'format filed' because of
 # https://github.com/ansible/ansible/issues/10156
 - name: inspect ceph version
-  shell: docker inspect "{{ ceph_nfs_docker_username }}/{{ ceph_nfs_docker_imagename }}:{{ ceph_nfs_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
+  shell: docker inspect "{{ ceph_docker_registry }}/{{ ceph_nfs_docker_username }}/{{ ceph_nfs_docker_imagename }}:{{ ceph_nfs_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
   changed_when: false
   failed_when: false
   run_once: true

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -20,7 +20,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    -e CEPH_DAEMON=NFS \
    {{ ceph_nfs_docker_extra_env }} \
    --name=nfs-{{ ansible_hostname }} \
-    {{ ceph_nfs_docker_username }}/{{ ceph_nfs_docker_imagename }}:{{ ceph_nfs_docker_image_tag }}
+   {{ ceph_docker_registry }}/{{ ceph_nfs_docker_username }}/{{ ceph_nfs_docker_imagename }}:{{ ceph_nfs_docker_image_tag }}
 ExecStopPost=-/usr/bin/docker stop %i
 Restart=always
 RestartSec=10s

--- a/roles/ceph-osd/meta/main.yml
+++ b/roles/ceph-osd/meta/main.yml
@@ -12,3 +12,4 @@ galaxy_info:
     - system
 dependencies:
   - { role: ceph.ceph-common, when: not osd_containerized_deployment }
+  - { role: ceph.ceph-docker-common, when: osd_containerized_deployment }

--- a/roles/ceph-osd/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-osd/tasks/docker/dirs_permissions.yml
@@ -2,7 +2,7 @@
 # NOTE (leseb): we can not use docker inspect with 'format filed' because of
 # https://github.com/ansible/ansible/issues/10156
 - name: inspect ceph version
-  shell: docker inspect "docker.io/{{ ceph_osd_docker_username }}/{{ ceph_osd_docker_imagename }}:{{ ceph_osd_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
+  shell: docker inspect "{{ ceph_docker_registry }}/{{ ceph_osd_docker_username }}/{{ ceph_osd_docker_imagename }}:{{ ceph_osd_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
   changed_when: false
   failed_when: false
   run_once: true

--- a/roles/ceph-osd/tasks/docker/start_docker_osd.yml
+++ b/roles/ceph-osd/tasks/docker/start_docker_osd.yml
@@ -33,7 +33,7 @@
     -e "OSD_DEVICE={{ item.0 }}" \
     -e CEPH_DAEMON=OSD_CEPH_DISK_PREPARE \
     {{ ceph_osd_docker_prepare_env }} \
-    "{{ ceph_osd_docker_username }}/{{ ceph_osd_docker_imagename }}:{{ ceph_osd_docker_image_tag }}"
+    "{{ ceph_docker_registry }}/{{ ceph_osd_docker_username }}/{{ ceph_osd_docker_imagename }}:{{ ceph_osd_docker_image_tag }}"
   with_together:
     - "{{ ceph_osd_docker_devices }}"
     - "{{ osd_prepared.results }}"
@@ -58,7 +58,7 @@
     -e KV_IP={{kv_endpoint}} \
     -e KV_PORT={{kv_port}} \
     {{ ceph_osd_docker_prepare_env }} \
-    "{{ ceph_osd_docker_username }}/{{ ceph_osd_docker_imagename }}:{{ ceph_osd_docker_image_tag }}" \
+    "{{ ceph_docker_registry }}/{{ ceph_osd_docker_username }}/{{ ceph_osd_docker_imagename }}:{{ ceph_osd_docker_image_tag }}" \
   with_together:
     - "{{ ceph_osd_docker_devices }}"
     - "{{ osd_prepared.results }}"

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/docker run --rm --net=host --pid=host\
    -e OSD_DEVICE=/dev/%i \
    {{ ceph_osd_docker_extra_env }} \
    --name={{ ansible_hostname }}-osd-dev%i \
-   {{ ceph_osd_docker_username }}/{{ ceph_osd_docker_imagename }}:{{ ceph_osd_docker_image_tag }}
+   {{ ceph_docker_registry }}/{{ ceph_osd_docker_username }}/{{ ceph_osd_docker_imagename }}:{{ ceph_osd_docker_image_tag }}
 ExecStop=-/usr/bin/docker stop {{ ansible_hostname }}-osd-dev%i
 Restart=always
 RestartSec=10s

--- a/roles/ceph-rbd-mirror/meta/main.yml
+++ b/roles/ceph-rbd-mirror/meta/main.yml
@@ -15,3 +15,4 @@ galaxy_info:
     - system
 dependencies:
   - { role: ceph.ceph-common, when: not rbd_mirror_containerized_deployment }
+  - { role: ceph.ceph-docker-common, when: rbd_mirror_containerized_deployment }

--- a/roles/ceph-rbd-mirror/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/dirs_permissions.yml
@@ -2,7 +2,7 @@
 # NOTE (leseb): we can not use docker inspect with 'format filed' because of
 # https://github.com/ansible/ansible/issues/10156
 - name: inspect ceph version
-  shell: docker inspect "docker.io/{{ ceph_rbd_mirror_docker_username }}/{{ ceph_rbd_mirror_docker_imagename }}:{{ ceph_rbd_mirror_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
+  shell: docker inspect "{{ ceph_docker_registry}}/{{ ceph_rbd_mirror_docker_username }}/{{ ceph_rbd_mirror_docker_imagename }}:{{ ceph_rbd_mirror_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
   changed_when: false
   failed_when: false
   always_run: true

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -17,7 +17,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    --privileged \
    -e CEPH_DAEMON=RBD_MIRROR \
    --name={{ ansible_hostname }} \
-   {{ ceph_rbd_mirror_docker_username }}/{{ ceph_rbd_mirror_docker_imagename }}:{{ ceph_rbd_mirror_docker_image_tag }}
+   {{ ceph_docker_registry }}/{{ ceph_rbd_mirror_docker_username }}/{{ ceph_rbd_mirror_docker_imagename }}:{{ ceph_rbd_mirror_docker_image_tag }}
 ExecStopPost=-/usr/bin/docker stop {{ ansible_hostname }}
 Restart=always
 RestartSec=10s

--- a/roles/ceph-restapi/meta/main.yml
+++ b/roles/ceph-restapi/meta/main.yml
@@ -12,3 +12,4 @@ galaxy_info:
     - system
 dependencies:
   - { role: ceph.ceph-common, when: not restapi_containerized_deployment }
+  - { role: ceph.ceph-docker-common, when: restapi_containerized_deployment }

--- a/roles/ceph-restapi/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-restapi/tasks/docker/dirs_permissions.yml
@@ -1,6 +1,6 @@
 ---
 - name: inspect ceph version
-  shell: docker inspect "docker.io/{{ ceph_restapi_docker_username }}/{{ ceph_restapi_docker_imagename }}:{{ ceph_restapi_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
+  shell: docker inspect "{{ ceph_docker_registry}}/{{ ceph_restapi_docker_username }}/{{ ceph_restapi_docker_imagename }}:{{ ceph_restapi_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
   changed_when: false
   failed_when: false
   run_once: true

--- a/roles/ceph-restapi/tasks/docker/start_docker_restapi.yml
+++ b/roles/ceph-restapi/tasks/docker/start_docker_restapi.yml
@@ -1,7 +1,7 @@
 ---
 - name: run the ceph rest api docker image
   docker:
-    image: "{{ ceph_restapi_docker_username }}/{{ ceph_restapi_docker_imagename }}:{{ ceph_restapi_docker_image_tag }}"
+    image: "{{ ceph_docker_registry }}/{{ ceph_restapi_docker_username }}/{{ ceph_restapi_docker_imagename }}:{{ ceph_restapi_docker_image_tag }}"
     name: "{{ ansible_hostname }}-ceph-restapi"
     net: host
     expose: "{{ ceph_restapi_port }}"

--- a/roles/ceph-rgw/meta/main.yml
+++ b/roles/ceph-rgw/meta/main.yml
@@ -12,3 +12,4 @@ galaxy_info:
     - system
 dependencies:
   - { role: ceph.ceph-common, when: not rgw_containerized_deployment }
+  - { role: ceph.ceph-docker-common, when: rgw_containerized_deployment }

--- a/roles/ceph-rgw/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-rgw/tasks/docker/dirs_permissions.yml
@@ -2,7 +2,7 @@
 # NOTE (leseb): we can not use docker inspect with 'format filed' because of
 # https://github.com/ansible/ansible/issues/10156
 - name: inspect ceph version
-  shell: docker inspect "docker.io/{{ ceph_rgw_docker_username }}/{{ ceph_rgw_docker_imagename }}:{{ ceph_rgw_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
+  shell: docker inspect "{{ ceph_docker_registry }}/{{ ceph_rgw_docker_username }}/{{ ceph_rgw_docker_imagename }}:{{ ceph_rgw_docker_image_tag }}" | awk -F '=' '/CEPH_VERSION/ { gsub ("\",", "", $2); print $2 }' | uniq
   changed_when: false
   failed_when: false
   always_run: true

--- a/roles/ceph-rgw/templates/ceph-rgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-rgw.service.j2
@@ -19,7 +19,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    -e CEPH_DAEMON=RGW \
    {{ ceph_rgw_docker_extra_env }} \
    --name={{ ansible_hostname }} \
-   {{ ceph_rgw_docker_username }}/{{ ceph_rgw_docker_imagename }}:{{ ceph_rgw_docker_image_tag }}
+   {{ ceph_docker_registry }}/{{ ceph_rgw_docker_username }}/{{ ceph_rgw_docker_imagename }}:{{ ceph_rgw_docker_image_tag }}
 ExecStopPost=-/usr/bin/docker stop {{ ansible_hostname }}
 Restart=always
 RestartSec=10s

--- a/roles/ceph.ceph-docker-common
+++ b/roles/ceph.ceph-docker-common
@@ -1,0 +1,1 @@
+ceph-docker-common


### PR DESCRIPTION
This adds the ability to deploy containers that are stored in a custom registry and not docker.io. Adding a ceph-docker-common role was the easiest way to share the new value of ``ceph_docker_registry`` across all the other roles. Eventually, I think we should move things like ``fetch_images.yml`` out of ``ceph-common`` and into ``ceph-docker-common``.

This is needed for ceph-docker testing as well: https://github.com/ceph/ceph-docker/pull/458