### PR TITLE
mon: run ceph-create-keys after startup for kraken release

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -1,4 +1,15 @@
 ---
+- name: collect admin and bootstrap keys (for or after kraken release)
+  command: ceph-create-keys --cluster {{ cluster }} -i {{ monitor_name }}
+  args:
+    creates: /etc/ceph/{{ cluster }}.client.admin.keyring
+  failed_when: false
+  changed_when: false
+  always_run: true
+  when:
+    - cephx
+    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel
+
 # NOTE (leseb): wait for mon discovery and quorum resolution
 # the admin key is not instantaneously created so we have to wait a bit
 - name: "wait for {{ cluster }}.client.admin.keyring exists"


### PR DESCRIPTION
Followup to #1173 

As part of https://github.com/ceph/ceph/pull/9345 the ceph-mon service no longer implicitly calls `ceph-create-keys` to generate the admin client key.