### PR TITLE
move pool_default_pg_num to ceph-common

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -84,7 +84,7 @@ dummy:
 #  - ceph-common    #|
 #  - ceph-fs-common #|--> yes, they are already all dependencies from 'ceph'
 #  - ceph-fuse      #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
-#  - libcephfs1     #|--> they don't get update so we need to force them
+#                   #|--> they don't get update so we need to force them
 
 # Whether or not to install the ceph-test package.
 #ceph_test: False
@@ -263,6 +263,9 @@ dummy:
 #monitor_address: 0.0.0.0
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 #monitor_address_block: false
+
+## CephFS
+#pool_default_pg_num: 128
 
 ## OSD options
 #

--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -23,7 +23,6 @@ dummy:
 #cephx: true
 
 # CephFS
-#pool_default_pg_num: 128
 #cephfs_data: cephfs_data
 #cephfs_metadata: cephfs_metadata
 #cephfs: cephfs

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -256,6 +256,9 @@ monitor_address: 0.0.0.0
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 monitor_address_block: false
 
+## CephFS
+pool_default_pg_num: 128
+
 ## OSD options
 #
 journal_size: 5120 # OSD journal size in MB

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -15,7 +15,6 @@ monitor_secret: "{{ monitor_keyring.stdout }}"
 cephx: true
 
 # CephFS
-pool_default_pg_num: 128
 cephfs_data: cephfs_data
 cephfs_metadata: cephfs_metadata
 cephfs: cephfs

--- a/tests/functional/centos/7/cluster/group_vars/all
+++ b/tests/functional/centos/7/cluster/group_vars/all
@@ -13,3 +13,4 @@ raw_multi_journal: True
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
+user_config: True

--- a/tests/functional/centos/7/cluster/hosts
+++ b/tests/functional/centos/7/cluster/hosts
@@ -11,3 +11,6 @@ mds0
 
 [rgws]
 rgw0
+
+[clients]
+client0

--- a/tests/functional/centos/7/cluster/vagrant_variables.yml
+++ b/tests/functional/centos/7/cluster/vagrant_variables.yml
@@ -10,7 +10,7 @@ mds_vms: 1
 rgw_vms: 1
 nfs_vms: 0
 rbd_mirror_vms: 0
-client_vms: 0
+client_vms: 1
 iscsi_gw_vms: 0
 
 # Deploy RESTAPI on each of the Monitors

--- a/tests/functional/ubuntu/16.04/cluster/group_vars/all
+++ b/tests/functional/ubuntu/16.04/cluster/group_vars/all
@@ -13,3 +13,4 @@ raw_multi_journal: True
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
+user_config: True

--- a/tests/functional/ubuntu/16.04/cluster/hosts
+++ b/tests/functional/ubuntu/16.04/cluster/hosts
@@ -11,3 +11,6 @@ mds0
 
 [rgws]
 rgw0
+
+[clients]
+client0

--- a/tests/functional/ubuntu/16.04/cluster/vagrant_variables.yml
+++ b/tests/functional/ubuntu/16.04/cluster/vagrant_variables.yml
@@ -10,7 +10,7 @@ mds_vms: 1
 rgw_vms: 1
 nfs_vms: 0
 rbd_mirror_vms: 0
-client_vms: 0
+client_vms: 1
 iscsi_gw_vms: 0
 
 # Deploy RESTAPI on each of the Monitors


### PR DESCRIPTION
The var ``pool_default_pg_num`` is being used in both the ``ceph-client`` and ``ceph-mon`` roles, so move it to ``ceph-common`` where they both can access it.

This resolves https://bugzilla.redhat.com/show_bug.cgi?id=1414213 and https://github.com/ceph/ceph-ansible/issues/1145

This also adds client nodes to our ``centos7_cluster`` and ``xenial_cluster`` testing scenarios.