### PR TITLE
ceph-docker-common: include a meta/main.yml so we can use galaxy

### DIFF
--- a/roles/ceph-docker-common/meta/main.yml
+++ b/roles/ceph-docker-common/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: Sébastien Han
+  description: Installs Ceph
+  license: Apache
+  min_ansible_version: 1.7
+  platforms:
+    - name: Ubuntu
+      versions:
+        - trusty
+  categories:
+    - system
+dependencies: []


### PR DESCRIPTION
This role needs a meta/main.yml before we can upload it to ansible
galaxy.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>