### PR TITLE
docker: make container name configurable

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -89,5 +89,6 @@ dummy:
 #ceph_docker_on_openstack: false
 #mon_docker_privileged: false
 #mon_docker_net_host: true
+#ceph_mon_name: "{{ ansible_hostname }}"
 #ceph_config_keys: [] # DON'T TOUCH ME
 

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -81,4 +81,5 @@ ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NA
 ceph_docker_on_openstack: false
 mon_docker_privileged: false
 mon_docker_net_host: true
+ceph_mon_name: "{{ ansible_hostname }}"
 ceph_config_keys: [] # DON'T TOUCH ME

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -23,6 +23,7 @@ ExecStart=/usr/bin/docker run --rm --name %i --net=host \
    --net=host \
    {% endif -%}
    -e CEPH_DAEMON=MON \
+   -e MON_NAME={{ ceph_mon_name }} \
    -e MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface]['ipv4']['address'] }} \
    -e CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }} \
    {{ ceph_mon_docker_extra_env }} \


### PR DESCRIPTION
You can now use the ceph_mon_name variable to set a different name for
your container. Obviously at your own risk. The default name will still
be the value of ansible_hostname, so the short hostname of the machine.

Closes: #1241
Signed-off-by: Sébastien Han <seb@redhat.com>