### PR TITLE
add unique filter to openstack pool names

### DIFF
--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -1,7 +1,7 @@
 ---
 - name: create openstack pool
   command: ceph --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pg_num }}
-  with_items: "{{ openstack_pools }}"
+  with_items: "{{ openstack_pools | unique }}"
   changed_when: false
   failed_when: false
 


### PR DESCRIPTION
could have scenario where different openstack components would
use the same pool, but the logic would create the same pool
more than once

add unique filter to account for this