### PR TITLE
Backport: Adds ip_version configuration option

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -251,6 +251,8 @@ dummy:
 # will go to monitor_interface if both are defined.
 #monitor_interface: interface
 #monitor_address: 0.0.0.0
+# set to either ipv4 or ipv6, whichever your network is using
+#ip_version: ipv4
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 #monitor_address_block: false
 

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -243,6 +243,8 @@ rbd_client_admin_socket_path: /var/run/ceph # must be writable by QEMU and allow
 # will go to monitor_interface if both are defined.
 monitor_interface: interface
 monitor_address: 0.0.0.0
+# set to either ipv4 or ipv6, whichever your network is using
+ip_version: ipv4
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 monitor_address_block: false
 

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -8,6 +8,9 @@ auth service required = none
 auth client required = none
 auth supported = none
 {% endif %}
+{% if ip_version == 'ipv6'  %}
+ms bind ipv6
+{% endif %}
 {% if not mon_containerized_deployment_with_kv and not mon_containerized_deployment %}
 fsid = {{ fsid }}
 {% endif %}
@@ -37,7 +40,7 @@ mon host = {% for host in groups[mon_group_name] %}
              {% if interface != "interface" %}
                {% for key in hostvars[host].keys() %}
                  {% if hostvars[host][key]['macaddress'] is defined and hostvars[host][key]['device'] is defined and hostvars[host][key]['device'] == interface -%}
-                    {{ hostvars[host][key]['ipv4']['address'] }}
+                    {{ hostvars[host][key][ip_version]['address'] }}
                  {%- endif %}
                {% endfor %}
              {% elif address != "0.0.0.0" -%}


### PR DESCRIPTION
This allows the user to set ip_version to either ipv4 or ipv6. This
resolves a bug where monitor_address is set to an ipv6 address, but the
template fails to render because it's hardcoded to look for an 'ipv4'
key in the ansible facts.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1416010

Signed-off-by: Andrew Schoen <aschoen@redhat.com>

Resolves: bz#1416010
(cherry picked from commit 03cb803bd1bd6da888e0483db40d444cd4ee86e3)

Original PR: https://github.com/ceph/ceph-ansible/pull/1247