### PR TITLE
Use ansible_hostname instead of ansible_host in handler

### DIFF
--- a/roles/ceph-rgw/handlers/main.yml
+++ b/roles/ceph-rgw/handlers/main.yml
@@ -4,5 +4,5 @@
 
 - name: restart rgw
   service:
-    name: ceph-radosgw@rgw.{{ ansible_host }}
+    name: ceph-radosgw@rgw.{{ ansible_hostname }}
     state: restarted


### PR DESCRIPTION
Use hostname instead of host (host can be an IP) and hostname matches the default nomenclature in ceph.conf