### PR TITLE
WIP - remove static references from roles

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -22,7 +22,7 @@
   failed_when: false
   register: activate_osd_disk
   when:
-    - not item.0.get("skipped")
+    - is_device_disk_activate
     - item.0.get("rc", 0) != 0
     - not osd_auto_discovery
     - raw_multi_journal
@@ -47,7 +47,7 @@
   failed_when: false
   register: activate_osd_disk_dmcrypt
   when:
-    - not item.0.get("skipped")
+    - is_device_disk_activate
     - item.0.get("rc", 0) != 0
     - not osd_auto_discovery
     - dmcrypt_dedicated_journal
@@ -74,7 +74,7 @@
   changed_when: false
   failed_when: false
   when:
-    - not item.0.get("skipped")
+    - is_device_disk_activate
     - item.0.get("rc", 0) == 0
     - not osd_auto_discovery
 

--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -49,7 +49,7 @@
   with_items:
     - "{{ journal_ispartition_results.results }}"
   set_fact:
-    fix_partitions_or_labels_for_journals: item.0.rc != 0
+    fix_partitions_or_labels_for_journals: item.0.rc != 0 and (raw_multi_journal or dmcrypt_dedicated_journal)
 
 - name: fix partitions gpt header or labels of the journal devices
   shell: "sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }} || sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }}"

--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -45,6 +45,12 @@
     - (raw_multi_journal or dmcrypt_dedicated_journal)
     - item.0.rc != 0
 
+- name: save flag to fix partitions or labels for journals
+  with_items:
+    - "{{ journal_ispartition_results.results }}"
+  set_fact:
+    fix_partitions_or_labels_for_journals: item.0.rc != 0
+
 - name: fix partitions gpt header or labels of the journal devices
   shell: "sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }} || sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }}"
   with_together:
@@ -53,5 +59,5 @@
   changed_when: false
   when:
     - (raw_multi_journal or dmcrypt_dedicated_journal)
-    - not item.0.get("skipped")
+    - fix_partitions_or_labels_for_journals
     - item.0.get("rc", 0) != 0

--- a/roles/ceph-osd/tasks/check_devices_auto.yml
+++ b/roles/ceph-osd/tasks/check_devices_auto.yml
@@ -49,3 +49,8 @@
   when:
     - ansible_devices is defined
     - item.value.removable == "0"
+
+- name: Set flag for preparing osds with dedicated journals
+  with_dict: "{{ ansible_devices }}"
+  set_fact:
+    prepare_osds_with_dedicated_journals: not (ansible_devices is defined and item.value.removable == "0")

--- a/roles/ceph-osd/tasks/check_devices_auto.yml
+++ b/roles/ceph-osd/tasks/check_devices_auto.yml
@@ -10,6 +10,11 @@
     - ansible_devices is defined
     - item.value.removable == "0"
 
+- name: Save flag for if device is a disk to use during activate osds
+  with_dict: "{{ ansible_devices }}"
+  set_fact:
+    is_device_disk_activate: (ansible_devices is defined) and item.value.removable == "0"
+
 - name: check the partition status of the osd disks (autodiscover disks)
   shell: "parted --script /dev/{{ item.key }} print > /dev/null 2>&1"
   with_dict: "{{ ansible_devices }}"

--- a/roles/ceph-osd/tasks/check_devices_static.yml
+++ b/roles/ceph-osd/tasks/check_devices_static.yml
@@ -7,6 +7,10 @@
   always_run: true
   register: ispartition_results
 
+- name: Save flag for if device is a disk to use during activate osds
+  set_fact:
+    is_device_disk_activate: True
+
 - name: check the partition status of the osd disks
   shell: "parted --script {{ item.1 }} print > /dev/null 2>&1"
   with_together:

--- a/roles/ceph-osd/tasks/check_devices_static.yml
+++ b/roles/ceph-osd/tasks/check_devices_static.yml
@@ -25,7 +25,6 @@
 - name: set flag for whether or not to check gpt headers
   with_together:
     - "{{ ispartition_results.results }}"
-    - "{{ devices }}"
   set_fact:
     fix_partitions_or_labels: item.0.rc != 0
 
@@ -54,3 +53,9 @@
   always_run: true
   register: parted_results
   when: item.0.rc != 0
+
+- name: Set flag for preparing osds with dedicated journals
+  with_together:
+    - "{{ ispartition_results.results }}"
+  set_fact:
+    prepare_osds_with_dedicated_journals: item.0.rc == 0

--- a/roles/ceph-osd/tasks/check_devices_static.yml
+++ b/roles/ceph-osd/tasks/check_devices_static.yml
@@ -18,6 +18,13 @@
   register: osd_partition_status_results
   when: item.0.rc != 0
 
+- name: set flag for whether or not to check gpt headers
+  with_together:
+    - "{{ ispartition_results.results }}"
+    - "{{ devices }}"
+  set_fact:
+    fix_partitions_or_labels: item.0.rc != 0
+
 # NOTE: The following calls to sgdisk are retried because sgdisk is known to
 # fully wipe a device the first time around. There is no need to halt execution
 # of zapping the whole device so these try again. It is easier to use `||` to
@@ -30,7 +37,7 @@
     - "{{ devices }}"
   changed_when: false
   when:
-    - not item.0.get("skipped")
+    - fix_partitions_or_labels
     - item.0.get("rc", 0) != 0
 
 - name: check if a partition named 'ceph' exists

--- a/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
+++ b/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
@@ -15,7 +15,7 @@
     - "{{ raw_journal_devices }}"
   changed_when: false
   when:
-    - item.0.get("skipped") or item.0.get("rc", 0) != 0
+    - prepare_osds_with_dedicated_journals or item.0.get("rc", 0) != 0
     - raw_multi_journal
     - not osd_auto_discovery
 


### PR DESCRIPTION
Adding static will cause roles to be run ( and skipped ) on
every run even when a seperate tag is specified.

For example, if you ran a playbook which uses these roles,
and specify "--tags foo", these ceph roles will still be run
and skipped, even though they are not part of the role.