### PR TITLE
ceph-common: remove absolute path to handler include files

### DIFF
--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -5,16 +5,16 @@
   when: ansible_os_family == 'Debian'
 
 - name: restart ceph mons
-  include: "{{ playbook_dir }}/roles/ceph-common/handlers/restart-mon.yml"
+  include: "./restart-mon.yml"
 
 - name: restart ceph osds
-  include: "{{ playbook_dir }}/roles/ceph-common/handlers/restart-osd.yml"
+  include: "./restart-osd.yml"
 
 - name: restart ceph mdss
-  include: "{{ playbook_dir }}/roles/ceph-common/handlers/restart-mds.yml"
+  include: "./restart-mds.yml"
 
 - name: restart ceph rgws
-  include: "{{ playbook_dir }}/roles/ceph-common/handlers/restart-rgw.yml"
+  include: "./restart-rgw.yml"
 
 - name: restart ceph nfss
   service:


### PR DESCRIPTION
This breaks if the roles don't live in the same place as the playbook.

See: https://github.com/ceph/ceph-ansible/issues/1265

Signed-off-by: Andrew Schoen <aschoen@redhat.com>