### PR TITLE
Backport: Using ini_file with ansible_hostname to ensure each INI block gets th…

### DIFF
--- a/roles/ceph-rgw/tasks/multisite/main.yml
+++ b/roles/ceph-rgw/tasks/multisite/main.yml
@@ -17,11 +17,10 @@
 
 # Continue with common tasks
 - name: add zone to rgw stanza in ceph.conf
-  lineinfile:
+  ini_file:
     dest: "/etc/ceph/{{ cluster }}.conf"
-    regexp: "{{ ansible_host }}"
-    insertafter: "^[client.rgw.{{ ansible_host }}]"
-    line: "rgw_zone = {{ rgw_zone }}"
-    state: present
+    section: "client.rgw.{{ ansible_hostname }}"
+    option: "rgw_zone"
+    value: "{{ rgw_zone }}"
   notify:
     - restart rgw


### PR DESCRIPTION
…e rgw_zone setting in a multi-RGW setup.  Also, ansible_hostname better matches what ceph-common does for the actual hostname (ansible_host != ansible_hostname under all conditions).