### PR TITLE
backport 1274: common: ability to disable handler osd health check

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -330,6 +330,7 @@ dummy:
 #handler_health_mon_check_delay: 10
 #handler_health_osd_check_retries: 40
 #handler_health_osd_check_delay: 30
+#handler_health_osd_check: true
 
 ###################
 # CONFIG OVERRIDE #

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -322,6 +322,7 @@ handler_health_mon_check_retries: 5
 handler_health_mon_check_delay: 10
 handler_health_osd_check_retries: 40
 handler_health_osd_check_delay: 30
+handler_health_osd_check: true
 
 ###################
 # CONFIG OVERRIDE #

--- a/roles/ceph-common/handlers/validate-osd.yml
+++ b/roles/ceph-common/handlers/validate-osd.yml
@@ -17,3 +17,4 @@
   retries: "{{ handler_health_osd_check_retries }}"
   delay: "{{ handler_health_osd_check_delay }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  when: handler_health_osd_check


### PR DESCRIPTION
Signed-off-by: Sébastien Han <seb@redhat.com>