### PR TITLE
fix all ceph components are installed

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -74,8 +74,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - mon_group_name in group_names
-      or ceph_origin == "distro"
-      or ceph_custom
 
 - name: install distro or red hat storage ceph osd
   package:
@@ -83,8 +81,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - osd_group_name in group_names
-      or ceph_origin == "distro"
-      or ceph_custom
 
 - name: install distro or red hat storage ceph mds
   package:
@@ -92,8 +88,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - mds_group_name in group_names
-      or ceph_origin == "distro"
-      or ceph_custom
 
 - name: install distro or red hat storage ceph-fuse
   package:
@@ -101,9 +95,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - client_group_name in group_names
-      or ceph_origin == "distro"
-      or ceph_dev
-      or ceph_custom
 
 - name: install distro or red hat storage ceph base
   package:
@@ -111,8 +102,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - client_group_name in group_names
-      or ceph_origin == "distro"
-      or ceph_custom
 
 - name: install ceph-test
   package:


### PR DESCRIPTION
This is a logic mistake introduced by #1243

previous the logic is:

```
  when:
    - mds_group_name in group_names
    - ansible_pkg_mgr == "yum"
    - ceph_release_num.{{ ceph_release }} > ceph_release_num.infernalis
      or ceph_origin == "distro"
      or ceph_custom
```

The third condition should always be true when we dropped the
infernalis support.