### PR TITLE
ceph-common: set ms bind ipv6 = true in ceph.conf when using ipv6

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -9,7 +9,7 @@ auth client required = none
 auth supported = none
 {% endif %}
 {% if ip_version == 'ipv6'  %}
-ms bind ipv6
+ms bind ipv6 = true
 {% endif %}
 {% if not mon_containerized_deployment_with_kv and not mon_containerized_deployment %}
 fsid = {{ fsid }}


### PR DESCRIPTION
This fixes an issue with parsing the ceph.conf file when ip_version is set to
ipv6.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1419814

Signed-off-by: Andrew Schoen <aschoen@redhat.com>