### PR TITLE
backport: "ceph-common: set ms bind ipv6 = true in ceph.conf when using ipv6 #1285"

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -9,7 +9,7 @@ auth client required = none
 auth supported = none
 {% endif %}
 {% if ip_version == 'ipv6'  %}
-ms bind ipv6
+ms bind ipv6 = true
 {% endif %}
 {% if not mon_containerized_deployment_with_kv and not mon_containerized_deployment %}
 fsid = {{ fsid }}


### PR DESCRIPTION
backport of https://github.com/ceph/ceph-ansible/pull/1285