### PR TITLE
ceph-mon: Fix bug #1242

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -73,7 +73,7 @@
   when:
     - pool_default_pg_num is not defined
     - default_pool_default_pg_num.rc == 0
-    - ceph_conf_overrides.global.osd_pool_default_pg_num is not defined
+    - (osd_pool_default_pg_num_in_overrides is not defined or not osd_pool_default_pg_num_in_overrides)
 
 - set_fact:
     osd_pool_default_pg_num: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}"


### PR DESCRIPTION
We shouldn't test directly the value of
`ceph_conf_overrides.global.osd_pool_default_pg_num` because this can
cause the playbook to fail if the key `global` is not present in
`ceph_conf_overrides`. Therefore we have to use the facts that have been defined earlier.

Fix: #1242

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>