### PR TITLE
Check if ceph_conf_overrides.global is defined before calling it

### DIFF
--- a/roles/ceph-client/tasks/main.yml
+++ b/roles/ceph-client/tasks/main.yml
@@ -3,4 +3,5 @@
 - include: create_users_keys.yml
   when:
     - user_config
+    - global_in_ceph_conf_overrides
     - ceph_conf_overrides.global.osd_pool_default_pg_num is defined

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -7,3 +7,7 @@
     group: "ceph"
     mode: "0600"
   when: cephx
+
+- name: check if global key exists in ceph_conf_overrides
+  set_fact:
+    global_in_ceph_conf_overrides: "{{ 'global' in ceph_conf_overrides }}"

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -77,7 +77,9 @@
 
 - set_fact:
     osd_pool_default_pg_num: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}"
-  when: ceph_conf_overrides.global.osd_pool_default_pg_num is defined
+  when:
+    - global_in_ceph_conf_overrides
+    - ceph_conf_overrides.global.osd_pool_default_pg_num is defined
 
 - name: test if rbd exists
   command: ceph --cluster {{ cluster }} osd pool stats rbd
@@ -91,11 +93,13 @@
 - include: rbd_pool_pgs.yml
   when:
     - rbd_pool_exist.rc == 0
+    - global_in_ceph_conf_overrides
     - ceph_conf_overrides.global.osd_pool_default_pg_num is defined
 
 - include: rbd_pool_size.yml
   when:
     - rbd_pool_exist.rc == 0
+    - global_in_ceph_conf_overrides
     - ceph_conf_overrides.global.osd_pool_default_size is defined
 
 - include: openstack_config.yml


### PR DESCRIPTION
Expand the fix in #1291 to all the playbook in order to get a full coverage.

Fix: #1294
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>