### PR TITLE
Skip facts_mon_fsid.yml if cephx is disabled

### DIFF
--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -42,6 +42,7 @@
 - include: facts_mon_fsid.yml
   run_once: true
   when:
+    - cephx
     - not monitor_keyring_conf.stat.exists
     - ceph_current_fsid.rc == 0
     - mon_group_name in group_names


### PR DESCRIPTION
If cephx is disabled it is not necessary to include `facts_mon_fsid.yml`
in `roles/ceph-common/tasks/facts.yml`.

Fix: #1300
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>