### PR TITLE
rgw-standalone.yml will also now collect keys

### DIFF
--- a/infrastructure-playbooks/rgw-standalone.yml
+++ b/infrastructure-playbooks/rgw-standalone.yml
@@ -1,8 +1,12 @@
 ---
 # Run ceph-rgw role standalone
 
-# Need to load the facts from mons because ceph-common need them to generate the ceph.conf
+# Need to load the facts from mons because ceph-common needs them to generate the ceph.conf
+# and collect keys from a mon to bootstrap the rgw nodes
 - hosts: mons
+  become: True
+  roles:
+    - ceph-fetch-keys
 
 - hosts: rgws
   become: True


### PR DESCRIPTION
This playbook is used to add an rgw node to an existing cluster when you
don't want to rerun the site.yml against your entire cluster again.

This is also used by the api/rgw/configure endpoint of ceph-installer.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>