### PR TITLE
docker: homogenise systemd file location

### DIFF
--- a/roles/ceph-mds/tasks/docker/start_docker_mds.yml
+++ b/roles/ceph-mds/tasks/docker/start_docker_mds.yml
@@ -1,27 +1,20 @@
 ---
-# Use systemd to manage container on Atomic host
 - name: generate systemd unit file
   become: true
   template:
     src: "{{ role_path }}/templates/ceph-mds.service.j2"
-    dest: /var/lib/ceph/ceph-mds@.service
+    dest: /etc/systemd/system/ceph-mds@.service
     owner: "root"
     group: "root"
     mode: "0644"
 
-- name: link systemd unit file for mds instance
-  file:
-    src: /var/lib/ceph/ceph-mds@.service
-    dest: /etc/systemd/system/multi-user.target.wants/ceph-mds@{{ ansible_hostname }}.service
-    state: link
-
 - name: enable systemd unit file for mds instance
-  command: systemctl enable /etc/systemd/system/multi-user.target.wants/ceph-mds@{{ ansible_hostname }}.service
+  shell: systemctl enable ceph-mds@{{ ansible_hostname }}.service
   failed_when: false
   changed_when: false
 
 - name: reload systemd unit files
-  command: systemctl daemon-reload
+  shell: systemctl daemon-reload
   changed_when: false
   failed_when: false
 

--- a/roles/ceph-nfs/tasks/docker/start_docker_nfs.yml
+++ b/roles/ceph-nfs/tasks/docker/start_docker_nfs.yml
@@ -1,22 +1,15 @@
 ---
-# Use systemd to manage container on Atomic host and CoreOS
 - name: generate systemd unit file
   become: true
   template:
-    src: "{{ playbook_dir }}/roles/ceph-nfs/templates/ceph-nfs.service.j2"
-    dest: /var/lib/nfs/ganesha/ceph-nfs@.service
+    src: "{{ role_path }}/templates/ceph-nfs.service.j2"
+    dest: /etc/systemd/system/ceph-nfs@.service
     owner: "root"
     group: "root"
     mode: "0644"
 
-- name: link systemd unit file for NFS instance
-  file:
-    src: /var/lib/nfs/ganesha/ceph-nfs@.service
-    dest: /etc/systemd/system/multi-user.target.wants/ceph-nfs@{{ ansible_hostname }}.service
-    state: link
-
-- name: enable systemd unit file for NFS instance
-  shell: systemctl enable /etc/systemd/system/multi-user.target.wants/ceph-nfs@{{ ansible_hostname }}.service
+- name: enable systemd unit file for nfs instance
+  shell: systemctl enable ceph-nfs@{{ ansible_hostname }}.service
   failed_when: false
   changed_when: false
 
@@ -25,7 +18,7 @@
   changed_when: false
   failed_when: false
 
-- name: systemd start NFS container
+- name: systemd start nfs container
   service:
     name: ceph-nfs@{{ ansible_hostname }}
     state: started
@@ -36,3 +29,4 @@
   wait_for:
       path: "/etc/ceph/{{ cluster }}.conf"
   when: is_atomic
+

--- a/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
+++ b/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
@@ -1,22 +1,15 @@
 ---
-# Use systemd to manage container on Atomic host
 - name: generate systemd unit file
   become: true
   template:
-    src: "{{ playbook_dir }}/roles/ceph-rgw/templates/ceph-rgw.service.j2"
-    dest: /var/lib/ceph/ceph-rgw@.service
+    src: "{{ role_path }}/templates/ceph-rgw.service.j2"
+    dest: /etc/systemd/system/ceph-rgw@.service
     owner: "root"
     group: "root"
     mode: "0644"
 
-- name: link systemd unit file for rgw instance
-  file:
-    src: /var/lib/ceph/ceph-rgw@.service
-    dest: /etc/systemd/system/multi-user.target.wants/ceph-rgw@{{ ansible_hostname }}.service
-    state: link
-
 - name: enable systemd unit file for rgw instance
-  shell: systemctl enable /etc/systemd/system/multi-user.target.wants/ceph-rgw@{{ ansible_hostname }}.service
+  shell: systemctl enable ceph-rgw@{{ ansible_hostname }}.service
   failed_when: false
   changed_when: false
 


### PR DESCRIPTION
So unit files were stored in /var/lib/ceph some where in
/etc/systemd/system. Now they are all under /etc/systemd/system.

closes: #1296

Signed-off-by: Sébastien Han <seb@redhat.com>