### PR TITLE
adds a testing scenario for rolling updates

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -410,3 +410,7 @@ dummy:
 # Set this to true to enable Object access via NFS. Requires an RGW role.
 #nfs_obj_gw: false
 
+# this is only here for usage with the rolling_update.yml playbook
+# do not ever change this here
+#rolling_update: false
+

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -78,7 +78,7 @@
         name: ceph-mon
         state: stopped
         args: id={{ ansible_hostname }}
-      when: ansible_service_mgr == 'systemd'
+      when: ansible_service_mgr == 'upstart'
 
     - name: stop ceph mons with sysvinit
       service:

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -401,3 +401,7 @@ mon_containerized_default_ceph_conf_with_kv: false
 nfs_file_gw: true
 # Set this to true to enable Object access via NFS. Requires an RGW role.
 nfs_obj_gw: false
+
+# this is only here for usage with the rolling_update.yml playbook
+# do not ever change this here
+rolling_update: false

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -285,7 +285,7 @@ mds_max_mds: 3
 #
 #radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
 radosgw_resolve_cname: false # enable for radosgw to resolve DNS CNAME based bucket names
-radosgw_civetweb_port: 8080 # on Infernalis we get: "set_ports_option: cannot bind to 80: 13 (Permission denied)"
+radosgw_civetweb_port: 8080
 radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4.address }}" # when using ipv6 enclose with brackets: "[{{ ansible_default_ipv6.address }}]"
 radosgw_civetweb_num_threads: 50
 # For additional civetweb configuration options available such as SSL, logging,

--- a/roles/ceph-common/tasks/facts.yml
+++ b/roles/ceph-common/tasks/facts.yml
@@ -5,6 +5,9 @@
   always_run: yes
   register: ceph_version
 
+# this task shouldn't run in a rolling_update situation
+# because it blindly picks a mon, which may be down because
+# of the rolling update
 - name: is ceph running already?
   command: ceph --connect-timeout 3 --cluster {{ cluster }} fsid
   changed_when: false
@@ -12,6 +15,14 @@
   always_run: yes
   register: ceph_current_fsid
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  when: not rolling_update
+
+# set this as a default when performing a rolling_update
+# so the rest of the tasks here will succeed
+- set_fact:
+    ceph_current_fsid:
+      rc: 1
+  when: rolling_update
 
 - name: create a local fetch directory if it does not exist
   local_action: file path={{ fetch_directory }} state=directory
@@ -22,7 +33,8 @@
 
 - set_fact:
     fsid: "{{ ceph_current_fsid.stdout }}"
-  when: ceph_current_fsid.rc == 0
+  when:
+    - ceph_current_fsid.rc == 0
 
 - set_fact:
     monitor_name: "{{ ansible_hostname }}"

--- a/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
@@ -6,18 +6,14 @@
   when: ceph_stable
 
 - name: add ceph stable repository
-  package:
-    name: "{{ ceph_mirror }}/rpm-{{ ceph_stable_release }}/{{ ceph_stable_redhat_distro }}/noarch/ceph-release-1-0.{{ ceph_stable_redhat_distro|replace('rhel', 'el') }}.noarch.rpm"
+  yum_repository:
+    name: ceph_stable
+    description: Ceph Stable repo
+    gpgcheck: yes
     state: present
-  changed_when: false
+    gpgkey: "{{ ceph_stable_key }}"
+    baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_stable_release }}/{{ ceph_stable_redhat_distro }}/$basearch"
   when: ceph_stable
-
-- name: change download url to ceph mirror
-  replace:
-    name: /etc/yum.repos.d/ceph.repo
-    regexp: http://download.ceph.com
-    replace: "{{ ceph_mirror }}"
-  when: ceph_mirror != "http://download.ceph.com"
 
 # we must use curl instead of ansible's uri module because SNI support in
 # Python is only available in 2.7.9 and later, and most supported distributions

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt}
+envlist = {ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,update_dmcrypt}
 skipsdist = True
 
 # extra commands for purging clusters
@@ -13,6 +13,16 @@ commands=
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/site.yml.sample --extra-vars="fetch_directory={changedir}/fetch"
   # test that the cluster can be redeployed in a healthy state
+  testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
+
+# extra commands for performing a rolling update
+# currently this hardcodes the release to kraken
+# as we're still installing jewel by default
+[update]
+commands=
+  cp {toxinidir}/infrastructure-playbooks/rolling_update.yml {toxinidir}/rolling_update.yml
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/rolling_update.yml --extra-vars="ceph_stable_release=kraken ireallymeanit=yes fetch_directory={changedir}/fetch"
+
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
 
 [testenv]
@@ -48,6 +58,7 @@ changedir=
   docker_cluster: {toxinidir}/tests/functional/centos/7/docker-cluster
   purge_cluster: {toxinidir}/tests/functional/ubuntu/16.04/cluster
   purge_dmcrypt: {toxinidir}/tests/functional/centos/7/dmcrypt-dedicated-journal
+  update_dmcrypt: {toxinidir}/tests/functional/centos/7/dmcrypt-dedicated-journal
 commands=
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
@@ -59,5 +70,6 @@ commands=
 
   purge_cluster: {[purge]commands}
   purge_dmcrypt: {[purge]commands}
+  update_dmcrypt: {[update]commands}
 
   vagrant destroy --force


### PR DESCRIPTION
This currently tests a rolling update on a cluster using dmcrypt dedicated journals from jewel to kraken. I had to change to using ``yum_repository`` to manage the ``ceph_stable`` repo because the ceph-release package from jewel -> kraken has the same version number and yum does not know to update anything. Also, this ways gives us much more flexibility in using other mirrors.