### PR TITLE
fix grep match pattern for osd ids

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -234,7 +234,7 @@
 
   - name: stop ceph osds on ubuntu
     shell: |
-      for id in $(ls /var/lib/ceph/osd/ |grep -oh '[0-9]*'); do
+      for id in $(ls /var/lib/ceph/osd/ |grep -oP '\d+$'); do
         initctl stop ceph-osd cluster={{ cluster }} id=$id
       done
     failed_when: false

--- a/roles/ceph-common/handlers/restart-osd.yml
+++ b/roles/ceph-common/handlers/restart-osd.yml
@@ -4,7 +4,7 @@
 # for restarting them specifically.
 - name: restart ceph osds
   shell: |
-    for id in $(ls /var/lib/ceph/osd/ |grep -oh '[0-9]*'); do
+    for id in $(ls /var/lib/ceph/osd/ |grep -oP '\d+$'); do
       systemctl restart ceph-osd@$id
       sleep 5
     done

--- a/roles/ceph-common/handlers/validate-osd.yml
+++ b/roles/ceph-common/handlers/validate-osd.yml
@@ -1,7 +1,7 @@
 ---
 - name: collect osds
   shell: |
-    ls /var/lib/ceph/osd/ |grep -oh '[0-9]*'
+    ls /var/lib/ceph/osd/ |grep -oP '\d+$'
   register: osd_ids
 
 - name: wait for ceph osd socket(s)


### PR DESCRIPTION
Some playbooks use [0-9]*, others use \d+$
The latter is more correct since cluster name may contain numbers.

Signed-off-by: Shengjing Zhu <zsj950618@gmail.com>