### PR TITLE
common: fix "disable transparent hugepage"

### DIFF
--- a/roles/ceph-common/tasks/misc/system_tuning.yml
+++ b/roles/ceph-common/tasks/misc/system_tuning.yml
@@ -5,7 +5,8 @@
   failed_when: false
 
 - name: disable transparent hugepage
-  command: "echo never > /sys/kernel/mm/transparent_hugepage/enabled"
+  shell: |
+    echo never > /sys/kernel/mm/transparent_hugepage/enabled
   changed_when: false
   failed_when: false
   when: disable_transparent_hugepage


### PR DESCRIPTION
To configure kernel the task is using "command" module which is not
respect operator ">". So this task just print to "stdout": "never >
/sys/kernel/mm/transparent_hugepage/enabled"

fix: #1319

Signed-off-by: Sébastien Han <seb@redhat.com>