### PR TITLE
group_vars: rm Infernalis comment

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -293,7 +293,7 @@ dummy:
 #
 #radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
 #radosgw_resolve_cname: false # enable for radosgw to resolve DNS CNAME based bucket names
-#radosgw_civetweb_port: 8080 # on Infernalis we get: "set_ports_option: cannot bind to 80: 13 (Permission denied)"
+#radosgw_civetweb_port: 8080
 #radosgw_civetweb_bind_ip: "{{ ansible_default_ipv4.address }}" # when using ipv6 enclose with brackets: "[{{ ansible_default_ipv6.address }}]"
 #radosgw_civetweb_num_threads: 50
 # For additional civetweb configuration options available such as SSL, logging,


### PR DESCRIPTION
As of Infernalis, the Ceph daemons run as an unprivileged "ceph" UID, and this is by design.

Commit f19b765f7995dab4aca46e1885320dc440485ead altered the default civetweb port from 80 to 8080 with a comment in the commit log about "until this gets solved"

Remove the comment about permissions on Infernalis, because this is always going to be the case on the Ceph versions we support, and it is just confusing.

If users want to expose civetweb to s3 clients using privileged TCP ports, they can redirect traffic with iptables, or use a reverse proxy application like HAproxy.