### PR TITLE
DO NOT MERGE: osd: activate - add --cluster support

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -3,7 +3,7 @@
 # partition.
 
 - name: automatically activate osd disk(s) without partitions
-  command: ceph-disk activate "/dev/{{ item.key | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1"
+  command: ceph-disk activate --cluster {{ cluster }} "/dev/{{ item.key | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1"
   ignore_errors: true
   with_dict: "{{ ansible_devices }}"
   when:
@@ -14,7 +14,7 @@
     - osd_auto_discovery
 
 - name: activate osd(s) when device is a disk
-  command: ceph-disk activate {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
+  command: ceph-disk activate --cluster {{ cluster }} {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
   with_together:
     - "{{ ispartition_results.results }}"
     - "{{ devices|unique }}"
@@ -28,7 +28,7 @@
     - raw_multi_journal
 
 - name: automatically activate osd disk(s) without partitions (dmcrypt)
-  command: ceph-disk activate --dmcrypt "/dev/{{ item.key }}"
+  command: ceph-disk activate --cluster {{ cluster }} --dmcrypt "/dev/{{ item.key }}"
   ignore_errors: true
   with_dict: "{{ ansible_devices }}"
   when:
@@ -39,7 +39,7 @@
     - dmcrypt_journal_collocation
 
 - name: activate osd(s) when device is a disk (dmcrypt)
-  command: ceph-disk activate --dmcrypt {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
+  command: ceph-disk activate --cluster {{ cluster }} --dmcrypt {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
   with_together:
     - "{{ ispartition_results.results }}"
     - "{{ devices|unique }}"


### PR DESCRIPTION
As per https://github.com/ceph/ceph/pull/13566 we now need to expose the
--cluster argument when activating a device.

DO NOT MERGE: we need to wait for https://github.com/ceph/ceph/pull/13566 and its backport.
So CI failures are expected.

Signed-off-by: Sébastien Han <seb@redhat.com>