### PR TITLE
ceph-mon: Check if ceph filesystem exists

### DIFF
--- a/roles/ceph-mon/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mon/tasks/create_mds_filesystems.yml
@@ -10,21 +10,31 @@
     - cephfs_metadata
   changed_when: false
 
+- name: check if ceph filesystem already exists
+  command: ceph --cluster {{ cluster }} fs get {{ cephfs }}
+  register: check_existing_cephfs
+  changed_when: false
+  failed_when: false
+  when: inventory_hostname == groups.mons|last
+
 - name: create ceph filesystem
   command: ceph --cluster {{ cluster }} fs new {{ cephfs }} {{ cephfs_metadata }} {{ cephfs_data }}
   changed_when: false
+  when:
+    - inventory_hostname == groups.mons|last
+    - check_existing_cephfs.rc != 0
 
 - name: allow multimds
   command: ceph --cluster {{ cluster }} fs set {{ cephfs }} allow_multimds true --yes-i-really-mean-it
   changed_when: false
   when:
-  - ceph_release_num.{{ ceph_release }} >= ceph_release_num.jewel
-  - mds_allow_multimds
+    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.jewel
+    - mds_allow_multimds
 
 - name: set max_mds
   command: ceph --cluster {{ cluster }} fs set {{ cephfs }} max_mds {{ mds_max_mds }}
   changed_when: false
   when:
-  - ceph_release_num.{{ ceph_release }} >= ceph_release_num.jewel
-  - mds_allow_multimds
-  - mds_max_mds > 1
+    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.jewel
+    - mds_allow_multimds
+    - mds_max_mds > 1


### PR DESCRIPTION
Check if ceph filesystem already exists before creating it.
If the ceph filesystem doesn't exist, execute the task only on one node.

Fix: #1314
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>