### PR TITLE
infra: fix cluster name detection

### DIFF
--- a/infrastructure-playbooks/take-over-existing-cluster.yml
+++ b/infrastructure-playbooks/take-over-existing-cluster.yml
@@ -28,7 +28,7 @@
 
     - name: get the name of the existing ceph cluster
       shell: |
-        grep -lE '\[global\]|fsid' /etc/ceph/*.conf
+        basename $(grep -R fsid /etc/ceph/ | egrep -o '^[^.]*')
       changed_when: false
       register: ceph_conf
 


### PR DESCRIPTION
The previous command was returning /etc/ceph/ceph.conf, we only need
'ceph' to be returned.

Signed-off-by: Sébastien Han <seb@redhat.com>