### PR TITLE
ceph-mon: create openstack pools and keys even for containerized deployments

### DIFF
--- a/group_vars/docker-commons.yml.sample
+++ b/group_vars/docker-commons.yml.sample
@@ -9,4 +9,5 @@ dummy:
 
 
 #ceph_docker_registry: docker.io
+#ceph_mon_docker_enable_centos_extra_repo: false
 

--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -77,7 +77,7 @@ dummy:
 ##########
 # DOCKER #
 ##########
-
+#docker_exec_cmd:
 #mon_containerized_deployment: false
 #mon_containerized_deployment_with_kv: false
 # This is currently in ceph-common defaults because it is shared with ceph-nfs
@@ -91,5 +91,4 @@ dummy:
 #mon_docker_privileged: false
 #mon_docker_net_host: true
 #ceph_config_keys: [] # DON'T TOUCH ME
-#ceph_mon_docker_enable_centos_extra_repo: false
 

--- a/roles/ceph-docker-common/tasks/main.yml
+++ b/roles/ceph-docker-common/tasks/main.yml
@@ -13,3 +13,12 @@
 
 - include: ./pre_requisites/prerequisites.yml
   when: not is_atomic
+
+# NOTE(guits): would be nice to refact this block with L39-45 in roles/ceph-common/tasks/facts.yml
+- set_fact:
+    monitor_name: "{{ ansible_hostname }}"
+  when: not mon_use_fqdn
+
+- set_fact:
+    monitor_name: "{{ ansible_fqdn }}"
+  when: mon_use_fqdn

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -69,7 +69,7 @@ openstack_keys:
 ##########
 # DOCKER #
 ##########
-
+docker_exec_cmd:
 mon_containerized_deployment: false
 mon_containerized_deployment_with_kv: false
 # This is currently in ceph-common defaults because it is shared with ceph-nfs

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -42,44 +42,7 @@
     - cephx
     - groups[restapi_group_name] is defined
 
-# NOTE(leseb): we add a conditional for backward compatibility
-# so people that had 'pool_default_pg_num' declared will get
-# the same behaviour
-#
-- name: check if does global key exist in ceph_conf_overrides
-  set_fact:
-    global_in_ceph_conf_overrides: "{{ 'global' in ceph_conf_overrides }}"
-
-- name: check if ceph_conf_overrides.global.osd_pool_default_pg_num is set
-  set_fact:
-    osd_pool_default_pg_num_in_overrides: "{{ 'osd_pool_default_pg_num' in ceph_conf_overrides.global }}"
-  when: global_in_ceph_conf_overrides
-
-- name: get default value for osd_pool_default_pg_num
-  shell: |
-    ceph --cluster {{ cluster }} daemon mon.{{ monitor_name }} config get osd_pool_default_pg_num | grep -Po '(?<="osd_pool_default_pg_num": ")[^"]*'
-  failed_when: false
-  changed_when: false
-  run_once: true
-  register: default_pool_default_pg_num
-  when: (pool_default_pg_num is not defined or not global_in_ceph_conf_overrides)
-
-- set_fact:
-    osd_pool_default_pg_num: "{{ pool_default_pg_num }}"
-  when: pool_default_pg_num is defined
-
-- set_fact:
-    osd_pool_default_pg_num: "{{ default_pool_default_pg_num.stdout }}"
-  when:
-    - pool_default_pg_num is not defined
-    - default_pool_default_pg_num.rc == 0
-    - (osd_pool_default_pg_num_in_overrides is not defined or not osd_pool_default_pg_num_in_overrides)
-
-- set_fact:
-    osd_pool_default_pg_num: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}"
-  when:
-    - global_in_ceph_conf_overrides
-    - ceph_conf_overrides.global.osd_pool_default_pg_num is defined
+- include: set_osd_pool_default_pg_num.yml
 
 - name: test if rbd exists
   command: ceph --cluster {{ cluster }} osd pool stats rbd
@@ -103,7 +66,9 @@
     - ceph_conf_overrides.global.osd_pool_default_size is defined
 
 - include: openstack_config.yml
-  when: openstack_config
+  when:
+    - openstack_config
+    - inventory_hostname == groups.mons|last
 
 - name: find ceph keys
   shell: ls -1 /etc/ceph/*.keyring

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -44,6 +44,10 @@
 - include: selinux.yml
   when: ansible_os_family == 'RedHat'
 
+- name: set docker_exec_cmd fact
+  set_fact:
+    docker_exec_cmd: "docker exec ceph-mon-{{ ansible_hostname }}"
+
 - include: start_docker_monitor.yml
 
 - name: wait for monitor socket to exist
@@ -76,3 +80,11 @@
     - groups[restapi_group_name] is defined
     - inventory_hostname == groups.mons|last
     - not mon_containerized_deployment_with_kv
+
+- include: "{{ playbook_dir }}/roles/ceph-mon/tasks/set_osd_pool_default_pg_num.yml"
+
+# create openstack pools only when all mons are up.
+- include: "{{ playbook_dir }}/roles/ceph-mon/tasks/openstack_config.yml"
+  when:
+    - openstack_config
+    - inventory_hostname == groups.mons|last

--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -1,12 +1,12 @@
 ---
 - name: create openstack pool
-  command: ceph --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pg_num }}
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pg_num }}"
   with_items: "{{ openstack_pools | unique }}"
   changed_when: false
   failed_when: false
 
 - name: create openstack keys
-  command: ceph --cluster {{ cluster }} auth get-or-create {{ item.name }} {{ item.value }} -o /etc/ceph/{{ cluster }}.{{ item.name }}.keyring
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} auth get-or-create {{ item.name }} {{ item.value }} -o /etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
   args:
     creates: /etc/ceph/{{ cluster }}.{{ item.name }}.keyring
   with_items: "{{ openstack_keys }}"

--- a/roles/ceph-mon/tasks/set_osd_pool_default_pg_num.yml
+++ b/roles/ceph-mon/tasks/set_osd_pool_default_pg_num.yml
@@ -1,0 +1,38 @@
+# NOTE(leseb): we add a conditional for backward compatibility
+# so people that had 'pool_default_pg_num' declared will get
+# the same behaviour
+#
+- name: check if does global key exist in ceph_conf_overrides
+  set_fact:
+    global_in_ceph_conf_overrides: "{{ 'global' in ceph_conf_overrides }}"
+
+- name: check if ceph_conf_overrides.global.osd_pool_default_pg_num is set
+  set_fact:
+    osd_pool_default_pg_num_in_overrides: "{{ 'osd_pool_default_pg_num' in ceph_conf_overrides.global }}"
+  when: global_in_ceph_conf_overrides
+
+- name: get default value for osd_pool_default_pg_num
+  shell: |
+   {{ docker_exec_cmd }} ceph --cluster {{ cluster }} daemon mon.{{ monitor_name }} config get osd_pool_default_pg_num | grep -Po '(?<="osd_pool_default_pg_num": ")[^"]*'
+  failed_when: false
+  changed_when: false
+  run_once: true
+  register: default_pool_default_pg_num
+  when: pool_default_pg_num is not defined or not global_in_ceph_conf_overrides
+
+- set_fact:
+    osd_pool_default_pg_num: "{{ pool_default_pg_num }}"
+  when: pool_default_pg_num is defined
+
+- set_fact:
+    osd_pool_default_pg_num: "{{ default_pool_default_pg_num.stdout }}"
+  when:
+    - pool_default_pg_num is not defined
+    - default_pool_default_pg_num.rc == 0
+    - (osd_pool_default_pg_num_in_overrides is not defined or not osd_pool_default_pg_num_in_overrides)
+
+- set_fact:
+    osd_pool_default_pg_num: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}"
+  when:
+    - global_in_ceph_conf_overrides
+    - ceph_conf_overrides.global.osd_pool_default_pg_num is defined


### PR DESCRIPTION
Add possibility to create openstack pools and keys even for containerized deployments

Fix: #1321 
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>