### PR TITLE
rgw: remove sudoers file

### DIFF
--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -25,11 +25,6 @@ dummy:
 #
 #cephx: true
 
-# Used for the sudo exception while starting the radosgw process
-# a new entry /etc/sudoers.d/ceph will be created
-# allowing root to not require tty
-#radosgw_user: root
-
 # Multi-site remote pull URL variables
 #rgw_pull_port: "{{ radosgw_civetweb_port }}"
 #rgw_pull_proto: "http"

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -17,11 +17,6 @@ copy_admin_key: false
 #
 cephx: true
 
-# Used for the sudo exception while starting the radosgw process
-# a new entry /etc/sudoers.d/ceph will be created
-# allowing root to not require tty
-radosgw_user: root
-
 # Multi-site remote pull URL variables
 rgw_pull_port: "{{ radosgw_civetweb_port }}"
 rgw_pull_proto: "http"

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -40,12 +40,3 @@
     group: "ceph"
     mode: "0600"
   when: cephx
-
-- name: generate rados gateway sudoers file
-  template:
-    src: ceph.j2
-    dest: /etc/sudoers.d/ceph
-    owner: root
-    group: root
-    mode: 0400
-  when: ansible_distribution != "Ubuntu"

--- a/roles/ceph-rgw/templates/ceph.j2
+++ b/roles/ceph-rgw/templates/ceph.j2
@@ -1,2 +1,0 @@
-# {{ ansible_managed }}
-Defaults:{{ radosgw_user }} !requiretty


### PR DESCRIPTION
This was needed for Hammer and older version, not needed anymore since
we have a 'ceph' user to run ceph processes.

Signed-off-by: Sébastien Han <seb@redhat.com>