### PR TITLE
 - add dependencies for redhat 7 upstream install

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -38,7 +38,8 @@
 
 - include: ./pre_requisites/prerequisite_redhat_install.yml
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version >= 7
     - not ceph_rhcs_iso_install
   tags:
     - package-install

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -40,7 +40,7 @@
   when:
     - ansible_distribution == "RedHat"
     - ansible_distribution_major_version >= 7
-    - not ceph_rhcs_iso_install
+    - not ceph_rhcs
   tags:
     - package-install
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -38,8 +38,8 @@
 
 - include: ./pre_requisites/prerequisite_redhat_install.yml
   when:
-    ansible_os_family == 'RedHat' and
-    not ceph_rhcs_iso_install
+    - ansible_os_family == 'RedHat'
+    - not ceph_rhcs_iso_install
   tags:
     - package-install
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
@@ -47,8 +47,8 @@
 
 - include: ./installs/install_on_redhat.yml
   when:
-    ansible_os_family == 'RedHat' and
-    not ceph_rhcs_iso_install
+    - ansible_os_family == 'RedHat'
+    - not ceph_rhcs_iso_install
   tags:
     - package-install
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -36,6 +36,15 @@
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 
+- include: ./pre_requisites/prerequisite_redhat_install.yml
+  when:
+    ansible_os_family == 'RedHat' and
+    not ceph_rhcs_iso_install
+  tags:
+    - package-install
+  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
+  static: False
+
 - include: ./installs/install_on_redhat.yml
   when:
     ansible_os_family == 'RedHat' and

--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_redhat_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_redhat_install.yml
@@ -1,0 +1,36 @@
+---
+- name: determine if node is registered with subscription-manager.
+  command: subscription-manager identity
+  register: subscription
+  changed_when: false
+  always_run: true
+
+- name: check if the rhel 7 extras repo is already present
+  shell: yum --noplugins --cacheonly repolist | grep -sq rhel-7-server-extras-rpms
+  changed_when: false
+  failed_when: false
+  register: rh_extras_repo
+  always_run: true
+  when: mon_group_name in group_names
+
+- name: enable rhel 7 extras repository
+  command: subscription-manager repos --enable rhel-7-server-extras-rpms
+  changed_when: false
+  when:
+    - mon_group_name in group_names
+    - rh_extras_repo.rc != 0
+
+- name: check if the EPEL repo is already present
+  shell: yum --noplugins --cacheonly repolist | grep -sq ^epel/{{ ansible_architecture }}
+  changed_when: false
+  failed_when: false
+  register: rh_epel_repo
+  always_run: true
+  when: mon_group_name in group_names
+
+- name: enable EPEL repository
+  shell: sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+  changed_when: false
+  when:
+    - mon_group_name in group_names
+    - rh_epel_repo.rc != 0

--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_redhat_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_redhat_install.yml
@@ -11,7 +11,9 @@
   failed_when: false
   register: rh_extras_repo
   always_run: true
-  when: mon_group_name in group_names
+  when:
+    - (mon_group_name in group_names or client_group_name in group_names)
+
 
 - name: enable rhel 7 extras repository
   command: subscription-manager repos --enable rhel-7-server-extras-rpms
@@ -27,12 +29,13 @@
   failed_when: false
   register: rh_epel_repo
   always_run: true
-  when: mon_group_name in group_names
+  when:
+    - (mon_group_name in group_names or client_group_name in group_names)
 
 - name: enable epel repository
   yum:
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
     state: installed
   when:
-    - mon_group_name in group_names
+    - (mon_group_name in group_names or client_group_name in group_names)
     - rh_epel_repo.rc != 0

--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_redhat_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_redhat_install.yml
@@ -14,7 +14,6 @@
   when:
     - (mon_group_name in group_names or client_group_name in group_names)
 
-
 - name: enable rhel 7 extras repository
   command: subscription-manager repos --enable rhel-7-server-extras-rpms
   changed_when: false

--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_redhat_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_redhat_install.yml
@@ -21,7 +21,8 @@
     - rh_extras_repo.rc != 0
 
 - name: check if the epel repo is already present
-  shell: yum --noplugins --cacheonly repolist | grep -sq ^epel/{{ ansible_architecture }}
+  shell: |
+    yum --noplugins --cacheonly repolist | grep -sq ^epel/{{ ansible_architecture }}
   changed_when: false
   failed_when: false
   register: rh_epel_repo
@@ -32,7 +33,6 @@
   yum:
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
     state: installed
-  changed_when: false
   when:
     - mon_group_name in group_names
     - rh_epel_repo.rc != 0

--- a/roles/ceph-common/tasks/pre_requisites/prerequisite_redhat_install.yml
+++ b/roles/ceph-common/tasks/pre_requisites/prerequisite_redhat_install.yml
@@ -1,5 +1,5 @@
 ---
-- name: determine if node is registered with subscription-manager.
+- name: determine if node is registered with subscription-manager
   command: subscription-manager identity
   register: subscription
   changed_when: false
@@ -20,7 +20,7 @@
     - mon_group_name in group_names
     - rh_extras_repo.rc != 0
 
-- name: check if the EPEL repo is already present
+- name: check if the epel repo is already present
   shell: yum --noplugins --cacheonly repolist | grep -sq ^epel/{{ ansible_architecture }}
   changed_when: false
   failed_when: false
@@ -28,8 +28,10 @@
   always_run: true
   when: mon_group_name in group_names
 
-- name: enable EPEL repository
-  shell: sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+- name: enable epel repository
+  yum:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+    state: installed
   changed_when: false
   when:
     - mon_group_name in group_names


### PR DESCRIPTION
 add the repos needed for package dependencies as instructed in
 the ceph docs:
  http://docs.ceph.com/docs/master/start/quick-start-preflight/#rhel-centos

 the packages have been moved to the extras repo:
  http://pkgs.fedoraproject.org/cgit/rpms/python-flask.git/commit/?h=epel7