### PR TITLE
ceph-docker: fix bootstrap directories permissions

### DIFF
--- a/group_vars/docker-commons.yml.sample
+++ b/group_vars/docker-commons.yml.sample
@@ -7,7 +7,12 @@
 # file as a good configuration file when no variable in it.
 dummy:
 
-
 #ceph_docker_registry: docker.io
 #ceph_docker_enable_centos_extra_repo: false
+
+# Set uid/gid to default '64045' for bootstrap directories.
+# '64045' is used for debian based distros. It must be set to 167 in case of rhel based distros.
+# These values have to be set according to the base OS used by the container image, NOT the host.
+#bootstrap_dirs_owner: "64045"
+#bootstrap_dirs_group: "64045"
 

--- a/roles/ceph-docker-common/defaults/main.yml
+++ b/roles/ceph-docker-common/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
-
 ceph_docker_registry: docker.io
 ceph_docker_enable_centos_extra_repo: false
+
+# Set uid/gid to default '64045' for bootstrap directories.
+# '64045' is used for debian based distros. It must be set to 167 in case of rhel based distros.
+# These values have to be set according to the base OS used by the container image, NOT the host.
+bootstrap_dirs_owner: "64045"
+bootstrap_dirs_group: "64045"

--- a/roles/ceph-docker-common/tasks/main.yml
+++ b/roles/ceph-docker-common/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - include: system_checks.yml
 
-
 - name: check if it is atomic host
   stat: path=/run/ostree-booted
   register: stat_ostree

--- a/roles/ceph-mds/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-mds/tasks/docker/dirs_permissions.yml
@@ -3,8 +3,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: "64045"
-    group: "64045"
+    owner: "{{ bootstrap_dirs_owner }}"
+    group: "{{ bootstrap_dirs_group }}"
     mode: "0755"
   with_items:
     - /etc/ceph/

--- a/roles/ceph-mon/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-mon/tasks/docker/dirs_permissions.yml
@@ -3,8 +3,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: "64045"
-    group: "64045"
+    owner: "{{ bootstrap_dirs_owner }}"
+    group: "{{ bootstrap_dirs_group }}"
     mode: "0755"
   with_items:
     - /etc/ceph/

--- a/roles/ceph-nfs/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-nfs/tasks/docker/dirs_permissions.yml
@@ -3,8 +3,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: "64045"
-    group: "64045"
+    owner: "{{ bootstrap_dirs_owner }}"
+    group: "{{ bootstrap_dirs_group }}"
     mode: "0755"
   with_items:
     - /etc/ceph/

--- a/roles/ceph-osd/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-osd/tasks/docker/dirs_permissions.yml
@@ -3,8 +3,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: "64045"
-    group: "64045"
+    owner: "{{ bootstrap_dirs_owner }}"
+    group: "{{ bootstrap_dirs_group }}"
     mode: "0755"
   with_items:
     - /etc/ceph/

--- a/roles/ceph-rbd-mirror/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/dirs_permissions.yml
@@ -3,8 +3,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: "64045"
-    group: "64045"
+    owner: "{{ bootstrap_dirs_owner }}"
+    group: "{{ bootstrap_dirs_group }}"
     mode: "0755"
   with_items:
     - /etc/ceph/

--- a/roles/ceph-restapi/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-restapi/tasks/docker/dirs_permissions.yml
@@ -3,8 +3,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: "64045"
-    group: "64045"
+    owner: "{{ bootstrap_dirs_owner }}"
+    group: "{{ bootstrap_dirs_group }}"
     mode: "0755"
   with_items:
     - /etc/ceph/

--- a/roles/ceph-rgw/tasks/docker/dirs_permissions.yml
+++ b/roles/ceph-rgw/tasks/docker/dirs_permissions.yml
@@ -3,8 +3,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: "64045"
-    group: "64045"
+    owner: "{{ bootstrap_dirs_owner }}"
+    group: "{{ bootstrap_dirs_group }}"
     mode: "0755"
   with_items:
     - /etc/ceph/


### PR DESCRIPTION
Make bootstrap directories permissions work for both RedHat and Debian
os families.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
Fix: #1338