### PR TITLE
check_system: improve RHCS support message and version comparison

### DIFF
--- a/roles/ceph-common/tasks/checks/check_system.yml
+++ b/roles/ceph-common/tasks/checks/check_system.yml
@@ -14,12 +14,12 @@
     msg: "Distribution not supported {{ ansible_os_family }}"
   when: "'{{ ansible_os_family }}' not in ['Debian', 'RedHat']"
 
-- name: fail on unsupported distribution for red hat storage
+- name: fail on unsupported distribution for red hat ceph storage
   fail:
-    msg: "Distribution not supported {{ ansible_distribution_version }} by Red Hat Ceph Storage, only RHEL 7.1"
+    msg: "Distribution not supported {{ ansible_distribution_version }} by Red Hat Ceph Storage, only RHEL 7"
   when:
     - ceph_rhcs
-    - ansible_distribution_version | version_compare('7.1', '<')
+    - ansible_distribution_version | version_compare('7.3', '<')
 
 - name: fail on unsupported distribution for ubuntu cloud archive
   fail:


### PR DESCRIPTION
"red hat storage" -> "red hat ceph storage"

"RHEL 7.1" -> "RHEL 7"

and make the version number check verify the very latest version

https://bugzilla.redhat.com/show_bug.cgi?id=1354059