### PR TITLE
avoid setting vfs_cache_pressure

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -383,7 +383,6 @@ dummy:
 #  - { name: kernel.pid_max, value: 4194303 }
 #  - { name: fs.file-max, value: 26234859 }
 #  - { name: vm.zone_reclaim_mode, value: 0 }
-#  - { name: vm.vfs_cache_pressure, value: 50 }
 #  - { name: vm.swappiness, value: 10 }
 #  - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }
 

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -375,7 +375,6 @@ os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
   - { name: vm.zone_reclaim_mode, value: 0 }
-  - { name: vm.vfs_cache_pressure, value: 50 }
   - { name: vm.swappiness, value: 10 }
   - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }
 


### PR DESCRIPTION
From Josh Durgin, "I'd recommend not setting vfs_cache_pressure in ceph-ansible. The syncfs issue is still there, and has caused real problems in the past, whereas there hasn't been good data showing lower vfs_cache_pressure is very helpful - the only cases I'm aware of have shown it makes little difference to performance."

https://bugzilla.redhat.com/show_bug.cgi?id=1395451