### PR TITLE
tests: adds an update_cluster testing scenario

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt}
+envlist = {ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster}
 skipsdist = True
 
 # extra commands for purging clusters
@@ -63,6 +63,7 @@ changedir=
   purge_cluster: {toxinidir}/tests/functional/ubuntu/16.04/cluster
   purge_dmcrypt: {toxinidir}/tests/functional/centos/7/dmcrypt-dedicated-journal
   update_dmcrypt: {toxinidir}/tests/functional/centos/7/dmcrypt-dedicated-journal
+  update_cluster: {toxinidir}/tests/functional/centos/7/cluster
 commands=
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
@@ -75,5 +76,6 @@ commands=
   purge_cluster: {[purge]commands}
   purge_dmcrypt: {[purge]commands}
   update_dmcrypt: {[update]commands}
+  update_cluster: {[update]commands}
 
   vagrant destroy --force


### PR DESCRIPTION
This updates the centos 7 cluster scenario from jewel to kraken using
the rolling_update playbook.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>