### PR TITLE
calamari: Add debugging option

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -42,6 +42,9 @@ dummy:
 # Enable the Calamari-backed REST API on a Monitor
 #calamari: false
 
+# Enable debugging for Calamari
+#calamari_debug: false
+
 #############
 # OPENSTACK #
 #############

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -34,6 +34,9 @@ secure_cluster_flags:
 # Enable the Calamari-backed REST API on a Monitor
 calamari: false
 
+# Enable debugging for Calamari
+calamari_debug: false
+
 #############
 # OPENSTACK #
 #############

--- a/roles/ceph-mon/tasks/calamari.yml
+++ b/roles/ceph-mon/tasks/calamari.yml
@@ -6,5 +6,16 @@
   tags:
     - package-install
 
+- name: increase calamari logging level when debug is on
+  ini_file:
+    dest: /etc/calamari/calamari.conf
+    section: "{{ item }}"
+    option: log_level
+    value: DEBUG
+  with_items:
+    - cthulhu
+    - calamari_web
+  when: calamari_debug
+
 - name: initialize the calamari server api
   command: calamari-ctl initialize


### PR DESCRIPTION
This patch introduces calamari_debug option which will turn on debugging
for calamari before initializing and running it.

Signed-off-by: Boris Ranto <branto@redhat.com>