### PR TITLE
ceph-common: install nfs-ganesha FSALs on Debian

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -53,7 +53,7 @@
 
 - name: install NFS gateway
   apt:
-    pkg: nfs-ganesha
+    pkg: nfs-ganesha-fsal
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     update_cache: yes
   when: nfs_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
@@ -87,6 +87,6 @@
 
 - name: install red hat storage nfs gateway
   apt:
-    name: nfs-ganesha
+    name: nfs-ganesha-fsal
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when: nfs_group_name in group_names


### PR DESCRIPTION
Prior to this change, ceph-ansible would install the main NFS Ganesha server daemon on Ubuntu, but it would skip the Ceph FSALs.

Running `apt-get install nfs-ganesha` will only install the main NFS Ganesha server. It does *not* pull in the RGW FSAL (`/usr/lib/x86_64-linux-gnu/ganesha/libfsalrgw.so`)

Running `apt-get install nfs-ganesha-fsal` will install the RGW FSAL as well as the main NFS Ganesha server package.