### PR TITLE
kv scenario: add KV_PORT option

### DIFF
--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -13,6 +13,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    {% else -%}
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}} \
+   -e KV_PORT={{kv_port}} \
    {% endif -%}
    -v /etc/localtime:/etc/localtime:ro \
    -e CEPH_DAEMON=MDS \

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    {% else -%}
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}}\
+   -e KV_PORT={{kv_port}} \
    {% endif -%}
    -v /etc/localtime:/etc/localtime:ro \
    --privileged \

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -12,6 +12,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    {% else -%}
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}} \
+   -e KV_PORT={{kv_port}} \
    {% endif -%}
    -v /etc/localtime:/etc/localtime:ro \
    -e CEPH_DAEMON=RBD_MIRROR \

--- a/roles/ceph-rgw/templates/ceph-rgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-rgw.service.j2
@@ -13,6 +13,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    {% else -%}
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}} \
+   -e KV_PORT={{kv_port}} \
    {% endif -%}
    -v /etc/localtime:/etc/localtime:ro \
    --privileged \


### PR DESCRIPTION
This option was missing for rrgw, mds, rbd mirror and nfs making these
daemon impossible to run on a kv deployment with containers.

Signed-off-by: Sébastien Han <seb@redhat.com>