### PR TITLE
Make ceph-common aware off osd config fragments

### DIFF
--- a/roles/ceph-common/tasks/generate_ceph_conf.yml
+++ b/roles/ceph-common/tasks/generate_ceph_conf.yml
@@ -1,22 +1,33 @@
 ---
-- name: create ceph conf directory
+- name: create ceph conf directory and assemble directory
   file:
-    path: /etc/ceph
+    path: "{{ item }}"
     state: directory
     owner: "ceph"
     group: "ceph"
     mode: "0755"
+  with_items:
+    - /etc/ceph/
+    - /etc/ceph/ceph.d/
 
 - name: "generate ceph configuration file: {{ cluster }}.conf"
   action: config_template
   args:
     src: ceph.conf.j2
-    dest: /etc/ceph/{{ cluster }}.conf
+    dest: /etc/ceph/ceph.d/{{ cluster }}.conf
     owner: "ceph"
     group: "ceph"
     mode: "0644"
     config_overrides: "{{ ceph_conf_overrides }}"
     config_type: ini
+
+- name: assemble {{ cluster }}.conf and fragments
+  assemble:
+    src: /etc/ceph/ceph.d/
+    dest: /etc/ceph/{{ cluster }}.conf
+    owner: "ceph"
+    group: "ceph"
+    mode: "0644"
   notify:
     - restart ceph mons
     - restart ceph osds


### PR DESCRIPTION
We are using the OSD fragements feature in the ceph-osd role to set OSD specific crush locations in the ceph.conf files on OSD nodes. We are currently co-locating OSDs and RGWs. After we created the ceph.conf on the OSD nodes, also the ceph-rgw role is executed on the same host. As the ceph-common role has no mechanism to include the OSD fragments they get removed from the resulting ceph.conf.