### PR TITLE
Fixing tabs that are breaking the syntax check

### DIFF
--- a/infrastructure-playbooks/make-osd-partitions.yml
+++ b/infrastructure-playbooks/make-osd-partitions.yml
@@ -31,15 +31,15 @@
   - "{{ osd_group_name }}"
 
   tasks:
-  
+
   - name: load a variable file for devices partition
-    include_vars: "{{ item }}"
-    with_first_found:
+    include_vars: "{{ item }}"
+    with_first_found:
       - files:
           - "host_vars/{{ ansible_hostname }}.yml"
           - "host_vars/default.yml"
         skip: true
-        
+
   - name: exit playbook, if devices not defined
     fail:
       msg: "devices must be define in host_vars/default.yml or host_vars/{{ ansible_hostname }}.yml"


### PR DESCRIPTION
With the merge of PR #1336 the syntax check fails. This commit replaces
the tabs with proper indentation.