### PR TITLE
activate LVM osds as well

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -3,7 +3,7 @@
 # partition.
 
 - name: automatically activate osd disk(s) without partitions
-  command: ceph-disk activate "/dev/{{ item.key | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1"
+  command: ceph-disk activate "/dev/{{ item.key | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') | regex_replace('^(\/dev\/mapper\/.*-.*)$', '\1p') }}1"
   ignore_errors: true
   with_dict: "{{ ansible_devices }}"
   when:
@@ -14,7 +14,7 @@
     - osd_auto_discovery
 
 - name: activate osd(s) when device is a disk
-  command: ceph-disk activate {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
+  command: ceph-disk activate {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') | regex_replace('^(\/dev\/mapper\/.*-.*)$', '\1p') }}1
   with_together:
     - "{{ ispartition_results.results }}"
     - "{{ devices|unique }}"
@@ -39,7 +39,7 @@
     - dmcrypt_journal_collocation
 
 - name: activate osd(s) when device is a disk (dmcrypt)
-  command: ceph-disk activate --dmcrypt {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
+  command: ceph-disk activate --dmcrypt {{ item.1 | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') | regex_replace('^(\/dev\/mapper\/.*-.*)$', '\1p') }}1
   with_together:
     - "{{ ispartition_results.results }}"
     - "{{ devices|unique }}"


### PR DESCRIPTION
The original phrase \\1 didn't work for me so I simply put just one backslash. so there is a discordance between the first regex_replace filter and the second; I hope the ceph-ansible maintainer will resolve this issue.

Disclaimer: I only tested with the task named 'activate osd(s) when device is a disk' but I added it to all 3 tasks without testing. I just don't have enough energy and time to test them all but I guess ceph-ansible team could have the ability to do it efficiently in a short time span.

Best Regards,
Nicholas Gim.

P.S. recently made a pull request for ceph lvm support ( https://github.com/ceph/ceph/pull/13994 )

Signed-off-by: Gunwoo Gim (a.k.a. Nicho1as) <wind8702@gmail.com>