### PR TITLE
docker: change centos extra repo var name

### DIFF
--- a/group_vars/docker-commons.yml.sample
+++ b/group_vars/docker-commons.yml.sample
@@ -9,5 +9,5 @@ dummy:
 
 
 #ceph_docker_registry: docker.io
-#ceph_mon_docker_enable_centos_extra_repo: false
+#ceph_docker_enable_centos_extra_repo: false
 

--- a/roles/ceph-docker-common/defaults/main.yml
+++ b/roles/ceph-docker-common/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 
 ceph_docker_registry: docker.io
-ceph_mon_docker_enable_centos_extra_repo: false
+ceph_docker_enable_centos_extra_repo: false

--- a/roles/ceph-docker-common/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-docker-common/tasks/pre_requisites/prerequisites.yml
@@ -20,7 +20,7 @@
     enabled: yes
   when:
     - ansible_distribution == 'CentOS'
-    - ceph_mon_docker_enable_centos_extra_repo
+    - ceph_docker_enable_centos_extra_repo
   tags:
     with_pkg
 


### PR DESCRIPTION
This is not only for monitors, but also mds, rgw and rbd mirror so
making the var name more generic:
ceph_docker_enable_centos_extra_repo

Signed-off-by: Sébastien Han <seb@redhat.com>