### PR TITLE
mon: increase wait for monitor socket timeout

### DIFF
--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -50,7 +50,7 @@
   command: docker exec ceph-mon-{{ ansible_hostname }} stat /var/run/ceph/{{ cluster }}-mon.{{ ansible_fqdn }}.asok
   register: monitor_socket
   retries: 5
-  delay: 10
+  delay: 15
   until: monitor_socket.rc == 0
 
 - name: force peer addition as potential bootstrap peer for cluster bringup


### PR DESCRIPTION
Sometimes the socket appears during the 5th attempt and sometimes not so
increasing the timeout a little bit.

Signed-off-by: Sébastien Han <seb@redhat.com>