### PR TITLE
Fix osd_crush_location to prevent systemd error message

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -59,7 +59,7 @@ dummy:
 # osd0 ceph_crush_root=foo ceph_crush_rack=bar
 
 #crush_location: false
-#osd_crush_location: "'root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} host={{ ansible_hostname }}'"
+#osd_crush_location: "\"root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} host={{ ansible_hostname }}\""
 
 
 ##############
@@ -119,7 +119,7 @@ dummy:
 
 # II.  Second scenario:  N journal devices for N OSDs
 # Use 'true' for 'raw_multi_journal' to enable this scenario
-# List devices under 'devices' variable above and 
+# List devices under 'devices' variable above and
 # write journal devices for those under 'raw_journal_devices'
 # In the following example:
 # * sdb and sdc will get sdf as a journal

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -51,7 +51,7 @@ copy_admin_key: false
 # osd0 ceph_crush_root=foo ceph_crush_rack=bar
 
 crush_location: false
-osd_crush_location: "'root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} host={{ ansible_hostname }}'"
+osd_crush_location: "\"root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} host={{ ansible_hostname }}\""
 
 
 ##############
@@ -111,7 +111,7 @@ journal_collocation: false
 
 # II.  Second scenario:  N journal devices for N OSDs
 # Use 'true' for 'raw_multi_journal' to enable this scenario
-# List devices under 'devices' variable above and 
+# List devices under 'devices' variable above and
 # write journal devices for those under 'raw_journal_devices'
 # In the following example:
 # * sdb and sdc will get sdf as a journal


### PR DESCRIPTION
With ' in osd_crush_location, systemd will show this error:
ceph-osd-prestart.sh[2931]: Invalid command:  invalid chars ' in 'root=

Signed-off-by: Christian Zunker <christian.zunker@codecentric.de>