### PR TITLE
ceph-mon: always call ceph-create-keys

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -1,5 +1,5 @@
 ---
-- name: collect admin and bootstrap keys (for or after kraken release)
+- name: collect admin and bootstrap keys
   command: ceph-create-keys --cluster {{ cluster }} -i {{ monitor_name }}
   args:
     creates: /etc/ceph/{{ cluster }}.client.admin.keyring
@@ -8,7 +8,7 @@
   always_run: true
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel
+
 # NOTE (leseb): wait for mon discovery and quorum resolution
 # the admin key is not instantaneously created so we have to wait a bit
 - name: "wait for {{ cluster }}.client.admin.keyring exists"


### PR DESCRIPTION
After the jewel release the mon startup does not generate keys, but it's
still harmless to call ceph-create-keys with jewel because this task has
a 'creates' argument that will cause it not to run if the keys already
exist.

Removing this when condition also allows the downstream CI tests to
install kraken or luminous without resetting ceph_stable_release, which does not
pertain to rhcs.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>