### PR TITLE
Add two variables to allow setting the monitor hosts explicitly.

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -258,6 +258,10 @@ ip_version: ipv4
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 monitor_address_block: false
 
+# Use the below variables to set these explicitly instead of relying on gathered facts.
+# mon_initial_members: [ mon1, mon2, mon3 ]
+# mon_host: [ 10.0.0.1, 10.0.0.2, 10.0.0.3 ]
+
 ## OSD options
 #
 journal_size: 5120 # OSD journal size in MB

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -19,7 +19,9 @@ max open files = {{ max_open_files }}
 osd crush chooseleaf type = 0
 {% endif %}
 {# NOTE (leseb): the blank lines in-between are needed otherwise we won't get any line break #}
-{% if groups[mon_group_name] is defined %}
+{% if mon_initial_members is defined %}
+mon initial members == {{ mon_initial_members|join(',') }}
+{% elif groups[mon_group_name] is defined %}
 mon initial members = {% for host in groups[mon_group_name] %}
       {% if hostvars[host]['ansible_fqdn'] is defined and mon_use_fqdn -%}
         {{ hostvars[host]['ansible_fqdn'] }}
@@ -31,7 +33,9 @@ mon initial members = {% for host in groups[mon_group_name] %}
 {% endif %}
 
 {% if not mon_containerized_deployment and not mon_containerized_deployment_with_kv %}
-{% if monitor_address_block %}
+{% if mon_host is defined %}
+mon host = {{ mon_host|join(',') }}
+{% elif monitor_address_block %}
 mon host = {% for host in groups[mon_group_name] %}{{ hostvars[host]['ansible_all_ipv4_addresses'] | ipaddr(monitor_address_block) | first }}{% if not loop.last %},{% endif %}{% endfor %}
 {% elif groups[mon_group_name] is defined %}
 mon host = {% for host in groups[mon_group_name] %}


### PR DESCRIPTION
This allows one to run a playbook for the monitor role with ``--limit`` to a single host
without using fact caching.