### PR TITLE
tests: enable testing of rhcs

### DIFF
--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -13,6 +13,13 @@
         dest: "{{ change_dir }}/vagrant_variables.yml"
       when: change_dir is defined
 
+    - name: change ceph/ubuntu-xenial vagrant box name to rhel7
+      replace:
+        regexp: "ceph/ubuntu-xenial"
+        replace: "rhel7"
+        dest: "{{ change_dir }}/vagrant_variables.yml"
+      when: change_dir is defined
+
 - hosts: all
   gather_facts: true
   become: yes

--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -66,7 +66,7 @@
       yum_repository:
         name: ceph-osd
         description: repo for rhcs ceph tools
-        baseurl: "{{ repo_url }}/TOOLS/x86_64/os/"
+        baseurl: "{{ repo_url }}/Tools/x86_64/os/"
         gpgcheck: no
         enabled: yes
       when:

--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -38,6 +38,7 @@
         description: repo for rhcs ceph-mon
         baseurl: "{{ repo_url }}/MON/x86_64/os/"
         gpgcheck: no
+        enabled: yes
       when:
         - not is_atomic
 
@@ -52,6 +53,7 @@
         description: repo for rhcs ceph-osd
         baseurl: "{{ repo_url }}/OSD/x86_64/os/"
         gpgcheck: no
+        enabled: yes
       when:
         - not is_atomic
 
@@ -66,5 +68,6 @@
         description: repo for rhcs ceph tools
         baseurl: "{{ repo_url }}/TOOLS/x86_64/os/"
         gpgcheck: no
+        enabled: yes
       when:
         - not is_atomic

--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -1,0 +1,70 @@
+---
+- hosts: local
+  gather_facts: false
+  become: yes
+  tags:
+    - vagrant_setup
+  tasks:
+
+    - name: change centos/7 vagrant box name to rhel7
+      replace:
+        regexp: "centos/7"
+        replace: "rhel7"
+        path: "{{ change_dir }}/vagrant_variables.yml"
+      when: change_dir is defined
+
+- hosts: all
+  gather_facts: true
+  become: yes
+  tasks:
+
+    - name: check if it is Atomic host
+      stat: path=/run/ostree-booted
+      register: stat_ostree
+      always_run: true
+
+    - name: set fact for using Atomic host
+      set_fact:
+        is_atomic: '{{ stat_ostree.stat.exists }}'
+
+- hosts: mons
+  gather_facts: false
+  become: yes
+  tasks:
+
+    - name: install ceph mon repo
+      yum_repository:
+        name: ceph-mon
+        description: repo for rhcs ceph-mon
+        baseurl: "{{ repo_url }}/MON/x86_64/os/"
+        gpgcheck: no
+      when:
+        - not is_atomic
+
+- hosts: osds
+  gather_facts: false
+  become: yes
+  tasks:
+
+    - name: install ceph osd repo
+      yum_repository:
+        name: ceph-osd
+        description: repo for rhcs ceph-osd
+        baseurl: "{{ repo_url }}/OSD/x86_64/os/"
+        gpgcheck: no
+      when:
+        - not is_atomic
+
+- hosts: mdss:rgws:clients 
+  gather_facts: false
+  become: yes
+  tasks:
+
+    - name: install ceph tools repo
+      yum_repository:
+        name: ceph-osd
+        description: repo for rhcs ceph tools
+        baseurl: "{{ repo_url }}/TOOLS/x86_64/os/"
+        gpgcheck: no
+      when:
+        - not is_atomic

--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: local
+- hosts: all
   gather_facts: false
   become: yes
   tags:
@@ -10,7 +10,7 @@
       replace:
         regexp: "centos/7"
         replace: "rhel7"
-        path: "{{ change_dir }}/vagrant_variables.yml"
+        dest: "{{ change_dir }}/vagrant_variables.yml"
       when: change_dir is defined
 
 - hosts: all

--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: localhost
   gather_facts: false
   become: yes
   tags:

--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -35,6 +35,12 @@
         group: root
       when: not is_atomic
 
+    - name: set MTU on eth0
+      command: "ifconfig eth0 mtu 1400 up"
+
+    - name: set MTU on eth1
+      command: "ifconfig eth1 mtu 1400 up"
+
 - hosts: mons
   gather_facts: false
   become: yes
@@ -64,6 +70,9 @@
         enabled: yes
       when:
         - not is_atomic
+
+    - name: set MTU on eth2
+      command: "ifconfig eth2 mtu 1400 up"
 
 - hosts: mdss:rgws:clients 
   gather_facts: false

--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -27,6 +27,14 @@
       set_fact:
         is_atomic: '{{ stat_ostree.stat.exists }}'
 
+    - name: install nightly rhel7 repo
+      get_url:
+        url: "{{ rhel7_repo_url }}"
+        dest: /etc/yum.repos.d
+        owner: root
+        group: root
+      when: not is_atomic
+
 - hosts: mons
   gather_facts: false
   become: yes

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ setenv=
   ANSIBLE_STDOUT_CALLBACK = debug
   docker_cluster: PLAYBOOK = site-docker.yml.sample
   docker_dedicated_journal: PLAYBOOK = site-docker.yml.sample
-  docker_dmcrypt_journal_collocation = site-docker.yml.sample
+  docker_dmcrypt_journal_collocation: PLAYBOOK = site-docker.yml.sample
 deps=
   ansible1.9: ansible==1.9.4
   ansible2.1: ansible==2.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster}
+envlist = {,rhcs-}{ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster}
 skipsdist = True
 
 # extra commands for purging clusters

--- a/tox.ini
+++ b/tox.ini
@@ -101,7 +101,7 @@ commands=
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
-  rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "repo_url={env:REPO_URL:}" --skip-tags "vagrant_setup"
+  rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars '\
     \{\

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ setenv=
   docker_cluster: PLAYBOOK = site-docker.yml.sample
   docker_dedicated_journal: PLAYBOOK = site-docker.yml.sample
   docker_dmcrypt_journal_collocation: PLAYBOOK = site-docker.yml.sample
+  rhcs: CEPH_RHCS = true
 deps=
   ansible1.9: ansible==1.9.4
   ansible2.1: ansible==2.1
@@ -95,8 +96,12 @@ changedir=
   update_dmcrypt: {toxinidir}/tests/functional/centos/7/dmcrypt-dedicated-journal
   update_cluster: {toxinidir}/tests/functional/centos/7/cluster
 commands=
+  rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
+
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
+
+  rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "repo_url={env:REPO_URL:}" --skip-tags "vagrant_setup"
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars '\
     \{\

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,7 @@ changedir=
   update_dmcrypt: {toxinidir}/tests/functional/centos/7/dmcrypt-dedicated-journal
   update_cluster: {toxinidir}/tests/functional/centos/7/cluster
 commands=
-  rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
+  rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
 
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,7 @@ setenv=
   docker_dedicated_journal: PLAYBOOK = site-docker.yml.sample
   docker_dmcrypt_journal_collocation: PLAYBOOK = site-docker.yml.sample
   rhcs: CEPH_RHCS = true
+  rhcs: CEPH_STABLE = false
 deps=
   ansible1.9: ansible==1.9.4
   ansible2.1: ansible==2.1


### PR DESCRIPTION
This adds a new prefix, ``rhcs-``, that when added will instruct our testing scenarios to install Red Hat Ceph Storage instead of upstream ceph.