### PR TITLE
Resolve issues when groups names not in default value.

### DIFF
--- a/infrastructure-playbooks/cluster-os-migration.yml
+++ b/infrastructure-playbooks/cluster-os-migration.yml
@@ -280,7 +280,7 @@
     - name: Set the noout flag
       command: ceph osd set noout
       delegate_to: "{{ item }}"
-      with_items: "{{ groups.mons[0] }}"
+      with_items: "{{ groups[mon_group_name][0] }}"
       when: migration_completed.stat.exists == False
 
     - name: Check if sysvinit
@@ -427,7 +427,7 @@
     - name: Unset the noout flag
       command: ceph osd unset noout
       delegate_to: "{{ item }}"
-      with_items: "{{ groups.mons[0] }}"
+      with_items: "{{ groups[mon_group_name][0] }}"
       when: migration_completed.stat.exists == False
 
 - hosts: rgws

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -62,7 +62,7 @@
 
   pre_tasks:
     - name: set mon_host_count
-      set_fact: mon_host_count={{ groups.mons | length }}
+      set_fact: mon_host_count={{ groups[mon_group_name] | length }}
 
     - debug: msg="WARNING - upgrading a ceph cluster with only one monitor node ({{ inventory_hostname }})"
       when: mon_host_count | int == 1
@@ -125,18 +125,18 @@
         - mon_containerized_deployment
 
     - name: set mon_host_count
-      set_fact: mon_host_count={{ groups.mons | length }}
+      set_fact: mon_host_count={{ groups[mon_group_name] | length }}
 
     - name: select a running monitor if multiple monitors
       set_fact: mon_host={{ item }}
-      with_items: "{{ groups.mons }}"
+      with_items: "{{ groups[mon_group_name] }}"
       when:
         - mon_host_count | int > 1
         - item != inventory_hostname
 
     - name: select first monitor if only one monitor
       set_fact: mon_host={{ item }}
-      with_items: "{{ groups.mons[0] }}"
+      with_items: "{{ groups[mon_group_name][0] }}"
       when:
         - mon_host_count | int == 1
 
@@ -181,17 +181,17 @@
         - noout
         - noscrub
         - nodeep-scrub
-      delegate_to: "{{ groups.mons[0] }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
       when: not mon_containerized_deployment
 
     - name: set containerized osd flags
       command: |
-          docker exec ceph-osd-{{ hostvars[groups.mons[0]]['ansible_hostname'] }} ceph osd set {{ item }} --cluster {{ cluster }}
+          docker exec ceph-osd-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph osd set {{ item }} --cluster {{ cluster }}
       with_items:
         - noout
         - noscrub
         - nodeep-scrub
-      delegate_to: "{{ groups.mons[0] }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
       when: mon_containerized_deployment
 
     - name: get osd numbers
@@ -271,17 +271,17 @@
       until: result.rc == 0
       retries: "{{ health_osd_check_retries }}"
       delay: "{{ health_osd_check_delay }}"
-      delegate_to: "{{ groups.mons[0] }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
       when: not osd_containerized_deployment
 
     - name: container - waiting for clean pgs...
       shell: |
-        test "$(docker exec ceph-osd-{{ hostvars[groups.mons[0]]['ansible_hostname'] }} ceph pg stat --cluster {{ cluster }} | sed 's/^.*pgs://;s/active+clean.*//;s/ //')" -eq "$(docker exec {{ hostvars[groups.mons[0]]['ansible_hostname'] }} ceph pg stat --cluster {{ cluster }} | sed 's/pgs.*//;s/^.*://;s/ //')" && docker exec {{ hostvars[groups.mons[0]]['ansible_hostname'] }} ceph health --cluster {{ cluster }}  | egrep -sq "HEALTH_OK|HEALTH_WARN"
+        test "$(docker exec ceph-osd-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph pg stat --cluster {{ cluster }} | sed 's/^.*pgs://;s/active+clean.*//;s/ //')" -eq "$(docker exec {{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph pg stat --cluster {{ cluster }} | sed 's/pgs.*//;s/^.*://;s/ //')" && docker exec {{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph health --cluster {{ cluster }}  | egrep -sq "HEALTH_OK|HEALTH_WARN"
       register: result
       until: result.rc == 0
       retries: "{{ health_osd_check_retries }}"
       delay: "{{ health_osd_check_delay }}"
-      delegate_to: "{{ groups.mons[0] }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
       when: osd_containerized_deployment
 
     - name: unset osd flags
@@ -290,17 +290,17 @@
         - noout
         - noscrub
         - nodeep-scrub
-      delegate_to: "{{ groups.mons[0] }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
       when: not osd_containerized_deployment
 
     - name: unset containerized osd flags
       command: |
-          docker exec ceph-osd-{{ hostvars[groups.mons[0]]['ansible_hostname'] }} ceph osd unset {{ item }} --cluster {{ cluster }}
+          docker exec ceph-osd-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph osd unset {{ item }} --cluster {{ cluster }}
       with_items:
         - noout
         - noscrub
         - nodeep-scrub
-      delegate_to: "{{ groups.mons[0] }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
       when: osd_containerized_deployment
 
 

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -98,7 +98,7 @@
 
   - name: select a running monitor
     set_fact: mon_host={{ item }}
-    with_items: "{{ groups.mons }}"
+    with_items: "{{ groups[mon_group_name] }}"
     when: item != inventory_hostname
 
   - name: get current ceph fsid
@@ -260,7 +260,7 @@
     retries: 10
     delay: 10
     changed_when: false
-    delegate_to: "{{ groups.mons[0] }}"
+    delegate_to: "{{ groups[mon_group_name][0] }}"
 
 
 - name: switching from non-containerized to containerized ceph mds

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -68,7 +68,7 @@
 - include: openstack_config.yml
   when:
     - openstack_config
-    - inventory_hostname == groups.mons|last
+    - "{{ inventory_hostname == groups[mon_group_name] | last }}"
 
 - name: find ceph keys
   shell: ls -1 /etc/ceph/*.keyring

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -59,11 +59,11 @@
 
 - name: force peer addition as potential bootstrap peer for cluster bringup
   command: docker exec ceph-mon-{{ ansible_hostname }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ ansible_fqdn }}.asok add_bootstrap_peer_hint {{ hostvars[item]['ansible_' + ceph_mon_docker_interface].ipv4.address }}
-  with_items: "{{ groups.mons }}"
+  with_items: "{{ groups[mon_group_name] }}"
   changed_when: false
   failed_when: false
   when:
-    - inventory_hostname == groups.mons[0]
+    - "{{ inventory_hostname == groups[mon_group_name][0] }}"
     - not mon_containerized_deployment_with_kv
 
 - include: copy_configs.yml
@@ -78,7 +78,7 @@
     - cephx
     - mon_containerized_deployment
     - groups[restapi_group_name] is defined
-    - inventory_hostname == groups.mons|last
+    - "{{ inventory_hostname == groups[mon_group_name] | last }}"
     - not mon_containerized_deployment_with_kv
 
 - include: "{{ playbook_dir }}/roles/ceph-mon/tasks/set_osd_pool_default_pg_num.yml"
@@ -87,4 +87,4 @@
 - include: "{{ playbook_dir }}/roles/ceph-mon/tasks/openstack_config.yml"
   when:
     - openstack_config
-    - inventory_hostname == groups.mons|last
+    - "{{ inventory_hostname == groups[mon_group_name] | last }}"

--- a/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
+++ b/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
@@ -11,7 +11,7 @@
       KV_PORT: "{{kv_port}}"
   run_once: true
   when:
-    - inventory_hostname == groups.mons[0]
+    - "{{ inventory_hostname == groups[mon_group_name][0] }}"
     - mon_containerized_deployment_with_kv
     - mon_containerized_default_ceph_conf_with_kv
 
@@ -29,7 +29,7 @@
       - /etc/ceph/"{{ cluster }}".conf:/etc/ceph/ceph.defaults
   run_once: true
   when:
-    - inventory_hostname == groups.mons[0]
+    - "{{ inventory_hostname == groups[mon_group_name][0] }}"
     - mon_containerized_deployment_with_kv
     - not mon_containerized_default_ceph_conf_with_kv
 

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -15,7 +15,7 @@
     - not mon_containerized_deployment
     - groups[mds_group_name] is defined
     - "{{ groups[mds_group_name]|length > 0 }}"
-    - inventory_hostname == groups.mons|last
+    - "{{ inventory_hostname == groups[mon_group_name] | last }}"
 
 - include: secure_cluster.yml
   when:

--- a/roles/ceph-nfs/tasks/docker/main.yml
+++ b/roles/ceph-nfs/tasks/docker/main.yml
@@ -41,7 +41,7 @@
 # let the first ganesha create configs and users
 - include: create_configs.yml
   when:
-    inventory_hostname == groups.nfss[0] and
+    inventory_hostname == groups[nfs_group_name][0] and
     not mon_containerized_default_ceph_conf_with_kv
 
 # Copy Ganesha configs to host

--- a/roles/ceph-rgw/tasks/docker/copy_configs.yml
+++ b/roles/ceph-rgw/tasks/docker/copy_configs.yml
@@ -9,7 +9,7 @@
   wait_for: path="/var/lib/ceph/radosgw/{{ ansible_hostname }}/keyring"
   when:
     - nfs_obj_gw
-    - inventory_hostname == groups.rgws[0]
+    - inventory_hostname == groups[rgw_group_name][0]
 
 - name: stat for config and keys
   local_action: stat path={{ fetch_directory }}/docker_mon_files/{{ item }}
@@ -21,7 +21,7 @@
   register: statconfig
   when:
     - nfs_obj_gw
-    - inventory_hostname == groups.rgws[0]
+    - inventory_hostname == groups[rgw_group_name][0]
 
 - name: push ceph files to the ansible server
   fetch:
@@ -34,4 +34,4 @@
   when:
     - nfs_obj_gw
     - item.1.stat.exists == false
-    - inventory_hostname == groups.rgws[0]
+    - inventory_hostname == groups[rgw_group_name][0]


### PR DESCRIPTION
Some tasks try to look to "default mon group in inventory", but if group have another name role is failed on `create openstack pool` : `The conditional check 'inventory_hostname == groups.mons|last' failed.`