### PR TITLE
BugFix: Fix #1374

### DIFF
--- a/roles/ceph-common/handlers/restart-mds.yml
+++ b/roles/ceph-common/handlers/restart-mds.yml
@@ -6,7 +6,7 @@
   # serial: 1 would be the proper solution here, but that can only be set on play level
   # upstream issue: https://github.com/ansible/ansible/issues/12170
   run_once: true
-  with_items: "{{ groups[mds_group_name] }}"
+  with_items: "{{ groups.get(mds_group_name, []) }}"
   delegate_to: "{{ item }}"
   when:
     - socket.rc == 0

--- a/roles/ceph-common/handlers/restart-mon.yml
+++ b/roles/ceph-common/handlers/restart-mon.yml
@@ -6,7 +6,7 @@
   # serial: 1 would be the proper solution here, but that can only be set on play level
   # upstream issue: https://github.com/ansible/ansible/issues/12170
   run_once: true
-  with_items: "{{ groups[mon_group_name] }}"
+  with_items: "{{ groups.get(mon_group_name, []) }}"
   delegate_to: "{{ item }}"
   when:
     - socket.rc == 0

--- a/roles/ceph-common/handlers/restart-osd.yml
+++ b/roles/ceph-common/handlers/restart-osd.yml
@@ -11,7 +11,7 @@
   # serial: 1 would be the proper solution here, but that can only be set on play level
   # upstream issue: https://github.com/ansible/ansible/issues/12170
   run_once: true
-  with_items: "{{ groups[osd_group_name] }}"
+  with_items: "{{ groups.get(osd_group_name, []) }}"
   delegate_to: "{{ item }}"
   when:
     - socket.rc == 0

--- a/roles/ceph-common/handlers/restart-rgw.yml
+++ b/roles/ceph-common/handlers/restart-rgw.yml
@@ -6,7 +6,7 @@
   # serial: 1 would be the proper solution here, but that can only be set on play level
   # upstream issue: https://github.com/ansible/ansible/issues/12170
   run_once: true
-  with_items: "{{ groups[rgw_group_name] }}"
+  with_items: "{{ groups.get(rgw_group_name, []) }}"
   delegate_to: "{{ item }}"
   when:
     - socketrgw.rc == 0


### PR DESCRIPTION
If a group of hosts is empty, (for instance 'mdss', in case of a
deployment without any mds node), the playbook will fails when trying
to restart service with `"'dict object' has no attribute u'XXX'"` error.

The idea here is to force the `with_items` statements in all included handler tasks
to get at least an empty array.