### PR TITLE
Common: Do not install ntp when ntp_service_enabled is false

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -56,20 +56,17 @@ dummy:
 #debian_package_dependencies:
 #  - python-pycurl
 #  - hdparm
-#  - ntp
 
 #centos_package_dependencies:
 #  - python-pycurl
 #  - hdparm
 #  - epel-release
-#  - ntp
 #  - python-setuptools
 #  - libselinux-python
 
 #redhat_package_dependencies:
 #  - python-pycurl
 #  - hdparm
-#  - ntp
 #  - python-setuptools
 
 # Enable the ntp service by default to avoid clock skew on

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -48,20 +48,17 @@ upgrade_ceph_packages: False
 debian_package_dependencies:
   - python-pycurl
   - hdparm
-  - ntp
 
 centos_package_dependencies:
   - python-pycurl
   - hdparm
   - epel-release
-  - ntp
   - python-setuptools
   - libselinux-python
 
 redhat_package_dependencies:
   - python-pycurl
   - hdparm
-  - ntp
   - python-setuptools
 
 # Enable the ntp service by default to avoid clock skew on

--- a/roles/ceph-common/tasks/checks/check_ntp_debian.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_debian.yml
@@ -6,3 +6,8 @@
   always_run: true
   changed_when: false
   when: ansible_os_family == 'Debian'
+
+- name: install ntp on debian
+  package:
+    name: ntp
+    state: present

--- a/roles/ceph-common/tasks/checks/check_ntp_redhat.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_redhat.yml
@@ -6,3 +6,8 @@
   always_run: true
   changed_when: false
   when: ansible_os_family == 'RedHat'
+
+- name: install ntp on redhat
+  package:
+    name: ntp
+    state: present


### PR DESCRIPTION
ntp is still installed even if ntp_service_enabled is set to false.
That could be a problem if the time synchronization is managed by
something else than ceph-ansible or if you want to use different NTP
implementation as suggested in #1354.

Fixes: #1354

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>