### PR TITLE
enable ceph-mon.target service after monitor start, fix the ceph moni…

### DIFF
--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -5,3 +5,9 @@
     state: started
     enabled: yes
   changed_when: false
+
+- name: enable the ceph-mon.target service
+  service:
+    name: ceph-mon.target
+    enabled: yes
+  changed_when: false

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -6,8 +6,8 @@
     enabled: yes
   changed_when: false
 
-# NOTE: This patch only effect Kraken. Fix when reboot machine, the monitor 
-# service do not auto start. Fix proposed upstream: ceph/ceph#14226
+# NOTE: This patch only affects Kraken. This fixes a bug when the monitor service
+# does not start automatically after a reboot. Fix proposed upstream: ceph/ceph#14226
 - name: enable the ceph-mon.target service
   service:
     name: ceph-mon.target

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -9,7 +9,8 @@
 # NOTE: This patch only affects Kraken. This fixes a bug when the monitor service
 # does not start automatically after a reboot. Fix proposed upstream: ceph/ceph#14226
 - name: enable the ceph-mon.target service
-  service:
+  systemd:
     name: ceph-mon.target
     enabled: yes
+    masked: no
   changed_when: false

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -6,6 +6,8 @@
     enabled: yes
   changed_when: false
 
+# NOTE: This patch only effect Kraken. Fix when reboot machine, the monitor 
+# service do not auto start. Fix proposed upstream: ceph/ceph#14226
 - name: enable the ceph-mon.target service
   service:
     name: ceph-mon.target


### PR DESCRIPTION
Use ceph-ansbile install kraken, when reboot machine, the monitor service do not auto start,

By default:

$ systemctl is-enabled ceph-mon.target
disable

I found ceph-mon.target do not set enable, the monitor service do not auto start when machine reboot. So it used add the lines mentioned to fix this