### PR TITLE
playbook: homogenize the way list osd ids

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -203,7 +203,7 @@
       - osd_auto_discovery
 
   - name: get osd numbers
-    shell: "if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | cut -d '-' -f 2 ; fi"
+    shell: "if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi"
     register: osd_ids
     changed_when: false
 
@@ -224,10 +224,7 @@
     when: ansible_service_mgr == 'sysvinit'
 
   - name: stop ceph osds on ubuntu
-    shell: |
-      for id in $(ls /var/lib/ceph/osd/ |grep -oP '\d+$'); do
-        initctl stop ceph-osd cluster={{ cluster }} id=$id
-      done
+    command: initctl stop ceph-osd cluster={{ cluster }} id={{ item }}
     failed_when: false
     when: ansible_service_mgr == 'upstart'
     with_items: "{{ osd_ids.stdout_lines }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -195,7 +195,7 @@
       when: mon_containerized_deployment
 
     - name: get osd numbers
-      shell: "if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | cut -d '-' -f 2 ; fi"
+      shell: "if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi"
       register: osd_ids
       changed_when: false
       when: not osd_containerized_deployment
@@ -227,7 +227,7 @@
 
   post_tasks:
     - name: get osd numbers
-      shell: "if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | cut -d '-' -f 2 ; fi"
+      shell: "if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi"
       register: osd_ids
       changed_when: false
       when: not osd_containerized_deployment

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -179,7 +179,7 @@
 
   - name: collect osd ids
     shell: |
-      if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | cut -d '-' -f 2 ; fi
+      if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi
     register: osd_ids
     changed_when: false
 

--- a/roles/ceph-common/handlers/restart-osd.yml
+++ b/roles/ceph-common/handlers/restart-osd.yml
@@ -4,7 +4,7 @@
 # for restarting them specifically.
 - name: restart ceph osds
   shell: |
-    for id in $(ls /var/lib/ceph/osd/ |grep -oP '\d+$'); do
+    for id in $(ls /var/lib/ceph/osd/ | sed 's/.*-//'); do
       systemctl restart ceph-osd@$id
       sleep 5
     done

--- a/roles/ceph-common/handlers/validate-osd.yml
+++ b/roles/ceph-common/handlers/validate-osd.yml
@@ -1,7 +1,7 @@
 ---
 - name: collect osds
   shell: |
-    ls /var/lib/ceph/osd/ |grep -oP '\d+$'
+    ls /var/lib/ceph/osd/ | sed 's/.*-//'
   register: osd_ids
 
 - name: wait for ceph osd socket(s)

--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -82,7 +82,8 @@
   when: crush_location
 
 - name: get osd id
-  shell: 'ls /var/lib/ceph/osd/ | grep -oP "\d+$"'
+  shell: |
+    ls /var/lib/ceph/osd/ | sed 's/.*-//'
   changed_when: false
   failed_when: false
   always_run: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def node(Ansible, Interface, Command, request):
         # boxes we test with use that interface. OSDs are the only
         # nodes that have this interface.
         cluster_address = Interface("eth2").addresses[0]
-        cmd = Command('sudo ls /var/lib/ceph/osd/ | grep -oP "\d+$"')
+        cmd = Command('sudo ls /var/lib/ceph/osd/ | sed "s/.*-//"')
         if cmd.rc == 0:
             osd_ids = cmd.stdout.rstrip("\n").split("\n")
             osds = osd_ids


### PR DESCRIPTION
Problem: too many different commands to do the same thing. The 'cut'
command on infrastructure-playbooks/purge-cluster.yml was also wrong.
This sed command from osixia in ceph-docker
https://github.com/ceph/ceph-docker/pull/580/ addresses all the
scenarios.

Signed-off-by: Sébastien Han <seb@redhat.com>