### PR TITLE
osd: fix osd creation when the device is a partition

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -70,7 +70,7 @@
   command: "ceph-disk activate {{ item.1 }}"
   with_together:
     - "{{ ispartition_results.results }}"
-    - "{{ devices|unique }}"
+    - "{{ devices }}"
   changed_when: false
   failed_when: false
   when:

--- a/roles/ceph-osd/tasks/check_devices_static.yml
+++ b/roles/ceph-osd/tasks/check_devices_static.yml
@@ -33,6 +33,42 @@
     - not item.0.get("skipped")
     - item.0.get("rc", 0) != 0
 
+- name: check if a partition named 'ceph' exists for device with existing partitions
+  shell: "parted --script {{ item.1[:-1] }} print | egrep -sq '^ 1.*ceph'"
+  with_together:
+    - "{{ ispartition_results.results }}"
+    - "{{ devices }}"
+  changed_when: false
+  failed_when: false
+  always_run: true
+  register: is_part_parted_results
+  when: item.0.rc == 0
+
+- name: make sure the partition does not have any name
+  shell: |
+    [[ "$(blkid -o value -s PARTLABEL {{ item.2 }} | wc -l)" == "0" ]]
+  with_together:
+    - "{{ ispartition_results.results }}"
+    - "{{ is_part_parted_results.results }}"
+    - "{{ devices }}"
+  changed_when: false
+  failed_when: false
+  always_run: true
+  register: partition_name_results
+  when:
+    - item.0.rc == 0
+    - item.1.rc != 0
+
+- fail:
+    msg: "Looks like your device partition already has a name and it's not 'ceph', please provide an unnamed partition."
+  with_together:
+    - "{{ partition_name_results.results }}"
+    - "{{ is_part_parted_results.results }}"
+  when:
+    - item.0.get("rc", 0) != 0
+    - item.1.get("rc", 0) != 0
+
+# we check again for both...
 - name: check if a partition named 'ceph' exists
   shell: "parted --script {{ item.1 }} print | egrep -sq '^ 1.*ceph'"
   with_together:
@@ -43,3 +79,28 @@
   always_run: true
   register: parted_results
   when: item.0.rc != 0
+
+- name: check if a partition named 'ceph' exists
+  shell: "parted --script {{ item.1[:-1] }} print | egrep -sq '^ 1.*ceph'"
+  with_together:
+    - "{{ ispartition_results.results }}"
+    - "{{ devices }}"
+  changed_when: false
+  failed_when: false
+  always_run: true
+  register: parted_results
+  when: item.0.rc == 0
+
+- name: name the unnamed partition
+  shell: |
+    parted $(readlink -f {{ item.2[:-1] }}) name {{ item.2[-1] }} '"ceph data"'
+  changed_when: false
+  failed_when: false
+  always_run: true
+  with_together:
+    - "{{ ispartition_results.results }}"
+    - "{{ is_part_parted_results.results }}"
+    - "{{ devices }}"
+  when:
+    - item.0.rc == 0
+    - item.1.rc != 0

--- a/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
+++ b/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
@@ -21,16 +21,13 @@
     - osd_auto_discovery
 
 - name: manually prepare filestore osd disk(s) with collocated osd data and journal
-  command: "ceph-disk prepare --cluster {{ cluster }} {{ item.2 }}"
+  command: "ceph-disk prepare --cluster {{ cluster }} {{ item.1 }}"
   with_together:
     - "{{ parted_results.results }}"
-    - "{{ ispartition_results.results }}"
     - "{{ devices }}"
   when:
     - not item.0.get("skipped")
-    - not item.1.get("skipped")
     - item.0.get("rc", 0) != 0
-    - item.1.get("rc", 0) != 0
     - journal_collocation
     - not osd_auto_discovery
 


### PR DESCRIPTION
You can now specify partitions for your devices to create OSD, e.g:

devices:
  - /dev/sda1
  - /dev/disk/by-partuuid/224303f9-29c9-4855-be52-ffd57ec0f38a

The only requirement is to NOT give any name to your partitions.
ceph-ansible will put the name on it.

Fixes: #1326

Signed-off-by: Sébastien Han <seb@redhat.com>