### PR TITLE
osd: autodiscovery mode, use holders to detect device

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -10,6 +10,7 @@
     - ansible_devices is defined
     - item.value.removable == "0"
     - item.value.partitions|count == 0
+    - item.value.holders|count == 0
     - journal_collocation
     - osd_auto_discovery
 
@@ -35,6 +36,7 @@
     - ansible_devices is defined
     - item.value.removable == "0"
     - item.value.partitions|count == 0
+    - item.value.holders|count == 0
     - osd_auto_discovery
     - dmcrypt_journal_collocation
 

--- a/roles/ceph-osd/tasks/check_devices_auto.yml
+++ b/roles/ceph-osd/tasks/check_devices_auto.yml
@@ -21,6 +21,7 @@
     - ansible_devices is defined
     - item.value.removable == "0"
     - item.value.partitions|count == 0
+    - item.value.holders|count == 0
 
 - name: fix partitions gpt header or labels of the osd disks (autodiscover disks)
   shell: "sgdisk --zap-all --clear --mbrtogpt -- '/dev/{{ item.0.item.key }}' || sgdisk --zap-all --clear --mbrtogpt -- '/dev/{{ item.0.item.key }}'"
@@ -32,6 +33,7 @@
     - ansible_devices is defined
     - item.0.item.value.removable == "0"
     - item.0.item.value.partitions|count == 0
+    - item.value.holders|count == 0
     - item.0.rc != 0
 
 - name: check if a partition named 'ceph' exists (autodiscover disks)

--- a/roles/ceph-osd/tasks/scenarios/bluestore.yml
+++ b/roles/ceph-osd/tasks/scenarios/bluestore.yml
@@ -17,6 +17,7 @@
     - ansible_devices is defined
     - item.value.removable == "0"
     - item.value.partitions|count == 0
+    - item.value.holders|count == 0
     - bluestore
     - osd_auto_discovery
 

--- a/roles/ceph-osd/tasks/scenarios/dmcrypt-journal-collocation.yml
+++ b/roles/ceph-osd/tasks/scenarios/dmcrypt-journal-collocation.yml
@@ -16,6 +16,7 @@
     - ansible_devices is defined
     - item.value.removable == "0"
     - item.value.partitions|count == 0
+    - item.value.holders|count == 0
     - dmcrypt_journal_collocation
     - osd_auto_discovery
 

--- a/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
+++ b/roles/ceph-osd/tasks/scenarios/journal_collocation.yml
@@ -17,6 +17,7 @@
     - ansible_devices is defined
     - item.value.removable == "0"
     - item.value.partitions|count == 0
+    - item.value.holders|count == 0
     - journal_collocation
     - osd_auto_discovery
 


### PR DESCRIPTION
As reported in
https://github.com/ceph/ceph-ansible/issues/1403 when devices are held
by lvm and `osd_auto_discovery` is set to true, it's not enough to check
for a partition count = 0 since Ansible does not report.
This patch also looks for 'holders' which in a case of lvm corresponds
to the name of the pv. Now we also look for holders = 0.

Fixes: #1403

Signed-off-by: Sébastien Han <seb@redhat.com>