### PR TITLE
tests: add an alias of cluster for the centos7_cluster scenario

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {jewel,kraken,rhcs}-{ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster}
+envlist = {jewel,kraken,rhcs}-{ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster,cluster}
 skipsdist = True
 
 # extra commands for purging clusters
@@ -91,6 +91,8 @@ changedir=
   dmcrypt_journal_collocation: {toxinidir}/tests/functional/centos/7/dmcrypt-journal-collocation
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw centos7 cluster using raw_multi_journal OSD scenario
   centos7_cluster: {toxinidir}/tests/functional/centos/7/cluster
+  # an alias for centos7_cluster, this makes the name better suited for rhcs testing
+  cluster: {toxinidir}/tests/functional/centos/7/cluster
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw centos7 cluster using docker
   docker_cluster: {toxinidir}/tests/functional/centos/7/docker-cluster
   docker_dedicated_journal: {toxinidir}/tests/functional/centos/7/docker-cluster-dedicated-journal


### PR DESCRIPTION
When testing this downstream it makes more sense for this scenario to be
named just 'cluster' because have 'centos7' in the name is misleading.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>