### PR TITLE
osd autodiscovery mode: fix holders detection

### DIFF
--- a/roles/ceph-osd/tasks/check_devices_auto.yml
+++ b/roles/ceph-osd/tasks/check_devices_auto.yml
@@ -33,7 +33,7 @@
     - ansible_devices is defined
     - item.0.item.value.removable == "0"
     - item.0.item.value.partitions|count == 0
-    - item.value.holders|count == 0
+    - item.0.item.value.holders|count == 0
     - item.0.rc != 0
 
 - name: check if a partition named 'ceph' exists (autodiscover disks)


### PR DESCRIPTION
Small fix for (probably copy&paste) issue from 42ffe6301.

Fixing following issue:
```
TASK [ceph-osd : fix partitions gpt header or labels of the osd disks (autodiscover disks)] ***
task path: /home/usmqe/ceph-ansible/roles/ceph-osd/tasks/check_devices_auto.yml:26
fatal: [n41.gusty]: FAILED! => {
    "failed": true, 
    "msg": "The conditional check 'item.value.holders|count == 0' failed. The error was: error while evaluating conditional (item.value.holders|count == 0): 'list object' has no attribute 'value'\n\nThe error appears to have been in '/home/usmqe/ceph-ansible/roles/ceph-osd/tasks/check_devices_auto.yml': line 26, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: fix partitions gpt header or labels of the osd disks (autodiscover disks)\n  ^ here\n"
}
```