### PR TITLE
enable ceph-mon.target service after monitor start

### DIFF
--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -5,3 +5,12 @@
     state: started
     enabled: yes
   changed_when: false
+
+# NOTE: This patch only affects Kraken. This fixes a bug when the monitor service
+# does not start automatically after a reboot. Fix proposed upstream: ceph/ceph#14226
+- name: enable the ceph-mon.target service
+  systemd:
+    name: ceph-mon.target
+    enabled: yes
+    masked: no
+  changed_when: false


### PR DESCRIPTION
ceph-create-keys unit file was removed here:

* https://github.com/ceph/ceph/commit/8bcb4646b6b9846bb965cdec3ca2a21eb3b26bab
* https://github.com/ceph/ceph/commit/dc5fe8d415858358bd0baf5d8dce0a753f5e0cea

As a consequence the systemctl preset command now fails to run since the
unit does not exist anymore. Due to the redirection in /dev/null we
don't know what's happening.

Ultimately the mon unit doesn't get enabled and the mon service won't
start after reboot.
Removing the old/non-existent unit makes the command succeed now.

ceph fix: https://github.com/ceph/ceph/pull/14226

Signed-off-by: WingkaiHo <sanguosfiang@163.com>
Co-Authored-By: Sébastien Han <seb@redhat.com>