### PR TITLE
tests: add docker environment variables to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -118,7 +118,10 @@ commands=
      "ceph_dev_branch":"{env:CEPH_DEV_BRANCH:master}",\
      "ceph_dev_sha1":"{env:CEPH_DEV_SHA1:latest}",\
      "ceph_stable_release":"{env:CEPH_STABLE_RELEASE:jewel}",\
-     "ceph_stable":{env:CEPH_STABLE:true}\
+     "ceph_stable":{env:CEPH_STABLE:true},\
+     "ceph_docker_registry":"{env:CEPH_DOCKER_REGISTRY:docker.io}",\
+     "ceph_docker_image":"{env:CEPH_DOCKER_IMAGE:ceph/daemon}",\
+     "ceph_docker_image_tag":"{env:CEPH_DOCKER_IMAGE_TAG:latest}"\
     \}'
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/setup.yml


### PR DESCRIPTION
This allows us to control the docker registry, image name and tag name
for the containers.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>