### PR TITLE
Allow NFS role to copy admin key

### DIFF
--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -19,6 +19,9 @@ dummy:
 #
 #cephx: true
 
+# The admin key is necessary with cephx to create users in RGW.  If ansible is
+# creating the user, you will need the admin key.
+#copy_admin_key: false
 
 #######################
 # Access type options #

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -11,6 +11,9 @@ fetch_directory: fetch/
 #
 cephx: true
 
+# The admin key is necessary with cephx to create users in RGW.  If ansible is
+# creating the user, you will need the admin key.
+copy_admin_key: false
 
 #######################
 # Access type options #

--- a/roles/ceph-nfs/tasks/pre_requisite.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite.yml
@@ -10,6 +10,20 @@
     - /var/lib/nfs/ganesha
     - /var/run/ganesha
 
+- name: copy rados gateway admin key
+  copy:
+    src: "{{ fetch_directory }}/{{ fsid }}{{ item.name }}"
+    dest: "{{ item.name }}"
+    owner: "ceph"
+    group: "ceph"
+    mode: "0600"
+  with_items:
+    - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  when:
+    - nfs_obj_gw
+    - cephx
+    - item.copy_key|bool
+
 - name: create rgw nfs user
   command: radosgw-admin user create --uid={{ ceph_nfs_rgw_user }} --display-name="RGW NFS User"
   register: rgwuser


### PR DESCRIPTION
If cephx is enabled, then the admin key is necessary to add RGW users.
Add the ability to copy the admin key for the object NFS case.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>