### PR TITLE
ceph-common: persist "disable_transparent_hugepage"

### DIFF
--- a/roles/ceph-common/tasks/misc/system_tuning.yml
+++ b/roles/ceph-common/tasks/misc/system_tuning.yml
@@ -4,11 +4,25 @@
   changed_when: false
   failed_when: false
 
+- name: create tmpfiles.d directory
+  file:
+    path: "/etc/tmpfiles.d"
+    state: "directory"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+  register: "tmpfiles_d"
+  when: disable_transparent_hugepage
+
 - name: disable transparent hugepage
-  shell: |
-    echo never > /sys/kernel/mm/transparent_hugepage/enabled
-  changed_when: false
-  failed_when: false
+  template:
+    src: "tmpfiles_hugepage.j2"
+    dest: "/etc/tmpfiles.d/ceph_transparent_hugepage.conf"
+    group: "root"
+    owner: "root"
+    mode: "0644"
+    force: "yes"
+    validate: "systemd-tmpfiles --create %s"
   when: disable_transparent_hugepage
 
 - name: get default vm.min_free_kbytes

--- a/roles/ceph-common/templates/tmpfiles_hugepage.j2
+++ b/roles/ceph-common/templates/tmpfiles_hugepage.j2
@@ -1,0 +1,3 @@
+{{ '# ' + ansible_managed }}
+
+{{ 'w /sys/kernel/mm/transparent_hugepage/enabled - - - - never' }}


### PR DESCRIPTION
Resolve #1408 and #1013.

First check tmpfiles.d directory for local administrator is present (or create it).
After file is created - systemd-tmpfiles is executed and if exit zero exit status - all okay and hugepage is tuned (can be covered in tests).