### PR TITLE
test: use vagrant inventory file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,7 @@ setenv=
   jewel: CEPH_STABLE_RELEASE = jewel
   kraken: CEPH_STABLE_RELEASE = kraken
   kraken: UPDATE_CEPH_STABLE_RELEASE = luminous
+  VAGRANT_INVENTORY = .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory
 deps=
   ansible1.9: ansible==1.9.4
   ansible2.1: ansible==2.1
@@ -107,9 +108,9 @@ commands=
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
-  rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
+  rhcs: ansible-playbook -vv -i {changedir}/{env:VAGRANT_INVENTORY} {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
 
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars '\
+  ansible-playbook -vv -i {changedir}/{env:VAGRANT_INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars '\
     \{\
      "fetch_directory":"{env:FETCH_DIRECTORY:{changedir}/fetch}",\
      "ceph_rhcs":{env:CEPH_RHCS:false},\
@@ -124,9 +125,9 @@ commands=
      "ceph_docker_image_tag":"{env:CEPH_DOCKER_IMAGE_TAG:latest}"\
     \}'
 
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/setup.yml
+  ansible-playbook -vv -i {changedir}/{env:VAGRANT_INVENTORY} {toxinidir}/tests/functional/setup.yml
 
-  testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
+  testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:VAGRANT_INVENTORY} {toxinidir}/tests/functional/tests
 
   purge_cluster: {[purge]commands}
   purge_dmcrypt: {[purge]commands}


### PR DESCRIPTION
Instead of writing a host file for each scenario, let's re use the file
generated by vagrant during the up sequence.

Signed-off-by: Sébastien Han <seb@redhat.com>