### PR TITLE
Only assemble {{ cluster }}.conf and osd.conf

### DIFF
--- a/roles/ceph-common/tasks/generate_ceph_conf.yml
+++ b/roles/ceph-common/tasks/generate_ceph_conf.yml
@@ -25,6 +25,7 @@
   assemble:
     src: /etc/ceph/ceph.d/
     dest: /etc/ceph/{{ cluster }}.conf
+    regexp: "^(({{cluster}})|(osd)).conf$"
     owner: "ceph"
     group: "ceph"
     mode: "0644"

--- a/roles/ceph-osd/tasks/osd_fragment.yml
+++ b/roles/ceph-osd/tasks/osd_fragment.yml
@@ -68,6 +68,7 @@
   assemble:
     src: /etc/ceph/ceph.d/
     dest: /etc/ceph/{{ cluster }}.conf
+    regexp: "^(({{cluster}})|(osd)).conf$"
     owner: "ceph"
     group: "ceph"
     mode: "0644"


### PR DESCRIPTION
Ansible's assemble module by default will put all files in the src
directory together into dest. We only want to put {{ cluster }}.conf
and osd.conf together, not anything that might have found its way into
/etc/ceph/ceph.d (e.g. files left by the sysadmin taking backups
before an ansible run). So specify a regexp that matches only those
two files.

Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>