### PR TITLE
Backport osd fragments fix

### DIFF
--- a/roles/ceph-common/tasks/generate_ceph_conf.yml
+++ b/roles/ceph-common/tasks/generate_ceph_conf.yml
@@ -25,6 +25,7 @@
   assemble:
     src: /etc/ceph/ceph.d/
     dest: /etc/ceph/{{ cluster }}.conf
+    regexp: "^(({{cluster}})|(osd)).conf$"
     owner: "ceph"
     group: "ceph"
     mode: "0644"

--- a/roles/ceph-common/tasks/generate_ceph_conf.yml
+++ b/roles/ceph-common/tasks/generate_ceph_conf.yml
@@ -1,22 +1,33 @@
 ---
-- name: create ceph conf directory
+- name: create ceph conf directory and assemble directory
   file:
-    path: /etc/ceph
+    path: "{{ item }}"
     state: directory
     owner: "{{ dir_owner }}"
     group: "{{ dir_group }}"
     mode: "{{ dir_mode }}"
+  with_items:
+    - /etc/ceph/
+    - /etc/ceph/ceph.d/
 
 - name: "generate ceph configuration file: {{ cluster }}.conf"
   action: config_template
   args:
     src: ceph.conf.j2
-    dest: /etc/ceph/{{ cluster }}.conf
+    dest: /etc/ceph/ceph.d/{{ cluster }}.conf
     owner: "{{ dir_owner }}"
     group: "{{ dir_group }}"
     mode: "{{ activate_file_mode }}"
     config_overrides: "{{ ceph_conf_overrides }}"
     config_type: ini
+
+- name: assemble {{ cluster }}.conf and fragments
+  assemble:
+    src: /etc/ceph/ceph.d/
+    dest: /etc/ceph/{{ cluster }}.conf
+    owner: "ceph"
+    group: "ceph"
+    mode: "0644"
   notify:
     - restart ceph mons
     - restart ceph osds

--- a/roles/ceph-osd/tasks/osd_fragment.yml
+++ b/roles/ceph-osd/tasks/osd_fragment.yml
@@ -68,6 +68,7 @@
   assemble:
     src: /etc/ceph/ceph.d/
     dest: /etc/ceph/{{ cluster }}.conf
+    regexp: "^(({{cluster}})|(osd)).conf$"
     owner: "{{ dir_owner }}"
     group: "{{ dir_group }}"
     mode: "{{ activate_file_mode }}"


### PR DESCRIPTION
This backports 3 fixes from master onto stable-2.1 They are 349b9ab3e72f188c50b5f84f3ce5ee2fddcfbf80 (which means that you don't lose the osd fragments from ceph.conf on nodes that are members of another group as well as osds) and the two commits from my PR https://github.com/ceph/ceph-ansible/pull/1431 which mean you don't pick up stray files from `/etc/ceph/ceph.d`