### PR TITLE
tests: fix ceph_rhcs setup

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -38,8 +38,8 @@
 
 - include: ./installs/install_on_redhat.yml
   when:
-    ansible_os_family == 'RedHat' and
-    not ceph_rhcs_iso_install
+    - ansible_os_family == 'RedHat'
+    - not ceph_rhcs
   tags:
     - package-install
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)

--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -46,6 +46,9 @@
         dest: "{{ change_dir }}/group_vars/all"
       when: change_dir is defined
 
+    - name: print contents of {{ change_dir }}/group_vars/all
+      command: "cat {{ change_dir }}/group_vars/all"
+
 - hosts: all
   gather_facts: true
   become: yes

--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -27,6 +27,25 @@
         dest: "{{ change_dir }}/vagrant_variables.yml"
       when: change_dir is defined
 
+    - name: change ceph_stable to False
+      replace:
+        regexp: "ceph_stable:.*"
+        replace: "ceph_stable: False"
+        dest: "{{ change_dir }}/group_vars/all"
+      when: change_dir is defined
+
+    - name: set ceph_rhcs to True
+      lineinfile:
+        line: "ceph_rhcs: True"
+        dest: "{{ change_dir }}/group_vars/all"
+      when: change_dir is defined
+
+    - name: set ceph_origin to distro
+      lineinfile:
+        line: "ceph_origin: distro"
+        dest: "{{ change_dir }}/group_vars/all"
+      when: change_dir is defined
+
 - hosts: all
   gather_facts: true
   become: yes

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ commands=
      "ceph_dev_branch":"{env:CEPH_DEV_BRANCH:master}",\
      "ceph_dev_sha1":"{env:CEPH_DEV_SHA1:latest}",\
      "ceph_stable_release":"{env:CEPH_STABLE_RELEASE:jewel}",\
-     "ceph_stable":{env:CEPH_STABLE:true}\
     \}'
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/site.yml.sample --extra-vars '\
@@ -30,7 +29,6 @@ commands=
      "ceph_dev_branch":"{env:CEPH_DEV_BRANCH:master}",\
      "ceph_dev_sha1":"{env:CEPH_DEV_SHA1:latest}",\
      "ceph_stable_release":"{env:CEPH_STABLE_RELEASE:jewel}",\
-     "ceph_stable":{env:CEPH_STABLE:true}\
     \}'
   # test that the cluster can be redeployed in a healthy state
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
@@ -50,7 +48,6 @@ commands=
       "ceph_dev_branch":"{env:UPDATE_CEPH_DEV_BRANCH:master}",\
       "ceph_dev_sha1":"{env:UPDATE_CEPH_DEV_SHA1:latest}",\
       "ceph_stable_release":"{env:UPDATE_CEPH_STABLE_RELEASE:kraken}",\
-      "ceph_stable":{env:CEPH_STABLE:true}\
     \}'
 
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
@@ -71,7 +68,6 @@ setenv=
   docker_dedicated_journal: PLAYBOOK = site-docker.yml.sample
   docker_dmcrypt_journal_collocation: PLAYBOOK = site-docker.yml.sample
   rhcs: CEPH_RHCS = true
-  rhcs: CEPH_STABLE = false
   jewel: CEPH_STABLE_RELEASE = jewel
   kraken: CEPH_STABLE_RELEASE = kraken
   kraken: UPDATE_CEPH_STABLE_RELEASE = luminous
@@ -118,7 +114,6 @@ commands=
      "ceph_dev_branch":"{env:CEPH_DEV_BRANCH:master}",\
      "ceph_dev_sha1":"{env:CEPH_DEV_SHA1:latest}",\
      "ceph_stable_release":"{env:CEPH_STABLE_RELEASE:jewel}",\
-     "ceph_stable":{env:CEPH_STABLE:true},\
      "ceph_docker_registry":"{env:CEPH_DOCKER_REGISTRY:docker.io}",\
      "ceph_docker_image":"{env:CEPH_DOCKER_IMAGE:ceph/daemon}",\
      "ceph_docker_image_tag":"{env:CEPH_DOCKER_IMAGE_TAG:latest}"\


### PR DESCRIPTION
When setting ``CEPH_STABLE = false`` as an environment variable it gets passed to --extra-vars as a string, which will always evaluate to ``true`` in the tasks. This PR avoids that by modifying the ``group_vars/all`` for the scenario being tested when we've used the ``rhcs`` prefix.

This also fixes a bug where the ``installs/install_on_redhat.yml`` task was always being included unless you were trying to do an iso install for rhcs.