### PR TITLE
ceph-mon: change command to see if rbd exists

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -57,7 +57,7 @@
 - include: set_osd_pool_default_pg_num.yml
 
 - name: test if rbd exists
-  command: ceph --cluster {{ cluster }} osd pool stats rbd
+  command: ceph --cluster {{ cluster }} osd pool get rbd size
   changed_when: false
   failed_when: false
   register: rbd_pool_exist


### PR DESCRIPTION
The previous command was hanging, see this issue:

https://github.com/ceph/ceph-ansible/issues/1440

Signed-off-by: Andrew Schoen <aschoen@redhat.com>