### PR TITLE
Backport "Make ceph-common aware off osd config fragments" to stable-2.1

### DIFF
--- a/roles/ceph-common/tasks/generate_ceph_conf.yml
+++ b/roles/ceph-common/tasks/generate_ceph_conf.yml
@@ -1,22 +1,33 @@
 ---
-- name: create ceph conf directory
+- name: create ceph conf directory and assemble directory
   file:
-    path: /etc/ceph
+    path: "{{ item }}"
     state: directory
     owner: "{{ dir_owner }}"
     group: "{{ dir_group }}"
     mode: "{{ dir_mode }}"
+  with_items:
+    - /etc/ceph/
+    - /etc/ceph/ceph.d/
 
 - name: "generate ceph configuration file: {{ cluster }}.conf"
   action: config_template
   args:
     src: ceph.conf.j2
-    dest: /etc/ceph/{{ cluster }}.conf
+    dest: /etc/ceph/ceph.d/{{ cluster }}.conf
     owner: "{{ dir_owner }}"
     group: "{{ dir_group }}"
     mode: "{{ activate_file_mode }}"
     config_overrides: "{{ ceph_conf_overrides }}"
     config_type: ini
+
+- name: assemble {{ cluster }}.conf and fragments
+  assemble:
+    src: /etc/ceph/ceph.d/
+    dest: /etc/ceph/{{ cluster }}.conf
+    owner: "{{ dir_owner }}"
+    group: "{{ dir_group }}"
+    mode: "{{ activate_file_mode }}"
   notify:
     - restart ceph mons
     - restart ceph osds


### PR DESCRIPTION
This is already in master, I just backported it to the stable-2.1 branch.
Original commit message below this line:

Make ceph-common aware off osd config fragments

This removes the implicit order requirement when using OSD fragments.
When you use OSD fragments and ceph-osd role is not the last one,
the fragments get removed from ceph.conf by ceph-common.

It is not nice to have this code at two locations, but this is
necessary to prevent problems, when ceph-osd is the last role as
ceph-common gets executed before ceph-osd.

This could be prevented when ceph-common would be explicitly called
at the end of the playbook.

Signed-off-by: Christian Zunker <christian.zunker@codecentric.de>