### PR TITLE
Fixing mgr group references where it is used with with_items and/or when

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -52,7 +52,7 @@
     - cephx
     - groups.get(mgr_group_name, []) | length > 0
     - inventory_hostname == groups[mon_group_name]|last
-  with_items: "{{ groups[mgr_group_name] }}"
+  with_items: "{{ groups.get(mgr_group_name, []) }}"
 
 - include: set_osd_pool_default_pg_num.yml
 

--- a/roles/ceph-mon/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-mon/tasks/docker/fetch_configs.yml
@@ -15,7 +15,6 @@
     tmp_ceph_mgr_keys: /etc/ceph/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring
   with_items: "{{ groups.get(mgr_group_name, []) }}"
   register: tmp_ceph_mgr_keys_result
-  when: "{{ groups.get(mgr_group_name, []) | length > 0 }}"
 
 - name: convert mgr keys to an array
   set_fact:

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -97,7 +97,6 @@
   when:
     - cephx
     - mon_containerized_deployment
-    - "{{ groups.get(mgr_group_name, []) | length > 0 }}"
     - inventory_hostname == groups[mon_group_name]|last
     - not mon_containerized_deployment_with_kv
-  with_items: "{{ groups[mgr_group_name] }}"
+  with_items: "{{ groups.get(mgr_group_name,[]) }}"


### PR DESCRIPTION
"with_items:" gets evaluated before "when:" to be able to skip specific
items. A few tasks using "groups[mgr_group_name]" in their "with_items"
tried to implement a check if the group has more then 0 elements with
"when". This breaks, if the mgr group is not defined:
```
TASK [ceph-mon : add mgr keys to config and keys paths]
************************
fatal: [mon0001]: FAILED! => {"failed": true, "msg": "'dict object' has
no attribute u'mgrs'"}
fatal: [mon0002]: FAILED! => {"failed": true, "msg": "'dict object' has
no attribute u'mgrs'"}
fatal: [mon0003]: FAILED! => {"failed": true, "msg": "'dict object' has
no attribute u'mgrs'"}
```
This commit fixes the "with_items" fields on those tasks and removes
unnecessary "when"s.