### PR TITLE
Apparmor on Ubuntu Xenial will not permit containers to mount devices.

### DIFF
--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -24,6 +24,9 @@ fi
   --rm \
   --net=host \
   --cap-add SYS_ADMIN \
+  {% if ansible_distribution == 'Ubuntu' -%}
+  --security-opt apparmor:unconfined \
+  {% endif -%}
   --pid=host \
   {% if not osd_containerized_deployment_with_kv -%}
   -v /var/lib/ceph:/var/lib/ceph \


### PR DESCRIPTION
The same issue is discussed here: https://github.com/moby/moby/issues/9950
This patch resolves the issue by adding the "--security-opt apparmor:unconfined" option in ceph-osd-run.sh.j2, but only for Debian systems.