### PR TITLE
purge-cluster: remove unneeded tasks

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -423,11 +423,6 @@
 
   tasks:
 
-  - name: check for anything running ceph
-    shell: "ps awux | grep -- /usr/bin/[c]eph-"
-    register: check_for_running_ceph
-    failed_when: check_for_running_ceph.rc == 0
-
   - name: purge ceph packages with yum
     yum:
       name: "{{ item }}"

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -481,19 +481,6 @@
      path: /var/log/ceph
      state: absent
 
-  - name: remove from sysv
-    shell: "update-rc.d -f ceph remove"
-    when: ansible_service_mgr == 'sysvinit'
-
-  - name: remove upstart and sysv files
-    shell: "find /etc -name '*ceph*' -delete"
-    when: ansible_service_mgr == 'upstart'
-
-  - name: remove upstart and apt logs and cache
-    shell: "find /var -name '*ceph*' -delete"
-    failed_when: false
-    when: ansible_distribution == 'Ubuntu'
-
   - name: request data removal
     local_action: shell echo requesting data removal
     become: false

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -423,13 +423,6 @@
 
   tasks:
 
-  - name: stop ceph.target with systemd
-    service:
-      name: ceph.target
-      state: stopped
-      enabled: no
-    when: ansible_service_mgr == 'systemd'
-
   - name: check for anything running ceph
     shell: "ps awux | grep -- /usr/bin/[c]eph-"
     register: check_for_running_ceph

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -506,6 +506,11 @@
       state: absent
     when: ansible_os_family == 'RedHat'
 
+  - name: check for anything running ceph
+    command: "ps -u ceph -U ceph"
+    register: check_for_running_ceph
+    failed_when: check_for_running_ceph.rc == 0
+
 
 - name: purge fetch directory
 


### PR DESCRIPTION
This removes tasks from the end of the purge-cluster playbook that are not needed anymore. This was noticed because in rhcs we install ``ceph-common`` on clients nodes and that package does not include ``ceph.target`` so the playbook would fail.  Removing the packages should stop that service anyway if it is running, eventually we'll want to not install ``ceph-base`` upstream on client nodes either as it's not meant to be installed standalone.

There is also some cleanup on sysv and upstart tasks.