### PR TITLE
ansible: add logging path

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,3 +2,5 @@
 ansible_managed = Please do not change this file directly since it is managed by Ansible and will be overwritten
 action_plugins = plugins/actions
 roles_path = ./roles
+# Be sure the user running Ansible has permissions on the logfile
+log_path = /var/log/ansible.log


### PR DESCRIPTION
Ability to log ansible plays in a log file. Default location is
/var/log/ansible.log
Be sure the user running Ansible has permissions on the logfile.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1445065

Signed-off-by: Sébastien Han <seb@redhat.com>