### PR TITLE
backport-1466: mon: upgrade calamari when running rolling_update playbook

### DIFF
--- a/roles/ceph-mon/tasks/calamari.yml
+++ b/roles/ceph-mon/tasks/calamari.yml
@@ -2,7 +2,7 @@
 - name: install calamari server
   package:
     name: calamari-server
-    state: present
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   tags:
     - package-install
 


### PR DESCRIPTION
Prior to this change, ansible was only checking for the existence of the
package, now if upgrade_ceph_packages is true this means we are
performing an upgrade.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1442016

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 84d96be197617ff8cdf8141e4a52657f172b2809)