### PR TITLE
Re-add osd_directory scenario and properly enabled osd services

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -142,6 +142,16 @@ dummy:
 #raw_journal_devices: []
 
 
+# III. Use directory instead of disk for OSDs
+# Use 'true' to enable this scenario
+
+#osd_directory: false
+#osd_directories:
+#  - /var/lib/ceph/osd/mydir1
+#  - /var/lib/ceph/osd/mydir2
+#osd_directories: []
+
+
 # IV. This will partition disks for BlueStore
 # Use 'true' to enable this scenario
 #bluestore: false

--- a/roles/ceph-osd/README.md
+++ b/roles/ceph-osd/README.md
@@ -17,11 +17,13 @@ Choose between the following scenario to configure your OSDs, **choose only one*
 
 * `journal_collocation`
 * `raw_multi_journal`
+* `osd_directory`
 
 Then:
 
 * `devices`
 * `raw_journal_devices` (**only if** you activated `raw_multi_journal`)
+* `osd_directories` (**only if** you activated `osd_directory`)
 
 # Dependencies
 

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -134,6 +134,16 @@ raw_multi_journal: false
 raw_journal_devices: []
 
 
+# III. Use directory instead of disk for OSDs
+# Use 'true' to enable this scenario
+
+osd_directory: false
+#osd_directories:
+#  - /var/lib/ceph/osd/mydir1
+#  - /var/lib/ceph/osd/mydir2
+osd_directories: []
+
+
 # IV. This will partition disks for BlueStore
 # Use 'true' to enable this scenario
 bluestore: false

--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -13,12 +13,14 @@
 - include: ./check_devices_static.yml
   when:
     - not osd_auto_discovery
+    - not osd_directory
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 
 - include: ./check_devices_auto.yml
   when:
     - osd_auto_discovery
+    - not osd_directory
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 

--- a/roles/ceph-osd/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-osd/tasks/check_mandatory_vars.yml
@@ -28,6 +28,7 @@
     - not osd_containerized_deployment
     - not journal_collocation
     - not raw_multi_journal
+    - not osd_directory
     - not bluestore
     - not dmcrypt_journal_collocation
     - not dmcrypt_dedicated_journal
@@ -40,13 +41,18 @@
     - osd_group_name in group_names
     - not osd_containerized_deployment
     - (journal_collocation and raw_multi_journal)
+      or (journal_collocation and osd_directory)
       or (journal_collocation and bluestore)
+      or (raw_multi_journal and osd_directory)
       or (raw_multi_journal and bluestore)
+      or (osd_directory and bluestore)
       or (dmcrypt_journal_collocation and journal_collocation)
       or (dmcrypt_journal_collocation and raw_multi_journal)
+      or (dmcrypt_journal_collocation and osd_directory)
       or (dmcrypt_journal_collocation and bluestore)
       or (dmcrypt_dedicated_journal and journal_collocation)
       or (dmcrypt_dedicated_journal and raw_multi_journal)
+      or (dmcrypt_dedicated_journal and osd_directory)
       or (dmcrypt_dedicated_journal and bluestore)
       or (dmcrypt_dedicated_journal and dmcrypt_journal_collocation)
 
@@ -71,3 +77,12 @@
     - raw_journal_devices|length == 0
       or devices|length == 0
 
+- name: verify directories have been provided
+  fail:
+    msg: "please provide directories to your osd scenario"
+  when:
+    - osd_group_name is defined
+    - osd_group_name in group_names
+    - not osd_containerized_deployment
+    - osd_directory
+    - osd_directories is not defined

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -20,6 +20,13 @@
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 
+- include: ./scenarios/osd_directory.yml
+  when:
+    - osd_directory
+    - not osd_containerized_deployment
+  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
+  static: False
+
 - include: ./scenarios/bluestore.yml
   when:
     - osd_objectstore == 'bluestore'

--- a/roles/ceph-osd/tasks/osd_fragment.yml
+++ b/roles/ceph-osd/tasks/osd_fragment.yml
@@ -6,6 +6,7 @@
   failed_when: false
   always_run: true
   register: osd_path
+  when: not osd_directory
 
 - name: get osd id
   command: cat {{ item.stdout }}/whoami
@@ -14,12 +15,22 @@
   failed_when: false
   always_run: true
   register: osd_id_non_dir_scenario
+  when: not osd_directory
+
+- name: get osd id for directory scenario
+  command: cat {{ item.stdout }}/whoami
+  with_items: "{{ osd_directories }}"
+  changed_when: false
+  failed_when: false
+  always_run: true
+  register: osd_id_dir_scenario
+  when: osd_directory
 
 # NOTE (leseb): we must do this because of
 # https://github.com/ansible/ansible/issues/4297
 - name: combine osd_path results
   set_fact:
-    combined_osd_id: "{{ osd_id_non_dir_scenario }}"
+    combined_osd_id: "{{ osd_id_non_dir_scenario if not osd_directory else osd_id_dir_scenario }}"
 
 - name: create a ceph fragment and assemble directory
   file:

--- a/roles/ceph-osd/tasks/scenarios/osd_directory.yml
+++ b/roles/ceph-osd/tasks/scenarios/osd_directory.yml
@@ -1,0 +1,49 @@
+---
+## SCENARIO 4: USE A DIRECTORY INSTEAD OF A DISK FOR OSD
+
+# NOTE (leseb): we do not check the filesystem underneath the directory
+# so it is really up to you to configure this properly.
+# Declaring more than one directory on the same filesystem will confuse Ceph.
+- name: create osd directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "ceph"
+    group: "ceph"
+  with_items: "{{ osd_directories }}"
+
+# NOTE (leseb): the prepare process must be parallelized somehow...
+# if you have 64 disks with 4TB each, this will take a while
+# since Ansible will sequential process the loop
+- name: prepare osd directory disk(s)
+  command: "ceph-disk prepare --cluster {{ cluster }} {{ item }}"
+  with_items: "{{ osd_directories }}"
+  changed_when: false
+  when: osd_directory
+
+- name: activate osd(s)
+  command: "ceph-disk activate {{ item }}"
+  with_items: "{{ osd_directories }}"
+  changed_when: false
+
+- name: get osd id
+  shell: |
+    ls /var/lib/ceph/osd/ | grep ceph | sed 's/.*-//'
+  changed_when: false
+  failed_when: false
+  always_run: true
+  register: osd_id
+
+- name: start and add that the osd service(s) to the init sequence
+  service:
+    name: ceph-osd@{{ item }}
+    state: started
+    enabled: yes
+  with_items: "{{ (osd_id|default({})).stdout_lines|default([]) }}"
+  changed_when: false
+
+- name: start and add osd target(s) to the systemd sequence
+  service:
+    name: ceph.target
+    state: started
+    enabled: yes


### PR DESCRIPTION
osd_directory scenario is a useful and ceph-supported deployment
scenario.  This patch set re-adds the scenario to ceph-ansible.

In addition, osd_directory scenario previously was not enabling
the systemd service units for each osd.  This patch set
allows systemd to enable the proper ceph-osd@.service for each
configured osd during the osd_directory scenario.