### PR TITLE
improve shrink-osd.yml can shrink osd when disk damage

### DIFF
--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -118,14 +118,50 @@
 
   - name: deactivating osd(s)
     command: ceph-disk deactivate --cluster {{ cluster }} --deactivate-by-id {{ item.0 }} --mark-out
+    register: deactivate 
+    ignore_errors: yes
     with_together:
       - "{{ osd_ids.split(',') }}"
       - "{{ real_ips }}"
     delegate_to: "{{ item.1 }}"
 
+  - name: set osd(s) out when ceph-disk deactivating fail
+    command: ceph --cluster {{ cluster }} osd out osd.{{ item.0 }}
+    with_together:
+      - "{{ osd_ids.split(',') }}"
+      - "{{ deactivate.results }}"
+    when: 
+      - item.1.stderr|length > 0
+
   - name: destroying osd(s)
     command: ceph-disk destroy --cluster {{ cluster }} --destroy-by-id {{ item.0 }} --zap
+    register: destroy 
+    ignore_errors: yes
     with_together:
       - "{{ osd_ids.split(',') }}"
       - "{{ real_ips }}"
     delegate_to: "{{ item.1 }}"
+
+  - name: remove osd(s) from crush_map when ceph-disk destroy fail
+    command: ceph --cluster {{ cluster }} osd crush remove osd.{{ item.0 }}
+    with_together:
+      - "{{ osd_ids.split(',') }}"
+      - "{{ destroy.results }}"
+    when: 
+      - item.1.stderr|length > 0
+
+  - name: delete osd(s) auth key when ceph-disk destroy fail 
+    command: ceph --cluster {{ cluster }} auth del osd.{{ item.0 }}
+    with_together:
+      - "{{ osd_ids.split(',') }}"
+      - "{{ destroy.results }}"
+    when: 
+      - item.1.stderr|length > 0
+
+  - name: deallocate osd(s) id when ceph-disk destroy fail 
+    command: ceph --cluster {{ cluster }} osd rm {{ item.0 }}
+    with_together:
+      - "{{ osd_ids.split(',') }}"
+      - "{{ destroy.results }}"
+    when: 
+      - item.1.stderr|length > 0


### PR DESCRIPTION
When the osd's disk or partition damage,  we could not use the ceph-disk deactivate and ceph-disk destroy to shrink osd.  It must use the ceph command to shrink osd. 

You can use the sgdisk --zap-all -- /dev/device_name to simulate partition damage.
This osd could not be shrink by this playbook, it will throw error "Cannot find any match device!!" at task deactivating osd(s) 


