### PR TITLE
ceph-common: remove debian_ceph_packages

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -74,15 +74,6 @@ dummy:
 # ceph nodes
 #ntp_service_enabled: true
 
-# The list of ceph packages needed for debian.
-# This variable should only be changed if packages are not available from a given
-# install source or architecture.
-#debian_ceph_packages:
-#  - ceph
-#  - ceph-common    #|--> yes, they are already all dependencies from 'ceph'
-#  - ceph-fs-common #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
-#  - ceph-fuse      #|--> they don't get update so we need to force them
-
 # Whether or not to install the ceph-test package.
 #ceph_test: False
 

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -66,15 +66,6 @@ redhat_package_dependencies:
 # ceph nodes
 ntp_service_enabled: true
 
-# The list of ceph packages needed for debian.
-# This variable should only be changed if packages are not available from a given
-# install source or architecture.
-debian_ceph_packages:
-  - ceph
-  - ceph-common    #|--> yes, they are already all dependencies from 'ceph'
-  - ceph-fs-common #|--> however while proceding to rolling upgrades and the 'ceph' package upgrade
-  - ceph-fuse      #|--> they don't get update so we need to force them
-
 # Whether or not to install the ceph-test package.
 ceph_test: False
 

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -17,11 +17,10 @@
 
 - name: install ceph
   apt:
-    name: "{{ item }}"
+    name: "ceph"
     update_cache: no
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default(ansible_distribution_release) }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-  with_items: "{{ debian_ceph_packages }}"
 
 - name: install ceph-test
   apt:


### PR DESCRIPTION
We shouldn't need this anymore as the upgrade bug that
debian_ceph_packages was used to workaround should have
been fixed as of jewel.

See https://github.com/ceph/ceph-ansible/issues/1481 for more
detailed information.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>