### PR TITLE
tests: collocate a mgr daemon on a mon node

### DIFF
--- a/tests/functional/centos/7/cluster/hosts
+++ b/tests/functional/centos/7/cluster/hosts
@@ -17,3 +17,4 @@ client0
 
 [mgrs]
 mgr0
+mon0


### PR DESCRIPTION
So we can find potential issues with a mgr collocated on a mon node.