### PR TITLE
backport: "tests: allow for insecure docker registries when testing rhcs #1490"

### DIFF
--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -80,6 +80,22 @@
     - name: set MTU on eth1
       command: "ifconfig eth1 mtu 1400 up"
 
+    - name: install docker
+      package:
+        name: docker
+        state: present
+      when: ansible_os_family == 'RedHat'
+
+    - name: allow insecure docker registries
+      lineinfile:
+        line: 'INSECURE_REGISTRY="--insecure-registry {{ ceph_docker_registry }}"'
+        dest: "/etc/sysconfig/docker"
+
+    - name: restart docker
+      service:
+        name: docker
+        state: restarted
+
 - hosts: mons
   gather_facts: false
   become: yes

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ commands=
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
-  rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
+  rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \


### PR DESCRIPTION
backport of #1490