### PR TITLE
Common: Do not install ceph-mgr packages on jewel

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -62,4 +62,6 @@
     pkg: ceph-mgr
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default(ansible_distribution_release) }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-  when: mgr_group_name in group_names
+  when:
+    - mgr_group_name in group_names
+    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -147,4 +147,6 @@
   package:
     name: ceph-mgr
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when: mgr_group_name in group_names
+  when:
+    - mgr_group_name in group_names
+    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
@@ -95,4 +95,6 @@
   apt:
     pkg: ceph-mgr
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when: mgr_group_name in group_names
+  when:
+    - mgr_group_name in group_names
+    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_redhat.yml
@@ -75,4 +75,6 @@
   package:
     name: ceph-mgr
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when: mgr_group_name in group_names
+  when:
+    - mgr_group_name in group_names
+    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -52,6 +52,7 @@
     - cephx
     - groups.get(mgr_group_name, []) | length > 0
     - inventory_hostname == groups[mon_group_name]|last
+    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel
   with_items: "{{ groups.get(mgr_group_name, []) }}"
 
 - include: set_osd_pool_default_pg_num.yml

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -125,3 +125,4 @@
       - item.stat.exists == true
   when:
     - inventory_hostname == groups[mon_group_name]|last
+    - ceph_release_num.{{ ceph_stable_release }} > ceph_release_num.jewel

--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -55,4 +55,4 @@
 - hosts: mgrs
   become: True
   roles:
-  - ceph-mgr
+    - { role: ceph-mgr, when: "ceph_release_num.{{ ceph_stable_release }} > ceph_release_num.jewel" }

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -103,4 +103,4 @@
   gather_facts: false
   become: True
   roles:
-  - ceph-mgr
+    - { role: ceph-mgr, when: "ceph_release_num.{{ ceph_stable_release }} > ceph_release_num.jewel" }

--- a/tests/functional/tests/test_install.py
+++ b/tests/functional/tests/test_install.py
@@ -1,11 +1,12 @@
 import pytest
 
+
 class TestInstall(object):
 
-    def test_ceph_dir_exists(self, File):
+    def test_ceph_dir_exists(self, File, node):
         assert File('/etc/ceph').exists
 
-    def test_ceph_dir_is_a_directory(self, File):
+    def test_ceph_dir_is_a_directory(self, File, node):
         assert File('/etc/ceph').is_directory
 
     def test_ceph_conf_exists(self, File, node):


### PR DESCRIPTION
ceph-mgr tasks have to be skipped on jewel.

Fix: #1494

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>