### PR TITLE
tests: update default of CEPH_STABLE_RELEASE to kraken

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,12 @@ commands=
   cp {toxinidir}/infrastructure-playbooks/purge-cluster.yml {toxinidir}/purge-cluster.yml
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/purge-cluster.yml --extra-vars "\
       ireallymeanit=yes \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:jewel} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:kraken} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
   "
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/site.yml.sample --extra-vars "\
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:jewel} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:kraken} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
   "
   # test that the cluster can be redeployed in a healthy state
@@ -92,7 +92,7 @@ commands=
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:jewel} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:kraken} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \


### PR DESCRIPTION
Now that the default value in ``ceph-common/defaults/main.yml`` for ``ceph_stable_release`` is kraken the CI should match that.