### PR TITLE
rgw: move default bucket quota conf vars to global

### DIFF
--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -73,6 +73,12 @@ public network = {{ public_network }}
 {% if cluster_network is defined %}
 cluster network = {{ cluster_network }}
 {% endif %}
+{% if rgw_override_bucket_index_max_shards is defined %}
+rgw override bucket index max shards = {{ rgw_override_bucket_index_max_shards }}
+{% endif %}
+{% if rgw_bucket_default_quota_max_objects is defined %}
+rgw bucket default quota max objects = {{ rgw_bucket_default_quota_max_objects }}
+{% endif %}
 
 [client.libvirt]
 admin socket = {{ rbd_client_admin_socket_path }}/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
@@ -108,12 +114,6 @@ host = {{ hostvars[host]['ansible_hostname'] }}
 [client.rgw.{{ hostvars[host]['ansible_hostname'] }}]
 {% if radosgw_dns_name is defined %}
 rgw dns name = {{ radosgw_dns_name }}
-{% endif %}
-{% if rgw_override_bucket_index_max_shards is defined %}
-rgw override bucket index max shards = {{ rgw_override_bucket_index_max_shards }}
-{% endif %}
-{% if rgw_bucket_default_quota_max_objects is defined %}
-rgw bucket default quota max objects = {{ rgw_bucket_default_quota_max_objects }}
 {% endif %}
 host = {{ hostvars[host]['ansible_hostname'] }}
 keyring = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_hostname'] }}/keyring


### PR DESCRIPTION
"rgw override bucket index max shards" and
"rgw bucket default quota max objects" were in the
client section of the ceph.conf and not being
applied, this commit moves them to global

Resolves: bz#1391500

Signed-off-by: Ali Maredia <amaredia@redhat.com>
(cherry picked from commit 2aeb3a4957e17f6abace7c58cb795a4c0f50c9fd)