### PR TITLE
tox: bump ansible version to 2.2.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ setenv=
 deps=
   ansible1.9: ansible==1.9.4
   ansible2.1: ansible==2.1
-  ansible2.2: ansible==2.2.2
+  ansible2.2: ansible==2.2.3
   -r{toxinidir}/tests/requirements.txt
 changedir=
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw xenial cluster using raw_multi_journal OSD scenario


### PR DESCRIPTION
The Ansible team has released v2.2.3, which fixes two CVEs:

CVE-2017-7481
CVE-2017-7466

https://www.ansible.com/security