### PR TITLE
ansible: shorten default control_path

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,3 +4,6 @@ action_plugins = plugins/actions
 roles_path = ./roles
 # Be sure the user running Ansible has permissions on the logfile
 log_path = /var/log/ansible.log
+
+[ssh_connection]
+control_path = %(directory)s/%%h-%%r # see: https://github.com/ansible/ansible/issues/11536


### PR DESCRIPTION
Default ansible control_path option is too long, so we shorten it by
changing the ansible.cfg file.

For more info see: https://github.com/ansible/ansible/issues/11536
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1447569

Signed-off-by: Sébastien Han <seb@redhat.com>