### PR TITLE
monitor_interface: document need to use monitor_address when using IPv6

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -249,6 +249,7 @@ dummy:
 #
 # You must define either monitor_interface or monitor_address. Preference
 # will go to monitor_interface if both are defined.
+# To use an IPv6 address, use the monitor_address setting instead (and set ip_version to ipv6)
 #monitor_interface: interface
 #monitor_address: 0.0.0.0
 # set to either ipv4 or ipv6, whichever your network is using

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -241,6 +241,7 @@ rbd_client_admin_socket_path: /var/run/ceph # must be writable by QEMU and allow
 #
 # You must define either monitor_interface or monitor_address. Preference
 # will go to monitor_interface if both are defined.
+# To use an IPv6 address, use the monitor_address setting instead (and set ip_version to ipv6)
 monitor_interface: interface
 monitor_address: 0.0.0.0
 # set to either ipv4 or ipv6, whichever your network is using


### PR DESCRIPTION
Already documented in the [Red Hat Ceph Storage 2 Installation Guide for Red Hat Enterprise Linux](https://access.redhat.com/webassets/avalon/d/Red_Hat_Ceph_Storage-2-Installation_Guide_for_Red_Hat_Enterprise_Linux-en-US/Red_Hat_Ceph_Storage-2-Installation_Guide_for_Red_Hat_Enterprise_Linux-en-US.pdf), but not here.