### PR TITLE
mon: do not create mgr key on jewel

### DIFF
--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -125,4 +125,5 @@
       - item.stat.exists == true
   when:
     - inventory_hostname == groups[mon_group_name]|last
-    - ceph_release_num.{{ ceph_stable_release }} > ceph_release_num.jewel
+    - not ceph_docker_image_tag.find('jewel') != -1
+    - ceph_docker_image != 'rhceph'


### PR DESCRIPTION
The CI on Docker is reporting the following error:

STDERR:
Error EINVAL: bad entity name

This is due to the fact that this auth entity name does not exist on
Jewel so we should not create that key when running Jewel containers.

Fixes: https://github.com/ceph/ceph-ansible/issues/1514

Signed-off-by: Sébastien Han <seb@redhat.com>