### PR TITLE
generate_group_vars_sample: merge role variables

### DIFF
--- a/generate_group_vars_sample.sh
+++ b/generate_group_vars_sample.sh
@@ -2,20 +2,20 @@
 
 set -euo pipefail
 
+#############
+# VARIABLES #
+#############
+
 basedir=$(dirname "$0")
+no_header="ceph-docker-common" # pipe separated list of roles with no header, MUST end with '$', e.g: 'foo$|bar$'
+merge_in_all="ceph-common$|ceph-docker-common$" # pipe separated list of roles you want to merge in all.yml.sample, MUST end with '$', e.g: 'foo$|bar$'
 
-for role in "$basedir"/roles/ceph-*; do
-  rolename=$(basename "$role")
-  if [[ $rolename == "ceph-common" ]]; then
-    output="all.yml.sample"
-  elif [[ $rolename == "ceph-agent" ]]; then
-    output="agent.yml.sample"
-  elif [[ $rolename == "ceph-fetch-keys" ]]; then
-    output="ceph-fetch-keys.yml.sample"
-  else
-    output="${rolename:5}s.yml.sample"
-  fi
 
+#############
+# FUNCTIONS #
+#############
+
+populate_header () {
   cat <<EOF > "$basedir"/group_vars/"$output"
 ---
 # Variables here are applicable to all host groups NOT roles
@@ -27,11 +27,9 @@ for role in "$basedir"/roles/ceph-*; do
 dummy:
 
 EOF
-  defaults="$role"/defaults/main.yml
-  if [[ ! -f $defaults ]]; then
-    continue
-  fi
+}
 
+generate_group_vars_file () {
   if [ "$(uname)" == "Darwin" ]; then
     sed '/^---/d; s/^\([A-Za-z[:space:]]\)/#\1/' \
       "$defaults" >> "$basedir"/group_vars/"$output"
@@ -44,4 +42,37 @@ EOF
     echo "Unsupported platform"
     exit 1
   fi
+}
+
+
+########
+# MAIN #
+########
+
+for role in "$basedir"/roles/ceph-*; do
+  rolename=$(basename "$role")
+
+  if echo "$rolename" | grep -qE "$merge_in_all"; then
+    output="all.yml.sample"
+  elif [[ $rolename == "ceph-agent" ]]; then
+    output="agent.yml.sample"
+  elif [[ $rolename == "ceph-fetch-keys" ]]; then
+    output="ceph-fetch-keys.yml.sample"
+  else
+    output="${rolename:5}s.yml.sample"
+  fi
+
+
+  # Do not re-regenerate the header for certain roles
+  # since we merge them in all.yml.sample
+  if ! echo "$rolename" | grep -qE "$no_header"; then
+    populate_header
+  fi
+
+  defaults="$role"/defaults/main.yml
+  if [[ ! -f $defaults ]]; then
+    continue
+  fi
+
+  generate_group_vars_file
 done

--- a/generate_group_vars_sample.sh
+++ b/generate_group_vars_sample.sh
@@ -7,13 +7,13 @@ basedir=$(dirname "$0")
 for role in "$basedir"/roles/ceph-*; do
   rolename=$(basename "$role")
   if [[ $rolename == "ceph-common" ]]; then
-      output="all.yml.sample"
+    output="all.yml.sample"
   elif [[ $rolename == "ceph-agent" ]]; then
-      output="agent.yml.sample"
+    output="agent.yml.sample"
   elif [[ $rolename == "ceph-fetch-keys" ]]; then
-      output="ceph-fetch-keys.yml.sample"
+    output="ceph-fetch-keys.yml.sample"
   else
-      output="${rolename:5}s.yml.sample"
+    output="${rolename:5}s.yml.sample"
   fi
 
   cat <<EOF > "$basedir"/group_vars/"$output"
@@ -29,16 +29,16 @@ dummy:
 EOF
   defaults="$role"/defaults/main.yml
   if [[ ! -f $defaults ]]; then
-      continue
+    continue
   fi
 
   if [ "$(uname)" == "Darwin" ]; then
-  sed '/^---/d; s/^\([A-Za-z[:space:]]\)/#\1/' \
-        "$defaults" >> "$basedir"/group_vars/"$output"
+    sed '/^---/d; s/^\([A-Za-z[:space:]]\)/#\1/' \
+      "$defaults" >> "$basedir"/group_vars/"$output"
     echo >> "$basedir"/group_vars/"$output"
   elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     sed '/^---/d; s/^\([A-Za-z[:space:]].\+\)/#\1/' \
-        "$defaults" >> "$basedir"/group_vars/"$output"
+      "$defaults" >> "$basedir"/group_vars/"$output"
     echo >> "$basedir"/group_vars/"$output"
   else
     echo "Unsupported platform"

--- a/generate_group_vars_sample.sh
+++ b/generate_group_vars_sample.sh
@@ -36,7 +36,7 @@ EOF
     sed '/^---/d; s/^\([A-Za-z[:space:]]\)/#\1/' \
       "$defaults" >> "$basedir"/group_vars/"$output"
     echo >> "$basedir"/group_vars/"$output"
-  elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  elif [ "$(uname -s)" == "Linux" ]; then
     sed '/^---/d; s/^\([A-Za-z[:space:]].\+\)/#\1/' \
       "$defaults" >> "$basedir"/group_vars/"$output"
     echo >> "$basedir"/group_vars/"$output"

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -403,3 +403,14 @@ dummy:
 # do not ever change this here
 #rolling_update: false
 
+#ceph_docker_registry: docker.io
+#ceph_docker_enable_centos_extra_repo: false
+
+#mon_use_fqdn: false # if set to true, the MON name used will be the fqdn
+
+# Set uid/gid to default '64045' for bootstrap directories.
+# '64045' is used for debian based distros. It must be set to 167 in case of rhel based distros.
+# These values have to be set according to the base OS used by the container image, NOT the host.
+#bootstrap_dirs_owner: "64045"
+#bootstrap_dirs_group: "64045"
+

--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -37,7 +37,7 @@ dummy:
 # important to split them into shards. We suggest about 100K
 # objects per shard as a conservative maximum.
 #rgw_override_bucket_index_max_shards: 16
- 
+# 
 # Consider setting a quota on buckets so that exceeding this
 # limit will require admin intervention.
 #rgw_bucket_default_quota_max_objects: 1638400 # i.e., 100K * 16


### PR DESCRIPTION
In some case, ceph_docker_registry does not match with a defined host
group in the playbook so we make this variable widely available.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1447179

Signed-off-by: Sébastien Han <seb@redhat.com>