### PR TITLE
tests: pin testinfra to 1.6.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
 # These are Python requirements needed to run the functional tests
-testinfra
+# 1.6.1 fails with 'testinfra is in an unsupported or invalid wheel'
+# see https://github.com/philpep/testinfra/issues/201
+testinfra==1.6.0
 pytest-xdist


### PR DESCRIPTION
1.6.1 fails with 'testinfra is in an unsupported or invalid wheel'

See: https://github.com/philpep/testinfra/issues/201

Signed-off-by: Andrew Schoen <aschoen@redhat.com>