### PR TITLE
mon: do not hardcode ipv4

### DIFF
--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
    --net=host \
    {% endif -%}
    -e CEPH_DAEMON=MON \
-   -e MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface]['ipv4']['address'] }} \
+   -e MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface][ip_version]['address'] }} \
    -e CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }} \
    {{ ceph_mon_docker_extra_env }} \
    {{ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}


### PR DESCRIPTION
Problem: fail to deploy a containerized Ceph cluster with ipv6
Solution: do not hardcode ipv4 when bootstrapping the container.

Now use ip_version: ipv6 to get a containerized cluster deployed with
ipv6.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1451786
Signed-off-by: Sébastien Han <seb@redhat.com>