### PR TITLE
common: explicitly set rhel os version support

### DIFF
--- a/roles/ceph-common/tasks/checks/check_system.yml
+++ b/roles/ceph-common/tasks/checks/check_system.yml
@@ -16,7 +16,7 @@
 
 - name: fail on unsupported distribution for red hat ceph storage
   fail:
-    msg: "Distribution not supported {{ ansible_distribution_version }} by Red Hat Ceph Storage, only RHEL 7"
+    msg: "Distribution not supported {{ ansible_distribution_version }} by Red Hat Ceph Storage, only RHEL >= 7.3"
   when:
     - ceph_rhcs
     - ansible_distribution_version | version_compare('7.3', '<')


### PR DESCRIPTION
Clarify in the error message that only RHEL version >= 7.3 are
supported.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1452431
Signed-off-by: Sébastien Han <seb@redhat.com>