### PR TITLE
Add an option for setting rbd_default_features in ceph.conf

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -209,6 +209,14 @@ dummy:
 #rbd_cache_writethrough_until_flush: "true"
 #rbd_concurrent_management_ops: 20
 
+## The different features are:
+# layering: layering support, where id is 1
+# striping: striping v2 support, where id is 2
+# exclusive-lock: exclusive locking support, where id is 4
+# object-map: object map support (requires exclusive-lock), where id is 8
+# To enable more than one just add the numbers. For example to enable exclusive-lock and object-map set rbd_default_features to 12
+#rbd_default_features: 3
+
 #rbd_client_directories: true # this will create rbd_client_log_path and rbd_client_admin_socket_path directories with proper permissions
 
 # Permissions for the rbd_client_log_path and

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -30,6 +30,10 @@ mon initial members = {% for host in groups[mon_group_name] %}
     {% endfor %}
 {% endif %}
 
+{% if rbd_default_features is defined %}
+rbd default features = {{ rbd_default_features }}
+{% endif %}
+
 {% if not mon_containerized_deployment and not mon_containerized_deployment_with_kv %}
 {% if monitor_address_block %}
 mon host = {% for host in groups[mon_group_name] %}{{ hostvars[host]['ansible_all_ipv4_addresses'] | ipaddr(monitor_address_block) | first }}{% if not loop.last %},{% endif %}{% endfor %}


### PR DESCRIPTION
Having exclusive-lock, object-map, fast-diff, and deep-flatten enabled was
preventing mapping on CentOS 7.