### PR TITLE
common: fix installation condition

### DIFF
--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -29,6 +29,6 @@
     - ceph_rhcs
     - not ceph_rhcs_cdn_install
     - not ceph_rhcs_iso_install
-    - ceph_origin == "upstream"
+    - ceph_origin != 'distro'
   tags:
     - package-install

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -74,8 +74,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - mon_group_name in group_names
-      or ceph_origin == "distro"
-      or ceph_custom
 
 - name: install distro or red hat storage ceph osd
   package:
@@ -83,8 +81,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - osd_group_name in group_names
-      or ceph_origin == "distro"
-      or ceph_custom
 
 - name: install distro or red hat storage ceph mds
   package:
@@ -92,8 +88,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - mds_group_name in group_names
-      or ceph_origin == "distro"
-      or ceph_custom
 
 - name: install distro or red hat storage ceph-fuse
   package:
@@ -101,9 +95,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - client_group_name in group_names
-      or ceph_origin == "distro"
-      or ceph_dev
-      or ceph_custom
 
 - name: install distro or red hat storage ceph base
   package:
@@ -111,8 +102,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - client_group_name in group_names
-      or ceph_origin == "distro"
-      or ceph_custom
 
 - name: install ceph-test
   package:


### PR DESCRIPTION
Problem: we could end up in situation where we would install a package
on a machine that does not have the right repo enabled. Because the
condition was set to OR we weren't pinning a particular host but just a
condition. Let's say someone sets 'ceph_origin == "distro"', this would
try to install OSD packages on Monitors.

Solution: use a AND condition to first pin to the group_name (which
identifies a set of hosts) AND then after this one of the installation
condition.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1453119
Signed-off-by: Sébastien Han <seb@redhat.com>