### PR TITLE
backport: mon: fix with_items being evaluated before when

### DIFF
--- a/roles/ceph-mon/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-mon/tasks/docker/fetch_configs.yml
@@ -13,7 +13,7 @@
 - name: add mgr keys to config and keys paths
   set_fact:
     tmp_ceph_mgr_keys: /etc/ceph/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring
-  with_items: "{{ groups[mgr_group_name] }}"
+  with_items: "{{ groups.get(mgr_group_name, []) }}"
   register: tmp_ceph_mgr_keys_result
   when: "{{ groups.get(mgr_group_name, []) | length > 0 }}"
 


### PR DESCRIPTION
Ansible evaluates the 'with_items' before the 'when' so if the inventory
does not have the group declared it'll fail. To fix this, we set an
empty array to make the with_items happy and then evaluate with the
'when'.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 05331a26348e162e4083131d2a259f6c983f3ec9)
Signed-off-by: Sébastien Han <seb@redhat.com>