### PR TITLE
purge-docker-cluster fix and test

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -360,29 +360,19 @@
       enabled: no
     when: not is_atomic
 
-  - name: remove docker-py
-    pip:
-      name: docker-py
-      version: 1.1.0
-      state: absent
-    when:
-      ansible_version['full'] | version_compare('2.1.0.0', '<') and
-      not is_atomic
-
-  - name: remove docker-py
+  - name: remove docker-py on Debian
     pip:
       name: docker-py
       state: absent
     when:
-      ansible_version['full'] | version_compare('2.1.0.0', '>=') and
-      not is_atomic
+      - ansible_distribution == 'Debian'
 
-  - name: remove six
+  - name: remove six on Debian
     pip:
       name: six
-      version: 1.9.0
       state: absent
-    when: not is_atomic
+    when:
+      - ansible_distribution == 'Debian'
 
   - name: remove pip and docker on ubuntu
     apt:

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -249,7 +249,7 @@
       zap_device
     with_items:
       - "{{ ceph_osd_docker_devices }}"
-      - "{{ raw_journal_devices }}"
+      - "{{ raw_journal_devices|default([]) }}"
 
   - name: wait until the zap containers die
     shell: |
@@ -267,7 +267,7 @@
       state: absent
     with_items:
       - "{{ ceph_osd_docker_devices }}"
-      - "{{ raw_journal_devices }}"
+      - "{{ raw_journal_devices|default([]) }}"
 
   - name: remove ceph osd service
     file:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {jewel,kraken,rhcs}-{ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster,cluster}
+envlist = {jewel,kraken,rhcs}-{ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster,cluster,purge_docker_cluster}
 skipsdist = True
 
 # extra commands for purging clusters
@@ -8,16 +8,23 @@ skipsdist = True
 # can be redployed to.
 [purge]
 commands=
-  cp {toxinidir}/infrastructure-playbooks/purge-cluster.yml {toxinidir}/purge-cluster.yml
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/purge-cluster.yml --extra-vars "\
+  cp {toxinidir}/infrastructure-playbooks/{env:PURGE_PLAYBOOK:purge-cluster.yml} {toxinidir}/{env:PURGE_PLAYBOOK:purge-cluster.yml}
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
       ireallymeanit=yes \
+      remove_packages=yes \
       ceph_stable_release={env:CEPH_STABLE_RELEASE:kraken} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \
   "
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/site.yml.sample --extra-vars "\
       ceph_stable_release={env:CEPH_STABLE_RELEASE:kraken} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \
   "
   # test that the cluster can be redeployed in a healthy state
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
@@ -49,6 +56,8 @@ setenv=
   # only available for ansible >= 2.2
   ANSIBLE_STDOUT_CALLBACK = debug
   docker_cluster: PLAYBOOK = site-docker.yml.sample
+  purge_docker_cluster: PLAYBOOK = site-docker.yml.sample
+  purge_docker_cluster: PURGE_PLAYBOOK = purge-docker-cluster.yml
   docker_dedicated_journal: PLAYBOOK = site-docker.yml.sample
   docker_dmcrypt_journal_collocation: PLAYBOOK = site-docker.yml.sample
   rhcs: CEPH_STABLE_RELEASE = jewel
@@ -76,6 +85,7 @@ changedir=
   cluster: {toxinidir}/tests/functional/centos/7/cluster
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw centos7 cluster using docker
   docker_cluster: {toxinidir}/tests/functional/centos/7/docker-cluster
+  purge_docker_cluster: {toxinidir}/tests/functional/centos/7/docker-cluster
   docker_dedicated_journal: {toxinidir}/tests/functional/centos/7/docker-cluster-dedicated-journal
   docker_dmcrypt_journal_collocation: {toxinidir}/tests/functional/centos/7/docker-cluster-dmcrypt-journal-collocation
   purge_cluster: {toxinidir}/tests/functional/ubuntu/16.04/cluster
@@ -104,6 +114,7 @@ commands=
 
   purge_cluster: {[purge]commands}
   purge_dmcrypt: {[purge]commands}
+  purge_docker_cluster: {[purge]commands}
   update_dmcrypt: {[update]commands}
   update_cluster: {[update]commands}
 


### PR DESCRIPTION
- defaults ``raw_journal_devices`` to ``[]``. This allows the purge-docker-cluster.yml playbook to complete if the cluster was not deployed with dedicated journals

- creates a testing scenario for purging containerized clusters

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1455187