### PR TITLE
DNM: docker: bindmount /var/log/ceph

### DIFF
--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -10,6 +10,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    {% if not mds_containerized_deployment_with_kv -%}
    -v /var/lib/ceph:/var/lib/ceph \
    -v /etc/ceph:/etc/ceph \
+   -v /var/log/ceph:/var/log/ceph \
    {% else -%}
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}} \

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -10,6 +10,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    {% if not mgr_containerized_deployment_with_kv -%}
    -v /var/lib/ceph:/var/lib/ceph \
    -v /etc/ceph:/etc/ceph \
+   -v /var/log/ceph:/var/log/ceph \
    {% else -%}
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}} \

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -10,6 +10,7 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
    {% if not mon_containerized_deployment_with_kv -%}
    -v /var/lib/ceph:/var/lib/ceph \
    -v /etc/ceph:/etc/ceph \
+   -v /var/log/ceph:/var/log/ceph \
    {% else -%}
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}}\

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -31,6 +31,7 @@ fi
   {% if not osd_containerized_deployment_with_kv -%}
   -v /var/lib/ceph:/var/lib/ceph \
   -v /etc/ceph:/etc/ceph \
+  -v /var/log/ceph:/var/log/ceph \
   {% else -%}
   -e KV_TYPE={{kv_type}} \
   -e KV_IP={{kv_endpoint}} \

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -9,6 +9,7 @@ ExecStartPre=-/usr/bin/docker rm ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStart=/usr/bin/docker run --rm --net=host \
    {% if not rbd_mirror_containerized_deployment_with_kv -%}
    -v /etc/ceph:/etc/ceph \
+   -v /var/log/ceph:/var/log/ceph \
    {% else -%}
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}} \

--- a/roles/ceph-rgw/templates/ceph-rgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-rgw.service.j2
@@ -10,6 +10,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    {% if not rgw_containerized_deployment_with_kv -%}
    -v /var/lib/ceph:/var/lib/ceph \
    -v /etc/ceph:/etc/ceph \
+   -v /var/log/ceph:/var/log/ceph \
    {% else -%}
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}} \


### PR DESCRIPTION
Currently, we do not export /var/log/ceph to the containers and we
remove them once they are stopped so we have no way of getting the logs
after e.g. a osd daemon crashes. The logs are just lost and we have no
idea why the daemon in the container stopped.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1455509
Signed-off-by: Sébastien Han <seb@redhat.com>