### PR TITLE
keep port as part of the control path

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,4 +10,4 @@ log_path = /var/log/ansible.log
 
 [ssh_connection]
 # see: https://github.com/ansible/ansible/issues/11536
-control_path = %(directory)s/%%h-%%r
+control_path = %(directory)s/%%h-%%r-%%p


### PR DESCRIPTION
On a Vagrant setup, every host is 127.0.0.1 and every user is vagrant.
To not have ansible do the same stuff on the same machine (the one
we connected first), we should keep the port as part of the
control path.

Also this helps in setups where different hosts might be hidden
behind the same IP, but on different ports (e.g. using DNAT).