### PR TITLE
tests: use docker playbook when redeploying a purged cluster

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands=
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \
   "
   # set up the cluster again
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/site.yml.sample --extra-vars "\
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ceph_stable_release={env:CEPH_STABLE_RELEASE:kraken} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \


### PR DESCRIPTION
When we purge a containerized cluster we need to use the correct
playbook when redploying the cluster.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>