### PR TITLE
DNM: Backport Common: Improve check pgs

### DIFF
--- a/roles/ceph-common/templates/restart_osd_daemon.sh.j2
+++ b/roles/ceph-common/templates/restart_osd_daemon.sh.j2
@@ -6,7 +6,7 @@ CEPH_CLI="--name client.bootstrap-osd --keyring /var/lib/ceph/bootstrap-osd/{{ c
 
 check_pgs() {
   while [ $RETRIES -ne 0 ]; do
-    ceph $CEPH_CLI -s | grep -sq 'active+clean'
+    test "$(ceph $CEPH_CLI -s | grep pgmap | sed -r 's/.*: ([0-9]+) pgs.*/\1/g')" -eq "$(ceph $CEPH_CLI -s | egrep '\sactive\+clean' | sed -r 's/[^0-9]*//g')" && ceph $CEPH_CLI health | egrep -sq "HEALTH_OK|HEALTH_WARN"
     RET=$?
     test $RET -eq 0 && exit 0
     sleep $DELAY


### PR DESCRIPTION
For some reason we changed the check of pgs but it appears it could be
dangerous because the current check might satisfied as long as 1 PG is
active+clean.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 0542a95b686eabe96e1a71f6a8c92dcba2a7b4e8)
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>

Backport of #1580 