### PR TITLE
rpm: do not package iscsi files

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -43,6 +43,13 @@ pushd %{buildroot}%{_datarootdir}/ceph-ansible
   rm group_vars/common-coreoss.yml.sample
 popd
 
+# Strip iscsi files.
+# These are just placeholders until ceph-iscsi-gw can merge into
+# ceph-ansible. (See https://bugzilla.redhat.com/1454945).
+pushd %{buildroot}%{_datarootdir}/ceph-ansible
+  rm -r roles/ceph-iscsi-gw
+popd
+
 %check
 # Borrowed from upstream's .travis.yml:
 ansible-playbook -i dummy-ansible-hosts test.yml --syntax-check


### PR DESCRIPTION
Currently we cannot install the ceph-iscsi-ansible RPM on a node where the ceph-ansible RPM is already installed.

ceph-iscsi-ansible should install on top of the ceph-ansible environment without issues.