### PR TITLE
ceph-mon: fix support for ipv6 on containerized mons

### DIFF
--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
    --net=host \
    {% endif -%}
    -e CEPH_DAEMON=MON \
-   -e MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface][ip_version]['address'] }} \
+   -e MON_IP={{ hostvars[inventory_hostname]['ansible_default_' + ip_version]['address'] }} \
    -e CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }} \
    {{ ceph_mon_docker_extra_env }} \
    {{ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}


### PR DESCRIPTION
The fact ['ansible_$interface']['ipv4'] is a dictionary where
['ansible_$interface']['ipv6'] is a list. If we use
ansible_default_ipv6|ipv4 is is always a dictionary which allows us to
get the ipv6 and ipv4 address without adding more complexity to the
template.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>