### PR TITLE
backport: "ceph-mon: fix support for ipv6 on containerized mons #1587"

### DIFF
--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
    --net=host \
    {% endif -%}
    -e CEPH_DAEMON=MON \
-   -e MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface][ip_version]['address'] }} \
+   -e MON_IP={{ hostvars[inventory_hostname]['ansible_default_' + ip_version]['address'] }} \
    -e CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }} \
    {{ ceph_mon_docker_extra_env }} \
    {{ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}


### PR DESCRIPTION
backport of #1587