### PR TITLE
remove ceph-iscsi-gw play from site.yml.sample

### DIFF
--- a/site.yml.sample
+++ b/site.yml.sample
@@ -11,7 +11,6 @@
   - restapis
   - rbdmirrors
   - clients
-  - iscsigws
   - mgrs
   gather_facts: false
   tags:
@@ -92,12 +91,6 @@
   become: True
   roles:
   - ceph-client
-
-- hosts: iscsigws
-  gather_facts: false
-  become: True
-  roles:
-  - ceph-iscsi-gw
 
 - hosts: mgrs
   gather_facts: false


### PR DESCRIPTION
We ship ceph-iscsi-gw in a separate repo downstream and do not package
it with ceph-ansible. Including the play for ceph-iscsi-gw in
site.yml.sample makes the playbook fail when using the downstream
packages.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1454945

Signed-off-by: Andrew Schoen <aschoen@redhat.com>