### PR TITLE
Common: Add a default for ceph_docker_on_openstack

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -409,6 +409,8 @@ dummy:
 #ceph_docker_registry: docker.io
 #ceph_docker_enable_centos_extra_repo: false
 
+#ceph_docker_on_openstack: false
+
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn
 
 # Set uid/gid to default '64045' for bootstrap directories.

--- a/roles/ceph-docker-common/defaults/main.yml
+++ b/roles/ceph-docker-common/defaults/main.yml
@@ -4,6 +4,8 @@ generate_fsid: true
 ceph_docker_registry: docker.io
 ceph_docker_enable_centos_extra_repo: false
 
+ceph_docker_on_openstack: false
+
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn
 
 # Set uid/gid to default '64045' for bootstrap directories.


### PR DESCRIPTION
Add a default value for `ceph_docker_on_openstack` to avoid a
conditional check error for the task `pause after docker install before starting` in
`roles/ceph-docker-common/tasks/pre_requisites/prerequisites.yml`

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>