### PR TITLE
backport: DNM: tox: add ansible2.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {jewel,kraken,rhcs}-{ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster,cluster,purge_docker_cluster}
+envlist = {jewel,kraken,rhcs}-{ansible2.2,ansible-2.3}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster,cluster,purge_docker_cluster}
 skipsdist = True
 
 # extra commands for purging clusters
@@ -69,6 +69,7 @@ deps=
   ansible1.9: ansible==1.9.4
   ansible2.1: ansible==2.1
   ansible2.2: ansible==2.2.3
+  ansible2.3: ansible==2.3.0.0
   -r{toxinidir}/tests/requirements.txt
 changedir=
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw xenial cluster using raw_multi_journal OSD scenario


### PR DESCRIPTION
Not sure if this is the right way to add this... But I really want us to be testing on both ansible2.2 and ansible2.3.