### PR TITLE
Common: Add ipv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ incorrect configuration options appearing in ceph.conf.
 * We will no longer accept pull requests that modify the ceph.conf template unless it helps the deployment. For simple configuration tweaks
 please use the `ceph_conf_overrides` variable.
 
+### Networking
+
+In any case, you must define `monitor_interface` variable with the network interface name which will carry the IP address in the `public_network` subnet.
+`monitor_interface` must be defined at least in `group_vars/all.yml` but it can be overrided in inventory host file if needed.
+You can specify for each monitor on which IP address it will bind to by specifying the `monitor_address` variable in the **inventory host file**.
+You can also use the `monitor_address_block` feature, just specify a subnet, ceph-ansible will automatically set the correct addresses in ceph.conf
+Preference will go to `monitor_address_block` if specified, then `monitor_address`, otherwise it will take the first IP address found on the network interface specified in `monitor_interface` by default.
+
 ## Special notes
 
 If you are looking at deploying a Ceph version older than Jewel.

--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -19,6 +19,7 @@ BuildRequires: ansible >= 2.2.0.0
 BuildRequires: python2-devel
 
 Requires: ansible >= 2.2.0.0
+Requires: python-netaddr
 
 %description
 Ansible playbooks for Ceph

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -247,15 +247,15 @@ dummy:
 
 ## Monitor options
 #
-# You must define either monitor_interface or monitor_address. Preference
-# will go to monitor_interface if both are defined.
+# You must define monitor_interface.
+# You can also specify for each monitor which address the monitor will bind to in your **inventory host file** by using 'monitor_address' variable.
+# Preference will go to monitor_address if both are defined.
 # To use an IPv6 address, use the monitor_address setting instead (and set ip_version to ipv6)
 #monitor_interface: interface
 #monitor_address: 0.0.0.0
 # set to either ipv4 or ipv6, whichever your network is using
 #ip_version: ipv4
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
-#monitor_address_block: false
 
 ## OSD options
 #

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -239,15 +239,16 @@ rbd_client_admin_socket_path: /var/run/ceph # must be writable by QEMU and allow
 
 ## Monitor options
 #
-# You must define either monitor_interface or monitor_address. Preference
-# will go to monitor_interface if both are defined.
+# You must define either monitor_interface, monitor_address or monitor_address_block.
+# These variables must be defined at least in all.yml and overrided if needed (inventory host file or group_vars/*.yml).
+# Eg. If you want to specify for each monitor which address the monitor will bind to you can set it in your **inventory host file** by using 'monitor_address' variable.
+# Preference will go to monitor_address if both monitor_address and monitor_interface are defined.
 # To use an IPv6 address, use the monitor_address setting instead (and set ip_version to ipv6)
 monitor_interface: interface
 monitor_address: 0.0.0.0
 # set to either ipv4 or ipv6, whichever your network is using
 ip_version: ipv4
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
-monitor_address_block: false
 
 ## OSD options
 #

--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -32,3 +32,9 @@
     - ceph_origin != 'distro'
   tags:
     - package-install
+
+- name: make sure monitor_interface is defined
+  fail:
+    msg: "you must set monitor_interface"
+  when:
+    - monitor_interface == 'interface'

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -30,41 +30,56 @@ mon initial members = {% for host in groups[mon_group_name] %}
     {% endfor %}
 {% endif %}
 
-{% if not containerized_deployment and not containerized_deployment_with_kv %}
-{% if monitor_address_block %}
-mon host = {% for host in groups[mon_group_name] %}{{ hostvars[host]['ansible_all_ipv4_addresses'] | ipaddr(monitor_address_block) | first }}{% if not loop.last %},{% endif %}{% endfor %}
-{% elif groups[mon_group_name] is defined %}
-mon host = {% for host in groups[mon_group_name] %}
-             {% set address = hostvars[host]['monitor_address'] if hostvars[host]['monitor_address'] is defined else monitor_address %}
-             {% set interface = hostvars[host]['monitor_interface'] if hostvars[host]['monitor_interface'] is defined else monitor_interface %}
-             {% if interface != "interface" %}
-               {% for key in hostvars[host].keys() %}
-                 {% if hostvars[host][key]['macaddress'] is defined and hostvars[host][key]['device'] is defined and hostvars[host][key]['device'] == interface -%}
-                    {{ hostvars[host][key][ip_version]['address'] }}
-                 {%- endif %}
-               {% endfor %}
-             {% elif address != "0.0.0.0" -%}
-               {{ address }}
-             {%- endif %}
-             {%- if not loop.last %},{% endif %}
-           {% endfor %}
-{% endif %}
-{% endif %}
+{% if not containerized_deployment and not containerized_deployment_with_kv -%}
+mon host = {% for host in groups[mon_group_name] -%}
+    {% if monitor_address_block is defined %}
+      {% if ip_version == 'ipv4' -%}
+        {{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}
+      {%- elif ip_version == 'ipv6' -%}
+        [{{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}]
+      {%- endif %}
+    {% elif hostvars[host]['monitor_address'] is defined and hostvars[host]['monitor_address'] != '0.0.0.0' -%}
+      {% if ip_version == 'ipv4' -%}
+        {{ hostvars[host]['monitor_address'] }}
+      {%- elif ip_version == 'ipv6' -%}
+        [{{ hostvars[host]['monitor_address'] }}]
+      {%- endif %}
+    {%- else -%}
+      {% if ip_version == 'ipv4' -%}
+       {{ hostvars[host]['ansible_' + monitor_interface][ip_version]['address'] }}
+      {%- elif ip_version == 'ipv6' -%}
+       [{{ hostvars[host]['ansible_' + monitor_interface][ip_version][0]['address'] }}]
+      {%- endif %}
+    {%- endif %}
+   {% if not loop.last -%},{%- endif %}
+  {%- endfor %}
+{%- endif %}
+
 {% if containerized_deployment %}
 fsid = {{ fsid }}
-{% if groups[mon_group_name] is defined %}
-mon host = {% for host in groups[mon_group_name] %}
-             {% set interface = ["ansible_",ceph_mon_docker_interface]|join %}
-             {% if containerized_deployment -%}
-                {{ hostvars[host][interface]['ipv4']['address'] }}
-             {%- elif hostvars[host]['monitor_address'] is defined -%}
-                {{ hostvars[host]['monitor_address'] }}
-             {%- elif monitor_address != "0.0.0.0" -%}
-                {{ monitor_address }}
-             {%- endif %}
-             {%- if not loop.last %},{% endif %}
-           {% endfor %}
-{% endif %}
+mon host = {% for host in groups[mon_group_name] -%}
+    {% if monitor_address_block is defined %}
+      {% if ip_version == 'ipv4' -%}
+        {{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}
+      {%- elif ip_version == 'ipv6' -%}
+        [{{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}]
+      {%- endif %}
+    {% elif hostvars[host]['monitor_address'] is defined and hostvars[host]['monitor_address'] != '0.0.0.0' -%}
+      {% if ip_version == 'ipv4' -%}
+        {{ hostvars[host]['monitor_address'] }}
+      {%- elif ip_version == 'ipv6' -%}
+        [{{ hostvars[host]['monitor_address'] }}]
+      {%- endif %}
+    {%- else -%}
+      {% set interface = ["ansible_",ceph_mon_docker_interface]|join %}
+      {% if ip_version == 'ipv4' -%}
+        {{ hostvars[host][interface][ip_version]['address'] }}
+      {%- elif ip_version == 'ipv6' -%}
+        [{{ hostvars[host][interface][ip_version][0]['address'] }}]
+      {%- endif %}
+    {%- endif %}
+    {% if not loop.last -%},{%- endif %}
+  {%- endfor %}
 {% endif %}
 
 {% if public_network is defined %}
@@ -85,12 +100,10 @@ admin socket = {{ rbd_client_admin_socket_path }}/$cluster-$type.$id.$pid.$cctid
 log file = {{ rbd_client_log_file }} # must be writable by QEMU and allowed by SELinux or AppArmor
 
 [osd]
-{% if osd_objectstore != 'bluestore' %}
 osd mkfs type = {{ osd_mkfs_type }}
 osd mkfs options xfs = {{ osd_mkfs_options_xfs }}
 osd mount options xfs = {{ osd_mount_options_xfs }}
 osd journal size = {{ journal_size }}
-{% endif %}
 {% if filestore_xattr_use_omap != None %}
 filestore xattr use omap = {{ filestore_xattr_use_omap }}
 {% elif osd_mkfs_type == "ext4" %}

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- include: check_mandatory_vars.yml
+
 - include: deploy_monitors.yml
   when: not containerized_deployment
 

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -23,8 +23,19 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
    --net=host \
    {% endif -%}
    -e CEPH_DAEMON=MON \
-   -e MON_IP={{ hostvars[inventory_hostname]['ansible_default_' + ip_version]['address'] }} \
    -e CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }} \
+   -e IP_VERSION={{ ip_version[-1:] }} \
+   {% if monitor_address is defined and monitor_address != '0.0.0.0' %}
+     {% if ip_version == 'ipv4' -%}
+       -e MON_IP={{ monitor_address }} \
+     {% elif ip_version == 'ipv6' -%}
+       -e MON_IP=[{{ monitor_address }}] \
+     {% endif -%}
+   {% elif ip_version == 'ipv4' -%}
+   -e MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface][ip_version]['address'] }} \
+   {% elif ip_version =='ipv6' -%}
+   -e MON_IP=[{{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface][ip_version][0]['address'] }}] \
+   {% endif -%}
    {{ ceph_mon_docker_extra_env }} \
    {{ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/docker stop ceph-mon-%i

--- a/tests/functional/centos/7/cluster/group_vars/all
+++ b/tests/functional/centos/7/cluster/group_vars/all
@@ -4,6 +4,7 @@ ceph_stable: True
 cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
+monitor_interface: eth1
 journal_size: 100
 devices:
   - '/dev/sda'

--- a/tests/functional/centos/7/dmcrypt-dedicated-journal/group_vars/all
+++ b/tests/functional/centos/7/dmcrypt-dedicated-journal/group_vars/all
@@ -4,6 +4,7 @@ ceph_stable: True
 public_network: "192.168.11.0/24"
 cluster_network: "192.168.12.0/24"
 journal_size: 100
+monitor_interface: eth1
 dmcrypt_dedicated_journal: true
 devices:
   - '/dev/sda'

--- a/tests/functional/centos/7/dmcrypt-dedicated-journal/hosts
+++ b/tests/functional/centos/7/dmcrypt-dedicated-journal/hosts
@@ -1,5 +1,5 @@
 [mons]
-mon0 monitor_interface=eth1
+mon0
 
 [osds]
 osd0

--- a/tests/functional/centos/7/dmcrypt-journal-collocation/group_vars/all
+++ b/tests/functional/centos/7/dmcrypt-journal-collocation/group_vars/all
@@ -4,6 +4,7 @@ ceph_stable: True
 public_network: "192.168.13.0/24"
 cluster_network: "192.168.14.0/24"
 journal_size: 100
+monitor_interface: eth1
 dmcrypt_journal_collocation: true
 devices:
   - '/dev/sda'

--- a/tests/functional/centos/7/dmcrypt-journal-collocation/hosts
+++ b/tests/functional/centos/7/dmcrypt-journal-collocation/hosts
@@ -1,5 +1,5 @@
 [mons]
-mon0 monitor_interface=eth1
+mon0
 
 [osds]
 osd0

--- a/tests/functional/centos/7/journal-collocation/group_vars/all
+++ b/tests/functional/centos/7/journal-collocation/group_vars/all
@@ -4,6 +4,7 @@ ceph_stable: True
 cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
+monitor_interface: eth1
 journal_size: 100
 devices:
   - '/dev/sda'

--- a/tests/functional/centos/7/journal-collocation/hosts
+++ b/tests/functional/centos/7/journal-collocation/hosts
@@ -1,5 +1,5 @@
 [mons]
-mon0 monitor_interface=eth1
+mon0
 
 [osds]
 osd0

--- a/tests/functional/ubuntu/16.04/cluster/group_vars/all
+++ b/tests/functional/ubuntu/16.04/cluster/group_vars/all
@@ -4,6 +4,7 @@ ceph_stable: True
 cluster: test
 public_network: "192.168.5.0/24"
 cluster_network: "192.168.6.0/24"
+monitor_interface: eth1
 journal_size: 100
 devices:
   - '/dev/sdb'

--- a/tests/functional/ubuntu/16.04/cluster/hosts
+++ b/tests/functional/ubuntu/16.04/cluster/hosts
@@ -1,7 +1,7 @@
 [mons]
 mon0 monitor_address=192.168.5.10
 mon1 monitor_address=192.168.5.11
-mon2 monitor_interface=eth1
+mon2 monitor_address=192.168.5.12
 
 [osds]
 osd0


### PR DESCRIPTION
e8187f6 does not fix the ipv6 as expected since `ansible_default_*` are
filled with the IP address carried by the network interface used by the
default gateway route. By the way, it assumes that the MON_IP address will
be this IP address which is not always the case.

We need to keep using the previous fact but add some intelligence in the
template to determine how to retrieve the ipv4|ipv6 address since the path
to the fact in `hostvars` is not the same according to ipv4 vs ipv6 case.

Fixes: https://github.com/ceph/ceph-ansible/issues/1352
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>