### PR TITLE
Restart OSDs during initial setup when crush location is used

### DIFF
--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -44,7 +44,8 @@
 
   when:
 # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - socket.rc == 0
+# except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
+    - ((crush_location is defined and crush_location) or socket.rc == 0)
     - ceph_current_fsid.rc == 0
     - osd_group_name in group_names
 # See https://github.com/ceph/ceph-ansible/issues/1457 for the condition below


### PR DESCRIPTION
OSDs get started by ceph-disk before the ceph.conf file is written
with a crush location. That results in a crush map without configured
crush location.

To prevent this, we have to restart the OSDs during the initial setup
after the crush location was added to the ceph.conf file.