### PR TITLE
ceph-mon: fix get rbd size hanging

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -59,7 +59,8 @@
 - include: set_osd_pool_default_pg_num.yml
 
 - name: test if rbd exists
-  command: ceph --cluster {{ cluster }} osd pool get rbd size
+  shell: |
+    ceph --cluster {{ cluster }} osd pool ls | grep -sq rbd
   changed_when: false
   failed_when: false
   register: rbd_pool_exist


### PR DESCRIPTION
For newly created cluster the command: ceph --cluster {{ cluster }} osd
pool get rbd size does not respond properly.
We only want to check if the rbd pool exists, so we know use an ls |
grep approach.

Closes: https://github.com/ceph/ceph-ansible/issues/1547
Signed-off-by: Sébastien Han <seb@redhat.com>