### PR TITLE
tests: adds a test for rolling updates of containerized clusters

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -52,7 +52,7 @@
 
   vars:
     health_mon_check_retries: 5
-    health_mon_check_delay: 10
+    health_mon_check_delay: 15
     upgrade_ceph_packages: True
 
   hosts:

--- a/tests/functional/centos/7/docker-cluster/group_vars/all
+++ b/tests/functional/centos/7/docker-cluster/group_vars/all
@@ -21,3 +21,7 @@ devices:
 ceph_osd_docker_run_script_path: /var/tmp
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
+ceph_conf_overrides:
+  global:
+    osd_pool_default_pg_num: 8
+    osd_pool_default_size: 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {jewel,kraken,rhcs}-{ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster,cluster,purge_docker_cluster}
+envlist = {jewel,kraken,rhcs}-{ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster,cluster,purge_docker_cluster,update_docker_cluster}
 skipsdist = True
 
 # extra commands for purging clusters
@@ -39,6 +39,9 @@ commands=
       ireallymeanit=yes \
       ceph_stable_release={env:UPDATE_CEPH_STABLE_RELEASE:kraken} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:UPDATE_CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:UPDATE_CEPH_DOCKER_IMAGE_TAG:latest} \
   "
 
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
@@ -56,6 +59,7 @@ setenv=
   # only available for ansible >= 2.2
   ANSIBLE_STDOUT_CALLBACK = debug
   docker_cluster: PLAYBOOK = site-docker.yml.sample
+  update_docker_cluster: PLAYBOOK = site-docker.yml.sample
   purge_docker_cluster: PLAYBOOK = site-docker.yml.sample
   purge_docker_cluster: PURGE_PLAYBOOK = purge-docker-cluster.yml
   docker_dedicated_journal: PLAYBOOK = site-docker.yml.sample
@@ -85,6 +89,7 @@ changedir=
   cluster: {toxinidir}/tests/functional/centos/7/cluster
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw centos7 cluster using docker
   docker_cluster: {toxinidir}/tests/functional/centos/7/docker-cluster
+  update_docker_cluster: {toxinidir}/tests/functional/centos/7/docker-cluster
   purge_docker_cluster: {toxinidir}/tests/functional/centos/7/docker-cluster
   docker_dedicated_journal: {toxinidir}/tests/functional/centos/7/docker-cluster-dedicated-journal
   docker_dmcrypt_journal_collocation: {toxinidir}/tests/functional/centos/7/docker-cluster-dmcrypt-journal-collocation
@@ -117,5 +122,6 @@ commands=
   purge_docker_cluster: {[purge]commands}
   update_dmcrypt: {[update]commands}
   update_cluster: {[update]commands}
+  update_docker_cluster: {[update]commands}
 
   vagrant destroy --force


### PR DESCRIPTION
I have yet to get this test to pass so I'm not going to enable it in the CI quite yet.

The failure I see is that the first updated MON does not start and join the quorum after being updated.