### PR TITLE
rbd-mirror should use per-host user id keyring

### DIFF
--- a/roles/ceph-common/tasks/create_ceph_initial_dirs.yml
+++ b/roles/ceph-common/tasks/create_ceph_initial_dirs.yml
@@ -17,3 +17,4 @@
     - /var/lib/ceph/bootstrap-rgw
     - /var/lib/ceph/bootstrap-mds
     - /var/lib/ceph/bootstrap-osd
+    - /var/lib/ceph/bootstrap-rbd

--- a/roles/ceph-docker-common/tasks/checks.yml
+++ b/roles/ceph-docker-common/tasks/checks.yml
@@ -1,4 +1,9 @@
 ---
+- name: register rbd bootstrap key
+  set_fact:
+    bootstrap_rbd_keyring: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
+  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+
 - name: set config and keys paths
   set_fact:
     ceph_config_keys:
@@ -9,6 +14,7 @@
       - /var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring
       - /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring
       - /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring
+      - "{{ bootstrap_rbd_keyring | default([]) }}"
 
 - name: stat for ceph config and keys
   stat:

--- a/roles/ceph-docker-common/tasks/dirs_permissions.yml
+++ b/roles/ceph-docker-common/tasks/dirs_permissions.yml
@@ -11,3 +11,4 @@
     - /var/lib/ceph/bootstrap-osd
     - /var/lib/ceph/bootstrap-mds
     - /var/lib/ceph/bootstrap-rgw
+    - /var/lib/ceph/bootstrap-rbd

--- a/roles/ceph-docker-common/tasks/fetch_configs.yml
+++ b/roles/ceph-docker-common/tasks/fetch_configs.yml
@@ -1,4 +1,9 @@
 ---
+- name: register rbd bootstrap key
+  set_fact:
+    bootstrap_rbd_keyring: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
+  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+
 - name: set config and keys paths
   set_fact:
     ceph_config_keys:
@@ -8,6 +13,7 @@
       - /var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring
       - /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring
       - /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring
+      - "{{ bootstrap_rbd_keyring | default([]) }}"
 
 - name: add mgr keys to config and keys paths
   set_fact:

--- a/roles/ceph-fetch-keys/tasks/main.yml
+++ b/roles/ceph-fetch-keys/tasks/main.yml
@@ -14,6 +14,11 @@
   with_items:
     - "{{ ceph_keys.stdout_lines }}"
 
+- name: register rbd bootstrap key
+  set_fact:
+    bootstrap_rbd_keyring: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
+  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+
 - name: copy keys to the ansible server
   fetch:
     src: "{{ item }}"
@@ -25,3 +30,4 @@
     - "/var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring"
     - "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring"
     - "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring"
+    - "{{ bootstrap_rbd_keyring | default([]) }}"

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -114,6 +114,11 @@
     - "{{ ceph_keys.get('stdout_lines') | default([]) }}"
   when: cephx
 
+- name: register rbd bootstrap key
+  set_fact:
+    bootstrap_rbd_keyring: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
+  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+
 - name: copy keys to the ansible server
   fetch:
     src: "{{ item }}"
@@ -124,6 +129,7 @@
     - /var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring
     - /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring
     - /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring
+    - "{{ bootstrap_rbd_keyring | default([]) }}"
   when:
     - cephx
     - "{{ inventory_hostname == groups[mon_group_name] | last }}"

--- a/roles/ceph-rbd-mirror/defaults/main.yml
+++ b/roles/ceph-rbd-mirror/defaults/main.yml
@@ -3,24 +3,17 @@
 # SETUP #
 #########
 
+fetch_directory: fetch/
 
-# NOTE (leseb): the rbd-mirror daemon needs a user to start
-# because it has to authenticate with the local cluster.
-# By default, using the admin user is fine, so you should not
-# need to change 'ceph_rbd_mirror_local_user' unless you have
-# a dedicated key available in /etc/ceph/.
-# Generally Ansible will use the admin key and put it
-# under /etc/ceph/. The same goes for 'ceph_rbd_mirror_remote_user'
-# there should not be any reason to change it.
-ceph_rbd_mirror_local_user: admin
-ceph_rbd_mirror_remote_user: admin
+# Even though rbd-mirror nodes should not have the admin key
+# at their disposal, some people might want to have it
+# distributed on rbd-mirror nodes. Setting 'copy_admin_key' to 'true'
+# will copy the admin key to the /etc/ceph/ directory. Only
+# valid for Luminous and later releases.
+copy_admin_key: false
 
-# NOTE (leseb): the following variable needs the name of the remote cluster.
-# The name of this cluster must be different than your local cluster simply
-# because we need to have both keys and ceph.conf inside /etc/ceph.
-# Thus if cluster names are identical we can not have them under /etc/ceph
-ceph_rbd_mirror_remote_cluster: ""
-
+# NOTE: deprecated generic local user id for pre-Luminous releases
+ceph_rbd_mirror_local_user: "admin"
 
 #################
 # CONFIGURATION #
@@ -29,6 +22,16 @@ ceph_rbd_mirror_remote_cluster: ""
 ceph_rbd_mirror_configure: false
 ceph_rbd_mirror_pool: ""
 
+# NOTE (leseb): the following variable needs the name of the remote cluster.
+# The name of this cluster must be different than your local cluster simply
+# because we need to have both keys and ceph.conf inside /etc/ceph.
+# Thus if cluster names are identical we can not have them under /etc/ceph
+ceph_rbd_mirror_remote_cluster: ""
+
+# NOTE: the rbd-mirror daemon needs a user to authenticate with the
+# remote cluster. By default, this key should be available under
+# /etc/ceph/<remote_cluster>.client.<remote_user>.keyring
+ceph_rbd_mirror_remote_user: ""
 
 ##########
 # DOCKER #

--- a/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
+++ b/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
@@ -15,4 +15,37 @@
     owner: "ceph"
     group: "ceph"
     mode: "0600"
-  when: cephx
+  when:
+    - cephx
+    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous or copy_admin_key
+
+- name: copy rbd-mirror bootstrap key
+  copy:
+    src: "{{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
+    dest: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
+    owner: "ceph"
+    group: "ceph"
+    mode: "0600"
+  when:
+    - cephx
+    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+
+- name: create rbd-mirror keyring
+  command: ceph --cluster {{ cluster }} --name client.bootstrap-rbd --keyring /var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring auth get-or-create client.rbd-mirror.{{ ansible_hostname }} mon 'profile rbd' osd 'profile rbd' -o /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring
+  args:
+    creates: /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}/keyring
+  changed_when: false
+  when:
+    - cephx
+    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+
+- name: set rbd-mirror key permissions
+  file:
+    path: /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring
+    owner: "ceph"
+    group: "ceph"
+    mode: "0600"
+  when:
+    - cephx
+    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+

--- a/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
@@ -19,7 +19,24 @@
 
 - name: start and add that the rbd mirror service to the init sequence
   service:
-      name: "ceph-rbd-mirror@{{ ceph_rbd_mirror_local_user }}"
-      state: started
-      enabled: yes
+    name: "ceph-rbd-mirror@{{ ceph_rbd_mirror_local_user }}"
+    state: started
+    enabled: yes
   changed_when: false
+  when: ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+
+- name: stop and remove the generic rbd-mirror service instance
+  service:
+    name: "ceph-rbd-mirror@{{ ceph_rbd_mirror_local_user }}"
+    state: stopped
+    enabled: no
+  changed_when: false
+  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+
+- name: start and add the rbd-mirror service instance
+  service:
+    name: "ceph-rbd-mirror@rbd-mirror.{{ ansible_hostname }}"
+    state: started
+    enabled: yes
+  changed_when: false
+  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous


### PR DESCRIPTION
The rbd-mirror daemon will be HA under luminous and new daemon health
features require a way to uniquely identify rbd-mirror instances.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>