### PR TITLE
mon/ceph_keys: Add timeout flag to ceph-create-keys

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -1,18 +1,42 @@
 ---
 - name: collect admin and bootstrap keys
-  command: ceph-create-keys --cluster {{ cluster }} -i {{ monitor_name }}
-  failed_when: false
+  command: ceph-create-keys --cluster {{ cluster }} -i {{ monitor_name }} -t 30
+  args:
+    creates: /etc/ceph/{{ cluster }}.client.admin.keyring
   changed_when: false
   always_run: true
   when:
     - cephx
+    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+
+- name: collect admin and bootstrap keys
+  command: ceph-create-keys --cluster {{ cluster }} -i {{ monitor_name }}
+  changed_when: false
+  always_run: true
+  when:
+    - cephx
+    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
 
 # NOTE (leseb): wait for mon discovery and quorum resolution
 # the admin key is not instantaneously created so we have to wait a bit
+# msg: is only supported as of Ansible 2.4.
 - name: "wait for {{ cluster }}.client.admin.keyring exists"
   wait_for:
     path: /etc/ceph/{{ cluster }}.client.admin.keyring
-  when: cephx
+    timeout: 30
+    msg: "Timed out while waiting for keyring creation. Check network settings on mon nodes."
+  when:
+    - cephx
+    - (ansible_version.major == 2 and ansible_version.minor >= 4) or
+      ansible_version.major > 2
+
+- name: "wait for {{ cluster }}.client.admin.keyring exists"
+  wait_for:
+    path: /etc/ceph/{{ cluster }}.client.admin.keyring
+    timeout: 30
+  when:
+    - cephx
+    - ansible_version.major == 2 and ansible_version.minor < 4
 
 - name: test if initial mon keyring is in mon kv store
   command: ceph --cluster {{ cluster }} config-key get initial_mon_keyring


### PR DESCRIPTION
Specify the timeout flag to ceph-create-keys, which causes it to time out
if a monitor quorum isn't achieved. This overrides the default timeout
of 10 minutes, causing ceph-ansible to fail faster in the event of cluster
network issues.

Signed-off-by: Douglas Fuller <dfuller@redhat.com>