### PR TITLE
Docker-common: Add missing variables declaration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,7 +74,7 @@ ansible_provision = proc do |ansible|
   if DOCKER then
     ansible.extra_vars = ansible.extra_vars.merge({
       containerized_deployment: 'true',
-      ceph_mon_docker_interface: ETH,
+      monitor_interface: ETH,
       ceph_mon_docker_subnet: "#{PUBLIC_SUBNET}.0/24",
       ceph_osd_docker_devices: settings['disks'],
       devices: settings['disks'],

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -247,12 +247,14 @@ dummy:
 
 ## Monitor options
 #
-# You must define monitor_interface.
-# You can also specify for each monitor which address the monitor will bind to in your **inventory host file** by using 'monitor_address' variable.
-# Preference will go to monitor_address if both are defined.
+# You must define either monitor_interface, monitor_address or monitor_address_block.
+# These variables must be defined at least in all.yml and overrided if needed (inventory host file or group_vars/*.yml).
+# Eg. If you want to specify for each monitor which address the monitor will bind to you can set it in your **inventory host file** by using 'monitor_address' variable.
+# Preference will go to monitor_address if both monitor_address and monitor_interface are defined.
 # To use an IPv6 address, use the monitor_address setting instead (and set ip_version to ipv6)
 #monitor_interface: interface
 #monitor_address: 0.0.0.0
+#monitor_address_block: []
 # set to either ipv4 or ipv6, whichever your network is using
 #ip_version: ipv4
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
@@ -420,6 +422,13 @@ dummy:
 #bootstrap_dirs_group: "64045"
 
 #ceph_conf_key_directory: /etc/ceph
+
+###########
+# Network #
+###########
+#monitor_interface: 'interface'
+#monitor_address: '0.0.0.0'
+#monitor_address_block: []
 
 ############
 # KV store #

--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -87,8 +87,7 @@ dummy:
 # DOCKER #
 ##########
 #docker_exec_cmd:
-#ceph_mon_docker_interface: "{{ monitor_interface }}"
-#ceph_mon_docker_subnet: "{{ public_network }}"# subnet of the ceph_mon_docker_interface
+#ceph_mon_docker_subnet: "{{ public_network }}"# subnet of the monitor_interface
 #ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NAME={{ monitor_name }}
 #mon_docker_privileged: false
 #mon_docker_net_host: true

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -150,7 +150,7 @@
       net: "host"
       state: "running"
       privileged: "{{ mon_docker_privileged }}"
-      env: "MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface]['ipv4']['address'] }},CEPH_DAEMON=MON,CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }},CEPH_FSID={{ ceph_fsid.stdout }},{{ ceph_mon_docker_extra_env }}"
+      env: "MON_IP={{ hostvars[inventory_hostname]['ansible_' + monitor_interface]['ipv4']['address'] }},CEPH_DAEMON=MON,CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }},CEPH_FSID={{ ceph_fsid.stdout }},{{ ceph_mon_docker_extra_env }}"
       volumes: "/var/lib/ceph:/var/lib/ceph,/etc/ceph:/etc/ceph,/etc/localtime:/etc/localtime:ro"
 
   - name: waiting for the monitor to join the quorum...

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -246,6 +246,7 @@ rbd_client_admin_socket_path: /var/run/ceph # must be writable by QEMU and allow
 # To use an IPv6 address, use the monitor_address setting instead (and set ip_version to ipv6)
 monitor_interface: interface
 monitor_address: 0.0.0.0
+monitor_address_block: []
 # set to either ipv4 or ipv6, whichever your network is using
 ip_version: ipv4
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -71,7 +71,7 @@ mon host = {% for host in groups[mon_group_name] -%}
         [{{ hostvars[host]['monitor_address'] }}]
       {%- endif %}
     {%- else -%}
-      {% set interface = ["ansible_",ceph_mon_docker_interface]|join %}
+      {% set interface = ["ansible_",monitor_interface]|join %}
       {% if ip_version == 'ipv4' -%}
         {{ hostvars[host][interface][ip_version]['address'] }}
       {%- elif ip_version == 'ipv6' -%}

--- a/roles/ceph-common/templates/ceph.conf.j2
+++ b/roles/ceph-common/templates/ceph.conf.j2
@@ -32,7 +32,7 @@ mon initial members = {% for host in groups[mon_group_name] %}
 
 {% if not containerized_deployment and not containerized_deployment_with_kv -%}
 mon host = {% for host in groups[mon_group_name] -%}
-    {% if monitor_address_block is defined %}
+    {% if monitor_address_block | length > 0 %}
       {% if ip_version == 'ipv4' -%}
         {{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}
       {%- elif ip_version == 'ipv6' -%}
@@ -58,7 +58,7 @@ mon host = {% for host in groups[mon_group_name] -%}
 {% if containerized_deployment %}
 fsid = {{ fsid }}
 mon host = {% for host in groups[mon_group_name] -%}
-    {% if monitor_address_block is defined %}
+    {% if monitor_address_block | length > 0 %}
       {% if ip_version == 'ipv4' -%}
         {{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}
       {%- elif ip_version == 'ipv6' -%}

--- a/roles/ceph-docker-common/defaults/main.yml
+++ b/roles/ceph-docker-common/defaults/main.yml
@@ -16,6 +16,13 @@ bootstrap_dirs_group: "64045"
 
 ceph_conf_key_directory: /etc/ceph
 
+###########
+# Network #
+###########
+monitor_interface: 'interface'
+monitor_address: '0.0.0.0'
+monitor_address_block: []
+
 ############
 # KV store #
 ############

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -79,8 +79,7 @@ openstack_keys:
 # DOCKER #
 ##########
 docker_exec_cmd:
-ceph_mon_docker_interface: "{{ monitor_interface }}"
-ceph_mon_docker_subnet: "{{ public_network }}"# subnet of the ceph_mon_docker_interface
+ceph_mon_docker_subnet: "{{ public_network }}"# subnet of the monitor_interface
 ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NAME={{ monitor_name }}
 mon_docker_privileged: false
 mon_docker_net_host: true

--- a/roles/ceph-mon/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-mon/tasks/check_mandatory_vars.yml
@@ -5,4 +5,4 @@
   when:
     - monitor_interface == 'interface'
     - monitor_address == '0.0.0.0'
-    - not monitor_address_block
+    - monitor_address_block | length == 0

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -13,7 +13,7 @@
   until: monitor_socket.rc == 0
 
 - name: force peer addition as potential bootstrap peer for cluster bringup
-  command: docker exec ceph-mon-{{ ansible_hostname }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[item]['ansible_' + ceph_mon_docker_interface].ipv4.address }}
+  command: docker exec ceph-mon-{{ ansible_hostname }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[item]['ansible_' + monitor_interface].ipv4.address }}
   with_items: "{{ groups[mon_group_name] }}"
   changed_when: false
   failed_when: false

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -32,9 +32,9 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
        -e MON_IP=[{{ monitor_address }}] \
      {% endif -%}
    {% elif ip_version == 'ipv4' -%}
-   -e MON_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface][ip_version]['address'] }} \
+   -e MON_IP={{ hostvars[inventory_hostname]['ansible_' + monitor_interface][ip_version]['address'] }} \
    {% elif ip_version =='ipv6' -%}
-   -e MON_IP=[{{ hostvars[inventory_hostname]['ansible_' + ceph_mon_docker_interface][ip_version][0]['address'] }}] \
+   -e MON_IP=[{{ hostvars[inventory_hostname]['ansible_' + monitor_interface][ip_version][0]['address'] }}] \
    {% endif -%}
    {{ ceph_mon_docker_extra_env }} \
    {{ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}

--- a/tests/functional/centos/7/docker-cluster-dedicated-journal/Vagrantfile
+++ b/tests/functional/centos/7/docker-cluster-dedicated-journal/Vagrantfile
@@ -73,7 +73,7 @@ ansible_provision = proc do |ansible|
   if DOCKER then
     ansible.extra_vars = ansible.extra_vars.merge({
       containerized_deployment: 'true',
-      ceph_mon_docker_interface: ETH,
+      monitor_interface: ETH,
       ceph_mon_docker_subnet: "#{PUBLIC_SUBNET}.0/24",
       ceph_osd_docker_devices: settings['disks'],
       devices: settings['disks'],

--- a/tests/functional/centos/7/docker-cluster-dedicated-journal/group_vars/all
+++ b/tests/functional/centos/7/docker-cluster-dedicated-journal/group_vars/all
@@ -6,7 +6,7 @@ docker: True
 ceph_stable: True
 containerized_deployment: True
 cluster: test
-ceph_mon_docker_interface: eth1
+monitor_interface: eth1
 ceph_mon_docker_subnet: "{{ public_network }}"
 journal_size: 100
 ceph_docker_on_openstack: False

--- a/tests/functional/centos/7/docker-cluster-dmcrypt-journal-collocation/Vagrantfile
+++ b/tests/functional/centos/7/docker-cluster-dmcrypt-journal-collocation/Vagrantfile
@@ -73,7 +73,7 @@ ansible_provision = proc do |ansible|
   if DOCKER then
     ansible.extra_vars = ansible.extra_vars.merge({
       containerized_deployment: 'true',
-      ceph_mon_docker_interface: ETH,
+      monitor_interface: ETH,
       ceph_mon_docker_subnet: "#{PUBLIC_SUBNET}.0/24",
       ceph_osd_docker_devices: settings['disks'],
       devices: settings['disks'],

--- a/tests/functional/centos/7/docker-cluster-dmcrypt-journal-collocation/group_vars/all
+++ b/tests/functional/centos/7/docker-cluster-dmcrypt-journal-collocation/group_vars/all
@@ -6,7 +6,7 @@ docker: True
 ceph_stable: True
 containerized_deployment: True
 cluster: ceph
-ceph_mon_docker_interface: eth1
+monitor_interface: eth1
 ceph_mon_docker_subnet: "{{ public_network }}"
 journal_size: 100
 ceph_docker_on_openstack: False

--- a/tests/functional/centos/7/docker-cluster/group_vars/all
+++ b/tests/functional/centos/7/docker-cluster/group_vars/all
@@ -6,7 +6,7 @@ docker: True
 ceph_stable: True
 containerized_deployment: True
 cluster: test
-ceph_mon_docker_interface: eth1
+monitor_interface: eth1
 ceph_mon_docker_subnet: "{{ public_network }}"
 journal_size: 100
 ceph_docker_on_openstack: False


### PR DESCRIPTION
Some variables are missing from ceph-docker-common role since the
include of check_mandatory_vars.yml has been re-added in the ceph-mon
role.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>