### PR TITLE
Mon: Allow to deploy with custom admin secret

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -20,6 +20,7 @@ dummy:
 # ACTIVATE BOTH FSID AND MONITOR_SECRET VARIABLES FOR NON-VAGRANT DEPLOYMENT
 #fsid: "{{ cluster_uuid.stdout }}"
 #monitor_secret: "{{ monitor_keyring.stdout }}"
+#admin_secret: 'admin_secret'
 
 # CephFS
 #cephfs_data: cephfs_data

--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -33,7 +33,7 @@ dummy:
 # important to split them into shards. We suggest about 100K
 # objects per shard as a conservative maximum.
 #rgw_override_bucket_index_max_shards: 16
- 
+# 
 # Consider setting a quota on buckets so that exceeding this
 # limit will require admin intervention.
 #rgw_bucket_default_quota_max_objects: 1638400 # i.e., 100K * 16

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -12,6 +12,7 @@ mon_group_name: mons
 # ACTIVATE BOTH FSID AND MONITOR_SECRET VARIABLES FOR NON-VAGRANT DEPLOYMENT
 fsid: "{{ cluster_uuid.stdout }}"
 monitor_secret: "{{ monitor_keyring.stdout }}"
+admin_secret: 'admin_secret'
 
 # CephFS
 cephfs_data: cephfs_data

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -1,8 +1,6 @@
 ---
 - name: collect admin and bootstrap keys
   command: ceph-create-keys --cluster {{ cluster }} -i {{ monitor_name }}
-  args:
-    creates: /etc/ceph/{{ cluster }}.client.admin.keyring
   failed_when: false
   changed_when: false
   always_run: true

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -38,6 +38,33 @@
     mode: "0755"
     recurse: true
 
+- name: create custom admin keyring
+  command: ceph-authtool /etc/ceph/{{ cluster }}.client.admin.keyring --create-keyring --name=client.admin --add-key={{ admin_secret }} --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
+  args:
+    creates: /etc/ceph/{{ cluster }}.client.admin.keyring
+  register: create_custom_admin_secret
+  when:
+    - cephx
+    - admin_secret != 'admin_secret'
+
+- name: set ownership of admin keyring
+  file:
+    path: /etc/ceph/{{ cluster }}.client.admin.keyring
+    state: file
+    owner: 'ceph'
+    group: 'ceph'
+    mode: '0600'
+  when:
+    - cephx
+    - admin_secret != 'admin_secret'
+
+- name: import admin keyring into mon keyring
+  command: ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ monitor_name }} --import-keyring /etc/ceph/{{ cluster }}.client.admin.keyring
+  when:
+    - cephx
+    - admin_secret != 'admin_secret'
+    - not create_custom_admin_secret.get('skipped')
+
 - name: ceph monitor mkfs with keyring
   command: ceph-mon --cluster {{ cluster }} --setuser ceph --setgroup ceph --mkfs -i {{ monitor_name }} --fsid {{ fsid }} --keyring /var/lib/ceph/tmp/keyring.mon.{{ monitor_name }}
   args:


### PR DESCRIPTION
Add a new parameter `admin_secret` that allow to deploy a ceph cluster
with a custom admin secret.

Fix: #1630

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>