### PR TITLE
Allow ceph-mon systemd overrides to be specified

### DIFF
--- a/group_vars/mdss.yml.sample
+++ b/group_vars/mdss.yml.sample
@@ -28,3 +28,13 @@ dummy:
 #ceph_mds_docker_extra_env: -e CLUSTER={{ cluster }} -e MDS_NAME={{ ansible_hostname }}
 #ceph_config_keys: [] # DON'T TOUCH ME
 
+###########
+# SYSTEMD #
+###########
+# ceph_mds_systemd_overrides will override the systemd settings
+# for the ceph-mds services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_mds_systemd_overrides:
+#  Service:
+#    PrivateDevices: False
+

--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -14,3 +14,13 @@ dummy:
 #ceph_mgr_docker_extra_env: -e CLUSTER={{ cluster }} -e MGR_NAME={{ ansible_hostname }}
 #ceph_config_keys: [] # DON'T TOUCH ME
 
+###########
+# SYSTEMD #
+###########
+# ceph_mgr_systemd_overrides will override the systemd settings
+# for the ceph-mgr services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_mgr_systemd_overrides:
+#  Service:
+#    PrivateDevices: False
+

--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -125,3 +125,13 @@ dummy:
 #mon_docker_net_host: true
 #ceph_config_keys: [] # DON'T TOUCH ME
 
+###########
+# SYSTEMD #
+###########
+# ceph_mon_systemd_overrides will override the systemd settings
+# for the ceph-mon services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_mon_systemd_overrides:
+#  Service:
+#    PrivateDevices: False
+

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -246,3 +246,13 @@ dummy:
 #ceph_osd_docker_extra_env: -e CLUSTER={{ cluster }} -e OSD_JOURNAL_SIZE={{ journal_size }}
 #ceph_osd_docker_run_script_path: "/usr/share" # script called by systemd to run the docker command
 
+###########
+# SYSTEMD #
+###########
+# ceph_osd_systemd_overrides will override the systemd settings
+# for the ceph-osd services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_osd_systemd_overrides:
+#  Service:
+#    PrivateDevices: False
+

--- a/group_vars/rbd-mirrors.yml.sample
+++ b/group_vars/rbd-mirrors.yml.sample
@@ -44,3 +44,14 @@ dummy:
 
 #ceph_config_keys: [] # DON'T TOUCH ME
 
+
+###########
+# SYSTEMD #
+###########
+# ceph_rbd_mirror_systemd_overrides will override the systemd settings
+# for the ceph-rbd-mirror services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_rbd_mirror_systemd_overrides:
+#  Service:
+#    PrivateDevices: False
+

--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -60,3 +60,13 @@ dummy:
 #ceph_config_keys: [] # DON'T TOUCH ME
 #rgw_config_keys: "/" # DON'T TOUCH ME
 
+###########
+# SYSTEMD #
+###########
+# ceph_rgw_systemd_overrides will override the systemd settings
+# for the ceph-rgw services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_rgw_systemd_overrides:
+#  Service:
+#    PrivateDevices: False
+

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -19,3 +19,14 @@ copy_admin_key: false
 
 ceph_mds_docker_extra_env: -e CLUSTER={{ cluster }} -e MDS_NAME={{ ansible_hostname }}
 ceph_config_keys: [] # DON'T TOUCH ME
+
+
+###########
+# SYSTEMD #
+###########
+# ceph_mds_systemd_overrides will override the systemd settings
+# for the ceph-mds services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_mds_systemd_overrides:
+#  Service:
+#    PrivateDevices: False

--- a/roles/ceph-mds/tasks/pre_requisite.yml
+++ b/roles/ceph-mds/tasks/pre_requisite.yml
@@ -44,6 +44,24 @@
     mode: "0600"
   when: cephx
 
+- name: ensure systemd service override directory exists
+  file:
+    state: directory
+    path: "/etc/systemd/system/ceph-mds@.service.d/"
+  when:
+    - ceph_mds_systemd_overrides is defined
+    - ansible_server_mgr == 'systemd'
+
+- name: add ceph-mds systemd service overrides
+  config_template:
+    src: "ceph-mds.service.d-overrides.j2"
+    dest: "/etc/systemd/system/ceph-mds@.service.d/ceph-mds-systemd-overrides.conf"
+    config_overrides: "{{ ceph_mds_systemd_overrides | default({}) }}"
+    config_type: "ini"
+  when:
+    - ceph_mds_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
 - name: start and add that the metadata service to the init sequence
   service:
     name: ceph-mds@{{ mds_name }}

--- a/roles/ceph-mds/templates/ceph-mds.service.d-overrides.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.d-overrides.j2
@@ -1,0 +1,1 @@
+# {{ ansible_managed }}

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -5,3 +5,14 @@
 
 ceph_mgr_docker_extra_env: -e CLUSTER={{ cluster }} -e MGR_NAME={{ ansible_hostname }}
 ceph_config_keys: [] # DON'T TOUCH ME
+
+
+###########
+# SYSTEMD #
+###########
+# ceph_mgr_systemd_overrides will override the systemd settings
+# for the ceph-mgr services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_mgr_systemd_overrides:
+#  Service:
+#    PrivateDevices: False

--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -34,6 +34,24 @@
   when:
     - cephx
 
+- name: ensure systemd service override directory exists
+  file:
+    state: directory
+    path: "/etc/systemd/system/ceph-mgr@.service.d/"
+  when:
+    - ceph_mgr_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
+- name: add ceph-mgr systemd service overrides
+  config_template:
+    src: "ceph-mgr.service.d-overrides.j2"
+    dest: "/etc/systemd/system/ceph-mgr@.service.d/ceph-mgr-systemd-overrides.conf"
+    config_overrides: "{{ ceph_mgr_systemd_overrides | default({}) }}"
+    config_type: "ini"
+  when:
+    - ceph_mgr_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
 - name: start and add that the mgr service to the init sequence
   service:
     name: "ceph-mgr@{{ ansible_hostname }}"

--- a/roles/ceph-mgr/templates/ceph-mgr.service.d-overrides.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.d-overrides.j2
@@ -1,0 +1,1 @@
+# {{ ansible_managed }}

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -116,3 +116,14 @@ ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NA
 mon_docker_privileged: false
 mon_docker_net_host: true
 ceph_config_keys: [] # DON'T TOUCH ME
+
+
+###########
+# SYSTEMD #
+###########
+# ceph_mon_systemd_overrides will override the systemd settings
+# for the ceph-mon services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_mon_systemd_overrides:
+#  Service:
+#    PrivateDevices: False

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -1,4 +1,22 @@
 ---
+- name: ensure systemd service override directory exists
+  file:
+    state: directory
+    path: "/etc/systemd/system/ceph-mon@.service.d/"
+  when:
+    - ceph_mon_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
+- name: add ceph-mon systemd service overrides
+  config_template:
+    src: "ceph-mon.service.d-overrides.j2"
+    dest: "/etc/systemd/system/ceph-mon@.service.d/ceph-mon-systemd-overrides.conf"
+    config_overrides: "{{ ceph_mon_systemd_overrides | default({}) }}"
+    config_type: "ini"
+  when:
+    - ceph_mon_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
 - name: start the monitor service
   service:
     name: ceph-mon@{{ monitor_name }}

--- a/roles/ceph-mon/templates/ceph-mon.service.d-overrides.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.d-overrides.j2
@@ -1,0 +1,1 @@
+# {{ ansible_managed }}

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -238,3 +238,14 @@ ceph_osd_docker_prepare_env: -e CLUSTER={{ cluster }} -e OSD_JOURNAL_SIZE={{ jou
 #
 ceph_osd_docker_extra_env: -e CLUSTER={{ cluster }} -e OSD_JOURNAL_SIZE={{ journal_size }}
 ceph_osd_docker_run_script_path: "/usr/share" # script called by systemd to run the docker command
+
+
+###########
+# SYSTEMD #
+###########
+# ceph_osd_systemd_overrides will override the systemd settings
+# for the ceph-osd services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_osd_systemd_overrides:
+#  Service:
+#    PrivateDevices: False

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -10,6 +10,24 @@
   always_run: true
   register: osd_id
 
+- name: ensure systemd service override directory exists
+  file:
+    state: directory
+    path: "/etc/systemd/system/ceph-osd@.service.d/"
+  when:
+    - ceph_osd_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
+- name: add ceph-osd systemd service overrides
+  config_template:
+    src: "ceph-osd.service.d-overrides.j2"
+    dest: "/etc/systemd/system/ceph-osd@.service.d/ceph-osd-systemd-overrides.conf"
+    config_overrides: "{{ ceph_osd_systemd_overrides | default({}) }}"
+    config_type: "ini"
+  when:
+    - ceph_osd_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
 - name: ensure osd daemons are started
   service:
     name: ceph-osd@{{ item }}

--- a/roles/ceph-osd/templates/ceph-osd.service.d-overrides.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.d-overrides.j2
@@ -1,0 +1,1 @@
+# {{ ansible_managed }}

--- a/roles/ceph-rbd-mirror/defaults/main.yml
+++ b/roles/ceph-rbd-mirror/defaults/main.yml
@@ -35,3 +35,14 @@ ceph_rbd_mirror_pool: ""
 ##########
 
 ceph_config_keys: [] # DON'T TOUCH ME
+
+
+###########
+# SYSTEMD #
+###########
+# ceph_rbd_mirror_systemd_overrides will override the systemd settings
+# for the ceph-rbd-mirror services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_rbd_mirror_systemd_overrides:
+#  Service:
+#    PrivateDevices: False

--- a/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
@@ -1,4 +1,22 @@
 ---
+- name: ensure systemd service override directory exists
+  file:
+    state: directory
+    path: "/etc/systemd/system/ceph-rbd-mirror@.service.d/"
+  when:
+    - ceph_rbd_mirror_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
+- name: add ceph-rbd-mirror systemd service overrides
+  config_template:
+    src: "ceph-rbd-mirror.service.d-overrides.j2"
+    dest: "/etc/systemd/system/ceph-rbd-mirror@.service.d/ceph-rbd-mirror-systemd-overrides.conf"
+    config_overrides: "{{ ceph_rbd_mirror_systemd_overrides | default({}) }}"
+    config_type: "ini"
+  when:
+    - ceph_rbd_mirror_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
 - name: start and add that the rbd mirror service to the init sequence
   service:
       name: "ceph-rbd-mirror@{{ ceph_rbd_mirror_local_user }}"

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.d-overrides.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.d-overrides.j2
@@ -1,0 +1,1 @@
+# {{ ansible_managed }}

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -51,3 +51,14 @@ ceph_rgw_civetweb_port: "{{ radosgw_civetweb_port }}"
 ceph_rgw_docker_extra_env: -e CLUSTER={{ cluster }} -e RGW_CIVETWEB_PORT={{ ceph_rgw_civetweb_port }}
 ceph_config_keys: [] # DON'T TOUCH ME
 rgw_config_keys: "/" # DON'T TOUCH ME
+
+
+###########
+# SYSTEMD #
+###########
+# ceph_rgw_systemd_overrides will override the systemd settings
+# for the ceph-rgw services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_rgw_systemd_overrides:
+#  Service:
+#    PrivateDevices: False

--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -6,6 +6,24 @@
   failed_when: false
   always_run: true
 
+- name: ensure systemd service override directory exists
+  file:
+    state: directory
+    path: "/etc/systemd/system/ceph-rgw@.service.d/"
+  when:
+    - ceph_rgw_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
+- name: add ceph-rgw systemd service overrides
+  config_template:
+    src: "ceph-rgw.service.d-overrides.j2"
+    dest: "/etc/systemd/system/ceph-rgw@.service.d/ceph-rgw-systemd-overrides.conf"
+    config_overrides: "{{ ceph_rgw_systemd_overrides | default({}) }}"
+    config_type: "ini"
+  when:
+    - ceph_rgw_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
 - name: start rgw
   service:
     name: ceph-radosgw@rgw.{{ ansible_hostname }}

--- a/roles/ceph-rgw/templates/ceph-rgw.service.d-overrides.j2
+++ b/roles/ceph-rgw/templates/ceph-rgw.service.d-overrides.j2
@@ -1,0 +1,1 @@
+# {{ ansible_managed }}


### PR DESCRIPTION
ceph-mon can fail to start under certain circumstances (for example,
when running in a container) because the default systemd service
configuration causes namespace issues.

To work around this we can override the system service settings by
placing an overrides file in the ceph-mon@.service.d directory. This can
be generic so as to allow any potential changes required to the ceph-mon
service file.

The overrides file is only setup when the "ceph_mon_systemd_overrides"
config_template override variable is specified.