### PR TITLE
Tests: fix scenario for docker-cluster-dmcrypt-journal-collocation

### DIFF
--- a/tests/functional/centos/7/docker-cluster-dmcrypt-journal-collocation/group_vars/all
+++ b/tests/functional/centos/7/docker-cluster-dmcrypt-journal-collocation/group_vars/all
@@ -12,7 +12,7 @@ journal_size: 100
 ceph_docker_on_openstack: False
 public_network: "192.168.15.0/24"
 cluster_network: "192.168.16.0/24"
-journal_collocation: true
+dmcrypt_journal_collocation: true
 ceph_rgw_civetweb_port: 8080
 ceph_osd_docker_devices: "{{ devices }}"
 devices:


### PR DESCRIPTION
The scenario set in `group_vars/all` for
docker-cluster-dmcrypt-journal-collocation is not the correct one.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>