### PR TITLE
common: ensure rsync is installed for local install

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -49,6 +49,13 @@
     - ceph_origin == 'local'
     - use_installer
 
+- name: ensure rsync is installed
+  package:
+    name: rsync
+    state: present
+  when:
+    - ceph_origin == 'local'
+
 - name: synchronize ceph install
   synchronize:
     src: "{{ceph_installation_dir}}/"


### PR DESCRIPTION
rsync is required by the ansible synchronize package. Ensure
it is installed when local installation is selected.

Signed-off-by: Douglas Fuller <dfuller@redhat.com>