### PR TITLE
Doc: containerized deploy with custom admin secret

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -115,6 +115,12 @@ dummy:
 ##########
 #docker_exec_cmd:
 #ceph_mon_docker_subnet: "{{ public_network }}"# subnet of the monitor_interface
+
+# ceph_mon_docker_extra_env:
+#
+# Use this variable to add extra env configuration to run your mon container.
+# If you want to set a custom admin keyring you can set this variable like following:
+# ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NAME={{ monitor_name }} -e ADMIN_SECRET={{ admin_secret }}
 #ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NAME={{ monitor_name }}
 #mon_docker_privileged: false
 #mon_docker_net_host: true

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -107,6 +107,12 @@ openstack_keys:
 ##########
 docker_exec_cmd:
 ceph_mon_docker_subnet: "{{ public_network }}"# subnet of the monitor_interface
+
+# ceph_mon_docker_extra_env:
+#
+# Use this variable to add extra env configuration to run your mon container.
+# If you want to set a custom admin keyring you can set this variable like following:
+# ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NAME={{ monitor_name }} -e ADMIN_SECRET={{ admin_secret }}
 ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NAME={{ monitor_name }}
 mon_docker_privileged: false
 mon_docker_net_host: true


### PR DESCRIPTION
In addition to ceph/ceph-docker@69d9aa6, this explains how to deploy a
containerized cluster with a custom admin secret.
Basically, just need to pass the `admin_secret` defined in your
`group_vars/all.yml` to the `ceph_mon_docker_extra_env` variable.

Eg:

`ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }}
-e MON_NAME={{ monitor_name }} -e ADMIN_SECRET={{ admin_secret }}`

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>