### PR TITLE
tests: fix test_osds_listen_on_* tests

### DIFF
--- a/tests/functional/tests/osd/test_osds.py
+++ b/tests/functional/tests/osd/test_osds.py
@@ -7,23 +7,15 @@ class TestOSDs(object):
     def test_ceph_osd_package_is_installed(self, node, Package):
         assert Package("ceph-osd").is_installed
 
-    def test_osds_listen_on_public_network(self, node, Socket):
+    def test_osds_listen_on_public_network(self, node, Command):
         # TODO: figure out way to paramaterize this test
-        for x in range(0, node["num_devices"] * 2):
-            port = "680{}".format(x)
-            assert Socket("tcp://{address}:{port}".format(
-                address=node["address"],
-                port=port,
-            )).is_listening
+        nb_port = (node["num_devices"] * 2)
+        assert Command.check_output("netstat -lntp | grep ceph-osd | grep %s | wc -l" % (node["address"])) == str(nb_port)
 
-    def test_osds_listen_on_cluster_network(self, node, Socket):
+    def test_osds_listen_on_cluster_network(self, node, Command):
         # TODO: figure out way to paramaterize this test
-        for x in range(0, node["num_devices"] * 2):
-            port = "680{}".format(x)
-            assert Socket("tcp://{address}:{port}".format(
-                address=node["cluster_address"],
-                port=port,
-            )).is_listening
+        nb_port = (node["num_devices"] * 2)
+        assert Command.check_output("netstat -lntp | grep ceph-osd | grep %s | wc -l" % (node["cluster_address"])) == str(nb_port)
 
     def test_osd_services_are_running(self, node, Service):
         # TODO: figure out way to paramaterize node['osds'] for this test


### PR DESCRIPTION
the `test_osds_listen_on_*` consider OSDs will always listen on tcp port
with consecutive tcp port number starting from `6800`.

Eg.
If you have 2 OSDs, tests will assume it should listen on 2 ports for each
network (`public_network` and `cluster_network`), therefore:
`6800, 6801, 6802, 6803`

but sometime it doesn't happen this way and you can get OSDs listening
on tcp port like this :

`6800, 6801, 6802, 6805`

Then the test are failing while it shouldn't.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>