### PR TITLE
fix: osd use filestore

### DIFF
--- a/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
+++ b/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
@@ -7,8 +7,14 @@
 # if you have 64 disks with 4TB each, this will take a while
 # since Ansible will sequential process the loop
 
+- set_fact:
+    osd_type: "--filestore"
+  when: 
+    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - osd_objectstore == 'filestore'
+
 - name: prepare filestore osd disk(s) with a dedicated journal device
-  command: "ceph-disk prepare --cluster {{ cluster }} {{ item.1 }} {{ item.2 }}"
+  command: "ceph-disk prepare {{ osd_type | default('') }} --cluster {{ cluster }} {{ item.1 }} {{ item.2 }}"
   with_together:
     - "{{ parted_results.results }}"
     - "{{ devices }}"


### PR DESCRIPTION
the newest ceph-disk use bluestore default, so if we want using filestore , we need to config filestore explicitly.