### PR TITLE
tests: run all existing tests with shaman repos

### DIFF
--- a/docs/source/testing/tox.rst
+++ b/docs/source/testing/tox.rst
@@ -36,6 +36,18 @@ The following environent variables are available for use:
 
 * ``CEPH_DOCKER_IMAGE_TAG``: (default: ``latest``) This would configure the ceph-ansible variable ``ceph_docker_image_name``.
 
+* ``CEPH_DEV_BRANCH``: (default: ``master``) This would configure the ceph-ansible variable ``ceph_dev_branch`` which defines which branch we'd
+  like to install from shaman.ceph.com.
+
+* ``CEPH_DEV_SHA1``: (default: ``latest``) This would configure the ceph-ansible variable ``ceph_dev_sha1`` which defines which sha1 we'd like
+  to install from shaman.ceph.com.
+
+* ``UPDATE_CEPH_DEV_BRANCH``: (default: ``master``) This would configure the ceph-ansible variable ``ceph_dev_branch`` which defines which branch we'd
+  like to update to from shaman.ceph.com.
+
+* ``UPDATE_CEPH_DEV_SHA1``: (default: ``latest``) This would configure the ceph-ansible variable ``ceph_dev_sha1`` which defines which sha1 we'd like
+  to update to from shaman.ceph.com.
+
 
 .. _tox_sections:
 

--- a/tests/functional/dev_setup.yml
+++ b/tests/functional/dev_setup.yml
@@ -1,0 +1,23 @@
+---
+- hosts: localhost
+  gather_facts: false
+  become: yes
+  tags:
+    - vagrant_setup
+  tasks:
+
+    - name: change ceph_stable to False
+      replace:
+        regexp: "ceph_stable:.*"
+        replace: "ceph_stable: False"
+        dest: "{{ change_dir }}/group_vars/all"
+      when: change_dir is defined
+
+    - name: set ceph_dev to True
+      lineinfile:
+        line: "ceph_dev: True"
+        dest: "{{ change_dir }}/group_vars/all"
+      when: change_dir is defined
+
+    - name: print contents of {{ change_dir }}/group_vars/all
+      command: "cat {{ change_dir }}/group_vars/all"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = {jewel,luminous,rhcs}-{ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster,cluster,purge_docker_cluster,update_docker_cluster}
-  {luminous}-{ansible2.2}-{bluestore_journal_collocation,bluestore_cluster,bluestore_dmcrypt_journal,bluestore_dmcrypt_journal_collocation,bluestore_docker_cluster,bluestore_docker_dedicated_journal,bluestore_docker_dmcrypt_journal_collocation}
+envlist = {dev,jewel,luminous,rhcs}-{ansible2.2}-{xenial_cluster,journal_collocation,centos7_cluster,dmcrypt_journal,dmcrypt_journal_collocation,docker_cluster,purge_cluster,purge_dmcrypt,docker_dedicated_journal,docker_dmcrypt_journal_collocation,update_dmcrypt,update_cluster,cluster,purge_docker_cluster,update_docker_cluster}
+  {dev,luminous}-{ansible2.2}-{bluestore_journal_collocation,bluestore_cluster,bluestore_dmcrypt_journal,bluestore_dmcrypt_journal_collocation,bluestore_docker_cluster,bluestore_docker_dedicated_journal,bluestore_docker_dmcrypt_journal_collocation}
 
 skipsdist = True
 
@@ -27,6 +27,8 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \
+      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
+      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
   # test that the cluster can be redeployed in a healthy state
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
@@ -44,6 +46,8 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:UPDATE_CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:UPDATE_CEPH_DOCKER_IMAGE_TAG:latest} \
+      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
+      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
   "
 
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
@@ -116,6 +120,7 @@ changedir=
 
 commands=
   rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
+  dev: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
 
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
@@ -128,6 +133,8 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \
+      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
+      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/setup.yml


### PR DESCRIPTION
If you use the 'dev' factor, the testing scenario will
use repos from shaman.ceph.com. You can define CEPH_DEV_BRANCH
and CEPH_DEV_SHA1 to specify which repo you'd like to test.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>