### PR TITLE
fix: when osd device is a disk partition

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -309,7 +309,14 @@
     when: "{{ encrypted_ceph_partuuid.stdout_lines | length > 0 }}"
 
   - name: zap osd disks
-    shell: ceph-disk zap "{{ item }}"
+    shell: |
+      if (echo "{{ item }}" | grep -Esq '[0-9]{1,2}$'); then
+        raw_device=$(echo "{{ item }}" | grep -Eo '/dev/([hsv]d[a-z]{1,2}|cciss/c[0-9]d[0-9]|nvme[0-9]n[0-9]){1,2}')
+        partition_nb=$(echo "{{ item }}" | grep -Eo '[0-9]{1,2}$')
+        sgdisk --delete $partition_nb $raw_device
+      else
+        ceph-disk zap "{{ item }}"
+      fi
     with_items: "{{ devices }}"
     when:
       - ceph_disk_present.rc == 0


### PR DESCRIPTION
when osd devices is a disk partition, ceph-disk zap "{{ item }}" will not work.
Check the osd device type first, is the osd device is a raw device, using ceph-disk, else using sgdisk