### PR TITLE
ceph-mds: Enable multimds under docker

### DIFF
--- a/roles/ceph-mds/tasks/docker/enable_multimds.yml
+++ b/roles/ceph-mds/tasks/docker/enable_multimds.yml
@@ -1,0 +1,22 @@
+---
+- name: wait for mds socket to exist
+  command: "{{ docker_exec_cmd }} stat /var/run/ceph/{{ cluster }}-mds.{{ ansible_hostname }}.asok"
+  register: mds_socket
+  retries: 5
+  delay: 15
+  until: mds_socket.rc == 0
+
+- name: enable multimds if requested when mon is containerized
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} fs set {{ cephfs }} allow_multimds true --yes-i-really-mean-it"
+  changed_when: false
+  when:
+    - containerized_deployment
+    - mds_allow_multimds
+
+- name: set max_mds when mon is containerized
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} fs set {{ cephfs }} max_mds {{ mds_max_mds }}"
+  changed_when: false
+  when:
+    - containerized_deployment
+    - mds_allow_multimds
+    - mds_max_mds > 1

--- a/roles/ceph-mds/tasks/docker/main.yml
+++ b/roles/ceph-mds/tasks/docker/main.yml
@@ -1,2 +1,7 @@
 ---
+- name: set docker_exec_cmd fact
+  set_fact:
+    docker_exec_cmd: "docker exec ceph-mds-{{ ansible_hostname }}"
+
 - include: start_docker_mds.yml
+- include: enable_multimds.yml


### PR DESCRIPTION
This is under the MDS role instead of the mon role because that role
does not create the filesystem under docker.

Signed-off-by: Douglas Fuller <dfuller@redhat.com>