### PR TITLE
Make ceph-fetch-keys depend on ceph-common (for cluster_uuid)

### DIFF
--- a/roles/ceph-fetch-keys/meta/main.yml
+++ b/roles/ceph-fetch-keys/meta/main.yml
@@ -13,4 +13,6 @@ galaxy_info:
         - 7
   categories:
     - system
-dependencies: []
+dependencies:
+  - { role: ceph.ceph-common, when: not containerized_deployment }
+  - { role: ceph.ceph-docker-common, when: containerized_deployment }


### PR DESCRIPTION
A typical deployment of ceph-ansible has fsid set to "{{
cluster_uuid.stdout }}". The ceph-fetch-keys role needs fsid defined
(it stores keys in "{{ fetch_directory }}/{{ fsid }}/{{ item }}"), so
should depend upon this role.

closes #1698
Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>