### PR TITLE
Keystone token type

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -289,6 +289,8 @@ radosgw_keystone: false # activate OpenStack Keystone options full detail here: 
 #radosgw_keystone_url: # url:admin_port ie: http://192.168.0.1:35357
 radosgw_keystone_api_version: 2 # API versions 2 and 3 are supported
 radosgw_keystone_ssl: true # Can be used to disable PKI revocation checks when other token types are used.
+# what type of tokens is keystone providing: fernet, uuid, pki
+radosgw_keystone_token_type: fernet
 # for admin_token method, define radosgw_keystone_admin_token
 # for auth_token method, define _user, _password, and _tenant
 radosgw_keystone_auth_method: admin_token

--- a/roles/ceph-rgw/tasks/openstack-keystone.yml
+++ b/roles/ceph-rgw/tasks/openstack-keystone.yml
@@ -3,13 +3,13 @@
   package:
     name: nss-tools
     state: present
-  when: ansible_pkg_mgr == "yum" or ansible_pkg_mgr == "dnf"
+  when: ( ansible_pkg_mgr == "yum" or ansible_pkg_mgr == "dnf" ) and radosgw_keystone_token_type == 'pki'
 
 - name: install libnss3-tools on debian
   package:
     name: libnss3-tools
     state: present
-  when: ansible_pkg_mgr == 'apt'
+  when: ansible_pkg_mgr == 'apt' and radosgw_keystone_token_type == 'pki'
 
 - name: create nss directory for keystone certificates
   file:
@@ -18,9 +18,11 @@
     owner: root
     group: root
     mode: 0644
+  when: radosgw_keystone_token_type == 'pki'
 
 - name: create nss entries for keystone certificates
   shell: "{{ item }}"
   with_items:
     - "openssl x509 -in /etc/keystone/ssl/certs/ca.pem -pubkey |certutil -d {{ radosgw_nss_db_path }} -A -n ca -t 'TCu,Cu,Tuw'"
     - "openssl x509 -in /etc/keystone/ssl/certs/signing_cert.pem -pubkey | certutil -A -d {{ radosgw_nss_db_path }} -n signing_cert -t 'P,P,P'"
+  when: radosgw_keystone_token_type == 'pki'


### PR DESCRIPTION
The NSS commands in radosgw openstack-keystone.yaml file are needed when the token type is PKI. 
this patch adds radosgw_keystone_token_type and checks to see if it is set to 'pki' prior to running the NSS commands. 