### PR TITLE
fix: add partprobe after ceph-disk prepare

### DIFF
--- a/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
+++ b/roles/ceph-osd/tasks/scenarios/raw_multi_journal.yml
@@ -40,4 +40,7 @@
     - osd_objectstore == 'bluestore'
     - not osd_auto_discovery
 
+- name: partprobe
+  command: partprobe
+  
 - include: ../activate_osds.yml


### PR DESCRIPTION
In my scenario, I used particular disk partitions for ceph devices, and jraw_journal_devices.
And ceph-disk activate always error, 
mkjournal error creating journal on /var/lib/ceph/tmp/mnt.n6qlKY/journal:  Permission denied
If I run partprobe before ceph-disk activate, it works well