### PR TITLE
osd: do not enable osd@id unit file

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -95,6 +95,5 @@
   service:
     name: ceph-osd@{{ item }}
     state: started
-    enabled: yes
   with_items: "{{ (osd_id|default({})).stdout_lines|default([]) }}"
   changed_when: false

--- a/tests/functional/tests/osd/test_osds.py
+++ b/tests/functional/tests/osd/test_osds.py
@@ -22,11 +22,6 @@ class TestOSDs(object):
         for osd in node["osds"]:
             assert Service("ceph-osd@%s" % osd).is_running
 
-    def test_osd_services_are_enabled(self, node, Service):
-        # TODO: figure out way to paramaterize node['osds'] for this test
-        for osd in node["osds"]:
-            assert Service("ceph-osd@%s" % osd).is_enabled
-
     @pytest.mark.no_docker
     def test_osd_are_mounted(self, node, MountPoint):
         # TODO: figure out way to paramaterize node['osd_ids'] for this test


### PR DESCRIPTION
ceph-disk is responsable for enabling the unit file if needed. Actually
since https://github.com/ceph/ceph/pull/12241 it seems that it's not
even needed. On an event of a restart, udev rules will be trigger and
they will ceph-disk activate the device too so the 'enabled' is not
needed.

Closes: https://github.com/ceph/ceph-ansible/issues/1142
Signed-off-by: Sébastien Han <seb@redhat.com>