### PR TITLE
common: override and autodetect ceph_stable_release

### DIFF
--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -27,7 +27,8 @@
     msg: "make sure ceph_stable_release is set to a release name (e.g: luminous), http://docs.ceph.com/docs/master/release-notes/"
   when:
     - ceph_stable_release == 'dummy'
-    - not ceph_rhcs
+    - ceph_origin == 'upstream'
+    - ceph_stable
   tags:
     - package-install
 
@@ -36,7 +37,8 @@
     msg: "wrong release name, see http://docs.ceph.com/docs/master/release-notes/"
   when:
     - ceph_stable_release not in ceph_release_num
-    - not ceph_rhcs
+    - ceph_origin == 'upstream'
+    - ceph_stable
   tags:
     - package-install
 

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -74,6 +74,12 @@
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 
+# override ceph_stable_release for ceph_dev and rhcs installations since ceph_stable_release is not mandatory
+- include: ./release-rhcs.yml
+  when: (ceph_rhcs or ceph_dev)
+  tags:
+    - always
+
 - include: ./misc/ntp_redhat.yml
   when:
     - ansible_os_family == 'RedHat'

--- a/roles/ceph-common/tasks/release-rhcs.yml
+++ b/roles/ceph-common/tasks/release-rhcs.yml
@@ -1,0 +1,13 @@
+---
+- set_fact:
+    ceph_release: jewel
+  when: ceph_version.split('.')[0] | version_compare('10', '==')
+
+- set_fact:
+    ceph_release: kraken
+  when: ceph_version.split('.')[0] | version_compare('11', '==')
+
+- set_fact:
+    ceph_release: luminous
+  when: ceph_version.split('.')[0] | version_compare('12', '==')
+


### PR DESCRIPTION
For ceph_dev and rhcs installation we need to detect the release since
we do not declare it explicitly. Keeping the default ceph_stable_release
could lead to several things going wrong and some have already been
reported.

Fixes: https://github.com/ceph/ceph-ansible/issues/1712 and https://bugzilla.redhat.com/show_bug.cgi?id=1476210
Signed-off-by: Sébastien Han <seb@redhat.com>