### PR TITLE
test: tox retry for 10min if vagrant up fails

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ whitelist_externals =
     bash
     pip
     cp
+    timeout
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
@@ -122,7 +123,7 @@ commands=
   rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
   dev: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
 
-  vagrant up --no-provision {posargs:--provider=virtualbox}
+  timeout 10m bash -c "until vagrant up --no-provision {posargs:--provider=virtualbox}; do vagrant destroy --force ; echo 'Vagrant up failed, trying again...'; done"
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"


### PR DESCRIPTION
Sometimes, we have ruby issues while running vagrant up, we end up
having dead machine and failed job. This is annoying so this patch will
vagrant destroy and then try to vagrant again, it will try until it
succeeds and will exit after 10 minutes.

Signed-off-by: Sébastien Han <seb@redhat.com>