### PR TITLE
Add ceph-defaults to galaxy role breakout script

### DIFF
--- a/contrib/push-roles-to-ansible-galaxy.sh
+++ b/contrib/push-roles-to-ansible-galaxy.sh
@@ -5,7 +5,7 @@ set -xe
 BASEDIR=$(dirname "$0")
 LOCAL_BRANCH=$(cd $BASEDIR && git rev-parse --abbrev-ref HEAD)
 BRANCHES="master ansible-1.9"
-ROLES="ceph-common ceph-mon ceph-osd ceph-mds ceph-rgw ceph-restapi ceph-agent ceph-fetch-keys ceph-rbd-mirror ceph-client ceph-docker-common ceph-mgr"
+ROLES="ceph-common ceph-mon ceph-osd ceph-mds ceph-rgw ceph-restapi ceph-agent ceph-fetch-keys ceph-rbd-mirror ceph-client ceph-docker-common ceph-mgr ceph-defaults"
 
 
 # FUNCTIONS


### PR DESCRIPTION
The `ceph/ansible-ceph-defaults` repo will need to be created.

This is needed because downstream projects that consume ceph-ansible, such as openstack-ansible, are unable to do so due to #1737 until there is a ceph-defaults breakout role created.