### PR TITLE
ceph-common: render ceph_conf_overrides into fetch_directory

### DIFF
--- a/roles/ceph-common/tasks/generate_ceph_conf.yml
+++ b/roles/ceph-common/tasks/generate_ceph_conf.yml
@@ -11,11 +11,13 @@
     - /etc/ceph/ceph.d/
 
 - name: template ceph_conf_overrides
-  local_action: copy content="{{ ceph_conf_overrides }}" dest=/tmp/ceph_conf_overrides_temp
+  local_action: copy content="{{ ceph_conf_overrides }}" dest="{{ fetch_directory }}/ceph_conf_overrides_temp"
+  become: false
   run_once: true
 
 - name: get rendered ceph_conf_overrides
-  local_action: set_fact ceph_conf_overrides_rendered="{{ lookup('template', '/tmp/ceph_conf_overrides_temp') | from_yaml }}"
+  local_action: set_fact ceph_conf_overrides_rendered="{{ lookup('template', '{{ fetch_directory }}/ceph_conf_overrides_temp') | from_yaml }}"
+  become: false
   run_once: true
 
 - name: "generate ceph configuration file: {{ cluster }}.conf"


### PR DESCRIPTION
Writing into /tmp is not always allowed, but we can assume the
fetch_directory is writable.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>