### PR TITLE
tests: do not use /dev/sda in the lvm scenario

### DIFF
--- a/tests/functional/centos/7/lvm-osds/group_vars/all
+++ b/tests/functional/centos/7/lvm-osds/group_vars/all
@@ -9,9 +9,9 @@ journal_size: 100
 osd_objectstore: "filestore"
 osd_scenario: lvm
 copy_admin_key: true
-# test-volume is created by tests/functional/lvm_setup.yml from /dev/sda
+# test-volume is created by tests/functional/lvm_setup.yml from /dev/sdb
 lvm_volumes:
-  test_volume: /dev/sdb
+  test_volume: /dev/sdc
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -6,11 +6,11 @@
   tasks:
     
     - name: create physical volume
-      command: pvcreate /dev/sda
+      command: pvcreate /dev/sdb
       failed_when: false
 
     - name: create volume group
-      command: vgcreate test_group /dev/sda
+      command: vgcreate test_group /dev/sdb
       failed_when: false
 
     - name: create logical volume


### PR DESCRIPTION
When you udpate to the latest version of the centos/7 box it always puts
the OS on /dev/sda, so do not use it as an OSD.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>