### PR TITLE
ceph-common: install base package to provide ceph CLI

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -29,6 +29,11 @@
     default_release: "{{ ceph_stable_release_uca | default(ansible_distribution_release) }}{{ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
   when: ceph_test
 
+- name: install ceph-common
+  package:
+    name: 'ceph-common'
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+
 - name: install rados gateway
   apt:
     pkg: radosgw

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -75,6 +75,11 @@
   when:
     - ceph_origin == 'local'
 
+- name: install ceph-common
+  package:
+    name: 'ceph-common'
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+
 - name: install distro or red hat storage ceph mon
   package:
     name: "ceph-mon"


### PR DESCRIPTION
This install the package `rbd-mirror` as it is not installed for rbdmirror nodes.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>