### PR TITLE
Add check for mon_address_block

### DIFF
--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -82,3 +82,20 @@
     - radosgw_interface == 'interface'
     - radosgw_address == 'address'
     - radosgw_address_block == 'subnet'
+
+- name: "make sure monitor_address_block is valid"
+  set_fact:
+    monitor_address_block_check: "{{ hostvars[item]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) }}"
+  when:
+    - not containerized_deployment
+    - not containerized_deployment_with_kv
+    - monitor_address_block is defined
+  with_items:
+    - "{{ groups[mon_group_name] }}"
+
+- name: "fail if monitor_address_block is invalid"
+  fail:
+    msg: "An IP address in the block {{ monitor_address_block }} was not found on one or more monitor nodes. Please check your monitor_address_block setting."
+  when:
+    - monitor_address_block_check is defined
+    - monitor_address_block_check | length == 0

--- a/tests/requirements2.4.txt
+++ b/tests/requirements2.4.txt
@@ -2,3 +2,4 @@
 # testinfra < 1.7.1 does not work Ansible 2.4, see https://github.com/philpep/testinfra/issues/249
 testinfra==1.7.1
 pytest-xdist
+netaddr

--- a/tox.ini
+++ b/tox.ini
@@ -162,7 +162,6 @@ deps=
   ansible2.3: -r{toxinidir}/tests/requirements2.2.txt
   ansible2.4: ansible==2.4.2
   ansible2.4: -r{toxinidir}/tests/requirements2.4.txt
-  ooo_collocation: netaddr
 changedir=
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw xenial cluster using non-collocated OSD scenario
   xenial_cluster: {toxinidir}/tests/functional/ubuntu/16.04/cluster


### PR DESCRIPTION
Return a sane error message if monitor_address_block is set incorrectly.

Fixes: https://github.com/ceph/ceph-ansible/issues/1766
Signed-off-by: Douglas Fuller <dfuller@redhat.com>