### PR TITLE
Update ceph_rgw_docker_extra_env to add bind ip

### DIFF
--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -48,6 +48,7 @@ rgw_pull_proto: "http"
 ##########
 
 ceph_rgw_civetweb_port: "{{ radosgw_civetweb_port }}"
-ceph_rgw_docker_extra_env: -e CLUSTER={{ cluster }} -e RGW_CIVETWEB_PORT={{ ceph_rgw_civetweb_port }}
+ceph_rgw_civetweb_ip: "{{ radosgw_civetweb_bind_ip }}"
+ceph_rgw_docker_extra_env: -e CLUSTER={{ cluster }} -e RGW_CIVETWEB_PORT={{ ceph_rgw_civetweb_port }} -e RGW_CIVETWEB_IP {{ ceph_rgw_civetweb_ip }}
 ceph_config_keys: [] # DON'T TOUCH ME
 rgw_config_keys: "/" # DON'T TOUCH ME

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -49,6 +49,6 @@ rgw_pull_proto: "http"
 
 ceph_rgw_civetweb_port: "{{ radosgw_civetweb_port }}"
 ceph_rgw_civetweb_ip: "{{ radosgw_civetweb_bind_ip }}"
-ceph_rgw_docker_extra_env: -e CLUSTER={{ cluster }} -e RGW_CIVETWEB_PORT={{ ceph_rgw_civetweb_port }} -e RGW_CIVETWEB_IP {{ ceph_rgw_civetweb_ip }}
+ceph_rgw_docker_extra_env: -e CLUSTER={{ cluster }} -e RGW_CIVETWEB_PORT={{ ceph_rgw_civetweb_port }} -e RGW_CIVETWEB_IP={{ ceph_rgw_civetweb_ip }}
 ceph_config_keys: [] # DON'T TOUCH ME
 rgw_config_keys: "/" # DON'T TOUCH ME


### PR DESCRIPTION
This patch adds passing the RGW_CIVETWEB_IP to the docker
container. This IP defaults to the value of radosgw_civetweb_bind_ip.
radosgw_civetweb_bind_ip default to ipv4.default

Without this value, the RGW containter will bind to 0.0.0.0