### PR TITLE
ceph-defaults: fix handler for osd container

### DIFF
--- a/roles/ceph-defaults/handlers/main.yml
+++ b/roles/ceph-defaults/handlers/main.yml
@@ -45,6 +45,7 @@
   # We do not want to run these checks on initial deployment (`socket_osd_container.results[n].rc == 0`)
   # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
     - containerized_deployment
+    - not item.get("skipped")
     - ((crush_location is defined and crush_location) or item.get('rc') == 0)
     - handler_health_osd_check
     # See https://github.com/ceph/ceph-ansible/issues/1457 for the condition below


### PR DESCRIPTION
Problem: task "check for a ceph socket in containerized deployment" will
be skipped if we are not an OSD.

with_items are still evaluated before when conditions so if the task was
skipped the dict will be empty and then fail.
Adding a "not skipped" condition skips the execution of the task.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1482061
Signed-off-by: Sébastien Han <seb@redhat.com>