### PR TITLE
mon, osd: fix skipped condition

### DIFF
--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -75,9 +75,9 @@
 - name: import admin keyring into mon keyring
   command: ceph-authtool /var/lib/ceph/tmp/keyring.mon.{{ monitor_name }} --import-keyring /etc/ceph/{{ cluster }}.client.admin.keyring
   when:
+    - not create_custom_admin_secret.get('skipped')
     - cephx
     - admin_secret != 'admin_secret'
-    - not create_custom_admin_secret.get('skipped')
 
 - name: ceph monitor mkfs with keyring
   command: ceph-mon --cluster {{ cluster }} --setuser ceph --setgroup ceph --mkfs -i {{ monitor_name }} --fsid {{ fsid }} --keyring /var/lib/ceph/tmp/keyring.mon.{{ monitor_name }}

--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -50,6 +50,6 @@
     - "{{ dedicated_devices|unique }}"
   changed_when: false
   when:
-    - osd_scenario == 'non-collocated'
     - not item.0.get("skipped")
+    - osd_scenario == 'non-collocated'
     - item.0.get("rc", 0) != 0

--- a/roles/ceph-osd/tasks/check_devices_auto.yml
+++ b/roles/ceph-osd/tasks/check_devices_auto.yml
@@ -30,8 +30,8 @@
     msg: "OSD device autodetection failed because one or more raw partitions is mounted on the host."
   with_items: "{{ mount_cmd.results }}"
   when:
-    - item.rc == 0
     - not item.get("skipped")
+    - item.rc == 0
 
 - name: check the partition status of the osd disks (autodiscover disks)
   shell: "parted --script /dev/{{ item.key }} print > /dev/null 2>&1"


### PR DESCRIPTION
To be properly evaluated the "skipped" conditions must always have the
first place on the list of condition, otherwise the other conditions are
evaluated before and make the task fail.

Signed-off-by: Sébastien Han <seb@redhat.com>