### PR TITLE
fix radosgw-admin call with another cluster name than "ceph"

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite.yml
@@ -11,7 +11,7 @@
     - /var/run/ganesha
 
 - name: create rgw nfs user
-  command: radosgw-admin user create --uid={{ ceph_nfs_rgw_user }} --display-name="RGW NFS User"
+  command: radosgw-admin --cluster {{ cluster }} user create --uid={{ ceph_nfs_rgw_user }} --display-name="RGW NFS User"
   register: rgwuser
   when: nfs_obj_gw
 


### PR DESCRIPTION
This commit fix the radosgw-admin call during [ceph-nfs : create rgw nfs user] TASK.
radosgw-admin should be use with the cluster name in option if cluster name is not "ceph"

Refer to this issue https://github.com/ceph/ceph-ansible/issues/1785