### PR TITLE
ability to deploy admin key with containers

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -15,6 +15,12 @@ dummy:
 
 #fetch_directory: fetch/
 
+# Even though some nodes should not have the admin key
+# at their disposal (e.g: mds, osd, rgw), some people might want to have it
+# distributed. Setting 'copy_admin_key' to 'true'
+# will copy the admin key to the /etc/ceph/ directory
+#copy_admin_key: false
+
 # The 'cluster' variable determines the name of the cluster.
 # Changing the default value to something else means that you will
 # need to change all the command line calls as well, for example if

--- a/group_vars/ceph-fetch-keys.yml.sample
+++ b/group_vars/ceph-fetch-keys.yml.sample
@@ -8,6 +8,3 @@
 dummy:
 
 
-#fetch_directory: fetch/
-#cluster: ceph
-

--- a/group_vars/clients.yml.sample
+++ b/group_vars/clients.yml.sample
@@ -11,8 +11,6 @@ dummy:
 # GENERAL #
 ###########
 
-#fetch_directory: fetch/
-
 #user_config: false
 #pools:
 #  - { name: test, pgs: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}" }

--- a/group_vars/mdss.yml.sample
+++ b/group_vars/mdss.yml.sample
@@ -9,18 +9,6 @@ dummy:
 
 # You can override vars by using host or group vars
 
-###########
-# GENERAL #
-###########
-
-#fetch_directory: fetch/
-
-# Even though MDS nodes should not have the admin key
-# at their disposal, some people might want to have it
-# distributed on MDS nodes. Setting 'copy_admin_key' to 'true'
-# will copy the admin key to the /etc/ceph/ directory
-#copy_admin_key: false
-
 ##########
 # DOCKER #
 ##########

--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -9,12 +9,6 @@ dummy:
 
 # You can override vars by using host or group vars
 
-###########
-# GENERAL #
-###########
-
-#fetch_directory: fetch/
-
 #######################
 # Access type options #
 #######################

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -10,18 +10,6 @@ dummy:
 # You can override default vars defined in defaults/main.yml here,
 # but I would advice to use host or group vars instead
 
-
-###########
-# GENERAL #
-###########
-
-# Even though OSD nodes should not have the admin key
-# at their disposal, some people might want to have it
-# distributed on OSD nodes. Setting 'copy_admin_key' to 'true'
-# will copy the admin key to the /etc/ceph/ directory
-#copy_admin_key: false
-
-
 ####################
 # OSD CRUSH LOCATION
 ####################

--- a/group_vars/rbd-mirrors.yml.sample
+++ b/group_vars/rbd-mirrors.yml.sample
@@ -11,15 +11,6 @@ dummy:
 # SETUP #
 #########
 
-#fetch_directory: fetch/
-
-# Even though rbd-mirror nodes should not have the admin key
-# at their disposal, some people might want to have it
-# distributed on rbd-mirror nodes. Setting 'copy_admin_key' to 'true'
-# will copy the admin key to the /etc/ceph/ directory. Only
-# valid for Luminous and later releases.
-#copy_admin_key: false
-
 # NOTE: deprecated generic local user id for pre-Luminous releases
 #ceph_rbd_mirror_local_user: "admin"
 

--- a/group_vars/restapis.yml.sample
+++ b/group_vars/restapis.yml.sample
@@ -8,12 +8,6 @@
 dummy:
 
 
-###########
-# GENERAL #
-###########
-
-#fetch_directory: fetch/
-
 ##########
 # DOCKER #
 ##########

--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -13,14 +13,6 @@ dummy:
 # GENERAL #
 ###########
 
-#fetch_directory: fetch/
-
-# Even though RGW nodes should not have the admin key
-# at their disposal, some people might want to have it
-# distributed on RGW nodes. Setting 'copy_admin_key' to 'true'
-# will copy the admin key to the /etc/ceph/ directory
-#copy_admin_key: false
-
 # Multi-site remote pull URL variables
 #rgw_pull_port: "{{ radosgw_civetweb_port }}"
 #rgw_pull_proto: "http"
@@ -29,18 +21,18 @@ dummy:
 #TUNING#
 ########
 
-# To support buckets with a very large number of objects it's 
+# To support buckets with a very large number of objects it's
 # important to split them into shards. We suggest about 100K
 # objects per shard as a conservative maximum.
 #rgw_override_bucket_index_max_shards: 16
-# 
+
 # Consider setting a quota on buckets so that exceeding this
 # limit will require admin intervention.
 #rgw_bucket_default_quota_max_objects: 1638400 # i.e., 100K * 16
 
-# This dictionary will create pools with the given number of pgs. 
+# This dictionary will create pools with the given number of pgs.
 # This is important because they would be created with the default
-# of 8. 
+# of 8.
 # New pools and their corresponding pg_nums can be created
 # by adding to the create_pools dictionary (see foo).
 #create_pools:

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -15,6 +15,12 @@ dummy:
 
 fetch_directory: ~/ceph-ansible-keys
 
+# Even though some nodes should not have the admin key
+# at their disposal (e.g: mds, osd, rgw), some people might want to have it
+# distributed. Setting 'copy_admin_key' to 'true'
+# will copy the admin key to the /etc/ceph/ directory
+#copy_admin_key: false
+
 # The 'cluster' variable determines the name of the cluster.
 # Changing the default value to something else means that you will
 # need to change all the command line calls as well, for example if

--- a/roles/ceph-client/defaults/main.yml
+++ b/roles/ceph-client/defaults/main.yml
@@ -3,8 +3,6 @@
 # GENERAL #
 ###########
 
-fetch_directory: fetch/
-
 user_config: false
 pools:
   - { name: test, pgs: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}" }

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -7,6 +7,12 @@
 
 fetch_directory: fetch/
 
+# Even though some nodes should not have the admin key
+# at their disposal (e.g: mds, osd, rgw), some people might want to have it
+# distributed. Setting 'copy_admin_key' to 'true'
+# will copy the admin key to the /etc/ceph/ directory
+copy_admin_key: false
+
 # The 'cluster' variable determines the name of the cluster.
 # Changing the default value to something else means that you will
 # need to change all the command line calls as well, for example if

--- a/roles/ceph-docker-common/tasks/fetch_configs.yml
+++ b/roles/ceph-docker-common/tasks/fetch_configs.yml
@@ -41,6 +41,18 @@
   register: statconfig
   always_run: true
 
+- name: stat for ceph admin key
+  local_action: stat path={{ fetch_directory }}/{{ fsid }}/{{ item.name }}
+  with_items:
+    - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  changed_when: false
+  become: false
+  failed_when: false
+  register: statadminkey
+  always_run: true
+  when:
+    - item.copy_key|bool
+
 - name: try to fetch ceph config and keys
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}/{{ item.0 }}"
@@ -52,4 +64,21 @@
   with_together:
     - "{{ ceph_config_keys }}"
     - "{{ statconfig.results }}"
-  when: item.1.stat.exists == true
+  when:
+    - item.1.stat.exists == true
+
+- name: try to fetch ceph admin key
+  copy:
+    src: "{{ fetch_directory }}/{{ fsid }}/{{ item.name }}"
+    dest: "{{ item.name }}"
+    owner: root
+    group: root
+    mode: 0644
+  changed_when: false
+  with_together:
+    - "{{ statadminkey.results }}"
+    - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  when:
+    - not item.0.get("skipped")
+    - item.0.stat.exists == true
+    - item.1.copy_key|bool

--- a/roles/ceph-fetch-keys/defaults/main.yml
+++ b/roles/ceph-fetch-keys/defaults/main.yml
@@ -1,4 +1,1 @@
 ---
-
-fetch_directory: fetch/
-cluster: ceph

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -1,18 +1,6 @@
 ---
 # You can override vars by using host or group vars
 
-###########
-# GENERAL #
-###########
-
-fetch_directory: fetch/
-
-# Even though MDS nodes should not have the admin key
-# at their disposal, some people might want to have it
-# distributed on MDS nodes. Setting 'copy_admin_key' to 'true'
-# will copy the admin key to the /etc/ceph/ directory
-copy_admin_key: false
-
 ##########
 # DOCKER #
 ##########

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -1,12 +1,6 @@
 ---
 # You can override vars by using host or group vars
 
-###########
-# GENERAL #
-###########
-
-fetch_directory: fetch/
-
 #######################
 # Access type options #
 #######################

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -2,18 +2,6 @@
 # You can override default vars defined in defaults/main.yml here,
 # but I would advice to use host or group vars instead
 
-
-###########
-# GENERAL #
-###########
-
-# Even though OSD nodes should not have the admin key
-# at their disposal, some people might want to have it
-# distributed on OSD nodes. Setting 'copy_admin_key' to 'true'
-# will copy the admin key to the /etc/ceph/ directory
-copy_admin_key: false
-
-
 ####################
 # OSD CRUSH LOCATION
 ####################

--- a/roles/ceph-rbd-mirror/defaults/main.yml
+++ b/roles/ceph-rbd-mirror/defaults/main.yml
@@ -3,15 +3,6 @@
 # SETUP #
 #########
 
-fetch_directory: fetch/
-
-# Even though rbd-mirror nodes should not have the admin key
-# at their disposal, some people might want to have it
-# distributed on rbd-mirror nodes. Setting 'copy_admin_key' to 'true'
-# will copy the admin key to the /etc/ceph/ directory. Only
-# valid for Luminous and later releases.
-copy_admin_key: false
-
 # NOTE: deprecated generic local user id for pre-Luminous releases
 ceph_rbd_mirror_local_user: "admin"
 

--- a/roles/ceph-restapi/defaults/main.yml
+++ b/roles/ceph-restapi/defaults/main.yml
@@ -1,11 +1,5 @@
 ---
 
-###########
-# GENERAL #
-###########
-
-fetch_directory: fetch/
-
 ##########
 # DOCKER #
 ##########

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -5,14 +5,6 @@
 # GENERAL #
 ###########
 
-fetch_directory: fetch/
-
-# Even though RGW nodes should not have the admin key
-# at their disposal, some people might want to have it
-# distributed on RGW nodes. Setting 'copy_admin_key' to 'true'
-# will copy the admin key to the /etc/ceph/ directory
-copy_admin_key: false
-
 # Multi-site remote pull URL variables
 rgw_pull_port: "{{ radosgw_civetweb_port }}"
 rgw_pull_proto: "http"
@@ -21,18 +13,18 @@ rgw_pull_proto: "http"
 #TUNING#
 ########
 
-# To support buckets with a very large number of objects it's 
+# To support buckets with a very large number of objects it's
 # important to split them into shards. We suggest about 100K
 # objects per shard as a conservative maximum.
 #rgw_override_bucket_index_max_shards: 16
- 
+
 # Consider setting a quota on buckets so that exceeding this
 # limit will require admin intervention.
 #rgw_bucket_default_quota_max_objects: 1638400 # i.e., 100K * 16
 
-# This dictionary will create pools with the given number of pgs. 
+# This dictionary will create pools with the given number of pgs.
 # This is important because they would be created with the default
-# of 8. 
+# of 8.
 # New pools and their corresponding pg_nums can be created
 # by adding to the create_pools dictionary (see foo).
 #create_pools:


### PR DESCRIPTION
Prior to this patch 'copy_admin_key: true' didn't have any effect on the
container deployment. Now it does.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1482822
Signed-off-by: Sébastien Han <seb@redhat.com>