### PR TITLE
ceph-osd: Fix osd start sequence

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -9,6 +9,8 @@
   failed_when: false
   always_run: true
   register: osd_id
+  until: osd_id.stdout_lines|length == devices|unique|length
+  retries: 10
 
 - name: ensure systemd service override directory exists
   file:
@@ -32,5 +34,6 @@
   service:
     name: ceph-osd@{{ item }}
     state: started
+    enabled: true
   with_items: "{{ (osd_id|default({})).stdout_lines|default([]) }}"
   changed_when: false


### PR DESCRIPTION
The script can fail to get the osd id because the osds are activated by
udev and it can take a while for them to activate. This commit fixes
that by trying to get all the osds per node in a loop.

This commit also makes the osd services enabled so that they are
available after reboot.

Signed-off-by: Boris Ranto <branto@redhat.com>