### PR TITLE
site: delegate fact to all the hosts

### DIFF
--- a/site.yml.sample
+++ b/site.yml.sample
@@ -12,9 +12,12 @@
   - rbdmirrors
   - clients
   - mgrs
+
   gather_facts: false
+
   tags:
     - always
+
   tasks:
     # If we can't get python2 installed before any module is used we will fail
     # so just try what we can to get it installed
@@ -23,20 +26,30 @@
         path: /usr/bin/python
       ignore_errors: yes
       register: systempython2
-    - name: install python2 for Debian based systems
+
+    - name: install python2 for debian based systems
       raw: sudo apt-get -y install python-simplejson
       ignore_errors: yes
-      when: systempython2.stat.exists is undefined or systempython2.stat.exists == false
-    # Try to install python2 on Fedora > 23
-    - name: install python2 for Fedora
+      when:
+        - systempython2.stat.exists is undefined or systempython2.stat.exists == false
+
+    - name: install python2 for fedora
       raw: sudo dnf -y install python creates=/usr/bin/python
       ignore_errors: yes
-      when: systempython2.stat.exists is undefined or systempython2.stat.exists == false
-    - name: gathering facts
+      when:
+        - systempython2.stat.exists is undefined or systempython2.stat.exists == false
+
+    - name: gather and delegate facts
       setup:
-    - name: install required packages for Fedora > 23
+      delegate_to: "{{ item }}"
+      delegate_facts: True
+      with_items: "{{ groups['all'] }}"
+
+    - name: install required packages for fedora > 23
       raw: sudo dnf -y install python2-dnf libselinux-python ntp
-      when: ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 23
+      when:
+        - ansible_distribution == 'Fedora'
+        - ansible_distribution_major_version|int >= 23
 
 - hosts: mons
   gather_facts: false


### PR DESCRIPTION
Before this patch we couldn't use --limit properly to only interact with
a particular set of hosts. We basically always required to have ceph-mon
role being played to properly get facts and then build the ceph.conf.

Now, the current running host will get the facts from the machines that
are not part of the current play. This is achieved with the help of the
new option delegate_facts, for more info see:
http://docs.ansible.com/ansible/latest/playbooks_delegation.html#delegated-facts

Signed-off-by: Sébastien Han <seb@redhat.com>