### PR TITLE
Do not install additional dependencies when ceph_origin is distro

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -6,6 +6,7 @@
     update_cache: yes
     cache_valid_time: 3600
   with_items: "{{ debian_package_dependencies }}"
+  when: ceph_origin != 'distro'
 
 - name: configure ceph apt repository
   include: debian_ceph_repository.yml

--- a/roles/ceph-common/tasks/installs/install_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_on_redhat.yml
@@ -4,14 +4,18 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ redhat_package_dependencies }}"
-  when: ansible_distribution == "RedHat"
+  when:
+    - ansible_distribution == "RedHat"
+    - ceph_origin != 'distro'
 
 - name: install centos dependencies
   package:
     name: "{{ item }}"
     state: present
   with_items: "{{ centos_package_dependencies }}"
-  when: ansible_distribution == "CentOS"
+  when:
+    - ansible_distribution == "CentOS"
+    - ceph_origin != 'distro'
 
 - name: configure ceph yum repository
   include: redhat_ceph_repository.yml

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_debian.yml
@@ -6,6 +6,7 @@
     update_cache: yes
     cache_valid_time: 3600
   with_items: "{{ debian_package_dependencies }}"
+  when: ceph_origin != 'distro'
 
 - name: install red hat storage ceph mon
   apt:

--- a/roles/ceph-common/tasks/installs/install_rh_storage_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_rh_storage_on_redhat.yml
@@ -21,6 +21,7 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ redhat_package_dependencies }}"
+  when: ceph_origin != 'distro'
 
 - name: install red hat storage ceph mon
   package:


### PR DESCRIPTION
When Ceph is preinstalled or provided by the distribution repositories,
we should not install additional dependencies because they aren't needed or
should be pulled in by the package manager.

This change adds a when: ceph_origin != 'distro' condition to the tasks
which explicitly install dependencies.