### PR TITLE
Symlink infrastructure playbooks in the module root from .spec file

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -36,6 +36,12 @@ for f in ansible.cfg *.yml *.sample group_vars roles library plugins infrastruct
   cp -a $f %{buildroot}%{_datarootdir}/ceph-ansible
 done
 
+# Symlink infrastructure playbooks which need to be executed
+# from the module root
+for p in %{buildroot}%{_datarootdir}/ceph-ansible/infrastructure-playbooks/*yml; do
+  ln -s infrastructure-playbooks/$(basename $p) %{buildroot}%{_datarootdir}/ceph-ansible
+done
+
 # Strip coreos files.
 # These are unneeded on RPM-based distros, and the playbooks download random
 # things from around the internet.


### PR DESCRIPTION
Given the infrastructure playbooks need to be executed from the
module root directory, we change the .spec file so that these are
linked in the module root when building the RPM.