### PR TITLE
rpm update the DOC section to point to rst

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -56,7 +56,7 @@ popd
 ansible-playbook -i dummy-ansible-hosts test.yml --syntax-check
 
 %files
-%doc README.md
+%doc README.rst
 %license LICENSE
 %{_datarootdir}/ceph-ansible
 


### PR DESCRIPTION
Fixes:

    + cp -pr README.md /builddir/build/BUILDROOT/ceph-ansible-3.0.0-0.rc3.62.gaadac71.el7.x86_64/usr/share/doc/ceph-ansible-3.0.0
    cp: cannot stat 'README.md': No such file or directory