### PR TITLE
ceph-mon: detect ANSIBLE_ROLES_PATH if present

### DIFF
--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -43,10 +43,10 @@
     - "{{ inventory_hostname == groups[mon_group_name] | last }}"
     - not containerized_deployment_with_kv
 
-- include: "{{ playbook_dir }}/roles/ceph-mon/tasks/set_osd_pool_default_pg_num.yml"
+- include: "{{ lookup('env', 'ANSIBLE_ROLES_PATH') | default (playbook_dir + '/roles', true) }}/ceph-mon/tasks/set_osd_pool_default_pg_num.yml"
 
 # create openstack pools only when all mons are up.
-- include: "{{ playbook_dir }}/roles/ceph-mon/tasks/openstack_config.yml"
+- include: "{{ lookup('env', 'ANSIBLE_ROLES_PATH') | default (playbook_dir + '/roles', true) }}/ceph-mon/tasks/openstack_config.yml"
   when:
     - openstack_config
     - "{{ inventory_hostname == groups[mon_group_name] | last }}"

--- a/roles/ceph-nfs/tasks/pre_requisite.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite.yml
@@ -28,7 +28,7 @@
 - name: generate ganesha configuration file
   action: config_template
   args:
-    src: "{{ playbook_dir }}/roles/ceph-common/templates/ganesha.conf.j2"
+    src: "{{ lookup('env', 'ANSIBLE_ROLES_PATH') | default (playbook_dir + '/roles', true) }}/ceph-common/templates/ganesha.conf.j2"
     dest: /etc/ganesha/ganesha.conf
     owner: "root"
     group: "root"


### PR DESCRIPTION
Some deployments can't copy infrastructure playbooks outside of the
infrastructure-playbooks directory. Thus they use ANSIBLE_ROLES_PATH to
overcome this. However some roles have 'playbook_dir' hardcoded, which
results in wrong path since the execution comes from
infrastructure-playbooks. Basically the role triggered by a playbook
from infrastructure-playbooks believes that the roles are in
infrastructure-playbooks/roles. This commit fixes that.

Signed-off-by: Sébastien Han <seb@redhat.com>