### PR TITLE
ceph-config: when using local_action set become: false

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -14,14 +14,17 @@
 
   - name: template ceph_conf_overrides
     local_action: copy content="{{ ceph_conf_overrides }}" dest="{{ fetch_directory }}/ceph_conf_overrides_temp"
+    become: false
     run_once: true
 
   - name: get rendered ceph_conf_overrides
     local_action: set_fact ceph_conf_overrides_rendered="{{ lookup('template', '{{ fetch_directory }}/ceph_conf_overrides_temp') | from_yaml }}"
+    become: false
     run_once: true
 
   - name: remove tmp template file for ceph_conf_overrides
     local_action: file path="{{ fetch_directory }}/ceph_conf_overrides_temp" state=absent
+    become: false
     run_once: true
 
   - name: "generate ceph configuration file: {{ cluster }}.conf"


### PR DESCRIPTION
There should be no need to use sudo when writing or using these files.
It creates and issue when the user running ansible-playbook does not
have sudo privs.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>