### PR TITLE
handler: default to empty array if task skipped

### DIFF
--- a/roles/ceph-defaults/handlers/main.yml
+++ b/roles/ceph-defaults/handlers/main.yml
@@ -40,12 +40,11 @@
 - name: restart containerized ceph osds daemon(s)
   command: /tmp/restart_osd_daemon.sh
   listen: "restart ceph osds"
-  with_items: "{{ socket_osd_container.results }}"
+  with_items: "{{ socket_osd_container.results | default([]) }}"
   when:
   # We do not want to run these checks on initial deployment (`socket_osd_container.results[n].rc == 0`)
   # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
     - containerized_deployment
-    - not item.get("skipped")
     - ((crush_location is defined and crush_location) or item.get('rc') == 0)
     - handler_health_osd_check
     # See https://github.com/ceph/ceph-ansible/issues/1457 for the condition below


### PR DESCRIPTION
with_items is evaluated before the when condition so if the task that
registers the 'results' is skipped the task will fail with:

{"failed": true, "msg": "'dict object' has no attribute 'results'"}

Defaulting to an empty array fixes the issue.

Reverts: abdd66619e1d5c94f74e994bff667b5ccc6b529f
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1482061
Signed-off-by: Sébastien Han <seb@redhat.com>