### PR TITLE
ceph-docker-common: apply 0600 to key permissions

### DIFF
--- a/roles/ceph-docker-common/tasks/fetch_configs.yml
+++ b/roles/ceph-docker-common/tasks/fetch_configs.yml
@@ -47,7 +47,7 @@
     dest: "{{ item.0 }}"
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   changed_when: false
   with_together:
     - "{{ ceph_config_keys }}"


### PR DESCRIPTION
Keys should only be readable and writable by their respective owners and that's all.

Closes: https://github.com/ceph/ceph-ansible/issues/1760
Signed-off-by: Sébastien Han <seb@redhat.com>