### PR TITLE
use when_failed to make stop of non-existent service ok

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -66,10 +66,12 @@
       name: ceph-mds@{{ ansible_hostname }}
       state: stopped
       enabled: no
+    failed_when: false
     when: ansible_service_mgr == 'systemd'
 
   - name: stop ceph mdss
     shell: "service ceph status mds ; if [ $? == 0 ] ; then service ceph stop mds ; else echo ; fi"
+    failed_when: false
     when: ansible_service_mgr == 'sysvinit'
 
   - name: stop ceph mdss on ubuntu
@@ -96,10 +98,12 @@
       name: ceph-radosgw@rgw.{{ ansible_hostname }}
       state: stopped
       enabled: no
+    failed_when: false
     when: ansible_service_mgr == 'systemd'
 
   - name: stop ceph rgws
     shell: "service ceph-radosgw status ; if [ $? == 0 ] ; then service ceph-radosgw stop ; else echo ; fi"
+    failed_when: false
     when: ansible_service_mgr == 'sysvinit'
 
   - name: stop ceph rgws on ubuntu
@@ -126,6 +130,7 @@
     service:
       name: ceph-rbd-mirror@admin.service
       state: stopped
+    failed_when: false
     when: ansible_service_mgr == 'systemd'
 
   - name: stop ceph rbd mirror on ubuntu
@@ -152,10 +157,12 @@
     service:
       name: nfs-ganesha
       state: stopped
+    failed_when: false
     when: ansible_service_mgr == 'systemd'
 
   - name: stop ceph nfss
     shell: "service nfs-ganesha status ; if [ $? == 0 ] ; then service nfs-ganesha stop ; else echo ; fi"
+    failed_when: false
     when: ansible_service_mgr == 'sysvinit'
 
   - name: stop ceph nfss on ubuntu
@@ -417,10 +424,12 @@
       name: ceph-mon@{{ ansible_hostname }}
       state: stopped
       enabled: no
+    failed_when: false
     when: ansible_service_mgr == 'systemd'
 
   - name: stop ceph mons
     shell: "service ceph status mon ; if [ $? == 0 ] ; then service ceph stop mon ; else echo ; fi"
+    failed_when: false
     when: ansible_service_mgr == 'sysvinit'
 
   - name: stop ceph mons on ubuntu

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -61,12 +61,20 @@
 
   tasks:
 
+  # this next task should go away if ansible service module worked correctly
+  
+  - name: get ceph mds status
+    shell: "systemctl status ceph-mds@{{ ansible_hostname }}"
+    register: ceph_mds_status
+    failed_when: false
+    when: ansible_service_mgr == 'systemd'
+
   - name: stop ceph mdss with systemd
     service:
       name: ceph-mds@{{ ansible_hostname }}
       state: stopped
       enabled: no
-    failed_when: false
+    failed_when: "'service could not be found' in ceph_mds_status.stdout_lines | join | lower"
     when: ansible_service_mgr == 'systemd'
 
   - name: stop ceph mdss
@@ -93,12 +101,18 @@
 
   tasks:
 
+  - name: get ceph rgw status
+    shell: "systemctl status ceph-rgw@{{ ansible_hostname }}"
+    register: ceph_rgw_status
+    failed_when: false
+    when: ansible_service_mgr == 'systemd'
+
   - name: stop ceph rgws with systemd
     service:
       name: ceph-radosgw@rgw.{{ ansible_hostname }}
       state: stopped
       enabled: no
-    failed_when: false
+    failed_when: "'service could not be found' in ceph_rgw_status.stdout_lines | join | lower"
     when: ansible_service_mgr == 'systemd'
 
   - name: stop ceph rgws
@@ -126,11 +140,17 @@
 
   tasks:
 
+  - name: get ceph rbd mirror status
+    shell: "systemctl status ceph-rbd-mirror@admin"
+    register: ceph_rbdmir_status
+    failed_when: false
+    when: ansible_service_mgr == 'systemd'
+
   - name: stop ceph rbd mirror with systemd
     service:
       name: ceph-rbd-mirror@admin.service
       state: stopped
-    failed_when: false
+    failed_when: "'service could not be found' in ceph_rbdmir_status.stdout_lines | join | lower"
     when: ansible_service_mgr == 'systemd'
 
   - name: stop ceph rbd mirror on ubuntu
@@ -153,11 +173,17 @@
 
   tasks:
 
+  - name: get ganesha status
+    shell: "systemctl status nfs-ganesha"
+    register: ceph_ganesha_status
+    failed_when: false
+    when: ansible_service_mgr == 'systemd'
+
   - name: stop ceph nfss with systemd
     service:
       name: nfs-ganesha
       state: stopped
-    failed_when: false
+    failed_when: "'service could not be found' in ceph_ganesha_status.stdout_lines | join | lower"
     when: ansible_service_mgr == 'systemd'
 
   - name: stop ceph nfss
@@ -419,12 +445,18 @@
 
   tasks:
 
+  - name: get monitor status
+    shell: "systemctl status ceph-mon@{{ ansible_hostname }}"
+    register: ceph_mon_status
+    failed_when: false
+    when: ansible_service_mgr == 'systemd'
+
   - name: stop ceph mons with systemd
     service:
       name: ceph-mon@{{ ansible_hostname }}
       state: stopped
       enabled: no
-    failed_when: false
+    failed_when: "'service could not be found' in ceph_mon_status.stdout_lines | join | lower"
     when: ansible_service_mgr == 'systemd'
 
   - name: stop ceph mons


### PR DESCRIPTION
This patch makes purge-cluster.yml service shutdowns idempotent.   Thus it possible to run purge-cluster.yml if ceph-ansible site.yml has not yet run or has run but only partially completed.  We use failed_when: false in systemd and sysvinit shutdown tasks - this was already being done for Ubuntu pre-systemd releases.  