### PR TITLE
ceph-docker-common: do not log inside the container

### DIFF
--- a/roles/ceph-docker-common/defaults/main.yml
+++ b/roles/ceph-docker-common/defaults/main.yml
@@ -1,1 +1,4 @@
 ---
+ceph_conf_overrides:
+  global:
+    log_file: /dev/null


### PR DESCRIPTION
Logging inside the container is not useful since it writes to the
overlayfs partition, resulting in potential performance degradation on
the container.

If you need to check the logs, just look at journald.

Signed-off-by: Sébastien Han <seb@redhat.com>