### PR TITLE
tests: always use sitepackages=True

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,6 +88,7 @@ whitelist_externals =
     pip
     cp
 passenv=*
+sitepackages=True
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions


### PR DESCRIPTION
This is mostly important in rhcs testing so that our tests can use
packages installed on the distro.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>