### PR TITLE
ceph-docker-common: detect ceph version

### DIFF
--- a/roles/ceph-docker-common/tasks/main.yml
+++ b/roles/ceph-docker-common/tasks/main.yml
@@ -44,28 +44,39 @@
     - ceph_health.rc != 0
     - not "{{ rolling_update | default(false) }}"
 
-- include: "./misc/ntp_atomic.yml"
+- include: ./misc/ntp_atomic.yml
   when:
     - is_atomic
     - ansible_os_family == 'RedHat'
     - ntp_service_enabled
 
-- include: "./misc/ntp_redhat.yml"
+- include: ./misc/ntp_redhat.yml
   when:
     - not is_atomic
     - ansible_os_family == 'RedHat'
     - ntp_service_enabled
 
-- include: "./misc/ntp_debian.yml"
+- include: ./misc/ntp_debian.yml
   when:
     - ansible_os_family == 'Debian'
     - ntp_service_enabled
 
-- include: "./fetch_image.yml"
+- include: fetch_image.yml
+
+- name: get ceph version
+  command: docker run --entrypoint /usr/bin/ceph {{ ceph_docker_registry}}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} --version
+  changed_when: false
+  always_run: yes
+  register: ceph_version
+
+- set_fact:
+    ceph_version: "{{ ceph_version.stdout.split(' ')[2] }}"
+
+- include: release.yml
 
 # NOTE (jimcurtis): dirs_permissions.yml must precede fetch_configs.yml
 # # because it creates the directories needed by the latter.
-- include: ./dirs_permissions.yml
+- include: dirs_permissions.yml
 
 - include: create_configs.yml
 

--- a/roles/ceph-docker-common/tasks/release.yml
+++ b/roles/ceph-docker-common/tasks/release.yml
@@ -1,0 +1,13 @@
+---
+- set_fact:
+    ceph_release: jewel
+  when: ceph_version.split('.')[0] | version_compare('10', '==')
+
+- set_fact:
+    ceph_release: kraken
+  when: ceph_version.split('.')[0] | version_compare('11', '==')
+
+- set_fact:
+    ceph_release: luminous
+  when: ceph_version.split('.')[0] | version_compare('12', '==')
+


### PR DESCRIPTION
By detecting the ceph version running in the container we can easily
apply conditions like:
ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous

We do that already, in ceph-docker-common/tasks/fetch_configs.yml.

This fixes the error:

```
TASK [ceph-docker-common : register rbd bootstrap key]
******************************************************

fatal: [magna005]: FAILED! => {"failed": true, "msg": "The conditional
check 'ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous'
failed. The error was: error while evaluating conditional
(ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous):
'dict object' has no attribute 'dummy'\n\nThe error appears to have been
in
'/home/ubuntu/ceph-ansible/roles/ceph-docker-common/tasks/fetch_configs.yml':
line 2, column 3, but may\nbe elsewhere in the file depending on the
exact syntax problem.\n\nThe offending line appears to be:\n\n---\n-
name: register rbd bootstrap key\n  ^ here\n"}

```
Signed-off-by: Sébastien Han <seb@redhat.com>