### PR TITLE
ceph-docker-common: fix empty array

### DIFF
--- a/roles/ceph-docker-common/tasks/fetch_configs.yml
+++ b/roles/ceph-docker-common/tasks/fetch_configs.yml
@@ -1,9 +1,4 @@
 ---
-- name: register rbd bootstrap key
-  set_fact:
-    bootstrap_rbd_keyring: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
-  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
-
 - name: set config and keys paths
   set_fact:
     ceph_config_keys:
@@ -13,7 +8,17 @@
       - /var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring
       - /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring
       - /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring
-      - "{{ bootstrap_rbd_keyring | default([]) }}"
+
+- name: register rbd bootstrap key
+  set_fact:
+    bootstrap_rbd_keyring:
+      - "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
+  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+
+- name: merge rbd bootstrap key to config and keys paths
+  set_fact:
+    ceph_config_keys: "{{ ceph_config_keys + bootstrap_rbd_keyring }}"
+  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
 
 - name: add mgr keys to config and keys paths
   set_fact:


### PR DESCRIPTION
The list can not be evaluated properly if it containers '[]', which is
the case when using the filter "default([])". To fix this, we have to
properly merge the lists.

This is fixing the issue: "list object has no element 1"

Signed-off-by: Sébastien Han <seb@redhat.com>