### PR TITLE
Fix RGW systemd directory

### DIFF
--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -17,7 +17,7 @@
 - name: add ceph-rgw systemd service overrides
   config_template:
     src: "ceph-rgw.service.d-overrides.j2"
-    dest: "/etc/systemd/system/ceph-rgw@.service.d/ceph-rgw-systemd-overrides.conf"
+    dest: "/etc/systemd/system/ceph-radosgw@.service.d/ceph-radosgw-systemd-overrides.conf"
     config_overrides: "{{ ceph_rgw_systemd_overrides | default({}) }}"
     config_type: "ini"
   when:


### PR DESCRIPTION
The ceph RGW systemd services are actually named "ceph-radosgw" and not
"ceph-rgw", this patch fixes that for the systemd overrides file.