### PR TITLE
site-docker.yml.sample: delegate facts

### DIFF
--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -13,7 +13,13 @@
   - clients
   - iscsigws
   - mgrs
-  tasks: []
+
+  tasks:
+    - name: gather and delegate facts
+      setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: True
+      with_items: "{{ groups['all'] }}"
 
 - hosts: mons
   become: True


### PR DESCRIPTION
Now we can use --limit on the container deployment too. This is useful
while deploying client nodes.
e.g: ansible-playbook -i inventory -l clients site-docker.yml.sample

Signed-off-by: Sébastien Han <seb@redhat.com>