### PR TITLE
docker: simplify variable declaration

### DIFF
--- a/group_vars/mdss.yml.sample
+++ b/group_vars/mdss.yml.sample
@@ -13,8 +13,6 @@ dummy:
 # GENERAL #
 ###########
 
-#fetch_directory: fetch/
-
 # Even though MDS nodes should not have the admin key
 # at their disposal, some people might want to have it
 # distributed on MDS nodes. Setting 'copy_admin_key' to 'true'
@@ -32,7 +30,10 @@ dummy:
 #ceph_mds_docker_memory_limit: 1g
 #ceph_mds_docker_cpu_limit: 1
 
-#ceph_mds_docker_extra_env: -e CLUSTER={{ cluster }} -e MDS_NAME={{ ansible_hostname }}
+# we currently for MDS_NAME to hostname because of a bug in ceph-docker
+# fix here: https://github.com/ceph/ceph-docker/pull/770
+# this will go away soon.
+#ceph_mds_docker_extra_env: -e MDS_NAME={{ ansible_hostname }}
 #ceph_config_keys: [] # DON'T TOUCH ME
 
 

--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -18,7 +18,7 @@ dummy:
 #ceph_mgr_docker_memory_limit: 1g
 #ceph_mgr_docker_cpu_limit: 1
 
-#ceph_mgr_docker_extra_env: -e CLUSTER={{ cluster }} -e MGR_NAME={{ ansible_hostname }}
+#ceph_mgr_docker_extra_env:
 #ceph_config_keys: [] # DON'T TOUCH ME
 
 

--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -113,7 +113,6 @@ dummy:
 ##########
 # DOCKER #
 ##########
-#ceph_mon_docker_subnet: "{{ public_network }}"# subnet of the monitor_interface
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
@@ -122,12 +121,10 @@ dummy:
 #ceph_mon_docker_memory_limit: 1g
 #ceph_mon_docker_cpu_limit: 1
 
-# ceph_mon_docker_extra_env:
-#
 # Use this variable to add extra env configuration to run your mon container.
 # If you want to set a custom admin keyring you can set this variable like following:
-# ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NAME={{ monitor_name }} -e ADMIN_SECRET={{ admin_secret }}
-#ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NAME={{ monitor_name }}
+# ceph_mon_docker_extra_env: -e ADMIN_SECRET={{ admin_secret }}
+#ceph_mon_docker_extra_env:
 #mon_docker_privileged: false
 #mon_docker_net_host: true
 #ceph_config_keys: [] # DON'T TOUCH ME

--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -13,8 +13,6 @@ dummy:
 # GENERAL #
 ###########
 
-#fetch_directory: fetch/
-
 # Even though NFS nodes should not have the admin key
 # at their disposal, some people might want to have it
 # distributed on RGW nodes. Setting 'copy_admin_key' to 'true'

--- a/group_vars/restapis.yml.sample
+++ b/group_vars/restapis.yml.sample
@@ -12,8 +12,6 @@ dummy:
 # GENERAL #
 ###########
 
-#fetch_directory: fetch/
-
 ##########
 # DOCKER #
 ##########

--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -13,8 +13,6 @@ dummy:
 # GENERAL #
 ###########
 
-#fetch_directory: fetch/
-
 # Even though RGW nodes should not have the admin key
 # at their disposal, some people might want to have it
 # distributed on RGW nodes. Setting 'copy_admin_key' to 'true'

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -5,8 +5,6 @@
 # GENERAL #
 ###########
 
-fetch_directory: fetch/
-
 # Even though MDS nodes should not have the admin key
 # at their disposal, some people might want to have it
 # distributed on MDS nodes. Setting 'copy_admin_key' to 'true'
@@ -24,7 +22,10 @@ copy_admin_key: false
 ceph_mds_docker_memory_limit: 1g
 ceph_mds_docker_cpu_limit: 1
 
-ceph_mds_docker_extra_env: -e CLUSTER={{ cluster }} -e MDS_NAME={{ ansible_hostname }}
+# we currently for MDS_NAME to hostname because of a bug in ceph-docker
+# fix here: https://github.com/ceph/ceph-docker/pull/770
+# this will go away soon.
+ceph_mds_docker_extra_env: -e MDS_NAME={{ ansible_hostname }}
 ceph_config_keys: [] # DON'T TOUCH ME
 
 

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -22,8 +22,9 @@ ExecStart=/usr/bin/docker run --rm --net=host \
   -e KV_PORT={{kv_port}} \
   {% endif -%}
   -v /etc/localtime:/etc/localtime:ro \
-  -e CEPH_DAEMON=MDS \
+  -e CLUSTER={{ cluster }} \
   -e CEPHFS_CREATE=1 \
+  -e CEPH_DAEMON=MDS \
   {{ ceph_mds_docker_extra_env }} \
   --name=ceph-mds-{{ ansible_hostname }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -10,7 +10,7 @@
 ceph_mgr_docker_memory_limit: 1g
 ceph_mgr_docker_cpu_limit: 1
 
-ceph_mgr_docker_extra_env: -e CLUSTER={{ cluster }} -e MGR_NAME={{ ansible_hostname }}
+ceph_mgr_docker_extra_env:
 ceph_config_keys: [] # DON'T TOUCH ME
 
 

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
   -e KV_PORT={{kv_port}} \
   {% endif -%}
   -v /etc/localtime:/etc/localtime:ro \
+  -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=MGR \
   {{ ceph_mgr_docker_extra_env }} \
   --name=ceph-mgr-{{ ansible_hostname }} \

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -105,7 +105,6 @@ openstack_keys:
 ##########
 # DOCKER #
 ##########
-ceph_mon_docker_subnet: "{{ public_network }}"# subnet of the monitor_interface
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
@@ -114,12 +113,10 @@ ceph_mon_docker_subnet: "{{ public_network }}"# subnet of the monitor_interface
 ceph_mon_docker_memory_limit: 1g
 ceph_mon_docker_cpu_limit: 1
 
-# ceph_mon_docker_extra_env:
-#
 # Use this variable to add extra env configuration to run your mon container.
 # If you want to set a custom admin keyring you can set this variable like following:
-# ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NAME={{ monitor_name }} -e ADMIN_SECRET={{ admin_secret }}
-ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NAME={{ monitor_name }}
+# ceph_mon_docker_extra_env: -e ADMIN_SECRET={{ admin_secret }}
+ceph_mon_docker_extra_env:
 mon_docker_privileged: false
 mon_docker_net_host: true
 ceph_config_keys: [] # DON'T TOUCH ME

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -28,8 +28,6 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
   {% if mon_docker_net_host -%}
   --net=host \
   {% endif -%}
-  -e CEPH_DAEMON=MON \
-  -e CEPH_PUBLIC_NETWORK={{ ceph_mon_docker_subnet }} \
   -e IP_VERSION={{ ip_version[-1:] }} \
   {% if monitor_address is defined and monitor_address != '0.0.0.0' %}
     {% if ip_version == 'ipv4' -%}
@@ -42,6 +40,10 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
   {% elif ip_version =='ipv6' -%}
   -e MON_IP=[{{ hostvars[inventory_hostname]['ansible_' + monitor_interface][ip_version][0]['address'] }}] \
   {% endif -%}
+  -e CLUSTER={{ cluster }} \
+  -e FSID={{ fsid }} \
+  -e CEPH_PUBLIC_NETWORK={{ public_network }} \
+  -e CEPH_DAEMON=MON \
   {{ ceph_mon_docker_extra_env }} \
   {{ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/docker stop ceph-mon-%i

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -5,8 +5,6 @@
 # GENERAL #
 ###########
 
-fetch_directory: fetch/
-
 # Even though NFS nodes should not have the admin key
 # at their disposal, some people might want to have it
 # distributed on RGW nodes. Setting 'copy_admin_key' to 'true'

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
   --cpu-quota={{ ceph_rbd_mirror_docker_cpu_limit * 100000 }} \
   {% endif -%}
   {% if not containerized_deployment_with_kv -%}
+  -v /var/lib/ceph:/var/lib/ceph \
   -v /etc/ceph:/etc/ceph \
   {% else -%}
   -e KV_TYPE={{kv_type}} \
@@ -21,6 +22,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
   -e KV_PORT={{kv_port}} \
   {% endif -%}
   -v /etc/localtime:/etc/localtime:ro \
+  -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=RBD_MIRROR \
   --name=ceph-rbd-mirror-{{ ansible_hostname }} \
   {{ ceph_rbd_mirror_docker_extra_env }} \

--- a/roles/ceph-restapi/defaults/main.yml
+++ b/roles/ceph-restapi/defaults/main.yml
@@ -4,8 +4,6 @@
 # GENERAL #
 ###########
 
-fetch_directory: fetch/
-
 ##########
 # DOCKER #
 ##########

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -5,8 +5,6 @@
 # GENERAL #
 ###########
 
-fetch_directory: fetch/
-
 # Even though RGW nodes should not have the admin key
 # at their disposal, some people might want to have it
 # distributed on RGW nodes. Setting 'copy_admin_key' to 'true'


### PR DESCRIPTION
Less configuration for the user, the container inherit from the global
variables. No more container specific variables.

Signed-off-by: Sébastien Han <seb@redhat.com>