### PR TITLE
ceph-common: remove useless changed task

### DIFF
--- a/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
+++ b/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
@@ -22,5 +22,6 @@
 # Remove yum caches so yum doesn't get confused if we are reinstalling a different ceph version
 - name: purge yum cache
   command: yum clean all
+  changed_when: false
   when:
     ansible_pkg_mgr == 'yum'


### PR DESCRIPTION
There is no need to show a "changed" at the end of the play for a
"command" module task.

Signed-off-by: Sébastien Han <seb@redhat.com>