### PR TITLE
client: support for external cluster, generate admin key

### DIFF
--- a/group_vars/clients.yml.sample
+++ b/group_vars/clients.yml.sample
@@ -11,7 +11,9 @@ dummy:
 # GENERAL #
 ###########
 
-#fetch_directory: fetch/
+# Set the admin keyring you want to generate on that node
+# It must match the current ceph admin key
+#admin_secret: admin_secret
 
 #user_config: false
 #pools:

--- a/roles/ceph-client/defaults/main.yml
+++ b/roles/ceph-client/defaults/main.yml
@@ -3,7 +3,9 @@
 # GENERAL #
 ###########
 
-fetch_directory: fetch/
+# Set the admin keyring you want to generate on that node
+# It must match the current ceph admin key
+admin_secret: admin_secret
 
 user_config: false
 pools:

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -52,3 +52,8 @@
   when:
     - cephx
     - keys | length > 0
+
+- name: remove the admin key when done with the other keys
+  file:
+    path: "/etc/ceph/{{ cluster }}.client.admin.keyring"
+    state: absent

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -1,4 +1,37 @@
 ---
+- set_fact:
+    ceph_authtool_cap: "--cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow' --cap mgr 'allow *'"
+  when:
+    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - cephx
+    - admin_secret != 'admin_secret'
+
+- set_fact:
+    ceph_authtool_cap: "--cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'"
+  when:
+    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - cephx
+    - admin_secret != 'admin_secret'
+
+- name: create custom admin keyring
+  command: "ceph-authtool /etc/ceph/{{ cluster }}.client.admin.keyring --create-keyring --name=client.admin --add-key={{ admin_secret }} --set-uid=0 {{ ceph_authtool_cap }}"
+  args:
+    creates: /etc/ceph/{{ cluster }}.client.admin.keyring
+  when:
+    - cephx
+    - admin_secret != 'admin_secret'
+
+- name: set ownership of admin keyring
+  file:
+    path: /etc/ceph/{{ cluster }}.client.admin.keyring
+    state: file
+    owner: 'ceph'
+    group: 'ceph'
+    mode: '0600'
+  when:
+    - cephx
+    - admin_secret != 'admin_secret'
+
 - name: copy ceph admin keyring
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.client.admin.keyring"
@@ -6,7 +39,9 @@
     owner: "ceph"
     group: "ceph"
     mode: "0600"
-  when: cephx
+  when:
+    - cephx
+    - admin_secret == 'admin_secret'
 
 - name: check if global key exists in ceph_conf_overrides
   set_fact:


### PR DESCRIPTION
We need the ability to generate a client.admin key based on the external
cluster.

Signed-off-by: Sébastien Han <seb@redhat.com>