### PR TITLE
ci: test luminous

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
       ireallymeanit=yes \
       remove_packages=yes \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:kraken} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
@@ -23,7 +23,7 @@ commands=
 
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:kraken} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
@@ -40,7 +40,7 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
       ireallymeanit=yes \
       remove_packages=yes \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:kraken} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
@@ -51,7 +51,7 @@ commands=
 
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:kraken} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
@@ -164,7 +164,7 @@ commands=
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:kraken} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \


### PR DESCRIPTION
Luminous is out so let's test it instead of Kraken.

Signed-off-by: Sébastien Han <seb@redhat.com>