### PR TITLE
shrink-mon: wait a little bit for the mon to be out

### DIFF
--- a/infrastructure-playbooks/shrink-mon.yml
+++ b/infrastructure-playbooks/shrink-mon.yml
@@ -118,7 +118,11 @@
       shell: |
         ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["quorum_names"])'
       delegate_to: "{{ mon_host }}"
+      failed_when: false
       register: result
+      until: mon_to_kill_hostname not in result.stdout
+      retries: 2
+      delay: 10
 
     - name: please remove the monitor from your ceph configuration file
       debug:


### PR DESCRIPTION
Monitor removal from the monmap is not immediate, so let's wait a little
bit and then fail if the monitor is still in the monmap.
We try twice in total with 10 sec intervals.

Signed-off-by: Sébastien Han <seb@redhat.com>