### PR TITLE
client: copy admin key so we can create pools and keys

### DIFF
--- a/tests/functional/centos/7/bluestore/group_vars/clients
+++ b/tests/functional/centos/7/bluestore/group_vars/clients
@@ -1,0 +1,2 @@
+---
+copy_admin_key: true

--- a/tests/functional/centos/7/cluster/group_vars/clients
+++ b/tests/functional/centos/7/cluster/group_vars/clients
@@ -1,0 +1,2 @@
+---
+copy_admin_key: true


### PR DESCRIPTION
Needed when user_config is set to true

Signed-off-by: Sébastien Han <seb@redhat.com>