### PR TITLE
ceph-osd: do not re-prepare if already prepared

### DIFF
--- a/roles/ceph-osd/tasks/scenarios/collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/collocated.yml
@@ -7,22 +7,26 @@
     docker run --net=host \
     --pid=host \
     --privileged=true \
-    --name=ceph-osd-prepare-{{ ansible_hostname }}-dev{{ item.1 | regex_replace('/', '') }} \
+    --name=ceph-osd-prepare-{{ ansible_hostname }}-dev{{ item.2 | regex_replace('/', '') }} \
     -v /etc/ceph:/etc/ceph \
     -v /var/lib/ceph/:/var/lib/ceph/ \
     -v /dev:/dev \
     -v /etc/localtime:/etc/localtime:ro \
     -e CLUSTER={{ cluster }} \
     -e CEPH_DAEMON=OSD_CEPH_DISK_PREPARE \
-    -e OSD_DEVICE={{ item.1 }} \
+    -e OSD_DEVICE={{ item.2 }} \
     {{ docker_env_args }} \
     {{ ceph_osd_docker_prepare_env }} \
     {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
   with_together:
-    - "{{ parted_results.results }}"
+    - "{{ parted_results.results | default([]) }}"
+    - "{{ ispartition_results.results | default([]) }}"
     - "{{ devices }}"
   when:
     - not item.0.get("skipped")
+    - not item.1.get("skipped")
+    - item.0.get("rc", 0) != 0
+    - item.1.get("rc", 0) != 0
     - not osd_auto_discovery
     - containerized_deployment
 
@@ -68,8 +72,8 @@
 - name: manually prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) with collocated osd data and journal
   command: "ceph-disk prepare {{ ceph_disk_cli_options }} {{ item.2 }}"
   with_together:
-    - "{{ parted_results.results }}"
-    - "{{ ispartition_results.results }}"
+    - "{{ parted_results.results | default([]) }}"
+    - "{{ ispartition_results.results | default([]) }}"
     - "{{ devices }}"
   when:
     - not item.0.get("skipped")


### PR DESCRIPTION
I forgot to re-add the partition check while refactoring the osd

Signed-off-by: Sébastien Han <seb@redhat.com>