### PR TITLE
tests: Add mgr node for all scenarios

### DIFF
--- a/tests/functional/centos/7/bluestore/hosts
+++ b/tests/functional/centos/7/bluestore/hosts
@@ -16,4 +16,4 @@ rgw0
 client0
 
 [mgrs]
-mgr0
+mon0

--- a/tests/functional/centos/7/bluestore/vagrant_variables.yml
+++ b/tests/functional/centos/7/bluestore/vagrant_variables.yml
@@ -12,7 +12,7 @@ nfs_vms: 0
 rbd_mirror_vms: 0
 client_vms: 1
 iscsi_gw_vms: 0
-mgr_vms: 1
+mgr_vms: 0
 
 # Deploy RESTAPI on each of the Monitors
 restapi: true

--- a/tests/functional/centos/7/bs-crypt-ded-jrn/hosts
+++ b/tests/functional/centos/7/bs-crypt-ded-jrn/hosts
@@ -3,3 +3,6 @@ mon0
 
 [osds]
 osd0
+
+[mgrs]
+mon0

--- a/tests/functional/centos/7/bs-crypt-jrn-col/hosts
+++ b/tests/functional/centos/7/bs-crypt-jrn-col/hosts
@@ -3,3 +3,6 @@ mon0
 
 [osds]
 osd0
+
+[mgrs]
+mon0

--- a/tests/functional/centos/7/bs-dock-crypt-jrn-col/hosts
+++ b/tests/functional/centos/7/bs-dock-crypt-jrn-col/hosts
@@ -3,3 +3,6 @@ mon0
 
 [osds]
 osd0
+
+[mgrs]
+mon0

--- a/tests/functional/centos/7/bs-dock-ded-jrn/hosts
+++ b/tests/functional/centos/7/bs-dock-ded-jrn/hosts
@@ -3,3 +3,6 @@ mon0
 
 [osds]
 osd0
+
+[mgrs]
+mon0

--- a/tests/functional/centos/7/bs-docker/hosts
+++ b/tests/functional/centos/7/bs-docker/hosts
@@ -13,4 +13,4 @@ mds0
 rgw0
 
 [mgrs]
-mgr0
+mon0

--- a/tests/functional/centos/7/bs-docker/vagrant_variables.yml
+++ b/tests/functional/centos/7/bs-docker/vagrant_variables.yml
@@ -12,7 +12,7 @@ nfs_vms: 0
 rbd_mirror_vms: 1
 client_vms: 0
 iscsi_gw_vms: 0
-mgr_vms: 1
+mgr_vms: 0
 
 # Deploy RESTAPI on each of the Monitors
 restapi: true

--- a/tests/functional/centos/7/bs-jrn-col/hosts
+++ b/tests/functional/centos/7/bs-jrn-col/hosts
@@ -3,3 +3,6 @@ mon0 monitor_interface=eth1
 
 [osds]
 osd0
+
+[mgrs]
+mon0

--- a/tests/functional/centos/7/crypt-ded-jrn/hosts
+++ b/tests/functional/centos/7/crypt-ded-jrn/hosts
@@ -5,4 +5,4 @@ mon0
 osd0
 
 [mgrs]
-mgr0
+mon0

--- a/tests/functional/centos/7/crypt-ded-jrn/vagrant_variables.yml
+++ b/tests/functional/centos/7/crypt-ded-jrn/vagrant_variables.yml
@@ -12,7 +12,7 @@ nfs_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0
-mgr_vms: 1
+mgr_vms: 0
 
 # Deploy RESTAPI on each of the Monitors
 restapi: true

--- a/tests/functional/centos/7/crypt-jrn-col/hosts
+++ b/tests/functional/centos/7/crypt-jrn-col/hosts
@@ -3,3 +3,6 @@ mon0
 
 [osds]
 osd0
+
+[mgrs]
+mon0

--- a/tests/functional/centos/7/docker-crypt-jrn-col/hosts
+++ b/tests/functional/centos/7/docker-crypt-jrn-col/hosts
@@ -3,3 +3,6 @@ mon0
 
 [osds]
 osd0
+
+[mgrs]
+mon0

--- a/tests/functional/centos/7/docker-ded-jrn/hosts
+++ b/tests/functional/centos/7/docker-ded-jrn/hosts
@@ -3,3 +3,6 @@ mon0
 
 [osds]
 osd0
+
+[mgrs]
+mon0

--- a/tests/functional/centos/7/jrn-col/hosts
+++ b/tests/functional/centos/7/jrn-col/hosts
@@ -3,3 +3,6 @@ mon0
 
 [osds]
 osd0
+
+[mgrs]
+mon0

--- a/tests/functional/centos/7/lvm-osds/hosts
+++ b/tests/functional/centos/7/lvm-osds/hosts
@@ -3,3 +3,6 @@ mon0
 
 [osds]
 osd0
+
+[mgrs]
+mon0


### PR DESCRIPTION
With Luminous we need to have a mgr daemon.
This commit adds an mgr node for all scenarios.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>