### PR TITLE
Dump radosgw_keystone_config into [client.rgw.*] section

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -153,6 +153,9 @@ keyring = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_hos
 rgw socket path = /tmp/radosgw-{{ hostvars[host]['ansible_hostname'] }}.sock
 log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[host]['ansible_hostname'] }}.log
 rgw data = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_hostname'] }}
+{% if radosgw_keystone_config %}
+{{ radosgw_keystone_config|safe }}
+{% endif %}
 {% if radosgw_address_block | length > 0 %}
     {% if ip_version == 'ipv4' -%}
       rgw frontends = civetweb port={{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}


### PR DESCRIPTION
To configure radosgw it is necessary to provide some config options
related to the keystone deployment.

This change adds support for dumping into ceph.conf, in the
[client.rgw.*] section, arbitrary key=value settings using the
radosgw_keystone_config variable.