### PR TITLE
ansible.cfg: increase ssh timeout

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,6 +11,11 @@ log_path = /var/log/ansible.log
 # Disable them in the context of https://review.openstack.org/#/c/469644
 retry_files_enabled = False
 
+# This is the default SSH timeout to use on connection attempts
+# CI slaves are slow so by setting a higher value we can avoid the following error:
+# Timeout (12s) waiting for privilege escalation prompt:
+timeout = 30
+
 [ssh_connection]
 # see: https://github.com/ansible/ansible/issues/11536
 control_path = %(directory)s/%%h-%%r-%%p


### PR DESCRIPTION
CI slaves are slow so by setting a higher value we can avoid the following error:
Timeout (12s) waiting for privilege escalation prompt:

Now we wait for 32 sec...

More info here: https://github.com/ansible/ansible/issues/14426

Signed-off-by: Sébastien Han <seb@redhat.com>