### PR TITLE
fail if ansible version < 2.3

### DIFF
--- a/roles/ceph-common/tasks/checks/check_system.yml
+++ b/roles/ceph-common/tasks/checks/check_system.yml
@@ -51,10 +51,16 @@
 
 - name: fail on unsupported ansible version
   fail:
-    msg: "Ansible version must be >= 1.9, please update!"
+    msg: "Ansible version must be >= 2.3.x, please update!"
   when:
-    - ansible_version.major|int == 1
-    - ansible_version.minor|int < 9
+    - ansible_version.major|int < 2
+
+- name: fail on unsupported ansible version
+  fail:
+    msg: "Ansible version must be >= 2.3.x, please update!"
+  when:
+    - ansible_version.major|int == 2
+    - ansible_version.minor|int < 3
 
 - name: fail if systemd is not present
   fail:


### PR DESCRIPTION
We only test and support 2.3.x at the moment.

Closes: https://github.com/ceph/ceph-ansible/issues/1858
Signed-off-by: Sébastien Han <seb@redhat.com>