### PR TITLE
rpm: better comments for file removals

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -36,12 +36,13 @@ for f in ansible.cfg *.yml *.sample group_vars roles library plugins infrastruct
   cp -a $f %{buildroot}%{_datarootdir}/ceph-ansible
 done
 
-# Strip coreos files.
-# These are unneeded on RPM-based distros, and the playbooks download random
-# things from around the internet.
 pushd %{buildroot}%{_datarootdir}/ceph-ansible
+  # Strip coreos files.
+  # These are unneeded on RPM-based distros, and the playbooks download random
+  # things from around the internet.
   rm -r roles/ceph-common-coreos
   rm group_vars/common-coreoss.yml.sample
+  # These untested playbooks are too unstable for users.
   rm -r infrastructure-playbooks/untested-by-ci
 popd
 


### PR DESCRIPTION
As of 54d7a81241eac26d87e2bee513df5efd8866a586, we're doing more than stripping CoreOS files in the RPM now. Move the comments around to better match the code that does what the comments describe.

The purpose of this change is to make it easier to read this part of the RPM spec file.