### PR TITLE
add new site-docker-tripleo.yml.sample for openstack

### DIFF
--- a/site-docker-tripleo.yml.sample
+++ b/site-docker-tripleo.yml.sample
@@ -1,0 +1,98 @@
+---
+# Defines deployment design and assigns role to server groups
+
+- hosts:
+  - mons
+  - agents
+  - osds
+  - mdss
+  - rgws
+  - nfss
+  - restapis
+  - rbdmirrors
+  - clients
+  - iscsigws
+  - mgrs
+
+  tasks: []
+
+- hosts: mons
+  become: True
+  gather_facts: false
+  roles:
+    - ceph-defaults
+    - ceph-docker-common
+    - ceph-config
+    - ceph-mon
+  serial: 1 # MUST be '1' WHEN DEPLOYING MONITORS ON DOCKER CONTAINERS
+
+- hosts: osds
+  become: True
+  gather_facts: false
+  roles:
+    - ceph-defaults
+    - ceph-docker-common
+    - ceph-config
+    - ceph-osd
+
+- hosts: mdss
+  become: True
+  gather_facts: false
+  roles:
+    - ceph-defaults
+    - ceph-docker-common
+    - ceph-config
+    - ceph-mds
+
+- hosts: rgws
+  become: True
+  gather_facts: false
+  roles:
+    - ceph-defaults
+    - ceph-docker-common
+    - ceph-config
+    - ceph-rgw
+
+- hosts: nfss
+  become: True
+  gather_facts: false
+  roles:
+    - ceph-defaults
+    - ceph-docker-common
+    - ceph-config
+    - ceph-nfs
+
+- hosts: rbd_mirrors
+  become: True
+  gather_facts: false
+  roles:
+    - ceph-defaults
+    - ceph-docker-common
+    - ceph-config
+    - ceph-rbd-mirror
+
+- hosts: restapis
+  become: True
+  gather_facts: false
+  roles:
+    - ceph-defaults
+    - ceph-docker-common
+    - ceph-config
+    - ceph-restapi
+
+- hosts: mgrs
+  become: True
+  gather_facts: false
+  roles:
+    - { role: ceph-defaults, when: "ceph_release_num.{{ ceph_stable_release }} > ceph_release_num.jewel" }
+    - { role: ceph-docker-common, when: "ceph_release_num.{{ ceph_stable_release }} > ceph_release_num.jewel" }
+    - { role: ceph-config, when: "ceph_release_num.{{ ceph_stable_release }} > ceph_release_num.jewel" }
+    - { role: ceph-mgr, when: "ceph_release_num.{{ ceph_stable_release }} > ceph_release_num.jewel" }
+
+- hosts: clients
+  become: True
+  gather_facts: false
+  roles:
+  - ceph-defaults
+  - ceph-config
+  - ceph-client


### PR DESCRIPTION
OpenStack nodes don't need to run the ceph-common role since packages re
already installed.

Closes: #1876
Signed-off-by: Sébastien Han <seb@redhat.com>