### PR TITLE
osd: force disabling OSD_ scenarios

### DIFF
--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -76,18 +76,22 @@ expose_partitions $1
   {% endif -%}
   {% if osd_objectstore == 'filestore' and not dmcrypt -%}
   -e OSD_FILESTORE=1 \
+  -e OSD_BLUESTORE=0 \
   -e OSD_DMCRYPT=0 \
   {% endif -%}
   {% if osd_objectstore == 'filestore' and dmcrypt -%}
   -e OSD_FILESTORE=1 \
+  -e OSD_BLUESTORE=0 \
   -e OSD_DMCRYPT=1 \
   {% endif -%}
   {% if osd_objectstore == 'bluestore' and not dmcrypt -%}
   -e OSD_BLUESTORE=1 \
+  -e OSD_FILESTORE=0 \
   -e OSD_DMCRYPT=0 \
   {% endif -%}
   {% if osd_objectstore == 'bluestore' and dmcrypt -%}
   -e OSD_BLUESTORE=1 \
+  -e OSD_FILESTORE=0 \
   -e OSD_DMCRYPT=1 \
   {% endif -%}
   -e CLUSTER={{ cluster }} \


### PR DESCRIPTION
ceph-docker by default has OSD_BLUESTORE=1 which means that if
OSD_FILESTORE=1 we have to force OSD_BLUESTORE=0 otherwise that'll mess
the setup.

Signed-off-by: Sébastien Han <seb@redhat.com>