### PR TITLE
ceph-rbd-mirror; docker fix typo

### DIFF
--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -7,11 +7,11 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/docker stop ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStartPre=-/usr/bin/docker rm ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStart=/usr/bin/docker run --rm --net=host \
-  --memory={{ ceph_rbd_mirorr_docker_memory_limit }} \
+  --memory={{ ceph_rbd_mirror_docker_memory_limit }} \
   {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
   --cpus={{ ceph_rbd_mirror_docker_cpu_limit }} \
   {% else -%}
-  --cpu-quota={{ ceph_rbd_mirorr_docker_cpu_limit * 100000 }} \
+  --cpu-quota={{ ceph_rbd_mirror_docker_cpu_limit * 100000 }} \
   {% endif -%}
   {% if not containerized_deployment_with_kv -%}
   -v /etc/ceph:/etc/ceph \


### PR DESCRIPTION
Signed-off-by: Sébastien Han <seb@redhat.com>