### PR TITLE
ceph-osd: remove deprecated comment in sample file

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -149,12 +149,6 @@ dummy:
 # - /dev/sdd will have /dev/sdg2 as a journal
 #
 #
-# NOTE(leseb):
-# On a containerized scenario we only support A SINGLE journal
-# for all the OSDs on a given machine. If you don't, bad things will happen
-# This is a limitation we plan to fix at some point.
-#
-#
 # If osd_objectstore: bluestore is enabled, both 'ceph block.db' and 'ceph block.wal' partitions will be stored
 # on a dedicated device.
 #

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -141,12 +141,6 @@ valid_osd_scenarios:
 # - /dev/sdd will have /dev/sdg2 as a journal
 #
 #
-# NOTE(leseb):
-# On a containerized scenario we only support A SINGLE journal
-# for all the OSDs on a given machine. If you don't, bad things will happen
-# This is a limitation we plan to fix at some point.
-#
-#
 # If osd_objectstore: bluestore is enabled, both 'ceph block.db' and 'ceph block.wal' partitions will be stored
 # on a dedicated device.
 #


### PR DESCRIPTION
Since #1724 has been merged, this comment is deprecated

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>