### PR TITLE
Makefile: remove fedpkg dependency for "srpm"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,11 @@ spec:
 	  > ceph-ansible.spec
 
 srpm: dist spec
-	fedpkg --dist epel7 srpm
+	rpmbuild -bs ceph-ansible.spec \
+	  --define "_topdir ." \
+	  --define "_sourcedir ." \
+	  --define "_srcrpmdir ." \
+	  --define "dist .el7"
 
 rpm: dist srpm
 	mock -r epel-7-x86_64 rebuild $(NVR).src.rpm \


### PR DESCRIPTION
It's not currently possible to install EPEL 7's fedpkg alongside the centos-packager package in CentOS 7 Extras (for `/usr/bin/cbs`), because they each depend on slightly different Koji package versions.

This means that we cannot run `make srpm` on a system where centos-packager is installed, because that depends on fedpkg.

Remove the dependency on fedpkg for the "srpm" target, and run `rpmbuild -bs` directly.

The purpose of this change is to make it easier to automatically build ceph-ansible SRPMs in Jenkins/cbs.centos.org.