### PR TITLE
client: ability to create keys and pool with no ceph binaries

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -1,15 +1,21 @@
 ---
-- name: create pools
-  command: "ceph --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pgs }}"
-  with_items: "{{ pools }}"
-  changed_when: false
-  failed_when: false
-  when: 
-    - pools | length > 0
-    - copy_admin_key
+- name: set docker_exec_client_cmd_binary to ceph-authtool
+  set_fact:
+    docker_exec_client_cmd_binary: ceph-authtool
+  when: containerized_deployment
+
+- name: set docker_exec_client_cmd for containers
+  set_fact:
+    docker_exec_client_cmd: docker run -v /etc/ceph:/etc/ceph --entrypoint /usr/bin/{{ docker_exec_client_cmd_binary }} {{ ceph_docker_registry}}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+  when: containerized_deployment
+
+- name: set docker_exec_client_cmd for non-containers
+  set_fact:
+    docker_exec_client_cmd: ceph-authtool
+  when: not containerized_deployment
 
 - name: create key(s)
-  shell: "ceph-authtool -C /etc/ceph/{{ cluster }}.{{ item.name }}.keyring --name {{ item.name }} --add-key {{ item.key }} --cap mon \"{{ item.mon_cap|default('') }}\" --cap osd \"{{ item.osd_cap|default('') }}\" --cap mds \"{{ item.mds_cap|default('') }}\""
+  shell: "{{ docker_exec_client_cmd }} -C /etc/ceph/{{ cluster }}.{{ item.name }}.keyring --name {{ item.name }} --add-key {{ item.key }} --cap mon \"{{ item.mon_cap|default('') }}\" --cap osd \"{{ item.osd_cap|default('') }}\" --cap mds \"{{ item.mds_cap|default('') }}\""
   args:
     creates: /etc/ceph/{{ cluster }}.{{ item.name }}.keyring
   with_items: "{{ keys }}"
@@ -18,8 +24,20 @@
     - cephx
     - keys | length > 0
 
+- name: set docker_exec_client_cmd_binary to ceph
+  set_fact:
+    docker_exec_client_cmd_binary: ceph
+  when: containerized_deployment
+
+- name: replace docker_exec_client_cmd by ceph
+  set_fact:
+    docker_exec_client_cmd: ceph
+  when:
+    - not containerized_deployment
+    - docker_exec_client_cmd == 'ceph-authtool'
+
 - name: check if key(s) already exist(s)
-  command: "ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  command: "{{ docker_exec_client_cmd }} --cluster {{ cluster }} auth get {{ item.name }}"
   changed_when: false
   failed_when: false
   with_items: "{{ keys }}"
@@ -27,16 +45,30 @@
   when:
     - copy_admin_key
 
+- name: create pools
+  command: "{{ docker_exec_client_cmd }} --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pgs }}"
+  with_items: "{{ pools }}"
+  changed_when: false
+  failed_when: false
+  when:
+    - pools | length > 0
+    - copy_admin_key
+
 - name: add key(s) to ceph
-  command: "ceph --cluster {{ cluster }} auth import -i /etc/ceph/{{ cluster }}.{{ item.0.name }}.keyring"
+  command: "{{ docker_exec_client_cmd }} --cluster {{ cluster }} auth import -i /etc/ceph/{{ cluster }}.{{ item.0.name }}.keyring"
   changed_when: false
   with_together:
     - "{{ keys }}"
     - "{{ keys_exist.results | default([]) }}"
   when:
-    - not item.1.get("skipped")    
+    - not item.1.get("skipped")
     - copy_admin_key
     - item.1.rc != 0
+
+- name: put docker_exec_client_cmd back to normal with a none value
+  set_fact:
+    docker_exec_client_cmd:
+  when: docker_exec_client_cmd == 'ceph'
 
 - name: setfacl for key(s)
   acl:

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -1,4 +1,16 @@
 ---
+- name: set selinux permissions
+  shell: |
+    chcon -Rt svirt_sandbox_file_t {{ item }}
+  with_items:
+    - /etc/ceph
+    - /var/lib/ceph
+  changed_when: false
+  when:
+    - sestatus is defined
+    - sestatus.stdout != 'Disabled'
+    - containerized_deployment
+
 - name: copy ceph admin keyring
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.client.admin.keyring"

--- a/roles/ceph-osd/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-osd/tasks/check_mandatory_vars.yml
@@ -13,7 +13,7 @@
 
 - name: make sure journal_size configured
   debug:
-    msg: "WARNING: journal_size is configured to less than 5GB. This is not recommended and can lead to severe issues."
+    msg: "WARNING: journal_size is configured to {{ journal_size }}, which is less than 5GB. This is not recommended and can lead to severe issues."
   when:
     - journal_size|int < 5120
     - osd_objectstore == 'filestore'

--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -101,6 +101,6 @@
   gather_facts: false
   roles:
   - ceph-defaults
-  - ceph-common
+  - ceph-docker-common
   - ceph-config
   - ceph-client

--- a/tests/functional/centos/7/docker/group_vars/all
+++ b/tests/functional/centos/7/docker/group_vars/all
@@ -26,3 +26,7 @@ ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
     osd_pool_default_size: 1
+user_config: True
+keys:
+  - { name: client.test, key: "AQAin8tUoMPDGRAACcfAQHbq4eTuUoTCZdW1Uw==", mon_cap: "allow r", osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool=test", mode: "0600", acls: [] }
+  - { name: client.test2, key: "AQAin8tUAJkGGhAA8WZ8Lz5c7IkT8QZ5s7bI1A==", mon_cap: "allow r", osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool=test2", mode: "0600", acls: [] }

--- a/tests/functional/centos/7/docker/hosts
+++ b/tests/functional/centos/7/docker/hosts
@@ -16,7 +16,7 @@ rgw0
 mgr0
 
 [clients]
-client0 ceph_origin="repository" ceph_repository="community" containerized_deployment="False"
+client0 ceph_origin="repository" ceph_repository="community"
 
 [rbdmirrors]
 rbd-mirror0


### PR DESCRIPTION
On a container env, machines don't have any ceph binaries so we need to
use a container to run the commands.

Signed-off-by: Sébastien Han <seb@redhat.com>