### PR TITLE
tests: fix lvm_setup.yml for purge_cluster.yml

### DIFF
--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -42,11 +42,6 @@
         unit: '%'
         state: present
 
-    - name: create filesystem on /dev/sdc1
-      filesystem:
-        fstype: ext4
-        dev: /dev/sdc1
-
     - name: create journals vg from /dev/sdc2
       lvg:
         vg: journals

--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -21,6 +21,21 @@
       command: lvcreate --yes -l 50%FREE -n data-lv2 test_group
       failed_when: false
 
+    # purge-cluster.yml does not properly destroy partitions
+    # used for lvm osd journals, this ensures they are removed
+    # for that testing scenario
+    - name: remove /dev/sdc1 if it exists
+      parted:
+        device: /dev/sdc
+        number: 1
+        state: absent
+
+    - name: remove /dev/sdc2 if it exists
+      parted:
+        device: /dev/sdc
+        number: 2
+        state: absent
+
     - name: partition /dev/sdc for journals
       parted:
         device: /dev/sdc


### PR DESCRIPTION
The ``dev-ansible2.3-purge_lvm_osds`` task has been failing because the ``purge-cluster.yml`` playbook does not destroy partitions used for lvm osd journals which causes the second run of ``lvm_setup.yml`` to fail during the purge scenario.

Proper support for purging partitions used for lvm osds will be added when ``ceph-volume lvm zap`` is available. 