### PR TITLE
purge: only purge specific directories for mon

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -450,8 +450,17 @@
 
   - name: remove monitor store and bootstrap keys
     file:
-      path: /var/lib/ceph/
+      path: "{{ item }}"
       state: absent
+    with_items:
+      - /var/lib/ceph/mon
+      - /var/lib/ceph/bootstrap-mds
+      - /var/lib/ceph/bootstrap-osd
+      - /var/lib/ceph/bootstrap-rgw
+      - /var/lib/ceph/bootstrap-rbd
+      - /var/lib/ceph/bootstrap-mgr
+      - /var/lib/ceph/tmp
+
 
 - name: purge iscsi gateway(s)
 


### PR DESCRIPTION
Handles the case when a mon is collocated with an OSD.

Closes: https://github.com/ceph/ceph-ansible/issues/1877
Signed-off-by: Sébastien Han <seb@redhat.com>