### PR TITLE
mon: create the mgr key for release >= luminous

### DIFF
--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -130,5 +130,4 @@
       - item.stat.exists == true
   when:
     - inventory_hostname == groups[mon_group_name]|last
-    - not ceph_docker_image_tag.find('jewel') != -1
-    - ceph_docker_image != 'rhceph'
+    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous


### PR DESCRIPTION
This fixes RHCS builds. We know which Ceph version we are running on.

Signed-off-by: Sébastien Han <seb@redhat.com>