### PR TITLE
rpm: ship different yml samples on RHEL vs CentOS

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -44,6 +44,13 @@ pushd %{buildroot}%{_datarootdir}/ceph-ansible
   rm group_vars/common-coreoss.yml.sample
   # These untested playbooks are too unstable for users.
   rm -r infrastructure-playbooks/untested-by-ci
+  %if 0%{?fedora} || 0%{?centos}
+    # Ship the upstream config (delete RHCS)
+    rm group_vars/rhcs.yml.sample
+  %else
+    # Ship only the Red Hat Ceph Storage config (delete upstream)
+    rm group_vars/all.yml.sample
+  %endif
 popd
 
 %check


### PR DESCRIPTION
When building the RPM on CentOS, we will ship the `all.yml.sample` file and delete `rhcs.yml.sample`.

When building the RPM on RHEL, we will ship the `rhcs.yml.sample` file and delete `all.yml.sample`.