### PR TITLE
defaults: restart docker daemon higher delay

### DIFF
--- a/roles/ceph-defaults/templates/restart_mon_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_mon_daemon.sh.j2
@@ -27,7 +27,7 @@ COUNT=10
 # Wait and ensure the socket exists after restarting the daemon
 while [ $COUNT -ne 0 ]; do
   {{ docker_exec_cmd }} test -S $SOCKET && check_quorum
-  sleep 1
+  sleep $DELAY
   let COUNT=COUNT-1
 done
 # If we reach this point, it means the socket is not present.

--- a/roles/ceph-defaults/templates/restart_osd_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_osd_daemon.sh.j2
@@ -39,7 +39,7 @@ get_docker_id_from_dev_name() {
   while [ $count -ne 0 ]; do
     id=$(docker ps -q -f "name=$1")
     test "$id" != "" && break
-    sleep 1
+    sleep $DELAY
     let count=count-1
   done
   echo "$id"
@@ -69,7 +69,7 @@ for unit in $(systemctl list-units | grep "loaded active" | grep -oE "ceph-osd@(
   SOCKET=/var/run/ceph/{{ cluster }}-osd.${osd_id}.asok
   while [ $COUNT -ne 0 ]; do
     $docker_exec test -S "$SOCKET" && check_pgs && continue 2
-    sleep 1
+    sleep $DELAY
     let COUNT=COUNT-1
   done
   # If we reach this point, it means the socket is not present.

--- a/roles/ceph-defaults/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_rgw_daemon.sh.j2
@@ -58,7 +58,7 @@ COUNT=10
 # Wait and ensure the socket exists after restarting the daemon
 while [ $COUNT -ne 0 ]; do
   {{ docker_exec_cmd }} test -S $SOCKET && check_rest
-  sleep 1
+  sleep $DELAY
   let COUNT=COUNT-1
 done
 echo "Socket file ${SOCKET} could not be found, which means Rados Gateway is not running."


### PR DESCRIPTION
Use default delay since the mon (in particular) can take more time to
restart.
Solves error with:

STDERR:

Error response from daemon: No such container: ceph-mon-mon0

Signed-off-by: Sébastien Han <seb@redhat.com>