### PR TITLE
rpm: Obsoletes ceph-iscsi-ansible

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -12,6 +12,7 @@ Summary:        Ansible playbooks for Ceph
 License:        ASL 2.0 and GPLv3+
 URL:            https://github.com/ceph/ceph-ansible
 Source0:        %{name}-%{version}-%{shortcommit}.tar.gz
+Obsoletes:      ceph-iscsi-ansible <= 1.5
 
 BuildArch:      noarch
 


### PR DESCRIPTION
The ceph-iscsi-ansible project has moved into ceph-ansible now. Make the ceph-ansible package obsolete the ceph-iscsi-ansible package. With this change, Yum updates will seamlessly uninstall the ceph-iscsi-ansible package.