### PR TITLE
rpm: ship rhcs.yaml.sample as all.yml.sample on RHEL

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -44,12 +44,9 @@ pushd %{buildroot}%{_datarootdir}/ceph-ansible
   rm group_vars/common-coreoss.yml.sample
   # These untested playbooks are too unstable for users.
   rm -r infrastructure-playbooks/untested-by-ci
-  %if 0%{?fedora} || 0%{?centos}
-    # Ship the upstream config (delete RHCS)
-    rm group_vars/rhcs.yml.sample
-  %else
-    # Ship only the Red Hat Ceph Storage config (delete upstream)
-    rm group_vars/all.yml.sample
+  %if ! 0%{?fedora} && ! 0%{?centos}
+    # Ship only the Red Hat Ceph Storage config (overwrite upstream settings)
+    cp group_vars/rhcs.yml.sample group_vars/all.yml.sample
   %endif
 popd
 


### PR DESCRIPTION
When building the RPM on RHEL, we will ship the conents of the `rhcs.yml.sample` file into `all.yml.sample`.

The purpose of this change is to expose "all.yml.sample" to both upstream and downstream users, so they use the same file name (but with different contents.)