### PR TITLE
rpm: require Ansible 2.3.1.0

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -16,10 +16,10 @@ Obsoletes:      ceph-iscsi-ansible <= 1.5
 
 BuildArch:      noarch
 
-BuildRequires: ansible >= 2.2.0.0
+BuildRequires: ansible >= 2.3.1.0
 BuildRequires: python2-devel
 
-Requires: ansible >= 2.2.0.0
+Requires: ansible >= 2.3.1.0
 Requires: python-netaddr
 
 %description


### PR DESCRIPTION
We require a newer verison of Ansible now.