### PR TITLE
Add glusterfs-3.8 PPA to enable nfs-ganesha installation

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
@@ -58,6 +58,7 @@
   with_items:
     - ppa:gluster/libntirpc
     - ppa:gluster/nfs-ganesha
+    - ppa:gluster/glusterfs-3.8
   changed_when: false
   when:
     - (nfs_obj_gw or nfs_file_gw)


### PR DESCRIPTION
The nfs-ganesha-fsal package has a dependency on glusterfs-common (>=
3.8.8), which must be installed from a PPA.

Fixes #1905.