### PR TITLE
Introduce ceph_nfs_ceph_user

### DIFF
--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -44,6 +44,7 @@ dummy:
 #ceph_nfs_ceph_pseudo_path: "/cephobject"
 #ceph_nfs_ceph_protocols: "3,4"
 #ceph_nfs_ceph_access_type: "RW"
+#ceph_nfs_ceph_user: "admin"
 
 ###################
 # FSAL RGW Config #

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -36,6 +36,7 @@ ceph_nfs_ceph_export_id: 20134
 ceph_nfs_ceph_pseudo_path: "/cephobject"
 ceph_nfs_ceph_protocols: "3,4"
 ceph_nfs_ceph_access_type: "RW"
+ceph_nfs_ceph_user: "admin"
 
 ###################
 # FSAL RGW Config #

--- a/roles/ceph-nfs/templates/ganesha.conf.j2
+++ b/roles/ceph-nfs/templates/ganesha.conf.j2
@@ -20,6 +20,7 @@ EXPORT
 
 	FSAL {
 		Name = CEPH;
+		User_Id = "{{ ceph_nfs_ceph_user }}";
 	}
 
         {{ ganesha_ceph_export_overrides | default(None) }}


### PR DESCRIPTION
In analogy to ceph_nfs_rgw_user, we should be able to define a user
with which the nfs-ganesha Ceph FSAL connects to the cluster.

Introduce a ceph_nfs_ceph_user, setting its default to "admin" (which
preserves the prior behavior of always connecting as client.admin).

Fixes #1910.