### PR TITLE
stable-2.2: Enable working nfs-ganesha deployment on Ubuntu

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_ceph_repository.yml
@@ -56,8 +56,8 @@
     repo: "{{ item }}"
     state: present
   with_items:
-    - ppa:gluster/libntirpc
-    - ppa:gluster/nfs-ganesha
+    - ppa:gluster/libntirpc-1.5
+    - ppa:gluster/nfs-ganesha-2.5
   changed_when: false
   when:
     - (nfs_obj_gw or nfs_file_gw)

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -53,7 +53,7 @@
 
 - name: install NFS gateway
   apt:
-    pkg: nfs-ganesha-fsal
+    pkg: nfs-ganesha-ceph
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     update_cache: yes
   when: nfs_group_name in group_names

--- a/roles/ceph-common/templates/ganesha.conf.j2
+++ b/roles/ceph-common/templates/ganesha.conf.j2
@@ -20,6 +20,7 @@ EXPORT
 
 	FSAL {
 		Name = CEPH;
+		User_Id = "{{ ceph_nfs_ceph_user }}";
 	}
 }
 {% endif %}

--- a/roles/ceph-common/templates/ganesha.conf.j2
+++ b/roles/ceph-common/templates/ganesha.conf.j2
@@ -4,7 +4,7 @@
 {% if nfs_file_gw %}
 EXPORT
 {
-	Export_ID={{ ceph_nfs_ceph_export_id }};
+	Export_id={{ ceph_nfs_ceph_export_id }};
 
 	Path = "/";
 
@@ -12,11 +12,11 @@ EXPORT
 
 	Access_Type = {{ ceph_nfs_ceph_access_type }};
 
-	NFS_Protocols = {{ ceph_nfs_ceph_protocols }};
+	Protocols = {{ ceph_nfs_ceph_protocols }};
 
-	Transport_Protocols = TCP;
+	Transports = TCP;
 
-	Sectype = sys,krb5,krb5i,krb5p;
+	SecType = sys,krb5,krb5i,krb5p;
 
 	FSAL {
 		Name = CEPH;
@@ -26,7 +26,7 @@ EXPORT
 {% if nfs_obj_gw %}
 EXPORT
 {
-	Export_ID={{ ceph_nfs_rgw_export_id }};
+	Export_id={{ ceph_nfs_rgw_export_id }};
 
 	Path = "/";
 
@@ -34,11 +34,11 @@ EXPORT
 
 	Access_Type = {{ ceph_nfs_rgw_access_type }};
 
-	NFS_Protocols = {{ ceph_nfs_rgw_protocols }};
+	Protocols = {{ ceph_nfs_rgw_protocols }};
 
-	Transport_Protocols = TCP;
+	Transports = TCP;
 
-	Sectype = sys,krb5,krb5i,krb5p;
+	SecType = sys,krb5,krb5i,krb5p;
 
 	FSAL {
 		Name = RGW;

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -37,6 +37,7 @@ ceph_nfs_ceph_export_id: 20134
 ceph_nfs_ceph_pseudo_path: "/cephobject"
 ceph_nfs_ceph_protocols: "3,4"
 ceph_nfs_ceph_access_type: "RW"
+ceph_nfs_ceph_user: "admin"
 
 ###################
 # FSAL RGW Config #


### PR DESCRIPTION
- Install `nfs-ganesha` packages on Ubuntu from the correct PPA (one with a build that actually contains a Ceph FSAL).
- Correct the `ganesha.conf` template to generate correct nfs-ganesha parameters.
- Enable nfs-ganesha to connect to Ceph using a CephX identity other than `client.admin` (but retain the default to connect as `client.admin`, to preserve compatibility).