### PR TITLE
DNM: mgr: add missing admin key for mgr container

### DIFF
--- a/roles/ceph-mgr/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mgr/tasks/docker/copy_configs.yml
@@ -4,6 +4,7 @@
     ceph_config_keys:
       - /etc/ceph/{{ cluster }}.conf
       - /etc/ceph/{{ cluster }}.mgr.{{ ansible_hostname }}.keyring
+      - /etc/ceph/{{ cluster }}.client.admin.keyring
 
 - name: stat for ceph config and keys
   local_action: stat path={{ fetch_directory }}/{{ fsid }}/{{ item }}


### PR DESCRIPTION
Followup on #1761.
Add missing admin key for mgr node in containerized deployment.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>