### PR TITLE
docker-common: re-introduce state for leftover files

### DIFF
--- a/roles/ceph-docker-common/tasks/checks.yml
+++ b/roles/ceph-docker-common/tasks/checks.yml
@@ -6,5 +6,5 @@
     msg: "looks like no cluster is running but ceph files are present, please remove them"
   with_together:
     - "{{ ceph_config_keys }}"
-    - "{{ statleftover.results }}"
+    - "{{ statconfig.results }}"
   when: item.1.stat.exists == true


### PR DESCRIPTION
The variable "statleftover" was removed by commit
a60c74f61eb4b7523ef6d4065624312bfd0aa03a
and never added back to the new playbook,
yet it is still being referenced.

Adding it back

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1492224
Signed-off-by: Sébastien Han <seb@redhat.com>