### PR TITLE
purge-cluster: default lvm_volumes if not defined

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -216,6 +216,11 @@
 
   tasks:
 
+  - name: default lvm_volumes if not defined
+    set_fact:
+      lvm_volumes: []
+    when: lvm_volumes is not defined
+
   - name: get osd numbers
     shell: "if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi"
     register: osd_ids


### PR DESCRIPTION
Most osd scenarios do not use lvm_volumes, so default it in
purge-cluster.yml if it's not defined.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>