### PR TITLE
common: fix rhel check

### DIFF
--- a/roles/ceph-common/tasks/checks/check_system.yml
+++ b/roles/ceph-common/tasks/checks/check_system.yml
@@ -71,13 +71,13 @@
   fail:
     msg: "iSCSI gateways can only be deployed on Red Hat Enterprise Linux or CentOS"
   when:
-    - ansible_distribution not in  ['Red Hat Enterprise Linux', 'CentOS']
+    - ansible_distribution not in ['RedHat', 'CentOS']
     - iscsi_gw_group_name in group_names
 
 - name: fail on unsupported distribution version for iscsi gateways
   fail:
     msg: "iSCSI gateways can only be deployed on Red Hat Enterprise Linux or CentOS >= 7.4"
   when:
-    - ansible_distribution == 'Red Hat Enterprise Linux' or ansible_distribution == 'CentOS'
+    - ansible_distribution in ['RedHat', 'CentOS']
     - ansible_distribution_version < '7.4'
     - iscsi_gw_group_name in group_names


### PR DESCRIPTION
Looks like Ansible is now using "RedHat" instead of "Red Hat Enterprise
Linux"

Signed-off-by: Sébastien Han <seb@redhat.com>