### PR TITLE
Make ceph-nfs service enablement/start optional

### DIFF
--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -10,6 +10,10 @@
 # distributed on RGW nodes. Setting 'copy_admin_key' to 'true'
 # will copy the admin key to the /etc/ceph/ directory
 copy_admin_key: false
+# whether docker container or systemd service should be enabled
+# and started, it's useful to set it to false if nfs-ganesha
+# service is managed by pacemaker
+ceph_nfs_enable_service: true
 
 #######################
 # Access type options #

--- a/roles/ceph-nfs/tasks/docker/start_docker_nfs.yml
+++ b/roles/ceph-nfs/tasks/docker/start_docker_nfs.yml
@@ -12,11 +12,13 @@
   shell: systemctl enable ceph-nfs@{{ ansible_hostname }}.service
   failed_when: false
   changed_when: false
+  when: ceph_nfs_enable_service
 
 - name: reload systemd unit files
   shell: systemctl daemon-reload
   changed_when: false
   failed_when: false
+  when: ceph_nfs_enable_service
 
 - name: systemd start nfs container
   service:
@@ -24,3 +26,4 @@
     state: started
     enabled: yes
   changed_when: false
+  when: ceph_nfs_enable_service

--- a/roles/ceph-nfs/tasks/pre_requisite.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite.yml
@@ -96,3 +96,4 @@
     name: nfs-ganesha
     state: started
     enabled: yes
+  when: ceph_nfs_enable_service


### PR DESCRIPTION
When ceph-nfs service is managed by pacemaker, it's useful to
not enable and start ceph-nfs service through systemd but let
pacemaker to start the service in a next step.