### PR TITLE
Restart service based on host specific vars

### DIFF
--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -52,7 +52,7 @@
 
 - name: restart ceph mdss
   service:
-    name: ceph-mds@{{ mds_name }}
+    name: ceph-mds@{{ hostvars[item]['mds_name'] }}
     state: restarted
   # serial: 1 would be the proper solution here, but that can only be set on play level
   # upstream issue: https://github.com/ansible/ansible/issues/12170
@@ -64,7 +64,7 @@
 
 - name: restart ceph rgws
   service:
-    name: ceph-radosgw@rgw.{{ ansible_hostname }}
+    name: ceph-radosgw@rgw.{{ hostvars[item]['ansible_hostname'] }}
     state: restarted
   # serial: 1 would be the proper solution here, but that can only be set on play level
   # upstream issue: https://github.com/ansible/ansible/issues/12170


### PR DESCRIPTION
The current approach to restarting rgw/mds servers can result in
inconsistent behaviour. Sometimes this will attempt to restart the
initial hosts "ansible_hostname" service on the delegated_to host, which
will fail.

This PR changes to specifically use the delegate_to: host's hostvars.
This will prevent a situation where the incorrect hostvars are used.

This doesn't apply to master, since the approach to restart handlers has
moved to in role and no longer runs as a "run_once" with delegation.

Fixes: #1921