### PR TITLE
docker: we don't need to copy the ceph.conf on all the nodes

### DIFF
--- a/roles/ceph-mds/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mds/tasks/docker/copy_configs.yml
@@ -2,7 +2,6 @@
 - name: set_fact ceph_config_keys
   set_fact:
     ceph_config_keys:
-      - /etc/ceph/{{ cluster }}.conf
       - /etc/ceph/{{ cluster }}.client.admin.keyring
       - /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring
 

--- a/roles/ceph-mgr/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mgr/tasks/docker/copy_configs.yml
@@ -2,7 +2,6 @@
 - name: set_fact ceph_config_keys
   set_fact:
     ceph_config_keys:
-      - /etc/ceph/{{ cluster }}.conf
       - /etc/ceph/{{ cluster }}.mgr.{{ ansible_hostname }}.keyring
 
 - name: stat for ceph config and keys

--- a/roles/ceph-mon/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mon/tasks/docker/copy_configs.yml
@@ -2,7 +2,6 @@
 - name: set_fact ceph_config_keys
   set_fact:
     ceph_config_keys:
-      - /etc/ceph/{{ cluster }}.conf
       - /etc/ceph/{{ cluster }}.client.admin.keyring
       - /etc/ceph/monmap-{{ cluster }}
       - /etc/ceph/{{ cluster }}.mon.keyring

--- a/roles/ceph-nfs/tasks/docker/copy_configs.yml
+++ b/roles/ceph-nfs/tasks/docker/copy_configs.yml
@@ -2,7 +2,6 @@
 - name: set config and keys paths
   set_fact:
     ceph_config_keys:
-      - /etc/ceph/{{ cluster }}.conf
       - /etc/ceph/{{ cluster }}.client.admin.keyring
       - /var/lib/ceph/radosgw/keyring
 

--- a/roles/ceph-osd/tasks/copy_configs.yml
+++ b/roles/ceph-osd/tasks/copy_configs.yml
@@ -2,7 +2,6 @@
 - name: set config and keys paths
   set_fact:
     ceph_config_keys:
-      - /etc/ceph/{{ cluster }}.conf
       - /var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring
 
 - name: wait for ceph.conf and keys

--- a/roles/ceph-rbd-mirror/tasks/docker/copy_configs.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/copy_configs.yml
@@ -8,7 +8,6 @@
 - name: set_fact ceph_config_keys
   set_fact:
     ceph_config_keys:
-      - /etc/ceph/{{ cluster }}.conf
       - /etc/ceph/{{ cluster }}.client.admin.keyring
       - "{{ bootstrap_rbd_keyring | default([]) }}"
 

--- a/roles/ceph-restapi/tasks/docker/copy_configs.yml
+++ b/roles/ceph-restapi/tasks/docker/copy_configs.yml
@@ -2,7 +2,6 @@
 - name: set_fact ceph_config_keys
   set_fact:
     ceph_config_keys:
-      - /etc/ceph/{{ cluster }}.conf
       - /etc/ceph/{{ cluster }}.client.admin.keyring
 
 - name: stat for ceph config and keys

--- a/roles/ceph-rgw/tasks/docker/copy_configs.yml
+++ b/roles/ceph-rgw/tasks/docker/copy_configs.yml
@@ -2,7 +2,6 @@
 - name: set config and keys paths
   set_fact:
     ceph_config_keys:
-      - /etc/ceph/{{ cluster }}.conf
       - /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring
 
 - name: stat for ceph config and keys


### PR DESCRIPTION
We generate the ceph.conf on all the nodes through the
ceph-docker-common so there is no need to push it to the Ansible file.

Also this is breaking the ceph.conf template generation since we only
generate sections based on the host the ansible task is running on.

For example, what's typically happening, we bootstrap the monitor, we
get a ceph.conf generated for a mon only, we go on an osd, we generate
the ceph.conf with osd section (done by ceph-docker-common) but this
gets overwritten by the copy_config task of the ceph-osd role.

Signed-off-by: Sébastien Han <seb@redhat.com>