### PR TITLE
config: no not generate osd section if bluestore

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -253,7 +253,6 @@ dummy:
 #ceph_conf_key_directory: /etc/ceph
 
 #cephx: true
-#max_open_files: 131072
 
 ## Client options
 #

--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -18,6 +18,10 @@ dummy:
 # distributed on RGW nodes. Setting 'copy_admin_key' to 'true'
 # will copy the admin key to the /etc/ceph/ directory
 #copy_admin_key: false
+# whether docker container or systemd service should be enabled
+# and started, it's useful to set it to false if nfs-ganesha
+# service is managed by pacemaker
+#ceph_nfs_enable_service: true
 
 #######################
 # Access type options #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -253,7 +253,6 @@ ceph_repository: rhcs
 #ceph_conf_key_directory: /etc/ceph
 
 #cephx: true
-#max_open_files: 131072
 
 ## Client options
 #

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -116,6 +116,7 @@ log file = {{ rbd_client_log_file }} # must be writable by QEMU and allowed by S
 {% endif %}
 
 {% if inventory_hostname in groups.get(osd_group_name, []) %}
+{% if osd_objectstore == 'filestore' %}
 [osd]
 osd mkfs type = {{ osd_mkfs_type }}
 osd mkfs options xfs = {{ osd_mkfs_options_xfs }}
@@ -126,6 +127,7 @@ filestore xattr use omap = {{ filestore_xattr_use_omap }}
 {% elif osd_mkfs_type == "ext4" %}
 filestore xattr use omap = true
 {# else, default is false #}
+{% endif %}
 {% endif %}
 {% endif %}
 

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -14,7 +14,6 @@ ms bind ipv6 = true
 {% if not containerized_deployment_with_kv and not containerized_deployment %}
 fsid = {{ fsid }}
 {% endif %}
-max open files = {{ max_open_files }}
 {% if common_single_host_mode is defined and common_single_host_mode %}
 osd crush chooseleaf type = 0
 {% endif %}

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -245,7 +245,6 @@ generate_fsid: true
 ceph_conf_key_directory: /etc/ceph
 
 cephx: true
-max_open_files: 131072
 
 ## Client options
 #


### PR DESCRIPTION
This section is not needed when running a bluestore osd.

Signed-off-by: Sébastien Han <seb@redhat.com>