### PR TITLE
stable-2.2: add ceph_nfs_ceph_user to nfss.yml.sample

### DIFF
--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -45,6 +45,7 @@ dummy:
 #ceph_nfs_ceph_pseudo_path: "/cephobject"
 #ceph_nfs_ceph_protocols: "3,4"
 #ceph_nfs_ceph_access_type: "RW"
+#ceph_nfs_ceph_user: "admin"
 
 ###################
 # FSAL RGW Config #


### PR DESCRIPTION
Add the ceph_nfs_ceph_user variable to nfss.yml.sample too (not just
all.yml.sample).

This was properly included in ada2f147f5c6537cf51171c995009b0b3288c027
in master, but was missing from
72e32ae0bf1f060aaabd88ddb9c8dd000c0c5d97 in stable-2.2.