### PR TITLE
config: fix rgw interface when using different interfaces

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -165,11 +165,10 @@ log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[host]['ansible_hostname']
       rgw frontends = civetweb port=[{{ hostvars[host]['radosgw_address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% endif %}
 {%- else -%}
-    {% set interface = ["ansible_",radosgw_interface]|join %}
-    {% if ip_version == 'ipv6' -%}
-      rgw frontends = civetweb port=[{{ hostvars[host][interface][ip_version][0]['address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
-    {%- elif ip_version == 'ipv4' -%}
-      rgw frontends = civetweb port={{ hostvars[host][interface][ip_version]['address'] }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+    {% if ip_version == 'ipv4' -%}
+      rgw frontends = civetweb port={{ hostvars[host]['ansible_' + hostvars[host]['radosgw_interface']][ip_version]['address'] }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+    {%- elif ip_version == 'ipv6' -%}
+      rgw frontends = civetweb port=[{{ hostvars[host]['ansible_' + hostvars[host]['radosgw_interface']][ip_version][0]['address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% endif %}
 {%- endif %}
 {% endif %}


### PR DESCRIPTION
Conf file generation failing on rgw nodes when nodes have different
interface names.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1493552
Signed-off-by: Sébastien Han <seb@redhat.com>