### PR TITLE
[skip ci] nfs: fix docker_exec_cmd_nfs default value

### DIFF
--- a/roles/ceph-nfs/tasks/create_rgw_nfs_user.yml
+++ b/roles/ceph-nfs/tasks/create_rgw_nfs_user.yml
@@ -6,7 +6,7 @@
     - containerized_deployment
 
 - name: create rgw nfs user
-  command: "{{ docker_exec_cmd_nfs | default([]) }} radosgw-admin --cluster {{ cluster }} user create --uid={{ ceph_nfs_rgw_user }} --display-name='RGW NFS User'"
+  command: "{{ docker_exec_cmd_nfs | default('') }} radosgw-admin --cluster {{ cluster }} user create --uid={{ ceph_nfs_rgw_user }} --display-name='RGW NFS User'"
   register: rgwuser
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:


### PR DESCRIPTION
the default is not an array, default is empty.

Signed-off-by: Sébastien Han <seb@redhat.com>