### PR TITLE
config: fix path to set `interface` in ceph.conf

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -81,7 +81,7 @@ mon host = {% if nb_mon > 0 %}
         [{{ hostvars[host]['monitor_address'] }}]
       {%- endif %}
     {%- else -%}
-      {% set interface = ["ansible_",monitor_interface]|join %}
+      {% set interface = 'ansible_' + hostvars[host]['monitor_interface'] %}
       {% if ip_version == 'ipv4' -%}
         {{ hostvars[host][interface][ip_version]['address'] }}
       {%- elif ip_version == 'ipv6' -%}
@@ -199,7 +199,7 @@ rgw data = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_ho
       rgw frontends = civetweb port=[{{ hostvars[host]['radosgw_address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% endif %}
 {%- else -%}
-    {% set interface = ["ansible_",radosgw_interface]|join %}
+    {% set interface = 'ansible_' + hostvars[host]['radosgw_interface'] %}
     {% if ip_version == 'ipv6' -%}
       rgw frontends = civetweb port=[{{ hostvars[host][interface][ip_version][0]['address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {%- elif ip_version == 'ipv4' -%}

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -42,7 +42,7 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
   -e MON_IP=[{{ hostvars[inventory_hostname]['monitor_address'] }}] \
     {% endif -%}
   {% else -%}
-    {% set interface = ["ansible_",monitor_interface]|join %}
+    {% set interface = 'ansible_' + hostvars[inventory_hostname]['monitor_interface'] %}
       {% if ip_version == 'ipv6' -%}
   -e MON_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
       {% elif ip_version == 'ipv4' -%}

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -34,7 +34,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
   -e RGW_CIVETWEB_IP=[{{ hostvars[inventory_hostname]['radosgw_address'] }}] \
     {% endif -%}
   {% else -%}
-    {% set interface = ["ansible_",radosgw_interface]|join %}
+    {% set interface = 'ansible_' + hostvars[inventory_hostname]['radosgw_interface'] %}
       {% if ip_version == 'ipv6' -%}
   -e RGW_CIVETWEB_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
       {% elif ip_version == 'ipv4' -%}


### PR DESCRIPTION
need to use `hostvars[host]['XXX']` to retrieve the monitor
interface and/or radosgw interface.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1493920

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>