### PR TITLE
update: update rgw systemd unit name

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -107,7 +107,7 @@
 
   - name: disable ceph rgw service (new unit name)
     service:
-      name: "ceph-radosgw@{{ ansible_hostname }}"
+      name: "ceph-radosgw@rgw.{{ ansible_hostname }}"
       state: stopped
       enabled: no
     ignore_errors: true

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -483,7 +483,7 @@
 
     - name: restart containerized ceph rgws with systemd
       service:
-        name: ceph-radosgw@{{ ansible_hostname }}
+        name: ceph-radosgw@rgw.{{ ansible_hostname }}
         state: restarted
         enabled: yes
       when:


### PR DESCRIPTION
The old name is used to restart the service in `rolling_update.yml`, it breaks the
`test_rgw_service_is_running()` test.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>