### PR TITLE
ceph-common: Fix logic for ceph_repository_type

### DIFF
--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -48,7 +48,7 @@
   when:
     - ceph_origin == 'repository'
     - ceph_repository == 'rhcs'
-    - ceph_repository_type in valid_ceph_repository_type
+    - ceph_repository_type not in valid_ceph_repository_type
   tags:
     - package-install
 


### PR DESCRIPTION
It's failing if a *valid* choice is specified.

Signed-off-by: Zack Cerza <zack@redhat.com>