### PR TITLE
[skip ci] nfs: bindmount /var/lib/ganesha

### DIFF
--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -11,6 +11,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
    {% if not containerized_deployment_with_kv -%}
    -v /etc/ceph:/etc/ceph \
    -v /etc/ganesha:/etc/ganesha \
+   -v /var/lib/ganesha:/var/lib/ganesha \
    {% else -%}
    -e KV_TYPE={{kv_type}} \
    -e KV_IP={{kv_endpoint}}\


### PR DESCRIPTION
If we restart the container we need to keep /var/lib/ganesha intact for
data/session persistence.

Signed-off-by: Sébastien Han <seb@redhat.com>