### PR TITLE
docker-common: fix wrong syntax

### DIFF
--- a/roles/ceph-docker-common/tasks/main.yml
+++ b/roles/ceph-docker-common/tasks/main.yml
@@ -47,7 +47,7 @@
 # AND
 # we are not playing rolling-update.yml playbook.
 - name: check if a cluster is already running
-  command: "docker ps -q --filter=\'name=ceph-mon-{{ ansible_hostname }}\'"
+  command: "docker ps -q --filter='name=ceph-mon-{{ ansible_hostname }}'"
   register: ceph_health
   changed_when: false
   failed_when: false


### PR DESCRIPTION
there is no need to backslash the quotes here.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>