### PR TITLE
tests: make all subnet uniq per scenario

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -134,6 +134,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # "host doesn't support requested feature: CPUID.01H:EDX.ds [bit 21]"
   config.vm.provider :libvirt do |lv|
     lv.cpu_mode = 'host-passthrough'
+    lv.volume_cache = 'unsafe'
   end
 
   # Faster bootup. Disables mounting the sync folder for libvirt and virtualbox

--- a/tests/functional/centos/7/bluestore/group_vars/all
+++ b/tests/functional/centos/7/bluestore/group_vars/all
@@ -5,8 +5,8 @@ ceph_repository: community
 cluster: test
 monitor_interface: eth1
 radosgw_interface: eth1
-public_network: "192.168.1.0/24"
-cluster_network: "192.168.2.0/24"
+public_network: "192.168.35.0/24"
+cluster_network: "192.168.36.0/24"
 journal_size: 100
 osd_objectstore: "bluestore"
 devices:

--- a/tests/functional/centos/7/bluestore/hosts
+++ b/tests/functional/centos/7/bluestore/hosts
@@ -1,7 +1,7 @@
 [mons]
-mon0 monitor_address=192.168.1.10
+mon0 monitor_address=192.168.35.10
 mon1 monitor_interface=eth1
-mon2 monitor_address=192.168.1.12
+mon2 monitor_address=192.168.35.12
 
 [mgrs]
 mon0

--- a/tests/functional/centos/7/bluestore/vagrant_variables.yml
+++ b/tests/functional/centos/7/bluestore/vagrant_variables.yml
@@ -58,7 +58,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/bluestore/vagrant_variables.yml
+++ b/tests/functional/centos/7/bluestore/vagrant_variables.yml
@@ -22,8 +22,8 @@ restapi: true
 ceph_install_source: stable
 
 # SUBNETS TO USE FOR THE VMS
-public_subnet: 192.168.1
-cluster_subnet: 192.168.2
+public_subnet: 192.168.35
+cluster_subnet: 192.168.36
 
 # MEMORY
 # set 1024 for CentOS

--- a/tests/functional/centos/7/bs-crypt-ded-jrn/vagrant_variables.yml
+++ b/tests/functional/centos/7/bs-crypt-ded-jrn/vagrant_variables.yml
@@ -58,7 +58,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/bs-crypt-jrn-col/vagrant_variables.yml
+++ b/tests/functional/centos/7/bs-crypt-jrn-col/vagrant_variables.yml
@@ -58,7 +58,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/bs-dock-crypt-jrn-col/vagrant_variables.yml
+++ b/tests/functional/centos/7/bs-dock-crypt-jrn-col/vagrant_variables.yml
@@ -58,7 +58,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/bs-dock-ded-jrn/vagrant_variables.yml
+++ b/tests/functional/centos/7/bs-dock-ded-jrn/vagrant_variables.yml
@@ -46,7 +46,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/bs-jrn-col/vagrant_variables.yml
+++ b/tests/functional/centos/7/bs-jrn-col/vagrant_variables.yml
@@ -61,7 +61,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/cluster/vagrant_variables.yml
+++ b/tests/functional/centos/7/cluster/vagrant_variables.yml
@@ -58,7 +58,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/crypt-ded-jrn/group_vars/all
+++ b/tests/functional/centos/7/crypt-ded-jrn/group_vars/all
@@ -2,8 +2,8 @@
 
 ceph_origin: repository
 ceph_repository: community
-public_network: "192.168.11.0/24"
-cluster_network: "192.168.12.0/24"
+public_network: "192.168.21.0/24"
+cluster_network: "192.168.22.0/24"
 journal_size: 100
 monitor_interface: eth1
 radosgw_interface: eth1

--- a/tests/functional/centos/7/crypt-ded-jrn/vagrant_variables.yml
+++ b/tests/functional/centos/7/crypt-ded-jrn/vagrant_variables.yml
@@ -58,7 +58,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/crypt-ded-jrn/vagrant_variables.yml
+++ b/tests/functional/centos/7/crypt-ded-jrn/vagrant_variables.yml
@@ -22,8 +22,8 @@ restapi: true
 ceph_install_source: stable
 
 # SUBNETS TO USE FOR THE VMS
-public_subnet: 192.168.11
-cluster_subnet: 192.168.12
+public_subnet: 192.168.21
+cluster_subnet: 192.168.22
 
 # MEMORY
 # set 1024 for CentOS

--- a/tests/functional/centos/7/crypt-jrn-col/group_vars/all
+++ b/tests/functional/centos/7/crypt-jrn-col/group_vars/all
@@ -2,8 +2,8 @@
 
 ceph_origin: repository
 ceph_repository: community
-public_network: "192.168.13.0/24"
-cluster_network: "192.168.14.0/24"
+public_network: "192.168.25.0/24"
+cluster_network: "192.168.26.0/24"
 journal_size: 100
 monitor_interface: eth1
 radosgw_interface: eth1

--- a/tests/functional/centos/7/crypt-jrn-col/vagrant_variables.yml
+++ b/tests/functional/centos/7/crypt-jrn-col/vagrant_variables.yml
@@ -58,7 +58,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/crypt-jrn-col/vagrant_variables.yml
+++ b/tests/functional/centos/7/crypt-jrn-col/vagrant_variables.yml
@@ -22,8 +22,8 @@ restapi: true
 ceph_install_source: stable
 
 # SUBNETS TO USE FOR THE VMS
-public_subnet: 192.168.13
-cluster_subnet: 192.168.14
+public_subnet: 192.168.25
+cluster_subnet: 192.168.26
 
 # MEMORY
 # set 1024 for CentOS

--- a/tests/functional/centos/7/docker-crypt-jrn-col/group_vars/all
+++ b/tests/functional/centos/7/docker-crypt-jrn-col/group_vars/all
@@ -10,8 +10,8 @@ radosgw_interface: eth1
 ceph_mon_docker_subnet: "{{ public_network }}"
 journal_size: 100
 ceph_docker_on_openstack: False
-public_network: "192.168.15.0/24"
-cluster_network: "192.168.16.0/24"
+public_network: "192.168.27.0/24"
+cluster_network: "192.168.28.0/24"
 osd_scenario: collocated
 osd_objectstore: filestore
 dmcrypt: true

--- a/tests/functional/centos/7/docker-crypt-jrn-col/vagrant_variables.yml
+++ b/tests/functional/centos/7/docker-crypt-jrn-col/vagrant_variables.yml
@@ -46,7 +46,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/docker-crypt-jrn-col/vagrant_variables.yml
+++ b/tests/functional/centos/7/docker-crypt-jrn-col/vagrant_variables.yml
@@ -18,8 +18,8 @@ mgr_vms: 0
 restapi: true
 
 # SUBNETS TO USE FOR THE VMS
-public_subnet: 192.168.15
-cluster_subnet: 192.168.16
+public_subnet: 192.168.27
+cluster_subnet: 192.168.28
 
 # MEMORY
 # set 1024 for CentOS

--- a/tests/functional/centos/7/docker-ded-jrn/group_vars/all
+++ b/tests/functional/centos/7/docker-ded-jrn/group_vars/all
@@ -10,8 +10,8 @@ radosgw_interface: eth1
 ceph_mon_docker_subnet: "{{ public_network }}"
 journal_size: 100
 ceph_docker_on_openstack: False
-public_network: "192.168.15.0/24"
-cluster_network: "192.168.16.0/24"
+public_network: "192.168.29.0/24"
+cluster_network: "192.168.30.0/24"
 ceph_rgw_civetweb_port: 8080
 osd_objectstore: filestore
 osd_scenario: non-collocated

--- a/tests/functional/centos/7/docker-ded-jrn/vagrant_variables.yml
+++ b/tests/functional/centos/7/docker-ded-jrn/vagrant_variables.yml
@@ -46,7 +46,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/docker-ded-jrn/vagrant_variables.yml
+++ b/tests/functional/centos/7/docker-ded-jrn/vagrant_variables.yml
@@ -18,8 +18,8 @@ mgr_vms: 0
 restapi: true
 
 # SUBNETS TO USE FOR THE VMS
-public_subnet: 192.168.15
-cluster_subnet: 192.168.16
+public_subnet: 192.168.29
+cluster_subnet: 192.168.30
 
 # MEMORY
 # set 1024 for CentOS

--- a/tests/functional/centos/7/docker/group_vars/all
+++ b/tests/functional/centos/7/docker/group_vars/all
@@ -10,8 +10,8 @@ radosgw_interface: eth1
 ceph_mon_docker_subnet: "{{ public_network }}"
 journal_size: 100
 ceph_docker_on_openstack: False
-public_network: "192.168.15.0/24"
-cluster_network: "192.168.16.0/24"
+public_network: "192.168.17.0/24"
+cluster_network: "192.168.18.0/24"
 osd_scenario: collocated
 ceph_rgw_civetweb_port: 8080
 osd_objectstore: filestore

--- a/tests/functional/centos/7/docker/vagrant_variables.yml
+++ b/tests/functional/centos/7/docker/vagrant_variables.yml
@@ -51,7 +51,7 @@ client_vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/docker/vagrant_variables.yml
+++ b/tests/functional/centos/7/docker/vagrant_variables.yml
@@ -18,8 +18,8 @@ mgr_vms: 1
 restapi: true
 
 # SUBNETS TO USE FOR THE VMS
-public_subnet: 192.168.15
-cluster_subnet: 192.168.16
+public_subnet: 192.168.17
+cluster_subnet: 192.168.18
 
 # MEMORY
 # set 1024 for CentOS

--- a/tests/functional/centos/7/jrn-col-auto-dm/group_vars/all
+++ b/tests/functional/centos/7/jrn-col-auto-dm/group_vars/all
@@ -3,8 +3,8 @@
 ceph_origin: repository
 ceph_repository: community
 cluster: test
-public_network: "192.168.3.0/24"
-cluster_network: "192.168.4.0/24"
+public_network: "192.168.37.0/24"
+cluster_network: "192.168.38.0/24"
 monitor_interface: eth1
 radosgw_interface: eth1
 journal_size: 100

--- a/tests/functional/centos/7/jrn-col-auto-dm/vagrant_variables.yml
+++ b/tests/functional/centos/7/jrn-col-auto-dm/vagrant_variables.yml
@@ -53,7 +53,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/jrn-col-auto-dm/vagrant_variables.yml
+++ b/tests/functional/centos/7/jrn-col-auto-dm/vagrant_variables.yml
@@ -22,8 +22,8 @@ restapi: true
 ceph_install_source: stable
 
 # SUBNETS TO USE FOR THE VMS
-public_subnet: 192.168.3
-cluster_subnet: 192.168.4
+public_subnet: 192.168.37
+cluster_subnet: 192.168.38
 
 # MEMORY
 # set 1024 for CentOS

--- a/tests/functional/centos/7/jrn-col-auto/group_vars/all
+++ b/tests/functional/centos/7/jrn-col-auto/group_vars/all
@@ -3,8 +3,8 @@
 ceph_origin: repository
 ceph_repository: community
 cluster: test
-public_network: "192.168.3.0/24"
-cluster_network: "192.168.4.0/24"
+public_network: "192.168.33.0/24"
+cluster_network: "192.168.34.0/24"
 monitor_interface: eth1
 radosgw_interface: eth1
 journal_size: 100

--- a/tests/functional/centos/7/jrn-col-auto/vagrant_variables.yml
+++ b/tests/functional/centos/7/jrn-col-auto/vagrant_variables.yml
@@ -53,7 +53,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/jrn-col-auto/vagrant_variables.yml
+++ b/tests/functional/centos/7/jrn-col-auto/vagrant_variables.yml
@@ -22,8 +22,8 @@ restapi: true
 ceph_install_source: stable
 
 # SUBNETS TO USE FOR THE VMS
-public_subnet: 192.168.3
-cluster_subnet: 192.168.4
+public_subnet: 192.168.33
+cluster_subnet: 192.168.34
 
 # MEMORY
 # set 1024 for CentOS

--- a/tests/functional/centos/7/jrn-col/group_vars/all
+++ b/tests/functional/centos/7/jrn-col/group_vars/all
@@ -3,8 +3,8 @@
 ceph_origin: repository
 ceph_repository: community
 cluster: test
-public_network: "192.168.3.0/24"
-cluster_network: "192.168.4.0/24"
+public_network: "192.168.31.0/24"
+cluster_network: "192.168.32.0/24"
 monitor_interface: eth1
 radosgw_interface: eth1
 journal_size: 100

--- a/tests/functional/centos/7/jrn-col/vagrant_variables.yml
+++ b/tests/functional/centos/7/jrn-col/vagrant_variables.yml
@@ -58,7 +58,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/jrn-col/vagrant_variables.yml
+++ b/tests/functional/centos/7/jrn-col/vagrant_variables.yml
@@ -22,8 +22,8 @@ restapi: true
 ceph_install_source: stable
 
 # SUBNETS TO USE FOR THE VMS
-public_subnet: 192.168.3
-cluster_subnet: 192.168.4
+public_subnet: 192.168.31
+cluster_subnet: 192.168.32
 
 # MEMORY
 # set 1024 for CentOS

--- a/tests/functional/centos/7/lvm-osds/group_vars/all
+++ b/tests/functional/centos/7/lvm-osds/group_vars/all
@@ -3,8 +3,8 @@
 ceph_origin: repository
 ceph_repository: community
 cluster: ceph
-public_network: "192.168.3.0/24"
-cluster_network: "192.168.4.0/24"
+public_network: "192.168.39.0/24"
+cluster_network: "192.168.40.0/24"
 monitor_interface: eth1
 radosgw_interface: eth1
 journal_size: 100

--- a/tests/functional/centos/7/lvm-osds/vagrant_variables.yml
+++ b/tests/functional/centos/7/lvm-osds/vagrant_variables.yml
@@ -58,7 +58,7 @@ vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true

--- a/tests/functional/centos/7/lvm-osds/vagrant_variables.yml
+++ b/tests/functional/centos/7/lvm-osds/vagrant_variables.yml
@@ -22,8 +22,8 @@ restapi: true
 ceph_install_source: stable
 
 # SUBNETS TO USE FOR THE VMS
-public_subnet: 192.168.3
-cluster_subnet: 192.168.4
+public_subnet: 192.168.39
+cluster_subnet: 192.168.40
 
 # MEMORY
 # set 1024 for CentOS

--- a/tests/functional/ubuntu/16.04/cluster/vagrant_variables.yml
+++ b/tests/functional/ubuntu/16.04/cluster/vagrant_variables.yml
@@ -58,7 +58,7 @@ vagrant_box: ceph/ubuntu-xenial
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync
-#vagrant_sync_dir: /
+vagrant_sync_dir: /vagrant
 # Disables synced folder creation. Not needed for testing, will skip mounting
 # the vagrant directory on the remote box regardless of the provider.
 vagrant_disable_synced_folder: true


### PR DESCRIPTION
If two environments are using the same subnet, we will get trouble
because of ips addresses conflicts.
This commit ensures each scenario has a uniq subnet for both public and cluster
network so we can setup several test environment at a time on a same hypervisor.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>