### PR TITLE
[skip ci] mgr: add condition to run selinux tasks only on rhel os family

### DIFF
--- a/roles/ceph-mds/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mds/tasks/docker/copy_configs.yml
@@ -34,4 +34,6 @@
     - "{{ ceph_conf_key_directory }}"
     - /var/lib/ceph
   changed_when: false
-  when: sestatus.stdout != 'Disabled'
+  when:
+    - ansible_os_family == 'RedHat'
+    - sestatus.stdout != 'Disabled'

--- a/roles/ceph-mgr/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mgr/tasks/docker/copy_configs.yml
@@ -49,4 +49,6 @@
     - "{{ ceph_conf_key_directory }}"
     - /var/lib/ceph
   changed_when: false
-  when: sestatus.stdout != 'Disabled'
+  when:
+    - ansible_os_family == 'RedHat'
+    - sestatus.stdout != 'Disabled'

--- a/roles/ceph-mon/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mon/tasks/docker/copy_configs.yml
@@ -72,4 +72,5 @@
     - /var/lib/ceph
   changed_when: false
   when:
+    - ansible_os_family == 'RedHat'
     - sestatus.stdout != 'Disabled'

--- a/roles/ceph-nfs/tasks/docker/copy_configs.yml
+++ b/roles/ceph-nfs/tasks/docker/copy_configs.yml
@@ -36,4 +36,5 @@
     - /var/lib/ceph
   changed_when: false
   when:
+    - ansible_os_family == 'RedHat'
     - sestatus.stdout != 'Disabled'

--- a/roles/ceph-osd/tasks/copy_configs.yml
+++ b/roles/ceph-osd/tasks/copy_configs.yml
@@ -36,4 +36,5 @@
     - /var/lib/ceph
   changed_when: false
   when:
+    - ansible_os_family == 'RedHat'
     - sestatus.stdout != 'Disabled'

--- a/roles/ceph-rbd-mirror/tasks/docker/copy_configs.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/copy_configs.yml
@@ -42,4 +42,5 @@
     - /var/lib/ceph
   changed_when: false
   when:
+    - ansible_os_family == 'RedHat'
     - sestatus.stdout != 'Disabled'

--- a/roles/ceph-restapi/tasks/docker/copy_configs.yml
+++ b/roles/ceph-restapi/tasks/docker/copy_configs.yml
@@ -35,4 +35,5 @@
     - /var/lib/ceph
   changed_when: false
   when:
+    - ansible_os_family == 'RedHat'
     - sestatus.stdout != 'Disabled'

--- a/roles/ceph-rgw/tasks/docker/copy_configs.yml
+++ b/roles/ceph-rgw/tasks/docker/copy_configs.yml
@@ -35,4 +35,5 @@
     - /var/lib/ceph
   changed_when: false
   when:
+    - ansible_os_family == 'RedHat'
     - sestatus.stdout != 'Disabled'


### PR DESCRIPTION
This fixes the error :

```
The conditional check 'sestatus.stdout != 'Disabled'' failed.
```

that occurs when running on non rhel based system since the
`sestatus` fact is registered only on rhel based distribution.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>