### PR TITLE
Use systemd module instead of service.

### DIFF
--- a/roles/ceph-mds/tasks/docker/start_docker_mds.yml
+++ b/roles/ceph-mds/tasks/docker/start_docker_mds.yml
@@ -8,19 +8,10 @@
     group: "root"
     mode: "0644"
 
-- name: enable systemd unit file for mds instance
-  shell: systemctl enable ceph-mds@{{ ansible_hostname }}.service
-  failed_when: false
-  changed_when: false
-
-- name: reload systemd unit files
-  shell: systemctl daemon-reload
-  changed_when: false
-  failed_when: false
-
 - name: systemd start mds container
-  service:
+  systemd:
     name: ceph-mds@{{ ansible_hostname }}
     state: started
     enabled: yes
+    daemon_reload: yes
   changed_when: false

--- a/roles/ceph-mgr/tasks/docker/start_docker_mgr.yml
+++ b/roles/ceph-mgr/tasks/docker/start_docker_mgr.yml
@@ -8,19 +8,10 @@
     group: "root"
     mode: "0644"
 
-- name: enable systemd unit file for mgr instance
-  shell: systemctl enable ceph-mgr@{{ ansible_hostname }}.service
-  failed_when: false
-  changed_when: false
-
-- name: reload systemd unit files
-  shell: systemctl daemon-reload
-  changed_when: false
-  failed_when: false
-
 - name: systemd start mgr container
-  service:
+  systemd:
     name: ceph-mgr@{{ ansible_hostname }}
     state: started
     enabled: yes
+    daemon_reload: yes
   changed_when: false

--- a/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
+++ b/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
@@ -49,19 +49,10 @@
     group: "root"
     mode: "0644"
 
-- name: enable systemd unit file for mon instance
-  shell: systemctl enable ceph-mon@{{ ansible_hostname }}.service
-  failed_when: false
-  changed_when: false
-
-- name: reload systemd unit files
-  shell: systemctl daemon-reload
-  changed_when: false
-  failed_when: false
-
 - name: systemd start mon container
-  service:
+  systemd:
     name: ceph-mon@{{ ansible_hostname }}
     state: started
     enabled: yes
+    daemon_reload: yes
   changed_when: false

--- a/roles/ceph-osd/tasks/docker/start_docker_osd.yml
+++ b/roles/ceph-osd/tasks/docker/start_docker_osd.yml
@@ -28,19 +28,11 @@
     group: "root"
     mode: "0644"
 
-- name: enable systemd unit file for osd instance
-  shell: systemctl enable ceph-osd@{{ item | basename }}.service
-  changed_when: false
-  with_items: "{{ devices }}"
-
-- name: reload systemd unit files
-  shell: systemctl daemon-reload
-  changed_when: false
-
 - name: systemd start osd container
-  service:
+  systemd:
     name: ceph-osd@{{ item | basename }}
     state: started
     enabled: yes
+    daemon_reload: yes
   changed_when: false
   with_items: "{{ devices }}"

--- a/roles/ceph-rbd-mirror/tasks/docker/start_docker_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/start_docker_rbd_mirror.yml
@@ -9,19 +9,10 @@
     group: "root"
     mode: "0644"
 
-- name: enable systemd unit file for rbd mirror instance
-  command: systemctl enable ceph-rbd-mirror@rbd-mirror.{{ ansible_hostname }}.service
-  failed_when: false
-  changed_when: false
-
-- name: reload systemd unit files
-  command: systemctl daemon-reload
-  changed_when: false
-  failed_when: false
-
 - name: systemd start rbd mirror container
-  service:
+  systemd:
     name: ceph-rbd-mirror@rbd-mirror.{{ ansible_hostname }}
     state: started
     enabled: yes
+    daemon_reload: yes
   changed_when: false


### PR DESCRIPTION
Using systemd module allows us to do in one task what we did in three
tasks:

- enable unit file,
- issue a `daemon-reload`,
- start the service

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>