### PR TITLE
defaults: change running order in main.yml

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -15,7 +15,7 @@
 # because it blindly picks a mon, which may be down because
 # of the rolling update
 - name: is ceph running already?
-  command: ceph --connect-timeout 3 --cluster {{ cluster }} fsid
+  command: "{{ docker_exec_cmd }} ceph --connect-timeout 3 --cluster {{ cluster }} fsid"
   changed_when: false
   failed_when: false
   always_run: yes
@@ -91,12 +91,6 @@
     fsid: "{{ cluster_uuid.stdout }}"
   when:
     - generate_fsid
-
-- name: set_fact docker_exec_cmd
-  set_fact:
-    docker_exec_cmd: "docker exec ceph-mon-{{ ansible_hostname }}"
-  when:
-    - containerized_deployment
 
 - name: set_fact mds_name ansible_hostname
   set_fact:

--- a/roles/ceph-defaults/tasks/main.yml
+++ b/roles/ceph-defaults/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: include facts.yml
-  include: facts.yml
-
 - name: include check_socket.yml
   include: check_socket.yml
+
+- name: include facts.yml
+  include: facts.yml


### PR DESCRIPTION
The task which sets `ceph_current_fsid` in `facts.yml` in case of containerized
deployment, will definitely fail because `docker_exec_cmd` is not set
yet.
This commits simply makes `facts.yml` played after `check_socket.yml` so
`docker_exec_cmd` is set properly.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>