### PR TITLE
upgrade: a support for mgrs

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -94,6 +94,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-mon
@@ -232,6 +233,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-osd
@@ -383,6 +385,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-mds
@@ -456,6 +459,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-rgw
@@ -505,5 +509,76 @@
 
   roles:
     - ceph-defaults
-    - ceph-common
+    - ceph-config
+    - { role: ceph-common, when: not containerized_deployment }
+    - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-client
+
+
+- name: upgrade ceph mgr node
+
+  vars:
+    upgrade_ceph_packages: True
+
+  hosts:
+    - "{{ mgr_group_name|default('mgrs') }}"
+
+  serial: 1
+  become: True
+
+  pre_tasks:
+    # this task has a failed_when: false to handle the scenario where no mgr existed before the upgrade
+    - name: stop ceph mgrs
+      service:
+        name: ceph-mgr@{{ ansible_hostname }}
+        state: stopped
+        enabled: yes
+      failed_when: false
+      when:
+        - not containerized_deployment
+
+  roles:
+    - ceph-defaults
+    - ceph-config
+    - { role: ceph-common, when: not containerized_deployment }
+    - { role: ceph-docker-common, when: containerized_deployment }
+    - { role: ceph-mgr, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
+
+  post_tasks:
+    - name: start ceph mgrs
+      service:
+        name: ceph-mgr@{{ ansible_hostname }}
+        state: started
+        enabled: yes
+      when:
+        - not containerized_deployment
+
+    - name: restart containerized ceph mgrs
+      service:
+        name: ceph-mgr@{{ ansible_hostname }}
+        state: restarted
+        enabled: yes
+      when:
+        - containerized_deployment
+
+
+- name: show ceph status
+
+  hosts:
+    - "{{ mon_group_name|default('mons') }}"
+
+  become: True
+
+  roles:
+    - ceph-defaults
+
+  tasks:
+    - name: set_fact docker_exec_cmd_status
+      set_fact:
+        docker_exec_cmd_status: "docker exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
+      when:
+        - containerized_deployment
+
+    - name: show ceph status
+      command: "{{ docker_exec_cmd_status|default('') }} ceph --cluster {{ cluster }} -s"
+      delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -7,9 +7,9 @@
     - /var/lib/ceph
   changed_when: false
   when:
+    - containerized_deployment
     - sestatus is defined
     - sestatus.stdout != 'Disabled'
-    - containerized_deployment
 
 - name: copy ceph admin keyring
   copy:


### PR DESCRIPTION
Also we now play ceph-config to have everything being generated for new
daemons bootstrap during upgrade.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1497959
Signed-off-by: Sébastien Han <seb@redhat.com>