### PR TITLE
Allow to override systemd service instance id

### DIFF
--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -23,6 +23,13 @@ dummy:
 # service is managed by pacemaker
 #ceph_nfs_enable_service: true
 
+# ceph-nfs systemd service uses ansible's hostname as an instance id,
+# so service name is ceph-nfs@{{ ansible_hostname }}, this is not
+# ideal when ceph-nfs is managed by pacemaker across multiple hosts - in
+# such case it's better to have constant instance id instead which
+# can be set by 'ceph_nfs_service_suffix'
+# ceph_nfs_service_suffix: ansible_hostname
+
 #######################
 # Access type options #
 #######################

--- a/roles/ceph-defaults/templates/restart_nfs_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_nfs_daemon.sh.j2
@@ -2,12 +2,12 @@
 
 RETRIES="{{ handler_health_nfs_check_retries }}"
 DELAY="{{ handler_health_nfs_check_delay }}"
-NFS_NAME="{{ ansible_hostname }}"
+NFS_NAME="ceph-nfs@{{ ceph_nfs_service_suffix | default(ansible_hostname) }}"
 PID=/var/run/ganesha.pid
 
 # First, restart the daemon
 {% if containerized_deployment -%}
-systemctl restart ceph-nfs@${NFS_NAME}
+systemctl restart $NFS_NAME
 COUNT=10
 # Wait and ensure the pid exists after restarting the daemon
 while [ $RETRIES -ne 0 ]; do

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -15,6 +15,13 @@ copy_admin_key: false
 # service is managed by pacemaker
 ceph_nfs_enable_service: true
 
+# ceph-nfs systemd service uses ansible's hostname as an instance id,
+# so service name is ceph-nfs@{{ ansible_hostname }}, this is not
+# ideal when ceph-nfs is managed by pacemaker across multiple hosts - in
+# such case it's better to have constant instance id instead which
+# can be set by 'ceph_nfs_service_suffix'
+# ceph_nfs_service_suffix: ansible_hostname
+
 #######################
 # Access type options #
 #######################

--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -32,7 +32,7 @@
 
 - name: systemd start nfs container
   systemd:
-    name: "ceph-nfs@{{ ansible_hostname }}.service"
+    name: ceph-nfs@{{ ceph_nfs_service_suffix | default(ansible_hostname) }}
     state: started
     enabled: yes
     daemon_reload: yes

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=NFS \
   {{ ceph_nfs_docker_extra_env }} \
-  --name=ceph-nfs-{{ ansible_hostname }} \
+  --name=ceph-nfs-{{ ceph_nfs_service_suffix | default(ansible_hostname) }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/docker stop ceph-nfs-%i
 Restart=always


### PR DESCRIPTION
It's useful to have constant service instance id when ceph-nfs
is managed by pacemaker.