### PR TITLE
Include exports dir in ceph-nfs config file

### DIFF
--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -40,6 +40,9 @@ dummy:
 #ceph_nfs_protocols: "3,4"
 #ceph_nfs_access_type: "RW"
 #ceph_nfs_log_file: "/var/log/ganesha/ganesha.log"
+# whether ganesha config file should include additional
+# sub-directory with exports definitions, this is useful for dynamic exports
+#ceph_nfs_include_exports_dir: false
 
 ####################
 # FSAL Ceph Config #

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -32,6 +32,9 @@ ceph_nfs_pseudo_path: "/cephfile"
 ceph_nfs_protocols: "3,4"
 ceph_nfs_access_type: "RW"
 ceph_nfs_log_file: "/var/log/ganesha/ganesha.log"
+# whether ganesha config file should include additional
+# sub-directory with exports definitions, this is useful for dynamic exports
+ceph_nfs_include_exports_dir: false
 
 ####################
 # FSAL Ceph Config #

--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -19,6 +19,25 @@
   notify:
     - restart ceph nfss
 
+- name: create exports directory
+  file:
+    path: /etc/ganesha/export.d
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: "0755"
+  when: ceph_nfs_include_exports_dir
+
+- name: create exports dir index file
+  copy:
+    content: ""
+    force: no
+    dest: /etc/ganesha/export.d/INDEX.conf
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  when: ceph_nfs_include_exports_dir
+
 - name: generate systemd unit file
   become: true
   template:

--- a/roles/ceph-nfs/templates/ganesha.conf.j2
+++ b/roles/ceph-nfs/templates/ganesha.conf.j2
@@ -1,6 +1,10 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "true"
 # {{ ansible_managed }}
 
+{% if ceph_nfs_include_exports_dir %}
+%include /etc/ganesha/export.d/INDEX.conf
+{% endif %}
+
 {% if nfs_file_gw %}
 EXPORT
 {


### PR DESCRIPTION
Exports dir is used when dynamic exports creation is enabled.