### PR TITLE
Auto discovery of devices for collocated and non-collocated scenarios

### DIFF
--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -61,8 +61,7 @@ osd_crush_location: "\"root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} hos
 #
 
 
-# Declare devices to be used as OSDs
-# All scenario(except 3rd) inherit from the following device declaration
+# Declare the list of devices to be used as OSDs
 
 #devices:
 #  - /dev/sdb
@@ -70,33 +69,60 @@ osd_crush_location: "\"root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} hos
 #  - /dev/sdd
 #  - /dev/sde
 
+# All scenarios (except 3rd) inherit from the following device declaration
 devices: []
 
 
-#'osd_auto_discovery'  mode prevents you from filling out the 'devices' variable above.
-#  You can use this option with First and Forth and Fifth OSDS scenario.
-# Device discovery is based on the Ansible fact 'ansible_devices'
-# which reports all the devices on a system. If chosen all the disks
-# found will be passed to ceph-disk. You should not be worried on using
-# this option since ceph-disk has a built-in check which looks for empty devices.
+# The osd_auto_discovery when set to True would perform auto device discovery
+# and populate the devices and dedicated_devices lists.
+#
+# Auto device discovery is based on the Ansible fact 'ansible_devices' which
+# reports all the devices on a system. For the disks that are selected, they
+# will be passed to ceph-disk.  You should not be worried on using this
+# variable since ceph-disk has a built-in check which looks for empty devices.
 # Thus devices with existing partition tables will not be used.
 #
+# The devices in devices and dedicated_devices variables must be manually
+# populated when osd_auto_discovery is set to False.
+#
+# Set osd_auto_discovery to True in the I and II OSD scenarios to discover
+# the list of available disks.
 osd_auto_discovery: false
+
+# The number of OSDs with their journals on one SSD disk.  If the default
+# is not right, change it here.
+osd_data_journal_ratio: "{{ 5 if osd_scenario == 'non-collocated' else 0 }}"
+
+# The default is to provision a ceph cluster.  This boolean is also used to
+# ensure idempotent when running the roles/ceph-* over-and-over-again.
+osd_provision: true
 
 # Encrypt your OSD device using dmcrypt
 # If set to True, no matter which osd_objecstore and osd_scenario you use the data will be encrypted
 dmcrypt: "{{ True if dmcrytpt_journal_collocation or dmcrypt_dedicated_journal else False }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 
+osd_scenario: "{{ 'collocated' if journal_collocation or dmcrytpt_journal_collocation else 'non-collocated' if raw_multi_journal or dmcrypt_dedicated_journal else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+valid_osd_scenarios:
+  - collocated
+  - non-collocated
+  - lvm
+
 
 # I. First scenario: collocated
 #
-# To enable this scenario do: osd_scenario: collocated
+# To enable this scenario, set osd_scenario to 'collocated'.  The collocated
+# boolean variable is set to 'True' and used throughout.
 #
+# The collected scenario places the OSD's data and journal on the same disk.
+# This scenario works well on environment with all HDD or all SSD disks.  Two
+# partitions are created from the beginning of the disk with the first
+# partition for the data and the second partition for the journal.
 #
-# If osd_objectstore: filestore is enabled both 'ceph data' and 'ceph journal' partitions
-# will be stored on the same device.
+# If osd_objectstore: filestore is enabled both 'ceph data' and 'ceph journal'
+# partitions will be stored on the same device.
 #
-# If osd_objectstore: bluestore is enabled 'ceph data', 'ceph block', 'ceph block.db', 'ceph block.wal' will be stored
+# If osd_objectstore: bluestore is enabled 'ceph data', 'ceph block',
+# 'ceph block.db', 'ceph block.wal' will be stored
 # on the same device. The device will get 2 partitions:
 # - One for 'data', called 'ceph data'
 # - One for 'ceph block', 'ceph block.db', 'ceph block.wal' called 'ceph block'
@@ -107,24 +133,32 @@ dmcrypt: "{{ True if dmcrytpt_journal_collocation or dmcrypt_dedicated_journal e
 # /dev/sda1: UUID="9c43e346-dd6e-431f-92d8-cbed4ccb25f6" TYPE="xfs" PARTLABEL="ceph data" PARTUUID="749c71c9-ed8f-4930-82a7-a48a3bcdb1c7"
 # /dev/sda2: PARTLABEL="ceph block" PARTUUID="e6ca3e1d-4702-4569-abfa-e285de328e9d"
 #
+collocated: "{{ True if osd_scenario == 'collocated' else False }}"
 
-osd_scenario: "{{ 'collocated' if journal_collocation or dmcrytpt_journal_collocation else 'non-collocated' if raw_multi_journal or dmcrypt_dedicated_journal else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
-valid_osd_scenarios:
-  - collocated
-  - non-collocated
-  - lvm
-
-
-# II.  Second scenario: non-collocated
+# II. Second scenario: non-collocated - M journal devices for N OSDs
 #
-# To enable this scenario do: osd_scenario: non-collocated
+# To enable this scenario, set osd_scenario to 'non-collocated'.  The non_collocated
+# boolean variable is set to True and used throughout.
+#
+# The non-collocated scenario places each OSD data on a HDD disk by itself and
+# the OSD journal on a SSD disk that is shared with other OSDs.  This scenario
+# works well on environment with mixture of HDD and SSD disks.  The disks for the
+# OSD data are assigned to the 'devices' list.  The disks for the OSD journals
+# are assigned to the 'dedicated_devices' list.
+#
+# NOTE: If a system has exclusive HDD or SSD disks, the non-collocated
+#       scenario is converted to use the collocated scenario.
+#
+# In the following example: M is 2 (sdf sdg in dedicated_devices)
+#                           N is 4 (sdb sdc sdd sde in devices)
 #
 # If osd_objectstore: filestore is enabled 'ceph data' and 'ceph journal' partitions
 # will be stored on different devices:
 # - 'ceph data' will be stored on the device listed in 'devices'
 # - 'ceph journal' will be stored on the device listed in 'dedicated_devices'
 #
-# Let's take an example, imagine 'devices' was declared like this:
+# Let's take an example, imagine 'devices' was declared like this (either
+# through auto discovery or manually filled):
 #
 # devices:
 #   - /dev/sda
@@ -136,19 +170,32 @@ valid_osd_scenarios:
 #
 # dedicated_devices:
 #   - /dev/sdf
+#   - /dev/sdg
+#
+# The dedicated_devices list is filled with additional devices to match
+# the number of entries in the devices list.
+#
+# dedicated_devices:
 #   - /dev/sdf
 #   - /dev/sdg
+#   - /dev/sdf
 #   - /dev/sdg
 #
 # This will result in the following mapping:
 # - /dev/sda will have /dev/sdf1 as a journal
-# - /dev/sdb will have /dev/sdf2 as a journal
-# - /dev/sdc will have /dev/sdg1 as a journal
+# - /dev/sdb will have /dev/sdg1 as a journal
+# - /dev/sdc will have /dev/sdf2 as a journal
 # - /dev/sdd will have /dev/sdg2 as a journal
 #
+# Instead of manually assigning disks to devices and dedicated_devices
+# lists, the discover_devices.yml is automated to select the M SSD disks
+# for the journal and the N HDD disks for the data.
 #
-# If osd_objectstore: bluestore is enabled, both 'ceph block.db' and 'ceph block.wal' partitions will be stored
-# on a dedicated device.
+# In auto discovery, M and N are set to the respective discovered devices
+# on a system.
+#
+# If osd_objectstore: bluestore is enabled, both 'ceph block.db' and
+# 'ceph block.wal' partitions will be stored on a dedicated device.
 #
 # So the following will happen:
 # - The devices listed in 'devices' will get 2 partitions, one for 'block' and one for 'data'.
@@ -167,7 +214,13 @@ valid_osd_scenarios:
 # /dev/sdb: PTTYPE="gpt"
 # /dev/sdb1: PARTLABEL="ceph block.db" PARTUUID="af5b2d74-4c08-42cf-be57-7248c739e217"
 # /dev/sdb2: PARTLABEL="ceph block.wal" PARTUUID="af3f8327-9aa9-4c2b-a497-cf0fe96d126a"
+
+non_collocated: "{{ True if osd_scenario == 'non-collocated' else False }}"
 dedicated_devices: []
+
+# Use this boolean variable instead of checking for non_collocated and
+# osd_auto_discovery
+non_collo_auto_disco: "{{ True if osd_auto_discovery and non_collocated else False }}"
 
 
 # More device granularity for Bluestore
@@ -234,6 +287,8 @@ bluestore_wal_devices: "{{ dedicated_devices }}"
 #     data_vg: vg4
 
 lvm_volumes: []
+
+lvm: "{{ True if osd_scenario == 'lvm' else False }}"
 
 
 ##########

--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -12,6 +12,16 @@
   when:
     - not osd_auto_discovery
 
+- name: automatically activate osd disk(s) without partitions
+  command: ceph-disk activate "{{ item | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1"
+  with_items: "{{ devices|unique }}"
+  changed_when: false
+  failed_when: false
+  register: activate_osd_disk
+  when:
+    - collocated
+    - osd_auto_discovery
+
 - name: activate osd(s) when device is a disk (dmcrypt)
   command: ceph-disk activate --dmcrypt {{ item | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
   with_items:

--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -42,10 +42,11 @@
     - "{{ dedicated_devices|unique }}"
   changed_when: false
   failed_when: false
-  check_mode: no
   register: journal_partition_status
   when:
-    - osd_scenario == 'non-collocated'
+    - non_collocated
+  tags:
+    - always
 
 - name: fix partitions gpt header or labels of the journal device(s)
   shell: "sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }} || sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }}"
@@ -55,7 +56,7 @@
   changed_when: false
   when:
     - not containerized_deployment
-    - osd_scenario == 'non-collocated'
+    - non_collocated
     - not item.0.get("skipped")
     - item.0.get("rc", 0) != 0
 
@@ -67,6 +68,6 @@
   changed_when: false
   when:
     - containerized_deployment
-    - osd_scenario == 'non-collocated'
+    - non_collocated
     - not item.0.get("skipped")
     - item.0.get("rc", 0) != 0

--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -10,26 +10,41 @@
 # allow 2-digit partition numbers so fast SSDs can be shared by > 9 disks
 # for SSD journals.
 
+# After devices discovery, sanity check the devices, dedicated_devices, osd_scenario
+- name: verify devices and dedicaed_devices in non-collocation scenario
+  fail:
+    msg: "non-collocation needs devices in devices and dedicated_devices lists"
+  when:
+    - non_collocated
+    - devices|length == 0 or dedicated_devices|length == 0
+
+- name: verify devices in collocation scenario
+  fail:
+    msg: "collocation needs devices in devices list"
+  when:
+    - collocated
+    - devices|length == 0
+
 - name: resolve dedicated device link(s)
   command: readlink -f {{ item }}
   changed_when: false
   with_items: "{{ dedicated_devices }}"
   register: dedicated_devices_prepare_canonicalize
   when:
-    - osd_scenario == 'non-collocated'
+    - non_collocated
 
 - name: set_fact build dedicated_devices from resolved symlinks
   set_fact:
     dedicated_devices_tmp: "{{ dedicated_devices_tmp | default([]) + [ item.stdout ] }}"
   with_items: "{{ dedicated_devices_prepare_canonicalize.results }}"
   when:
-    - osd_scenario == 'non-collocated'
+    - non_collocated
 
 - name: set_fact build final dedicated_devices list
   set_fact:
     dedicated_devices: "{{ dedicated_devices_tmp | reject('search','/dev/disk') | list }}"
   when:
-    - osd_scenario == 'non-collocated'
+    - non_collocated
 
 - name: include check_devices_static.yml
   include: check_devices_static.yml

--- a/roles/ceph-osd/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-osd/tasks/check_mandatory_vars.yml
@@ -1,4 +1,10 @@
 ---
+- name: verify the osd_group_name is valid
+  fail:
+    msg: "osd_group_name is either not defined or not a member of group_names"
+  when:
+    - osd_group_name is not defined or osd_group_name not in group_names
+
 - name: make sure public_network configured
   fail:
     msg: "public_network must be configured. Ceph public network"
@@ -18,51 +24,34 @@
   when:
     - journal_size|int < 5120
     - osd_objectstore == 'filestore'
-    - osd_group_name in group_names
 
-- name: make sure an osd scenario was chosen
+- name: verify a valid osd scenario was chosen
   fail:
-    msg: "please choose an osd scenario"
+    msg: "The scenario {{ osd_scenario }} is invalid or not supported, valid scenarios are {{ valid_osd_scenarios }}"
   when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
-    - osd_scenario == 'dummy'
+    - osd_scenario not in valid_osd_scenarios
 
-- name: make sure a valid osd scenario was chosen
+- name: verify devices have been populated in non-auto discovery
   fail:
-    msg: "please choose an osd scenario, valid scenarios are {{ valid_osd_scenarios }}"
+    msg: "specify discovery option or pre-populate devices for your osd scenario"
   when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
-    - not osd_scenario in valid_osd_scenarios
-
-- name: verify devices have been provided
-  fail:
-    msg: "please provide devices to your osd scenario"
-  when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
+    - collocated or non_collocated
     - not osd_auto_discovery
-    - not osd_scenario == "lvm"
     - devices|length == 0
 
 - name: check if osd_scenario lvm is supported by the selected ceph version
   fail:
     msg: "osd_scenario lvm is not supported by the selected Ceph version, use Luminous or newer."
   when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
     - not containerized_deployment
-    - osd_scenario == "lvm"
+    - lvm
     - ceph_release_num[ceph_release] < ceph_release_num.luminous
 
 - name: verify lvm_volumes have been provided
   fail:
     msg: "please provide lvm_volumes to your osd scenario"
   when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
-    - osd_scenario == "lvm"
+    - lvm
     - not osd_auto_discovery
     - lvm_volumes|length == 0
 
@@ -70,47 +59,43 @@
   fail:
     msg: "lvm_volumes: must be a list"
   when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
+    - lvm
     - not osd_auto_discovery
-    - osd_scenario == "lvm"
     - lvm_volumes is string
 
 - name: make sure the devices variable is a list
   fail:
     msg: "devices: must be a list, not a string, i.e. [ \"/dev/sda\" ]"
   when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
-    - not osd_auto_discovery
+    - collocated or non_collocated
     - devices is string
-
-- name: verify dedicated devices have been provided
-  fail:
-    msg: "please provide devices and dedicated_devices to your osd scenario"
-  when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
-    - osd_scenario == 'non-collocated'
-    - dedicated_devices|length == 0
-      or devices|length == 0
 
 - name: make sure the dedicated_devices variable is a list
   fail:
-    msg: "dedicated_devices: must be a list, not a string, i.e. [ \"/dev/sda\" ]"
+    msg: "dedicated_devices: must be a list, not a string, i.e. [ \"/dev/sdj\" ]"
   when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
-    - osd_scenario == 'non-collocated'
+    - non_collocated
     - dedicated_devices is string
+
+- name: verify journal devices have been populated in non-auto discovery
+  fail:
+    msg: "specify discovery option or pre-populate ceph journal devices in non-collocated osd scenario"
+  when:
+    - non_collocated
+    - not osd_auto_discovery
     - dedicated_devices|length == 0
-      or devices|length == 0
+
+- name: verify auto discovery populates devices and journal devices
+  fail:
+    msg: "auto discovery did not populate devices and journal devices"
+  when:
+    - osd_auto_discovery
+    - (collocated and devices|length == 0) or
+      (non_collocated and devices|length == 0 and dedicated_devices|length == 0)
 
 - name: check if bluestore is supported by the selected ceph version
   fail:
     msg: "bluestore is not supported by the selected Ceph version, use Luminous or above."
   when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
     - osd_objectstore == 'bluestore'
     - ceph_release_num[ceph_release] < ceph_release_num.luminous

--- a/roles/ceph-osd/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-osd/tasks/check_mandatory_vars.yml
@@ -85,13 +85,19 @@
     - not osd_auto_discovery
     - dedicated_devices|length == 0
 
-- name: verify auto discovery populates devices and journal devices
+- name: verify non-collocation scenario and the devices and dedicated_devices lists
   fail:
-    msg: "auto discovery did not populate devices and journal devices"
+    msg: "non-collocation scenario has mismatch in osd_auto_discovery, devices, and dedicated_devices lists"
   when:
-    - osd_auto_discovery
-    - (collocated and devices|length == 0) or
-      (non_collocated and devices|length == 0 and dedicated_devices|length == 0)
+    - non_collocated
+    - (osd_auto_discovery and (devices|length > 0 or dedicated_devices|length > 0)) or (not osd_auto_discovery and (devices|length == 0 or dedicated_devices|length == 0))
+
+- name: verify collocation scenario and the devices list
+  fail:
+    msg: "collocation scenario has mismatch in osd_auto_discovery and devices list"
+  when:
+    - collocated
+    - (osd_auto_discovery and devices|length > 0) or (not osd_auto_discovery and devices|length == 0)
 
 - name: check if bluestore is supported by the selected ceph version
   fail:

--- a/roles/ceph-osd/tasks/discover_devices.yml
+++ b/roles/ceph-osd/tasks/discover_devices.yml
@@ -1,0 +1,46 @@
+---
+- name: verifies devices and osd_auto_discovery for collocated scenario
+  fail:
+    msg: "collocated has a mismatch in auto discovery and devices list"
+  when:
+    - collocated
+    - (osd_auto_discovery and devices|length > 0) or (not osd_auto_discovery and devices|length == 0)
+
+- name: verifies devices, dedicated_devices, osd_auto_discovery for non-collocated scenario
+  fail:
+    msg: "non-collocated scenario has a mismatch in auto discovery and devices/dedicated_devices lists"
+  when:
+    - non_collocated
+    - (osd_auto_discovery and (devices|length > 0 or dedicated_devices|length > 0)) or (not osd_auto_discovery and (devices|length == 0 or dedicated_devices|length == 0))
+
+- name: populating the devices list with devices from auto discovery
+  set_fact:
+    devices: "{{ devices | default([]) }} + [ '/dev/{{ item.key }}' ]"
+  with_dict: "{{ ansible_devices }}"
+  when:
+    - osd_auto_discovery
+    - ansible_devices is defined
+    - item.value.removable == "0"
+    - item.value.partitions|count == 0
+    - item.value.holders|count == 0
+
+# Cannot modify the devices list while iterating over the list.
+# In non-collocated scenario, the non rotational SSD disks are sought for
+# storing the ceph journals.
+- name: populating the dedicated_devices list with devices from auto discovery
+  set_fact:
+    dedicated_devices: "{{ dedicated_devices|default([]) }} + [ '{{ item }}' ]"
+  with_items: "{{ devices }}"
+  when:
+    - ansible_devices.{{ item | basename }}.rotational == "0"
+    - devices|length > 0
+    - non_collo_auto_disco
+
+# Update the list devices
+- name: remove dedicated devices from devices list
+  set_fact:
+    devices: "{{ devices | difference(dedicated_devices) }}"
+  when:
+    - devices|length > 0
+    - dedicated_devices|length > 0
+    - non_collo_auto_disco

--- a/roles/ceph-osd/tasks/docker/start_docker_osd.yml
+++ b/roles/ceph-osd/tasks/docker/start_docker_osd.yml
@@ -38,7 +38,7 @@
 
 - name: systemd start osd container
   systemd:
-    name: ceph-osd@{{ item | regex_replace('/dev/', '') }}
+    name: ceph-osd@{{ item | basename }}
     state: started
     enabled: yes
     daemon_reload: yes

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -18,16 +18,8 @@
 - name: include ceph_disk_cli_options_facts.yml
   include: ceph_disk_cli_options_facts.yml
 
-- name: set_fact devices generate device list when osd_auto_discovery
-  set_fact:
-    devices: "{{ devices | default([]) + [ item.key | regex_replace('^', '/dev/') ] }}"
-  with_dict: "{{ ansible_devices }}"
-  when:
-    - osd_auto_discovery
-    - ansible_devices is defined
-    - item.value.removable == "0"
-    - item.value.partitions|count == 0
-    - item.value.holders|count == 0
+- name: include discover_devices.yml
+  include: discover_devices.yml
 
 - name: include check_devices.yml
   include: check_devices.yml
@@ -49,26 +41,9 @@
     - containerized_deployment
     - not containerized_deployment_with_kv
 
-- name: include scenarios/collocated.yml
-  include: scenarios/collocated.yml
-  when:
-    - osd_scenario == 'collocated'
-  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
-  static: False
-
-- name: include scenarios/non-collocated.yml
-  include: scenarios/non-collocated.yml
-  when:
-    - not osd_auto_discovery
-    - osd_scenario == 'non-collocated'
-  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
-  static: False
-
-- name: include scenarios/lvm.yml
-  include: scenarios/lvm.yml
-  when:
-    - osd_scenario == 'lvm'
-    - not containerized_deployment
+# osd_scenario's value was verified in check_mandatory_vars.yml
+- name: include scenarios/{{ osd_scenario }}.yml
+  include: scenarios/{{ osd_scenario }}.yml
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 

--- a/roles/ceph-osd/tasks/scenarios/collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/collocated.yml
@@ -1,4 +1,9 @@
 ---
+- name: scenario 1 - every osd data and journal collocated on the same device
+  fail:
+    msg: "OSD scenario {{ osd_scenario }} is not collocated"
+  when: not collocated
+
 # use shell rather than docker module
 # to ensure osd disk prepare finishes before
 # starting the next task
@@ -8,7 +13,7 @@
     --rm \
     --pid=host \
     --privileged=true \
-    --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.1 | regex_replace('/dev/', '') }} \
+    --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.1 | basename }} \
     -v /etc/ceph:/etc/ceph \
     -v /var/lib/ceph/:/var/lib/ceph/ \
     -v /dev:/dev \
@@ -35,7 +40,7 @@
     --rm \
     --pid=host \
     --privileged=true \
-    --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.key }} \
+    --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item | basename }} \
     -v /etc/ceph:/etc/ceph \
     -v /var/lib/ceph/:/var/lib/ceph/ \
     -v /dev:/dev \
@@ -43,18 +48,21 @@
     -e DEBUG=verbose \
     -e CLUSTER={{ cluster }} \
     -e CEPH_DAEMON=OSD_CEPH_DISK_PREPARE \
-    -e OSD_DEVICE=/dev/{{ item.key }} \
+    -e OSD_DEVICE={{ item }} \
     {{ docker_env_args }} \
     {{ ceph_osd_docker_prepare_env }} \
     {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
-  with_dict: "{{ ansible_devices }}"
+  with_items: "{{ devices }}"
   when:
     - osd_auto_discovery
     - containerized_deployment
-    - ansible_devices is defined
-    - item.value.removable == "0"
-    - item.value.partitions|count == 0
-    - item.value.holders|count == 0
+
+- name: automatically prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) with collocated osd data and journal
+  command: "ceph-disk prepare {{ ceph_disk_cli_options }} {{ item }}"
+  with_items: "{{ devices }}"
+  when:
+    - osd_auto_discovery
+    - not containerized_deployment
 
 - name: manually prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) with collocated osd data and journal
   command: "ceph-disk prepare {{ ceph_disk_cli_options }} {{ item.1 }}"
@@ -63,5 +71,6 @@
     - "{{ devices }}"
   when:
     - not containerized_deployment
+    - not osd_auto_discovery
     - not item.0.get("skipped")
     - item.0.get("rc", 0) != 0

--- a/roles/ceph-osd/tasks/scenarios/lvm.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm.yml
@@ -1,4 +1,8 @@
 ---
+- name: scenario 3 - use lvm volumes to store OSD data and journal
+  fail:
+    msg: "OSD scenario {{ osd_scenario }} is not lvm"
+  when: not lvm
 
 - name: list all lvm osds
   command: ceph-volume lvm list

--- a/roles/ceph-osd/tasks/scenarios/non-collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/non-collocated.yml
@@ -1,4 +1,71 @@
 ---
+- name: scenario 2 - osds round-robin their journals on dedicated devices
+  fail:
+    msg: "OSD scenario {{ osd_scenario }} is not non-collocated"
+  when: not non_collocated
+
+# ceph.service does not appear to be configured anymore.  Need to find a
+# way to ensure idempotency on the devices and dedicated_devices with
+# respect to osd_provision boolean variable.
+
+# Each OSD device in the devices list has a corresponding journal device in
+# the dedicated_devices list.  Use round-robin to fill up the remaining
+# entries in the dedicated_devices to match the entries in the devices list.
+#
+# For example, assuming the devices list has these entries on a system
+# devices: [ /dev/sdt, /dev/sdu, /dev/sdv, /dev/sdw, /dev/sdx ]
+# On this system, it has two SSD disks
+# dedicated_devices: [ /dev/sdb, /dev/sdc ]
+#
+# In this use case, we need to add three more entries to dedicated_devices:
+# dedicated_devices: [ /dev/sdb, /dev/sdc, /dev/sdb, /dev/sdc, /dev/sdb ]
+#
+# Each distinct device in dedicated_devices can only be used up to the ratio
+# set in the osd_data_journal_ratio tunable.
+- name: set_fact journal_cnt temporary variable for populating dedicated_devices list
+  set_fact:
+    journal_cnt: "{{ dedicated_devices|length|int }}"
+
+# These devices in the devices list are used to create file systems that
+# store the OSD data.
+# devices:
+#   - "/dev/sdt"
+#   - "/dev/sdu"
+#   - "/dev/sdv"
+#   - "/dev/sdw"
+#   - "/dev/sdx"
+#
+# The dedicated_devices list has the list of devices for the OSD journals.
+# A journal disk is shared with certain number of OSD data.  Assuming that
+# there are two SSD disks that are picked as journal disks.
+# dedicated_devices:
+#   - "/dev/sdb"
+#   - "/dev/sdc"
+#
+# The 'ceph-disk prepare' handles the creation of a journal partition with
+# the size specified by the journal_size tunable in the ceph.conf file.
+#
+# This task loops over the devices list and fill in the missing journal disk
+# in the dedicated_devices.  The round-robin method is used.
+# dedicated_devices:
+#   - "/dev/sdb"
+#   - "/dev/sdc"
+#   - "/dev/sdb"
+#   - "/dev/sdc"
+#   - "/dev/sdb"
+- name: set_fact dedicated_devices assign a journal device to each osd
+  set_fact:
+    dedicated_devices: "{{ dedicated_devices }} + [ '{{ dedicated_devices[ item.0 % journal_cnt|int ] }}' ]"
+  with_indexed_items: "{{ devices }}"
+  when:
+    - dedicated_devices|length < devices|length
+
+- name: entries in devices and dedicated_devices lists are the same
+  fail:
+    msg: "Entries in devices and dedicated_devices are not the same"
+  when:
+    - devices|length != dedicated_devices|length
+
 # use shell rather than docker module
 # to ensure osd disk prepare finishes before
 # starting the next task
@@ -8,7 +75,7 @@
     --rm \
     --pid=host \
     --privileged=true \
-    --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.1 | regex_replace('/dev/', '') }} \
+    --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.1 | basename }} \
     -v /etc/ceph:/etc/ceph \
     -v /var/lib/ceph/:/var/lib/ceph/ \
     -v /dev:/dev \
@@ -37,7 +104,7 @@
     --rm \
     --pid=host \
     --privileged=true \
-    --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.1 | regex_replace('/dev/', '') }} \
+    --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.1 | basename }} \
     -v /etc/ceph:/etc/ceph \
     -v /var/lib/ceph/:/var/lib/ceph/ \
     -v /dev:/dev \


### PR DESCRIPTION
The changes in this pull request were tested and deployed into production
in our environment.  The collocated and non-collocated scenarios are the ones
we focused on.

Added the ceph-osd/tasks/discover_devices.yml to inventory the ansible_devices
dictionary for the list of usable devices.  The discovered devices in the
devices list are applicable to all the supported scenarios.

In the ceph-osd/tasks/main.yml, include the discover_devices.yml before the
check_devices.yml to populate the devices and dedicated_devices (when
non-collocated scenario is chosen) lists.  Use the osd_scenario to include
the correct scenario in tasks/scenarios/*.yml.

Added additional checks in the check_mandatory_vars.yml file.

The directive always_run is obsolete. Replaced it with the tags set to always.