### PR TITLE
Fix bind mount for /var/lib/nfs/ganesha directory

### DIFF
--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -11,7 +11,7 @@ ExecStart=/usr/bin/docker run --rm --net=host \
   {% if not containerized_deployment_with_kv -%}
   -v /var/lib/ceph:/var/lib/ceph \
   -v /etc/ceph:/etc/ceph \
-  -v /var/lib/ganesha:/var/lib/ganesha \
+  -v /var/lib/nfs/ganesha:/var/lib/nfs/ganesha \
   -v /etc/ganesha:/etc/ganesha \
   {% else -%}
   -e KV_TYPE={{kv_type}} \


### PR DESCRIPTION
It's useful to keep logs permanently, also this fixes bind mount
for /var/lib/nfs/ganesha directory.