### PR TITLE
DNM: ci: test remove CEPH_STABLE_RELEASE

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
       ireallymeanit=yes \
       remove_packages=yes \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
@@ -23,7 +22,6 @@ commands=
 
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
@@ -40,7 +38,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
       ireallymeanit=yes \
       remove_packages=yes \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
@@ -51,7 +48,6 @@ commands=
 
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
@@ -138,15 +134,11 @@ setenv=
   shrink_mon_container: MON_TO_KILL = mon2
   shrink_osd_container: PLAYBOOK = site-docker.yml.sample
 
-  rhcs: CEPH_STABLE_RELEASE = luminous
-  jewel: CEPH_STABLE_RELEASE = jewel
   jewel: CEPH_DOCKER_IMAGE_TAG = tag-build-master-jewel-ubuntu-16.04
   jewel: UPDATE_CEPH_STABLE_RELEASE = kraken
-  luminous: CEPH_STABLE_RELEASE = luminous
   luminous: CEPH_DOCKER_IMAGE_TAG = tag-build-master-luminous-ubuntu-16.04
   luminous: UPDATE_CEPH_STABLE_RELEASE = luminous
   luminous: UPDATE_CEPH_DOCKER_IMAGE_TAG = tag-build-master-luminous-ubuntu-16.04
-  lvm_osds: CEPH_STABLE_RELEASE = luminous
 deps=
   ansible2.2: ansible==2.2.3
   ansible2.3: ansible==2.3.1
@@ -207,7 +199,6 @@ commands=
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \
@@ -234,7 +225,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} \
       --extra-vars "\
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \


### PR DESCRIPTION
The CEPH_STABLE_RELEASE, ceph_stable_release is hardcoded in tox, which
makes the playbook passing when sometimes it should fail.
So let's remove it since this variable is generated by the playbook
itself during the play.

Signed-off-by: Sébastien Han <seb@redhat.com>