### PR TITLE
common: remove unusuable conditions

### DIFF
--- a/roles/ceph-common/tasks/installs/install_debian_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_packages.yml
@@ -68,4 +68,3 @@
     default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
   when:
     - mgr_group_name in group_names
-    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel

--- a/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
@@ -77,4 +77,3 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - mgr_group_name in group_names
-    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel

--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -100,7 +100,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - mgr_group_name in group_names
-    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel
 
 - name: install redhat ceph iscsi package
   package:
@@ -112,4 +111,3 @@
     - targetcli
   when:
     - iscsi_gw_group_name in group_names
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous


### PR DESCRIPTION
`ceph_release` isn't available at this step of the playbook because it
is set later based on the installed binaries.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1486062

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>