### PR TITLE
[skip ci] osd: do not do unique on dedicated_devices

### DIFF
--- a/roles/ceph-osd/tasks/check_devices.yml
+++ b/roles/ceph-osd/tasks/check_devices.yml
@@ -27,7 +27,7 @@
 
 - name: set_fact build final dedicated_devices list
   set_fact:
-    dedicated_devices: "{{ dedicated_devices | reject('search','/dev/disk') | list | unique }}"
+    dedicated_devices: "{{ dedicated_devices | reject('search','/dev/disk') | list }}"
   when:
     - osd_scenario == 'non-collocated'
 


### PR DESCRIPTION
This is needed later, if we do unique, only the first OSD will get a
journal.

Signed-off-by: Sébastien Han <seb@redhat.com>