### PR TITLE
[skip ci] purge: fix journal purge

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -394,7 +394,7 @@
       - "{{ ceph_lockbox_partition_to_erase_path.stdout_lines | default([]) }}"
     when:
       - ceph_disk_present.rc == 0
-      - ceph_data_partlabels.rc == 0
+      - (ceph_data_partlabels.rc == 0 or ceph_lockbox_partlabels.rc == 0)
 
   # this should go away once 'ceph-volume lvm zap' is available
   - name: remove osd logical volumes
@@ -461,7 +461,6 @@
       - "{{ ceph_wal_partition_to_erase_path.stdout_lines | default([]) }}"
     when:
       - (ceph_block_partlabels.rc == 0 or ceph_journal_partlabels.rc == 0 or ceph_db_partlabels.rc == 0 or ceph_wal_partlabels.rc == 0)
-      - osd_scenario == 'non-collocated'
 
 - name: purge ceph mon cluster
 


### PR DESCRIPTION
Using a condition when osd_scenario == 'non-collocated' was wrong since
these partitions can be collocated on a single device also. Removing the
check makes the purge of these partitions.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1499871
Signed-off-by: Sébastien Han <seb@redhat.com>