### PR TITLE
Ceph-nfs dynamic exports fixes

### DIFF
--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -43,9 +43,7 @@ dummy:
 # NFS Ganesha Config #
 ######################
 #ceph_nfs_log_file: "/var/log/ganesha/ganesha.log"
-# whether ganesha config file should include additional
-# sub-directory with exports definitions, this is useful for dynamic exports
-#ceph_nfs_include_exports_dir: false
+#ceph_nfs_dynamic_exports: false
 
 ####################
 # FSAL Ceph Config #

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -35,9 +35,7 @@ nfs_obj_gw: true
 # NFS Ganesha Config #
 ######################
 ceph_nfs_log_file: "/var/log/ganesha/ganesha.log"
-# whether ganesha config file should include additional
-# sub-directory with exports definitions, this is useful for dynamic exports
-ceph_nfs_include_exports_dir: false
+ceph_nfs_dynamic_exports: false
 
 ####################
 # FSAL Ceph Config #

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -37,3 +37,19 @@
   when:
     - ansible_os_family == 'RedHat'
     - sestatus.stdout != 'Disabled'
+
+- name: create dbus service file
+  become: true
+  template:
+    src: "{{ role_path }}/templates/org.ganesha.nfsd.conf"
+    dest: /etc/dbus-1/system.d/org.ganesha.nfsd.conf
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  when:
+    - ceph_nfs_dynamic_exports
+
+- name: reload dbus configuration
+  command: "killall -SIGHUP dbus-daemon"
+  when:
+    - ceph_nfs_dynamic_exports

--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -26,7 +26,7 @@
     owner: "root"
     group: "root"
     mode: "0755"
-  when: ceph_nfs_include_exports_dir
+  when: ceph_nfs_dynamic_exports
 
 - name: create exports dir index file
   copy:
@@ -36,7 +36,7 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  when: ceph_nfs_include_exports_dir
+  when: ceph_nfs_dynamic_exports
 
 - name: generate systemd unit file
   become: true

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -13,6 +13,10 @@ ExecStart=/usr/bin/docker run --rm --net=host \
   -v /etc/ceph:/etc/ceph \
   -v /var/lib/nfs/ganesha:/var/lib/nfs/ganesha \
   -v /etc/ganesha:/etc/ganesha \
+  {% if ceph_nfs_dynamic_exports %}
+  --privileged \
+  -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket \
+  {% endif -%}
   {% else -%}
   -e KV_TYPE={{kv_type}} \
   -e KV_IP={{kv_endpoint}}\

--- a/roles/ceph-nfs/templates/ganesha.conf.j2
+++ b/roles/ceph-nfs/templates/ganesha.conf.j2
@@ -1,7 +1,7 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "true"
 # {{ ansible_managed }}
 
-{% if ceph_nfs_include_exports_dir %}
+{% if ceph_nfs_dynamic_exports %}
 %include /etc/ganesha/export.d/INDEX.conf
 {% endif %}
 


### PR DESCRIPTION
* DBus on host should include ganesha service file
* to allow ganesha container to respond on DBus it needs to run
  in --privileged mode (ganesha folks contacted to look at this)
* ceph_nfs_include_exports_dir variable replaced with more general
  ceph_nfs_dynamic_exports