### PR TITLE
[skip ci] bpk-2021 - Remove duplicate 'package' key

### DIFF
--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -43,7 +43,6 @@
 
 - name: install redhat ceph-base package
   package:
-  package:
     name: "ceph-base"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:


### PR DESCRIPTION
This patch fixes a typo where "package:" was used twice in the same
task.

(cherry picked from commit 10e1d464e5664e4f440378289b96c70f1aa1e1b3)
Signed-off-by: Sébastien Han <seb@redhat.com>