### PR TITLE
tests: rbd/rgw adapt testinfra for jewel

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,12 @@ def node(host, request):
     docker = ansible_vars.get("docker")
     osd_auto_discovery = ansible_vars.get("osd_auto_discovery")
     lvm_scenario = ansible_vars.get("osd_scenario") == 'lvm'
+    ceph_release_num = {
+      'jewel': 10,
+      'kraken': 11,
+      'luminous': 12,
+      'mimic': 13
+    }
     if not request.node.get_marker(node_type) and not request.node.get_marker('all'):
         pytest.skip("Not a valid test for node type: %s" % node_type)
 
@@ -41,6 +47,12 @@ def node(host, request):
 
     if node_type == "nfss" and ceph_stable_release == "jewel":
         pytest.skip("nfs nodes can not be tested with ceph release jewel")
+
+    if request.node.get_marker("from_luminous") and ceph_release_num[ceph_stable_release] < ceph_release_num['luminous']:
+        pytest.skip("This test is only valid for releases starting from Luminous and above")
+
+    if request.node.get_marker("before_luminous") and ceph_release_num[ceph_stable_release] >= ceph_release_num['luminous']:
+        pytest.skip("This test is only valid for release before Luminous")
 
     journal_collocation_test = ansible_vars.get("osd_scenario") == "collocated"
     if request.node.get_marker("journal_collocation") and not journal_collocation_test:

--- a/tests/functional/centos/7/docker-collocation/ceph-override.json
+++ b/tests/functional/centos/7/docker-collocation/ceph-override.json
@@ -1,0 +1,1 @@
+../cluster/ceph-override.json

--- a/tests/functional/tests/rbd-mirror/test_rbd_mirror.py
+++ b/tests/functional/tests/rbd-mirror/test_rbd_mirror.py
@@ -1,5 +1,6 @@
 import pytest
 import json
+import os
 
 class TestRbdMirrors(object):
 
@@ -7,19 +8,51 @@ class TestRbdMirrors(object):
     def test_rbd_mirror_is_installed(self, node, host):
         assert host.package("rbd-mirror").is_installed
 
-    def test_rbd_mirror_service_is_running(self, node, host):
+    @pytest.mark.no_docker
+    @pytest.mark.before_luminous
+    def test_rbd_mirror_service_is_running_before_luminous(self, node, host):
+        service_name = "ceph-rbd-mirror@admin"
+        assert host.service(service_name).is_running
+
+    @pytest.mark.docker
+    @pytest.mark.before_luminous
+    def test_rbd_mirror_service_is_running_docker_before_luminous(self, node, host):
         service_name = "ceph-rbd-mirror@rbd-mirror.{hostname}".format(
             hostname=node["vars"]["inventory_hostname"]
         )
         assert host.service(service_name).is_running
 
-    def test_rbd_mirror_service_is_enabled(self, node, host):
+    @pytest.mark.docker
+    @pytest.mark.from_luminous
+    def test_rbd_mirror_service_is_running_docker_from_luminous(self, node, host):
+        service_name = "ceph-rbd-mirror@rbd-mirror.{hostname}".format(
+            hostname=node["vars"]["inventory_hostname"]
+        )
+        assert host.service(service_name).is_running
+
+    @pytest.mark.no_docker
+    @pytest.mark.before_luminous
+    def test_rbd_mirror_service_is_enabled_before_luminous(self, node, host):
+        service_name = "ceph-rbd-mirror@admin"
+        assert host.service(service_name).is_enabled
+
+    @pytest.mark.docker
+    @pytest.mark.before_luminous
+    def test_rbd_mirror_service_is_enabled_docker_before_luminous(self, node, host):
+        service_name = "ceph-rbd-mirror@rbd-mirror.{hostname}".format(
+            hostname=node["vars"]["inventory_hostname"]
+        )
+        assert host.service(service_name).is_enabled
+
+    @pytest.mark.from_luminous
+    def test_rbd_mirror_service_is_enabled_from_luminous(self, node, host):
         service_name = "ceph-rbd-mirror@rbd-mirror.{hostname}".format(
             hostname=node["vars"]["inventory_hostname"]
         )
         assert host.service(service_name).is_enabled
 
     @pytest.mark.no_docker
+    @pytest.mark.from_luminous
     def test_rbd_mirror_is_up(self, node, host):
         hostname = node["vars"]["inventory_hostname"]
         cluster = node['cluster_name']
@@ -32,6 +65,7 @@ class TestRbdMirrors(object):
         assert hostname in daemons
 
     @pytest.mark.docker
+    @pytest.mark.from_luminous
     def test_docker_rbd_mirror_is_up(self, node, host):
         hostname = node["vars"]["inventory_hostname"]
         cluster = node['cluster_name']

--- a/tests/functional/tests/rgw/test_rgw.py
+++ b/tests/functional/tests/rgw/test_rgw.py
@@ -23,6 +23,7 @@ class TestRGWs(object):
         assert host.service(service_name).is_enabled
 
     @pytest.mark.no_docker
+    @pytest.mark.from_luminous
     def test_rgw_is_up(self, node, host):
         hostname = node["vars"]["inventory_hostname"]
         cluster = node['cluster_name']
@@ -42,6 +43,7 @@ class TestRGWs(object):
 
 
     @pytest.mark.docker
+    @pytest.mark.from_luminous
     def test_docker_rgw_is_up(self, node, host):
         hostname = node["vars"]["inventory_hostname"]
         cluster = node['cluster_name']


### PR DESCRIPTION
- the rbd-mirror unit systemd name is not the same when running jewel vs
luminous.
- servicemap is not available on jewel.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>