### PR TITLE
Pass list of packages instead of with_items

### DIFF
--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -1,17 +1,15 @@
 ---
 - name: install redhat dependencies
   package:
-    name: "{{ item }}"
+    name: "{{ redhat_package_dependencies }}"
     state: present
-  with_items: "{{ redhat_package_dependencies }}"
   when:
     - ansible_distribution == 'RedHat'
 
 - name: install centos dependencies
   yum:
-    name: "{{ item }}"
+    name: "{{ centos_package_dependencies }}"
     state: present
-  with_items: "{{ centos_package_dependencies }}"
   when:
     - ansible_distribution == 'CentOS'
 


### PR DESCRIPTION
Modern versions of Ansible can handle a list of packages passed
directly to the package modules. This patch optimizes the package
install process by passing the list of packages directly to the
module.