### PR TITLE
Suppress yum/dnf/rpm command warnings

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -610,6 +610,8 @@
 
   - name: remove package dependencies on redhat
     command: yum -y autoremove
+    args:
+      warn: no
     when:
       ansible_os_family == 'RedHat' and
       ansible_pkg_mgr == "yum" and
@@ -617,6 +619,8 @@
 
   - name: remove package dependencies on redhat again
     command: yum -y autoremove
+    args:
+      warn: no
     when:
       ansible_os_family == 'RedHat' and
       ansible_pkg_mgr == "yum" and
@@ -624,6 +628,8 @@
 
   - name: remove package dependencies on redhat
     command: dnf -y autoremove
+    args:
+      warn: no
     when:
       ansible_os_family == 'RedHat' and
       ansible_pkg_mgr == "dnf" and
@@ -631,6 +637,8 @@
 
   - name: remove package dependencies on redhat again
     command: dnf -y autoremove
+    args:
+      warn: no
     when:
       ansible_os_family == 'RedHat' and
       ansible_pkg_mgr == "dnf" and

--- a/roles/ceph-common/tasks/checks/check_ntp_atomic.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_atomic.yml
@@ -1,6 +1,8 @@
 ---
 - name: check ntp installation on atomic
   command: rpm -q chrony
+  args:
+    warn: no
   register: ntp_pkg_query
   ignore_errors: true
   always_run: true

--- a/roles/ceph-common/tasks/checks/check_ntp_redhat.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_redhat.yml
@@ -1,6 +1,8 @@
 ---
 - name: check ntp installation on redhat
   command: rpm -q ntp
+  args:
+    warn: no
   register: ntp_pkg_query
   ignore_errors: true
   always_run: true

--- a/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
+++ b/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
@@ -22,6 +22,8 @@
 # Remove yum caches so yum doesn't get confused if we are reinstalling a different ceph version
 - name: purge yum cache
   command: yum clean all
+  args:
+    warn: no
   changed_when: false
   when:
     ansible_pkg_mgr == 'yum'

--- a/roles/ceph-docker-common/tasks/checks/check_ntp_atomic.yml
+++ b/roles/ceph-docker-common/tasks/checks/check_ntp_atomic.yml
@@ -1,6 +1,8 @@
 ---
 - name: check ntp installation on atomic
   command: rpm -q chrony
+  args:
+    warn: no
   register: ntp_pkg_query
   ignore_errors: true
   always_run: true

--- a/roles/ceph-docker-common/tasks/checks/check_ntp_redhat.yml
+++ b/roles/ceph-docker-common/tasks/checks/check_ntp_redhat.yml
@@ -1,6 +1,8 @@
 ---
 - name: check ntp installation on redhat
   command: rpm -q ntp
+  args:
+    warn: no
   register: ntp_pkg_query
   ignore_errors: true
   always_run: true


### PR DESCRIPTION
Ansible throws warnings when using yum/dnf/rpm with the command
module:

    [WARNING]: Consider using yum module rather than running yum

This patch adds the `warn: no` argument to suppress the warnings
in the Ansible output.