### PR TITLE
Enable profile_tasks callback plugin

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -123,6 +123,7 @@ sitepackages=True
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
+  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
   # only available for ansible >= 2.2
   ANSIBLE_STDOUT_CALLBACK = debug
   docker_cluster: PLAYBOOK = site-docker.yml.sample


### PR DESCRIPTION
This patch adds the `profile_tasks` callback plugin to the whitelist
so that we can identify the tasks which are taking the longest amount
of time to run.