### PR TITLE
ceph-mon: Remove jinja2 delimiters from when

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -7,7 +7,7 @@
   always_run: true
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
 
 - name: collect admin and bootstrap keys
   command: ceph-create-keys --cluster {{ cluster }} -i {{ monitor_name }}
@@ -15,7 +15,7 @@
   always_run: true
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous
 
 # NOTE (leseb): wait for mon discovery and quorum resolution
 # the admin key is not instantaneously created so we have to wait a bit
@@ -75,7 +75,7 @@
     - cephx
     - groups.get(mgr_group_name, []) | length > 0
     - inventory_hostname == groups[mon_group_name]|last
-    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel
+    - current_ceph_release_num > ceph_release_num.jewel
   with_items: "{{ groups.get(mgr_group_name, []) }}"
 
 - name: crush_rules.yml
@@ -106,7 +106,7 @@
   set_fact:
     bootstrap_rbd_keyring: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
 
 - name: copy keys to the ansible server
   fetch:

--- a/roles/ceph-mon/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mon/tasks/create_mds_filesystems.yml
@@ -25,13 +25,13 @@
   command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} fs set {{ cephfs }} allow_multimds true --yes-i-really-mean-it"
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.jewel
+    - current_ceph_release_num >= ceph_release_num.jewel
     - mds_allow_multimds
 
 - name: set max_mds
   command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} fs set {{ cephfs }} max_mds {{ mds_max_mds }}"
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.jewel
+    - current_ceph_release_num >= ceph_release_num.jewel
     - mds_allow_multimds
     - mds_max_mds > 1

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -42,7 +42,7 @@
   set_fact:
     ceph_authtool_cap: "--cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow' --cap mgr 'allow *'"
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
     - cephx
     - admin_secret != 'admin_secret'
 
@@ -50,7 +50,7 @@
   set_fact:
     ceph_authtool_cap: "--cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'"
   when:
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous
     - cephx
     - admin_secret != 'admin_secret'
 

--- a/roles/ceph-mon/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mon/tasks/docker/copy_configs.yml
@@ -13,12 +13,12 @@
   set_fact:
     bootstrap_rbd_keyring:
       - "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
-  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+  when: current_ceph_release_num >= ceph_release_num.luminous
 
 - name: merge rbd bootstrap key to config and keys paths
   set_fact:
     ceph_config_keys: "{{ ceph_config_keys + bootstrap_rbd_keyring }}"
-  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+  when: current_ceph_release_num >= ceph_release_num.luminous
 
 - name: set_fact tmp_ceph_mgr_keys add mgr keys to config and keys paths
   set_fact:

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -125,4 +125,4 @@
       - item.stat.exists == true
   when:
     - inventory_hostname == groups[mon_group_name]|last
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -5,6 +5,12 @@
   when:
     - containerized_deployment
 
+- name: set a fact for the release number of the current release
+  set_fact:
+    current_ceph_release_num: "ceph_release_num.{{ ceph_release }}"
+  tags:
+    - always
+
 - name: include check_mandatory_vars.yml
   include: check_mandatory_vars.yml
 


### PR DESCRIPTION
Modern versions of Ansible throw a warning when jinja2 delimiters
are used in `when:` keys:

    [WARNING]: when statements should not include jinja2 templating delimiters
    such as {{ }} or {% %}. Found: ceph_release_num.{{ ceph_release }} >=
    ceph_release_num.luminous

This patch sets a fact for `current_ceph_release_num` in the
`ceph-mon` role that can be re-used throughout the role.