### PR TITLE
ceph-osd: Remove jinja2 delimiters from when

### DIFF
--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -5,6 +5,12 @@
   when:
     - containerized_deployment
 
+- name: set a fact for the release number of the current release
+  set_fact:
+    current_ceph_release_num: "ceph_release_num.{{ ceph_release }}"
+  tags:
+    - always
+
 - name: include pre_requisite.yml
   include: pre_requisite.yml
   when: not containerized_deployment

--- a/roles/ceph-osd/tasks/ceph_disk_cli_options_facts.yml
+++ b/roles/ceph-osd/tasks/ceph_disk_cli_options_facts.yml
@@ -5,7 +5,7 @@
   when:
     - osd_objectstore == 'bluestore'
     - not dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options 'ceph_disk_cli_options'
@@ -14,7 +14,7 @@
   when:
     - osd_objectstore == 'filestore'
     - not dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }}'
@@ -23,7 +23,7 @@
   when:
     - osd_objectstore == 'filestore'
     - not dmcrypt
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }} --bluestore --dmcrypt'
@@ -32,7 +32,7 @@
   when:
     - osd_objectstore == 'bluestore'
     - dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }} --filestore --dmcrypt'
@@ -41,7 +41,7 @@
   when:
     - osd_objectstore == 'filestore'
     - dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }} --dmcrypt'
@@ -50,7 +50,7 @@
   when:
     - osd_objectstore == 'filestore'
     - dmcrypt
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact docker_env_args '-e KV_TYPE={{ kv_type }} -e KV_IP={{ kv_endpoint }} -e KV_PORT={{ kv_port }}'

--- a/roles/ceph-osd/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-osd/tasks/check_mandatory_vars.yml
@@ -56,7 +56,7 @@
     - osd_group_name in group_names
     - not containerized_deployment
     - osd_scenario == "lvm"
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous
 
 - name: verify osd_objectstore is 'filestore' when using the lvm osd_scenario
   fail:
@@ -128,4 +128,4 @@
     - osd_group_name in group_names
     - not containerized_deployment
     - osd_objectstore == 'bluestore'
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -5,6 +5,12 @@
   when:
     - containerized_deployment
 
+- name: set a fact for the release number of the current release
+  set_fact:
+    current_ceph_release_num: "ceph_release_num.{{ ceph_release }}"
+  tags:
+    - always
+
 - name: include check_mandatory_vars.yml
   include: check_mandatory_vars.yml
 


### PR DESCRIPTION
Modern versions of Ansible throw a warning when jinja2 delimiters
are used in `when:` keys:

    [WARNING]: when statements should not include jinja2 templating delimiters
    such as {{ }} or {% %}. Found: ceph_release_num.{{ ceph_release }} >=
    ceph_release_num.luminous

This patch sets a fact for `current_ceph_release_num` in the
`ceph-osd` role that can be re-used throughout the role.