### PR TITLE
ceph-rbd-mirror: Remove jinja2 delimiters from when

### DIFF
--- a/roles/ceph-rbd-mirror/tasks/docker/copy_configs.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/copy_configs.yml
@@ -3,7 +3,7 @@
   set_fact:
     bootstrap_rbd_keyring: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
 
 - name: set_fact ceph_config_keys
   set_fact:

--- a/roles/ceph-rbd-mirror/tasks/main.yml
+++ b/roles/ceph-rbd-mirror/tasks/main.yml
@@ -5,6 +5,12 @@
   when:
     - containerized_deployment
 
+- name: set a fact for the release number of the current release
+  set_fact:
+    current_ceph_release_num: "ceph_release_num.{{ ceph_release }}"
+  tags:
+    - always
+
 - name: include pre_requisite.yml
   include: pre_requisite.yml
   when:

--- a/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
+++ b/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
@@ -17,7 +17,7 @@
     mode: "0600"
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous or copy_admin_key
+    - (current_ceph_release_num < ceph_release_num.luminous) or copy_admin_key
 
 - name: copy rbd-mirror bootstrap key
   copy:
@@ -28,7 +28,7 @@
     mode: "0600"
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
 
 - name: create rbd-mirror keyring
   command: ceph --cluster {{ cluster }} --name client.bootstrap-rbd --keyring /var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring auth get-or-create client.rbd-mirror.{{ ansible_hostname }} mon 'profile rbd' osd 'profile rbd' -o /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring
@@ -37,7 +37,7 @@
   changed_when: false
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
 
 - name: set rbd-mirror key permissions
   file:
@@ -47,5 +47,5 @@
     mode: "0600"
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
 

--- a/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
@@ -24,7 +24,7 @@
     enabled: yes
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous
 
 - name: stop and remove the generic rbd-mirror service instance
   service:
@@ -33,7 +33,7 @@
     enabled: no
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
 
 # This task is a workaround for rbd-mirror not starting after reboot
 # The upstream fix is: https://github.com/ceph/ceph/pull/17969
@@ -44,7 +44,7 @@
     enabled: yes
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
 
 - name: start and add the rbd-mirror service instance
   service:
@@ -53,4 +53,4 @@
     enabled: yes
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous


### PR DESCRIPTION
Modern versions of Ansible throw a warning when jinja2 delimiters
are used in `when:` keys:

    [WARNING]: when statements should not include jinja2 templating delimiters
    such as {{ }} or {% %}. Found: ceph_release_num.{{ ceph_release }} >=
    ceph_release_num.luminous

This patch sets a fact for `current_ceph_release_num` in the
`ceph-rbd-mirror` role that can be re-used throughout the role.