### PR TITLE
Avoid jinja in `when` keys

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -72,6 +72,12 @@
   set_fact:
     ceph_version: "{{ ceph_version.stdout.split(' ')[2] }}"
 
+- name: set_fact current_ceph_release_num - store the ceph release number
+  set_fact:
+    current_ceph_release_num: "ceph_release_num.{{ ceph_release }}"
+  tags:
+    - always
+
 # override ceph_stable_release for ceph_dev and rhcs installations since ceph_stable_release is not mandatory
 - name: include release-rhcs.yml
   include: release-rhcs.yml

--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -5,6 +5,12 @@
   when:
     - containerized_deployment
 
+- name: set a fact for the release number of the current release
+  set_fact:
+    current_ceph_release_num: "ceph_release_num.{{ ceph_release }}"
+  tags:
+    - always
+
 - name: include pre_requisite.yml
   include: pre_requisite.yml
   when: not containerized_deployment

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -7,7 +7,7 @@
   always_run: true
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
 
 - name: collect admin and bootstrap keys
   command: ceph-create-keys --cluster {{ cluster }} -i {{ monitor_name }}
@@ -15,7 +15,7 @@
   always_run: true
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous
 
 # NOTE (leseb): wait for mon discovery and quorum resolution
 # the admin key is not instantaneously created so we have to wait a bit
@@ -75,7 +75,7 @@
     - cephx
     - groups.get(mgr_group_name, []) | length > 0
     - inventory_hostname == groups[mon_group_name]|last
-    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel
+    - current_ceph_release_num > ceph_release_num.jewel
   with_items: "{{ groups.get(mgr_group_name, []) }}"
 
 - name: crush_rules.yml
@@ -106,7 +106,7 @@
   set_fact:
     bootstrap_rbd_keyring: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
 
 - name: copy keys to the ansible server
   fetch:

--- a/roles/ceph-mon/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mon/tasks/create_mds_filesystems.yml
@@ -25,13 +25,13 @@
   command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} fs set {{ cephfs }} allow_multimds true --yes-i-really-mean-it"
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.jewel
+    - current_ceph_release_num >= ceph_release_num.jewel
     - mds_allow_multimds
 
 - name: set max_mds
   command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} fs set {{ cephfs }} max_mds {{ mds_max_mds }}"
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.jewel
+    - current_ceph_release_num >= ceph_release_num.jewel
     - mds_allow_multimds
     - mds_max_mds > 1

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -42,7 +42,7 @@
   set_fact:
     ceph_authtool_cap: "--cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow' --cap mgr 'allow *'"
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
     - cephx
     - admin_secret != 'admin_secret'
 
@@ -50,7 +50,7 @@
   set_fact:
     ceph_authtool_cap: "--cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'"
   when:
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous
     - cephx
     - admin_secret != 'admin_secret'
 

--- a/roles/ceph-mon/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mon/tasks/docker/copy_configs.yml
@@ -13,12 +13,12 @@
   set_fact:
     bootstrap_rbd_keyring:
       - "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
-  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+  when: current_ceph_release_num >= ceph_release_num.luminous
 
 - name: merge rbd bootstrap key to config and keys paths
   set_fact:
     ceph_config_keys: "{{ ceph_config_keys + bootstrap_rbd_keyring }}"
-  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+  when: current_ceph_release_num >= ceph_release_num.luminous
 
 - name: set_fact tmp_ceph_mgr_keys add mgr keys to config and keys paths
   set_fact:

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -125,4 +125,4 @@
       - item.stat.exists == true
   when:
     - inventory_hostname == groups[mon_group_name]|last
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous

--- a/roles/ceph-osd/tasks/ceph_disk_cli_options_facts.yml
+++ b/roles/ceph-osd/tasks/ceph_disk_cli_options_facts.yml
@@ -5,7 +5,7 @@
   when:
     - osd_objectstore == 'bluestore'
     - not dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options 'ceph_disk_cli_options'
@@ -14,7 +14,7 @@
   when:
     - osd_objectstore == 'filestore'
     - not dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }}'
@@ -23,7 +23,7 @@
   when:
     - osd_objectstore == 'filestore'
     - not dmcrypt
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }} --bluestore --dmcrypt'
@@ -32,7 +32,7 @@
   when:
     - osd_objectstore == 'bluestore'
     - dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }} --filestore --dmcrypt'
@@ -41,7 +41,7 @@
   when:
     - osd_objectstore == 'filestore'
     - dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - current_ceph_release_num >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }} --dmcrypt'
@@ -50,7 +50,7 @@
   when:
     - osd_objectstore == 'filestore'
     - dmcrypt
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact docker_env_args '-e KV_TYPE={{ kv_type }} -e KV_IP={{ kv_endpoint }} -e KV_PORT={{ kv_port }}'

--- a/roles/ceph-osd/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-osd/tasks/check_mandatory_vars.yml
@@ -56,7 +56,7 @@
     - osd_group_name in group_names
     - not containerized_deployment
     - osd_scenario == "lvm"
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous
 
 - name: verify osd_objectstore is 'filestore' when using the lvm osd_scenario
   fail:
@@ -128,4 +128,4 @@
     - osd_group_name in group_names
     - not containerized_deployment
     - osd_objectstore == 'bluestore'
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - current_ceph_release_num < ceph_release_num.luminous

--- a/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
+++ b/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
@@ -17,7 +17,7 @@
     mode: "0600"
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous or copy_admin_key
+    - (current_ceph_release_num < ceph_release_num.luminous) or copy_admin_key
 
 - name: copy rbd-mirror bootstrap key
   copy:


### PR DESCRIPTION
This series of patches does the following:

* Sets a `current_ceph_release_num` fact to hold the current ceph release number
* Adjusts tasks to use the `current_ceph_release_num` fact to avoid "jinja2 in when" warnings