### PR TITLE
Remove jinja2 delimiters from `when` keys

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -541,7 +541,7 @@
     - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
-    - { role: ceph-mgr, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
+    - { role: ceph-mgr, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 
   post_tasks:
     - name: start ceph mgrs

--- a/roles/ceph-fetch-keys/tasks/main.yml
+++ b/roles/ceph-fetch-keys/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: set_fact bootstrap_rbd_keyring
   set_fact:
     bootstrap_rbd_keyring: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
-  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+  when: ceph_release_num[ceph_release] >= ceph_release_num.luminous
 
 - name: copy keys to the ansible server
   fetch:

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -6,7 +6,7 @@
   changed_when: false
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
   tags:
     - always
 
@@ -15,7 +15,7 @@
   changed_when: false
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - ceph_release_num[ceph_release] < ceph_release_num.luminous
   tags:
     - always
 
@@ -79,7 +79,7 @@
     - cephx
     - groups.get(mgr_group_name, []) | length > 0
     - inventory_hostname == groups[mon_group_name]|last
-    - ceph_release_num.{{ ceph_release }} > ceph_release_num.jewel
+    - ceph_release_num[ceph_release] > ceph_release_num.jewel
   with_items: "{{ groups.get(mgr_group_name, []) }}"
 
 - name: crush_rules.yml
@@ -111,7 +111,7 @@
   set_fact:
     bootstrap_rbd_keyring: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
 
 - name: copy keys to the ansible server
   fetch:

--- a/roles/ceph-mon/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mon/tasks/create_mds_filesystems.yml
@@ -21,13 +21,13 @@
   command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} fs set {{ cephfs }} allow_multimds true --yes-i-really-mean-it"
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.jewel
+    - ceph_release_num[ceph_release] >= ceph_release_num.jewel
     - mds_allow_multimds
 
 - name: set max_mds
   command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} fs set {{ cephfs }} max_mds {{ mds_max_mds }}"
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.jewel
+    - ceph_release_num[ceph_release] >= ceph_release_num.jewel
     - mds_allow_multimds
     - mds_max_mds > 1

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -43,7 +43,7 @@
   set_fact:
     ceph_authtool_cap: "--cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow' --cap mgr 'allow *'"
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
     - cephx
     - admin_secret != 'admin_secret'
 
@@ -51,7 +51,7 @@
   set_fact:
     ceph_authtool_cap: "--cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'"
   when:
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - ceph_release_num[ceph_release] < ceph_release_num.luminous
     - cephx
     - admin_secret != 'admin_secret'
 

--- a/roles/ceph-mon/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mon/tasks/docker/copy_configs.yml
@@ -13,12 +13,12 @@
   set_fact:
     bootstrap_rbd_keyring:
       - "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
-  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+  when: ceph_release_num[ceph_release] >= ceph_release_num.luminous
 
 - name: merge rbd bootstrap key to config and keys paths
   set_fact:
     ceph_config_keys: "{{ ceph_config_keys + bootstrap_rbd_keyring }}"
-  when: ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+  when: ceph_release_num[ceph_release] >= ceph_release_num.luminous
 
 - name: set_fact tmp_ceph_mgr_keys add mgr keys to config and keys paths
   set_fact:

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -126,4 +126,4 @@
       - item.stat.exists == true
   when:
     - inventory_hostname == groups[mon_group_name]|last
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous

--- a/roles/ceph-osd/tasks/ceph_disk_cli_options_facts.yml
+++ b/roles/ceph-osd/tasks/ceph_disk_cli_options_facts.yml
@@ -5,7 +5,7 @@
   when:
     - osd_objectstore == 'bluestore'
     - not dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options 'ceph_disk_cli_options'
@@ -14,7 +14,7 @@
   when:
     - osd_objectstore == 'filestore'
     - not dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }}'
@@ -23,7 +23,7 @@
   when:
     - osd_objectstore == 'filestore'
     - not dmcrypt
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - ceph_release_num[ceph_release] < ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }} --bluestore --dmcrypt'
@@ -32,7 +32,7 @@
   when:
     - osd_objectstore == 'bluestore'
     - dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }} --filestore --dmcrypt'
@@ -41,7 +41,7 @@
   when:
     - osd_objectstore == 'filestore'
     - dmcrypt
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact ceph_disk_cli_options '--cluster {{ cluster }} --dmcrypt'
@@ -50,7 +50,7 @@
   when:
     - osd_objectstore == 'filestore'
     - dmcrypt
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - ceph_release_num[ceph_release] < ceph_release_num.luminous
     - not containerized_deployment
 
 - name: set_fact docker_env_args '-e KV_TYPE={{ kv_type }} -e KV_IP={{ kv_endpoint }} -e KV_PORT={{ kv_port }}'

--- a/roles/ceph-osd/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-osd/tasks/check_mandatory_vars.yml
@@ -56,7 +56,7 @@
     - osd_group_name in group_names
     - not containerized_deployment
     - osd_scenario == "lvm"
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - ceph_release_num[ceph_release] < ceph_release_num.luminous
 
 - name: verify osd_objectstore is 'filestore' when using the lvm osd_scenario
   fail:
@@ -128,4 +128,4 @@
     - osd_group_name in group_names
     - not containerized_deployment
     - osd_objectstore == 'bluestore'
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - ceph_release_num[ceph_release] < ceph_release_num.luminous

--- a/roles/ceph-rbd-mirror/tasks/docker/copy_configs.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/copy_configs.yml
@@ -3,7 +3,7 @@
   set_fact:
     bootstrap_rbd_keyring: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
 
 - name: set_fact ceph_config_keys
   set_fact:

--- a/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
+++ b/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
@@ -17,7 +17,7 @@
     mode: "0600"
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous or copy_admin_key
+    - ceph_release_num[ceph_release] < ceph_release_num.luminous or copy_admin_key
 
 - name: copy rbd-mirror bootstrap key
   copy:
@@ -28,7 +28,7 @@
     mode: "0600"
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
 
 - name: create rbd-mirror keyring
   command: ceph --cluster {{ cluster }} --name client.bootstrap-rbd --keyring /var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring auth get-or-create client.rbd-mirror.{{ ansible_hostname }} mon 'profile rbd' osd 'profile rbd' -o /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring
@@ -37,7 +37,7 @@
   changed_when: false
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
 
 - name: set rbd-mirror key permissions
   file:
@@ -47,5 +47,5 @@
     mode: "0600"
   when:
     - cephx
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
 

--- a/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
@@ -24,7 +24,7 @@
     enabled: yes
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} < ceph_release_num.luminous
+    - ceph_release_num[ceph_release] < ceph_release_num.luminous
 
 - name: stop and remove the generic rbd-mirror service instance
   service:
@@ -33,7 +33,7 @@
     enabled: no
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
 
 # This task is a workaround for rbd-mirror not starting after reboot
 # The upstream fix is: https://github.com/ceph/ceph/pull/17969
@@ -44,7 +44,7 @@
     enabled: yes
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
 
 - name: start and add the rbd-mirror service instance
   service:
@@ -53,4 +53,4 @@
     enabled: yes
   changed_when: false
   when:
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous

--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -38,7 +38,7 @@
   when:
     - rgw_zone is defined
     - rgw_multisite
-    - ceph_release_num.{{ ceph_release }} >= ceph_release_num.jewel
+    - ceph_release_num[ceph_release] >= ceph_release_num.jewel
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 

--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -39,8 +39,8 @@
   roles:
     - ceph-defaults
     - ceph-docker-common
-    - { role: ceph-config, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
-    - { role: ceph-mgr, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
+    - { role: ceph-config, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - { role: ceph-mgr, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 
 - hosts: osds
   become: True
@@ -75,8 +75,8 @@
   roles:
     - ceph-defaults
     - ceph-docker-common
-    - { role: ceph-config, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
-    - { role: ceph-nfs, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
+    - { role: ceph-config, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - { role: ceph-nfs, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 
 - hosts: rbdmirrors
   become: True

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -67,8 +67,8 @@
   roles:
     - ceph-defaults
     - ceph-common
-    - { role: ceph-config, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
-    - { role: ceph-mgr, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
+    - { role: ceph-config, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - { role: ceph-mgr, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 
 - hosts: agents
   gather_facts: false
@@ -112,8 +112,8 @@
   roles:
     - ceph-defaults
     - ceph-common
-    - { role: ceph-config, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
-    - { role: ceph-nfs, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
+    - { role: ceph-config, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - { role: ceph-nfs, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 
 - hosts: restapis
   gather_facts: false
@@ -148,6 +148,6 @@
   roles:
     - ceph-defaults
     - ceph-common
-    - { role: ceph-config, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
-    - { role: ceph-iscsi-gw, when: "ceph_release_num.{{ ceph_release }} >= ceph_release_num.luminous" }
+    - { role: ceph-config, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - { role: ceph-iscsi-gw, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 


### PR DESCRIPTION
This patch changes the `when:` keys so that they have no jinja2
delimiters. This avoids Ansible warnings which could turn into
errors in a future Ansible release.