### PR TITLE
rbd-mirror: enable ceph-rbd-mirror.target

### DIFF
--- a/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
@@ -26,6 +26,15 @@
   when:
     - ceph_release_num[ceph_release] < ceph_release_num.luminous
 
+- name: enable ceph-rbd-mirror.target on jewel
+  systemd:
+    name: "ceph-rbd-mirror.target"
+    state: started
+    enabled: yes
+  changed_when: false
+  when:
+    - ceph_release_num[ceph_release] < ceph_release_num.luminous
+
 - name: stop and remove the generic rbd-mirror service instance
   service:
     name: "ceph-rbd-mirror@{{ ceph_rbd_mirror_local_user }}"


### PR DESCRIPTION
on jewel `ceph-rbd-mirror.target` isn't enabled, therefore, if the node
is rebooted, the service doesn't get started.

from ceph-rbd-mirror unit file:
```
[Install]
WantedBy=ceph-rbd-mirror.target
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>