### PR TITLE
ceph-defaults: fix handlers that are always triggered

### DIFF
--- a/plugins/actions/_v1_config_template.py
+++ b/plugins/actions/_v1_config_template.py
@@ -26,7 +26,7 @@ from ansible import errors
 from ansible.runner.return_data import ReturnData
 from ansible import utils
 from ansible.utils import template
-
+from collections import OrderedDict
 
 CONFIG_TYPES = {
     'ini': 'return_config_overrides_ini',
@@ -145,14 +145,14 @@ class ConfigTemplateParser(ConfigParser.RawConfigParser):
     def write(self, fp):
         if self._defaults:
             fp.write("[%s]\n" % 'DEFAULT')
-            for key, value in self._defaults.items():
+            for key, value in OrderedDict(sorted(self._defaults.items())).items():
                 self._write_check(fp, key=key, value=value)
             else:
                 fp.write("\n")
 
         for section in self._sections:
             fp.write("[%s]\n" % section)
-            for key, value in self._sections[section].items():
+            for key, value in OrderedDict(sorted(self._sections[section].items())).items():
                 self._write_check(fp, key=key, value=value, section=True)
             else:
                 fp.write("\n")

--- a/plugins/actions/_v2_config_template.py
+++ b/plugins/actions/_v2_config_template.py
@@ -37,7 +37,7 @@ from ansible.plugins.action import ActionBase
 from ansible.utils.unicode import to_bytes, to_unicode
 from ansible import constants as C
 from ansible import errors
-
+from collections import OrderedDict
 
 CONFIG_TYPES = {
     'ini': 'return_config_overrides_ini',
@@ -173,14 +173,14 @@ class ConfigTemplateParser(ConfigParser.RawConfigParser):
     def write(self, fp):
         if self._defaults:
             fp.write("[%s]\n" % 'DEFAULT')
-            for key, value in self._defaults.items():
+            for key, value in OrderedDict(sorted(self._defaults.items())).items():
                 self._write_check(fp, key=key, value=value)
             else:
                 fp.write("\n")
 
         for section in self._sections:
             fp.write("[%s]\n" % section)
-            for key, value in self._sections[section].items():
+            for key, value in OrderedDict(sorted(self._sections[section].items())).items():
                 self._write_check(fp, key=key, value=value, section=True)
             else:
                 fp.write("\n")


### PR DESCRIPTION
Handlers are always triggered in ceph-ansible because ceph.conf file is
generated with a random order for the different keys/values pairs
in sections.

In python, a dict is not sorted. It means in our case each time we try
to generate the ceph.conf file it will be rendered with a random order
since the mechanism behind consist of rendering a file from a python dict
with keys/values. Therefore, as a quick workaround, forcing this dict to be
sorted before rendering the configuration file will ensure that it will be
rendered always the same way.

I don't know whether it should be fixed upstream, fixing this at ceph-ansible level means forking this plugin. However, it's not a huge modification and should be pretty easy to maintain or revert if ever we could find a better fix.
@leseb @andrewschoen any thoughts?

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>