### PR TITLE
mds: fix fs pool creation

### DIFF
--- a/roles/ceph-mon/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-mon/tasks/check_mandatory_vars.yml
@@ -12,5 +12,5 @@
     msg: "You must set pg num for your cephfs pools, see the cephfs_pools variable."
   with_items: "{{ cephfs_pools }}"
   when:
-    - inventory_hostname in groups.get(mds_group_name, [])
+    - groups.get(mds_group_name, []) | length > 0
     - item.pgs == ''

--- a/tests/functional/centos/7/docker-collocation/group_vars/mons
+++ b/tests/functional/centos/7/docker-collocation/group_vars/mons
@@ -1,0 +1,4 @@
+---
+cephfs_pools:
+  - { name: "{{ cephfs_data }}", pgs: "8" }
+  - { name: "{{ cephfs_metadata }}", pgs: "8" }


### PR DESCRIPTION
1. add the variables to docker_collocation
2. trigger the check when a MDS is part of the inventory file, not when
we run on an MDS...

Signed-off-by: Sébastien Han <seb@redhat.com>