### PR TITLE
Add ability to enable ceph mgr modules.

### DIFF
--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -7,6 +7,12 @@
 # file as a good configuration file when no variable in it.
 dummy:
 
+###########
+# MODULES #
+###########
+# Ceph mgr modules to enable, current modules available are: status,dashboard,localpool,restful,zabbix,prometheus,influx
+#ceph_mgr_modules: [status]
+
 ##########
 # DOCKER #
 ##########

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
+###########
+# MODULES #
+###########
+# Ceph mgr modules to enable, current modules available are: status,dashboard,localpool,restful,zabbix,prometheus,influx
+ceph_mgr_modules: [status]
+
 ##########
 # DOCKER #
 ##########

--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: set_fact docker_exec_cmd
   set_fact:
-    docker_exec_cmd: "docker exec ceph-mgr-{{ ansible_hostname }}"
+    docker_exec_cmd_mgr: "docker exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
   when:
     - containerized_deployment
 
@@ -12,3 +12,18 @@
 - name: include docker/main.yml
   include: docker/main.yml
   when: containerized_deployment
+
+- name: get enabled modules from ceph-mgr
+  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} --format json mgr module ls"
+  register: enabled_ceph_mgr_modules
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+
+- name: disable ceph mgr enabled modules
+  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module disable {{ item }}"
+  with_items: "{{ enabled_ceph_mgr_modules.stdout | from_json }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+
+- name: add modules to ceph-mgr
+  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module enable {{ item }}"
+  with_items: "{{ ceph_mgr_modules }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
The ceph mgr daemon has modules that can be enabled, for example the dashboard: http://docs.ceph.com/docs/master/mgr/dashboard/
This PR adds the capability to enable the modules.