### PR TITLE
In docker start scripts replace \u00a0 with \u0020

### DIFF
--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -9,7 +9,7 @@ ExecStartPre=-/usr/bin/docker rm ceph-mds-{{ ansible_hostname }}
 ExecStart=/usr/bin/docker run --rm --net=host \
   --memory={{ ceph_mds_docker_memory_limit }} \
   {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
-  --cpus={{ ceph_mds_docker_cpu_limit }} \
+  --cpus={{ ceph_mds_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_mds_docker_cpu_limit * 100000 }} \
   {% endif -%}

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -9,7 +9,7 @@ ExecStartPre=-/usr/bin/docker rm ceph-mgr-{{ ansible_hostname }}
 ExecStart=/usr/bin/docker run --rm --net=host \
   --memory={{ ceph_mgr_docker_memory_limit }} \
   {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
-  --cpus={{ ceph_mgr_docker_cpu_limit }} \
+  --cpus={{ ceph_mgr_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_mgr_docker_cpu_limit * 100000 }} \
   {% endif -%}

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -9,7 +9,7 @@ ExecStartPre=$(command -v mkdir) -p /etc/ceph /var/lib/ceph/mon
 ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
   --memory={{ ceph_mon_docker_memory_limit }} \
   {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
-  --cpus={{ ceph_mon_docker_cpu_limit }} \
+  --cpus={{ ceph_mon_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_mon_docker_cpu_limit * 100000 }} \
   {% endif -%}

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -26,7 +26,7 @@ expose_partitions "$1"
   --pid=host \
   --memory={{ ceph_osd_docker_memory_limit }} \
   {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
-  --cpus={{ ceph_osd_docker_cpu_limit }} \
+  --cpus={{ ceph_osd_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_osd_docker_cpu_limit * 100000 }} \
   {% endif -%}

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -9,7 +9,7 @@ ExecStartPre=-/usr/bin/docker rm ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStart=/usr/bin/docker run --rm --net=host \
   --memory={{ ceph_rbd_mirror_docker_memory_limit }} \
   {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
-  --cpus={{ ceph_rbd_mirror_docker_cpu_limit }} \
+  --cpus={{ ceph_rbd_mirror_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_rbd_mirror_docker_cpu_limit * 100000 }} \
   {% endif -%}

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -9,7 +9,7 @@ ExecStartPre=-/usr/bin/docker rm ceph-rgw-{{ ansible_hostname }}
 ExecStart=/usr/bin/docker run --rm --net=host \
   --memory={{ ceph_rgw_docker_memory_limit }} \
   {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
-  --cpus={{ ceph_rgw_docker_cpu_limit }} \
+  --cpus={{ ceph_rgw_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_rgw_docker_cpu_limit * 100000 }} \
   {% endif -%}


### PR DESCRIPTION
This will solve the following issue when starting docker containers on ubuntu:

invalid argument "1\u00a0" for --cpus=1 : failed to parse 1  as a rational number

Closes-bug: #2056