### PR TITLE
pin test-infra requirement at 1.5.5

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 # These are Python requirements needed to run the functional tests
-testinfra
+testinfra==1.5.5
 pytest-xdist


### PR DESCRIPTION
This allows us to deal with API change of "host" fixture
see https://github.com/philpep/testinfra/blob/master/CHANGELOG.rst#160
Now we can run tox against stable-2.2 release of ceph-ansible

Signed-off-by: Gregory Meno <gmeno@redhat.com>