### PR TITLE
Add set `devices` to empty list when `osd_auto_discovery` used

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -127,6 +127,13 @@
     - rbd_client_directory_mode is not defined
       or not rbd_client_directory_mode
 
+- name: set_fact devices to empty list
+  set_fact:
+    devices: []
+  when:
+    - osd_auto_discovery is defined
+    - osd_auto_discovery
+
 - name: resolve device link(s)
   command: readlink -f {{ item }}
   changed_when: false


### PR DESCRIPTION
- `osd_auto_discovery` intend to setup OSD automatically, so one does not
need that `devices` contain any value.
- when `osd_auto_discovery` used, one may ommit `devices`

Signed-off-by: Arano-kai <captcha.is.evil@gmail.com>