### PR TITLE
[skip ci] rpm: remove ability to install ceph community version

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -46,6 +46,8 @@ pushd %{buildroot}%{_datarootdir}/ceph-ansible
   # These untested playbooks are too unstable for users.
   rm -r infrastructure-playbooks/untested-by-ci
   %if ! 0%{?fedora} && ! 0%{?centos}
+    # remove ability to install ceph community version
+    rm roles/ceph-common/tasks/installs/redhat_{community,custom,dev}_repository.yml
     # Ship only the Red Hat Ceph Storage config (overwrite upstream settings)
     cp group_vars/rhcs.yml.sample group_vars/all.yml.sample
   %endif


### PR DESCRIPTION
Downstream version of ceph-ansible could still trigger install from
upstream repo and import keys.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1503019
Signed-off-by: Sébastien Han <seb@redhat.com>