### PR TITLE
defaults: fix handlers for collocation

### DIFF
--- a/roles/ceph-defaults/handlers/main.yml
+++ b/roles/ceph-defaults/handlers/main.yml
@@ -24,8 +24,10 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - mon_group_name in group_names
     - not containerized_deployment
+    - inventory_hostname == groups.get(mon_group_name) | last
+    - inventory_hostname in play_hosts
     - mon_socket_stat.rc == 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[mon_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -36,8 +38,10 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - mon_group_name in group_names
     - containerized_deployment
+    - inventory_hostname == groups.get(mon_group_name) | last
+    - inventory_hostname in play_hosts
     - ceph_mon_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[mon_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -62,6 +66,7 @@
   when:
     - osd_group_name in group_names
     - not containerized_deployment
+    - inventory_hostname == groups.get(osd_group_name) | last
     # We do not want to run these checks on initial deployment (`socket_osd_container.results[n].rc == 0`)
     # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
     - ((crush_location is defined and crush_location) or osd_socket_stat.rc == 0)
@@ -69,7 +74,7 @@
     - handler_health_osd_check
     # See https://github.com/ceph/ceph-ansible/issues/1457 for the condition below
     - inventory_hostname in play_hosts
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[osd_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -81,11 +86,12 @@
     # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
     - osd_group_name in group_names
     - containerized_deployment
+    - inventory_hostname == groups.get(osd_group_name) | last
     - ((crush_location is defined and crush_location) or ceph_osd_container_stat.get('stdout_lines', [])|length != 0)
     - handler_health_osd_check
     # See https://github.com/ceph/ceph-ansible/issues/1457 for the condition below
     - inventory_hostname in play_hosts
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[osd_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -108,8 +114,10 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - mds_group_name in group_names
     - not containerized_deployment
+    - inventory_hostname == groups.get(mds_group_name) | last
+    - inventory_hostname in play_hosts
     - mds_socket_stat.rc == 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[mds_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -120,8 +128,10 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - mds_group_name in group_names
     - containerized_deployment
+    - inventory_hostname == groups.get(mds_group_name) | last
+    - inventory_hostname in play_hosts
     - ceph_mds_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[mds_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -144,8 +154,10 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - rgw_group_name in group_names
     - not containerized_deployment
+    - inventory_hostname == groups.get(rgw_group_name) | last
+    - inventory_hostname in play_hosts
     - rgw_socket_stat.rc == 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[rgw_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -156,8 +168,10 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - rgw_group_name in group_names
     - containerized_deployment
+    - inventory_hostname == groups.get(rgw_group_name) | last
+    - inventory_hostname in play_hosts
     - ceph_rgw_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[rgw_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -180,8 +194,10 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - nfs_group_name in group_names
     - not containerized_deployment
+    - inventory_hostname == groups.get(nfs_group_name) | last
+    - inventory_hostname in play_hosts
     - nfs_socket_stat.rc == 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[nfs_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -192,8 +208,10 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - nfs_group_name in group_names
     - containerized_deployment
+    - inventory_hostname == groups.get(nfs_group_name) | last
+    - inventory_hostname in play_hosts
     - ceph_nfs_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[nfs_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -216,8 +234,10 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - rbdmirror_group_name in group_names
     - not containerized_deployment
+    - inventory_hostname == groups.get(rbdmirror_group_name) | last
+    - inventory_hostname in play_hosts
     - rbd_mirror_socket_stat.rc == 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[rbdmirror_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -228,8 +248,10 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - rbdmirror_group_name in group_names
     - containerized_deployment
+    - inventory_hostname == groups.get(rbdmirror_group_name) | last
+    - inventory_hostname in play_hosts
     - ceph_rbd_mirror_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[rbdmirror_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -252,8 +274,10 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - mgr_group_name in group_names
     - not containerized_deployment
+    - inventory_hostname == groups.get(mgr_group_name) | last
+    - inventory_hostname in play_hosts
     - mgr_socket_stat.rc == 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[mgr_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"
 
@@ -264,7 +288,9 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - mgr_group_name in group_names
     - containerized_deployment
+    - inventory_hostname == groups.get(mgr_group_name) | last
+    - inventory_hostname in play_hosts
     - ceph_mgr_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ ansible_play_batch }}"
+  with_items: "{{ groups[mgr_group_name] }}"
   run_once: true
   delegate_to: "{{ item }}"


### PR DESCRIPTION
When doing collocation the condition "inventory_hostname in play_hosts"
is breaking the restart workflow.

Signed-off-by: Sébastien Han <seb@redhat.com>