### PR TITLE
Docker image pull retry

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -495,3 +495,8 @@ dummy:
 #rolling_update: false
 
 
+#####################
+# Docker pull retry #
+#####################
+#docker_pull_retry: 3
+#docker_pull_timeout: "300s"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -495,3 +495,8 @@ ceph_repository: rhcs
 #rolling_update: false
 
 
+#####################
+# Docker pull retry #
+#####################
+#docker_pull_retry: 3
+#docker_pull_timeout: "300s"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -486,3 +486,8 @@ kv_port: 2379
 # do not ever change this here
 rolling_update: false
 
+#####################
+# Docker pull retry #
+#####################
+docker_pull_retry: 3
+docker_pull_timeout: "300s"

--- a/roles/ceph-docker-common/tasks/fetch_image.yml
+++ b/roles/ceph-docker-common/tasks/fetch_image.yml
@@ -1,8 +1,12 @@
 ---
 # Normal case - pull image from registry
 - name: "pull {{ ceph_docker_image }} image"
-  command: "docker pull {{ ceph_docker_registry}}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+  command: "timeout {{ docker_pull_timeout }} docker pull {{ ceph_docker_registry}}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
   changed_when: false
+  register: docker_image
+  until: docker_image.rc == 0
+  retries: "{{ docker_pull_retry }}"
+  delay: 10
   when:
     - (ceph_docker_dev_image is undefined or not ceph_docker_dev_image)
 


### PR DESCRIPTION
This change sets a default timeout of 300s for the image pull. If the
image pull times out (300s), we will retry 3 times by default.

fixes #1954