### PR TITLE
[skip ci] rbd: fix restart script for jewel

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -51,7 +51,8 @@
       - restart ceph osds
       - restart ceph mdss
       - restart ceph rgws
-      - restart ceph nfss
+      - restart ceph mgrs
+      - restart ceph rbdmirrors
   when:
     - not containerized_deployment|bool
 
@@ -118,8 +119,8 @@
       - restart ceph osds
       - restart ceph mdss
       - restart ceph rgws
-      - restart ceph rbdmirrors
       - restart ceph mgrs
+      - restart ceph rbdmirrors
 
   - name: set fsid fact when generate_fsid = true
     set_fact:

--- a/roles/ceph-defaults/templates/restart_rbd_mirror_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_rbd_mirror_daemon.sh.j2
@@ -3,7 +3,11 @@
 RETRIES="{{ handler_health_rbd_mirror_check_retries }}"
 DELAY="{{ handler_health_rbd_mirror_check_delay }}"
 RBD_MIRROR_NAME="{{ ansible_hostname }}"
+{% if ceph_release_num[ceph_release] < ceph_release_num['luminous'] %}
+SOCKET=/var/run/ceph/{{ cluster }}-client.admin.asok
+{% else %}
 SOCKET=/var/run/ceph/{{ cluster }}-client.rbd-mirror.${RBD_MIRROR_NAME}.asok
+{% endif %}
 {% if containerized_deployment %}
 DOCKER_EXEC="docker exec ceph-rbd-mirror-{{ ansible_hostname }}"
 {% endif %}


### PR DESCRIPTION
In Jewel, we don't use bootstrap-rbd keyring for rbd-mirror nodes, it
results with a socket path/name different according to which ceph
release you are deploying.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>