### PR TITLE
[skip ci] mgr: fix broken task on jewel

### DIFF
--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -20,8 +20,12 @@
 
 - name: disable ceph mgr enabled modules
   command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module disable {{ item }}"
-  with_items: "{{ enabled_ceph_mgr_modules.stdout | from_json }}"
+  # When ceph release is jewel, ceph-mgr role is skipped. It means, the enabled_ceph_mgr_modules doesn't contain 'stdout' attribute.
+  # Therefore, we need to get a default value which can be used up by from_json filter.
+  with_items: "{{ enabled_ceph_mgr_modules.get('stdout', '{}') | from_json }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  when:
+    - not enabled_ceph_mgr_modules.get('skipped')
 
 - name: add modules to ceph-mgr
   command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module enable {{ item }}"


### PR DESCRIPTION
3a58757 introduced an issue for Jewel deployments, since this role is
skipped, `enabled_ceph_mgr_modules.stdout` doesn't exist, therefore, it
ends up with an attribute error.

Uses `.get()` to retrieve `stdout` with a default value so it won't fail
if this attribute doesn't exist (jewel).

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>