### PR TITLE
[skip ci] all: backward compatibility between stable-2.2 and 3.0

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -104,7 +104,15 @@ dummy:
 ###########
 # INSTALL #
 ###########
-
+#ceph_rhcs_cdn_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_repository_type: "{{ 'cdn' if ceph_rhcs_cdn_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_rhcs_iso_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_repository_type: "{{ 'iso' if ceph_rhcs_iso_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_rhcs: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_stable: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_dev: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_stable_uca: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_custom: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 # ORIGIN SOURCE
 #
@@ -113,14 +121,14 @@ dummy:
 # - 'distro' means that no separate repo file will be added
 #  you will get whatever version of Ceph is included in your Linux distro.
 # 'local' means that the ceph binaries will be copied over from the local machine
-#ceph_origin: 'dummy'
+#ceph_origin: "{{ 'repository' if ceph_rhcs or ceph_stable or ceph_dev or ceph_stable_uca or ceph_custom else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #valid_ceph_origins:
 #  - repository
 #  - distro
 #  - local
 
 
-#ceph_repository: dummy
+#ceph_repository: "{{ 'community' if ceph_stable else 'rhcs' if ceph_rhcs else 'dev' if ceph_dev else 'uca' if ceph_stable_uca else 'custom' if ceph_custom else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #valid_ceph_repository:
 #  - community
 #  - rhcs
@@ -309,7 +317,7 @@ dummy:
 # To use an IPv6 address, use the monitor_address setting instead (and set ip_version to ipv6)
 #monitor_interface: interface
 #monitor_address: 0.0.0.0
-#monitor_address_block: []
+#monitor_address_block: subnet
 # set to either ipv4 or ipv6, whichever your network is using
 #ip_version: ipv4
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
@@ -353,8 +361,8 @@ dummy:
 # Preference will go to radosgw_address if both radosgw_address and radosgw_interface are defined.
 # To use an IPv6 address, use the radosgw_address setting instead (and set ip_version to ipv6)
 #radosgw_interface: interface
-#radosgw_address: 0.0.0.0
-#radosgw_address_block: []
+#radosgw_address: "{{ '0.0.0.0' if rgw_containerized_deployment else 'address' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#radosgw_address_block: subnet
 #radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 # Rados Gateway options
 #email_address: foo@bar.com
@@ -460,20 +468,23 @@ dummy:
 #docker: false
 #ceph_docker_image: "ceph/daemon"
 #ceph_docker_image_tag: latest
-
-# Do not comment the following variables containerized_deployment_* here. These variables are being used
-# by ceph.conf.j2 template. so it should always be defined
-#containerized_deployment_with_kv: false
-#containerized_deployment: false
-#mon_containerized_default_ceph_conf_with_kv: false
 #ceph_docker_registry: docker.io
 #ceph_docker_enable_centos_extra_repo: false
 #ceph_docker_on_openstack: false
+#ceph_mon_docker_interface: "{{ monitor_interface }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_mon_docker_subnet: "{{ public_network }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#mon_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#osd_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#mds_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#rgw_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#containerized_deployment: "{{ True if mon_containerized_deployment or osd_containerized_deployment or mds_containerized_deployment or rgw_containerized_deployment else False }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
 ############
 # KV store #
 ############
+#containerized_deployment_with_kv: false
+#mon_containerized_default_ceph_conf_with_kv: false
 #kv_type: etcd
 #kv_endpoint: 127.0.0.1
 #kv_port: 2379
@@ -482,4 +493,5 @@ dummy:
 # this is only here for usage with the rolling_update.yml playbook
 # do not ever change this here
 #rolling_update: false
+
 

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -10,6 +10,12 @@ dummy:
 # You can override default vars defined in defaults/main.yml here,
 # but I would advice to use host or group vars instead
 
+#raw_journal_devices: "{{ dedicated_devices }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#raw_multi_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#dmcrytpt_journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#dmcrypt_dedicated_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+
 
 ###########
 # GENERAL #
@@ -87,7 +93,7 @@ dummy:
 
 # Encrypt your OSD device using dmcrypt
 # If set to True, no matter which osd_objecstore and osd_scenario you use the data will be encrypted
-#dmcrypt: false
+#dmcrypt: "{{ True if dmcrytpt_journal_collocation or dmcrypt_dedicated_journal else False }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
 # I. First scenario: collocated
@@ -110,7 +116,7 @@ dummy:
 # /dev/sda2: PARTLABEL="ceph block" PARTUUID="e6ca3e1d-4702-4569-abfa-e285de328e9d"
 #
 
-#osd_scenario: dummy
+#osd_scenario: "{{ 'collocated' if journal_collocation or dmcrytpt_journal_collocation else 'non-collocated' if raw_multi_journal or dmcrypt_dedicated_journal else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #valid_osd_scenarios:
 #  - collocated
 #  - non-collocated

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -104,7 +104,15 @@ fetch_directory: ~/ceph-ansible-keys
 ###########
 # INSTALL #
 ###########
-
+#ceph_rhcs_cdn_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_repository_type: "{{ 'cdn' if ceph_rhcs_cdn_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_rhcs_iso_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_repository_type: "{{ 'iso' if ceph_rhcs_iso_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_rhcs: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_stable: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_dev: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_stable_uca: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_custom: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 # ORIGIN SOURCE
 #
@@ -309,7 +317,7 @@ ceph_repository: rhcs
 # To use an IPv6 address, use the monitor_address setting instead (and set ip_version to ipv6)
 #monitor_interface: interface
 #monitor_address: 0.0.0.0
-#monitor_address_block: []
+#monitor_address_block: subnet
 # set to either ipv4 or ipv6, whichever your network is using
 #ip_version: ipv4
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
@@ -353,8 +361,8 @@ ceph_repository: rhcs
 # Preference will go to radosgw_address if both radosgw_address and radosgw_interface are defined.
 # To use an IPv6 address, use the radosgw_address setting instead (and set ip_version to ipv6)
 #radosgw_interface: interface
-#radosgw_address: 0.0.0.0
-#radosgw_address_block: []
+#radosgw_address: "{{ '0.0.0.0' if rgw_containerized_deployment else 'address' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#radosgw_address_block: subnet
 #radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 # Rados Gateway options
 #email_address: foo@bar.com
@@ -460,20 +468,23 @@ ceph_repository: rhcs
 #docker: false
 #ceph_docker_image: "ceph/daemon"
 #ceph_docker_image_tag: latest
-
-# Do not comment the following variables containerized_deployment_* here. These variables are being used
-# by ceph.conf.j2 template. so it should always be defined
-#containerized_deployment_with_kv: false
-#containerized_deployment: false
-#mon_containerized_default_ceph_conf_with_kv: false
 #ceph_docker_registry: docker.io
 #ceph_docker_enable_centos_extra_repo: false
 #ceph_docker_on_openstack: false
+#ceph_mon_docker_interface: "{{ monitor_interface }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_mon_docker_subnet: "{{ public_network }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#mon_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#osd_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#mds_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#rgw_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#containerized_deployment: "{{ True if mon_containerized_deployment or osd_containerized_deployment or mds_containerized_deployment or rgw_containerized_deployment else False }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
 ############
 # KV store #
 ############
+#containerized_deployment_with_kv: false
+#mon_containerized_default_ceph_conf_with_kv: false
 #kv_type: etcd
 #kv_endpoint: 127.0.0.1
 #kv_port: 2379
@@ -482,4 +493,5 @@ ceph_repository: rhcs
 # this is only here for usage with the rolling_update.yml playbook
 # do not ever change this here
 #rolling_update: false
+
 

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -175,10 +175,12 @@
 
   roles:
     - ceph-defaults
-    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
-    - { role: ceph-mgr, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - ceph-config
+    - { role: ceph-mgr,
+        when: "(ceph_release_num[ceph_release] >= ceph_release_num.luminous) or
+               (ceph_release_num[ceph_release] < ceph_release_num.luminous and rolling_update)" }
 
   post_tasks:
     - name: start ceph mgr

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -16,6 +16,8 @@
 
 - name: confirm whether user really meant to upgrade the cluster
   hosts: localhost
+  vars:
+    - mgr_group_name: mgrs
 
   vars_prompt:
     - name: ireallymeanit
@@ -24,14 +26,20 @@
       private: no
 
   tasks:
-  - name: exit playbook, if user did not mean to upgrade cluster
-    fail:
-      msg: >
-        "Exiting rolling_update.yml playbook, cluster was NOT upgraded.
-         To upgrade the cluster, either say 'yes' on the prompt or
-         use `-e ireallymeanit=yes` on the command line when
-         invoking the playbook"
-    when: ireallymeanit != 'yes'
+    - name: exit playbook, if user did not mean to upgrade cluster
+      fail:
+        msg: >
+          "Exiting rolling_update.yml playbook, cluster was NOT upgraded.
+           To upgrade the cluster, either say 'yes' on the prompt or
+           use `-e ireallymeanit=yes` on the command line when
+           invoking the playbook"
+      when: ireallymeanit != 'yes'
+
+    - name: fail if no mgr host is present in the inventory
+      fail:
+        msg: "Please add a mgr host to your inventory."
+      when:
+        - groups.get(mgr_group_name, []) | length == 0
 
 
 - name: gather facts and check the init system
@@ -47,8 +55,24 @@
     - "{{ client_group_name|default('clients') }}"
 
   become: True
+  gather_facts: False
+  vars:
+    delegate_facts_host: True
   tasks:
     - debug: msg="gather facts on all Ceph hosts for following reference"
+
+    - name: gather facts
+      setup:
+      when:
+        - not delegate_facts_host | bool
+
+    - name: gather and delegate facts
+      setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: True
+      with_items: "{{ groups['all'] }}"
+      when:
+        - delegate_facts_host | bool
 
     - set_fact: rolling_update=true
 
@@ -89,9 +113,9 @@
 
   roles:
     - ceph-defaults
-    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
+    - ceph-config
     - ceph-mon
 
   post_tasks:
@@ -251,9 +275,9 @@
 
   roles:
     - ceph-defaults
-    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
+    - ceph-config
     - ceph-osd
 
   post_tasks:
@@ -374,9 +398,9 @@
 
   roles:
     - ceph-defaults
-    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
+    - ceph-config
     - ceph-mds
 
   post_tasks:
@@ -420,9 +444,9 @@
 
   roles:
     - ceph-defaults
-    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
+    - ceph-config
     - ceph-rgw
 
   post_tasks:
@@ -474,9 +498,9 @@
 
   roles:
     - ceph-defaults
-    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
+    - ceph-config
     - ceph-rbd-mirror
 
   post_tasks:
@@ -561,9 +585,9 @@
 
   roles:
     - ceph-defaults
-    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
+    - ceph-config
     - ceph-client
 
 

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -520,10 +520,12 @@
 
   roles:
     - ceph-defaults
-    - ceph-config
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
-    - ceph-nfs
+    - ceph-config
+    - { role: ceph-nfs,
+        when: "(ceph_release_num[ceph_release] >= ceph_release_num.luminous) or
+               (ceph_release_num[ceph_release] < ceph_release_num.luminous and rolling_update)" }
 
   post_tasks:
     - name: start nfs gateway

--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -64,18 +64,20 @@
   tags:
     - package-install
 
-- name: make sure monitor_interface or monitor_address is defined
+- name: make sure monitor_interface, monitor_address or monitor_address_block is defined
   fail:
-    msg: "you must set monitor_interface or monitor_address"
+    msg: "you must set monitor_interface, monitor_address or monitor_address_block"
   when:
+    - mon_group_name in group_names
     - monitor_interface == 'interface'
     - monitor_address == "0.0.0.0"
-    - mon_group_name in group_names
+    - monitor_address_block == 'subnet'
 
-- name: make sure radosgw_interface or radosgw_address is defined
+- name: make sure radosgw_interface, radosgw_address or radosgw_address_block is defined
   fail:
-    msg: "you must set radosgw_interface or radosgw_address"
+    msg: "you must set radosgw_interface, radosgw_address or radosgw_address_block"
   when:
-    - radosgw_interface == 'interface'
-    - radosgw_address == "0.0.0.0"
     - rgw_group_name in group_names
+    - radosgw_interface == 'interface'
+    - radosgw_address == 'address'
+    - radosgw_address_block == 'subnet'

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -38,7 +38,7 @@ mon initial members = {% for host in groups[mon_group_name] %}
 {% if not containerized_deployment and not containerized_deployment_with_kv -%}
 mon host = {% if nb_mon > 0 %}
   {% for host in groups[mon_group_name] -%}
-    {% if monitor_address_block | length > 0 %}
+    {% if monitor_address_block != 'subnet' %}
       {% if ip_version == 'ipv4' -%}
         {{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}
       {%- elif ip_version == 'ipv6' -%}
@@ -68,7 +68,7 @@ mon host = {% if nb_mon > 0 %}
 fsid = {{ fsid }}
 mon host = {% if nb_mon > 0 %}
 {% for host in groups[mon_group_name] -%}
-    {% if monitor_address_block | length > 0 %}
+    {% if monitor_address_block != 'subnet' %}
       {% if ip_version == 'ipv4' -%}
         {{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}
       {%- elif ip_version == 'ipv6' -%}
@@ -155,23 +155,41 @@ host = {{ hostvars[host]['ansible_hostname'] }}
 host = {{ hostvars[host]['ansible_hostname'] }}
 keyring = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ hostvars[host]['ansible_hostname'] }}/keyring
 log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[host]['ansible_hostname'] }}.log
-{% if hostvars[host]['radosgw_address_block'] is defined and hostvars[host]['radosgw_address_block'] | length > 0 %}
+{% if hostvars[host]['radosgw_address_block'] is defined and hostvars[host]['radosgw_address_block'] != 'subnet' %}
     {% if ip_version == 'ipv4' %}
 rgw frontends = civetweb port={{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% elif ip_version == 'ipv6' %}
 rgw frontends = civetweb port=[{{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% endif %}
-{% elif hostvars[host]['radosgw_address'] is defined and hostvars[host]['radosgw_address'] != '0.0.0.0' -%}
+{% elif radosgw_address_block is defined and radosgw_address_block != 'subnet' -%}
+    {% if ip_version == 'ipv4' %}
+rgw frontends = civetweb port={{ radosgw_address_block | ipaddr(radosgw_address_block) | first }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+    {% elif ip_version == 'ipv6' %}
+rgw frontends = civetweb port=[{{ radosgw_address_block | ipaddr(radosgw_address_block) | first }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+    {% endif %}
+{% elif hostvars[host]['radosgw_address'] is defined and hostvars[host]['radosgw_address'] != 'address' -%}
     {% if ip_version == 'ipv4' %}
 rgw frontends = civetweb port={{ hostvars[host]['radosgw_address'] }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% elif ip_version == 'ipv6' %}
 rgw frontends = civetweb port=[{{ hostvars[host]['radosgw_address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% endif %}
-{% else %}
+{% elif radosgw_address is defined and radosgw_address != 'address' -%}
+    {% if ip_version == 'ipv4' %}
+rgw frontends = civetweb port={{ radosgw_address }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+    {% elif ip_version == 'ipv6' %}
+rgw frontends = civetweb port=[{{ radosgw_address }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+    {% endif %}
+{% elif hostvars[host]['radosgw_interface'] is defined -%}
     {% if ip_version == 'ipv4' %}
 rgw frontends = civetweb port={{ hostvars[host]['ansible_' + hostvars[host]['radosgw_interface']][ip_version]['address'] }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% elif ip_version == 'ipv6' %}
 rgw frontends = civetweb port=[{{ hostvars[host]['ansible_' + hostvars[host]['radosgw_interface']][ip_version][0]['address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+    {% endif %}
+{% else %}
+    {% if ip_version == 'ipv4' %}
+rgw frontends = civetweb port={{ ['ansible_' + radosgw_interface][ip_version]['address'] }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+    {% elif ip_version == 'ipv6' %}
+rgw frontends = civetweb port=[{{ ['ansible_' + radosgw_interface][ip_version][0]['address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% endif %}
 {% endif %}
 {% endif %}

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -96,7 +96,15 @@ ceph_use_distro_backports: false # DEBIAN ONLY
 ###########
 # INSTALL #
 ###########
-
+ceph_rhcs_cdn_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+ceph_repository_type: "{{ 'cdn' if ceph_rhcs_cdn_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+ceph_rhcs_iso_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+ceph_repository_type: "{{ 'iso' if ceph_rhcs_iso_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+ceph_rhcs: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+ceph_stable: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+ceph_dev: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+ceph_stable_uca: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+ceph_custom: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 # ORIGIN SOURCE
 #
@@ -105,14 +113,14 @@ ceph_use_distro_backports: false # DEBIAN ONLY
 # - 'distro' means that no separate repo file will be added
 #  you will get whatever version of Ceph is included in your Linux distro.
 # 'local' means that the ceph binaries will be copied over from the local machine
-ceph_origin: 'dummy'
+ceph_origin: "{{ 'repository' if ceph_rhcs or ceph_stable or ceph_dev or ceph_stable_uca or ceph_custom else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 valid_ceph_origins:
   - repository
   - distro
   - local
 
 
-ceph_repository: dummy
+ceph_repository: "{{ 'community' if ceph_stable else 'rhcs' if ceph_rhcs else 'dev' if ceph_dev else 'uca' if ceph_stable_uca else 'custom' if ceph_custom else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 valid_ceph_repository:
   - community
   - rhcs
@@ -301,7 +309,7 @@ rbd_client_admin_socket_path: /var/run/ceph # must be writable by QEMU and allow
 # To use an IPv6 address, use the monitor_address setting instead (and set ip_version to ipv6)
 monitor_interface: interface
 monitor_address: 0.0.0.0
-monitor_address_block: []
+monitor_address_block: subnet
 # set to either ipv4 or ipv6, whichever your network is using
 ip_version: ipv4
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
@@ -345,8 +353,8 @@ radosgw_civetweb_options: "num_threads={{ radosgw_civetweb_num_threads }}"
 # Preference will go to radosgw_address if both radosgw_address and radosgw_interface are defined.
 # To use an IPv6 address, use the radosgw_address setting instead (and set ip_version to ipv6)
 radosgw_interface: interface
-radosgw_address: 0.0.0.0
-radosgw_address_block: []
+radosgw_address: "{{ '0.0.0.0' if rgw_containerized_deployment else 'address' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+radosgw_address_block: subnet
 radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
 # Rados Gateway options
 email_address: foo@bar.com
@@ -452,20 +460,23 @@ docker_exec_cmd:
 docker: false
 ceph_docker_image: "ceph/daemon"
 ceph_docker_image_tag: latest
-
-# Do not comment the following variables containerized_deployment_* here. These variables are being used
-# by ceph.conf.j2 template. so it should always be defined
-containerized_deployment_with_kv: false
-containerized_deployment: false
-mon_containerized_default_ceph_conf_with_kv: false
 ceph_docker_registry: docker.io
 ceph_docker_enable_centos_extra_repo: false
 ceph_docker_on_openstack: false
+ceph_mon_docker_interface: "{{ monitor_interface }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+ceph_mon_docker_subnet: "{{ public_network }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+mon_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+osd_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+mds_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+rgw_containerized_deployment: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+containerized_deployment: "{{ True if mon_containerized_deployment or osd_containerized_deployment or mds_containerized_deployment or rgw_containerized_deployment else False }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
 ############
 # KV store #
 ############
+containerized_deployment_with_kv: false
+mon_containerized_default_ceph_conf_with_kv: false
 kv_type: etcd
 kv_endpoint: 127.0.0.1
 kv_port: 2379
@@ -474,3 +485,4 @@ kv_port: 2379
 # this is only here for usage with the rolling_update.yml playbook
 # do not ever change this here
 rolling_update: false
+

--- a/roles/ceph-defaults/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_rgw_daemon.sh.j2
@@ -8,27 +8,45 @@ SOCKET=/var/run/ceph/{{ cluster }}-client.rgw.${RGW_NAME}.asok
 {% if containerized_deployment %}
 DOCKER_EXEC="docker exec ceph-rgw-{{ ansible_hostname }}"
 {% endif %}
-
-{% if radosgw_address_block | length > 0 %}
-  {% if ip_version == 'ipv4' -%}
-RGW_IP={{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}
-  {%- elif ip_version == 'ipv6' -%}
-RGW_IP=[{{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}]
-  {%- endif %}
-{% elif hostvars[inventory_hostname]['radosgw_address'] is defined and hostvars[inventory_hostname]['radosgw_address'] != '0.0.0.0' -%}
-  {% if ip_version == 'ipv4' -%}
-RGW_IP={{ hostvars[inventory_hostname]['radosgw_address'] }}
-  {%- elif ip_version == 'ipv6' -%}
-RGW_IP=[{{ hostvars[inventory_hostname]['radosgw_address'] }}]
-  {% endif %}
-{%- else -%}
-  {% set interface = ["ansible_",radosgw_interface]|join %}
-  {% if ip_version == 'ipv6' -%}
-RGW_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}]
-  {%- elif ip_version == 'ipv4' -%}
-RGW_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }}
-  {% endif %}
-{%- endif %}
+{% if hostvars[inventory_hostname]['radosgw_address_block'] is defined and hostvars[inventory_hostname]['radosgw_address_block'] != 'subnet' %}
+    {% if ip_version == 'ipv4' %}
+RGW_IP={{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }} \
+    {% elif ip_version == 'ipv6' %}
+RGW_IP=[{{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}] \
+    {% endif %}
+{% elif radosgw_address_block is defined and radosgw_address_block != 'subnet' -%}
+    {% if ip_version == 'ipv4' %}
+RGW_IP={{ ['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }} \
+    {% elif ip_version == 'ipv6' %}
+RGW_IP=[{{ ['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}] \
+    {% endif %}
+{% elif hostvars[inventory_hostname]['radosgw_address'] is defined and hostvars[inventory_hostname]['radosgw_address'] != 'address' -%}
+    {% if ip_version == 'ipv4' %}
+RGW_IP={{ hostvars[inventory_hostname]['radosgw_address'] }} \
+    {% elif ip_version == 'ipv6' %}
+RGW_IP=[{{ hostvars[inventory_hostname]['radosgw_address'] }}] \
+    {% endif %}
+{% elif radosgw_address is defined and radosgw_address != 'address' -%}
+    {% if ip_version == 'ipv4' %}
+RGW_IP={{ radosgw_address }} \
+    {% elif ip_version == 'ipv6' %}
+RGW_IP=[{{ radosgw_address }}] \
+    {% endif %}
+{% elif hostvars[inventory_hostname]['radosgw_interface'] is defined -%}
+    {% set interface = 'ansible_' + hostvars[inventory_hostname]['radosgw_interface'] %}
+    {% if ip_version == 'ipv4' %}
+RGW_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
+    {% elif ip_version == 'ipv6' %}
+RGW_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
+    {% endif %}
+{% else %}
+    {% set interface = 'ansible_' + radosgw_interface %}
+    {% if ip_version == 'ipv4' %}
+RGW_IP={{ [interface][ip_version]['address'] }} \
+    {% elif ip_version == 'ipv6' %}
+RGW_IP=[{{ [interface][ip_version][0]['address'] }}] \
+    {% endif %}
+{% endif %}
 
 check_for_curl_or_wget() {
   if $DOCKER_EXEC command -v wget &>/dev/null; then

--- a/roles/ceph-docker-common/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-docker-common/tasks/check_mandatory_vars.yml
@@ -1,0 +1,18 @@
+---
+- name: make sure monitor_interface, monitor_address or monitor_address_block is defined
+  fail:
+    msg: "you must set monitor_interface, monitor_address or monitor_address_block"
+  when:
+    - mon_group_name in group_names
+    - monitor_interface == 'interface'
+    - monitor_address == "0.0.0.0"
+    - monitor_address_block == 'subnet'
+
+- name: make sure radosgw_interface, radosgw_address or radosgw_address_block is defined
+  fail:
+    msg: "you must set radosgw_interface, radosgw_address or radosgw_address_block"
+  when:
+    - rgw_group_name in group_names
+    - radosgw_interface == 'interface'
+    - radosgw_address == 'address'
+    - radosgw_address_block == 'subnet'

--- a/roles/ceph-docker-common/tasks/main.yml
+++ b/roles/ceph-docker-common/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: include system_checks.yml
   include: system_checks.yml
 
+- name: include check_mandatory_vars.yml
+  include: check_mandatory_vars.yml
+
 - name: check if it is atomic host
   stat:
     path: /run/ostree-booted

--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -31,7 +31,7 @@
     - ceph_release_num[ceph_release] >= ceph_release_num['luminous']
 
 - name: add modules to ceph-mgr
-  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module enable {{ item }}"
+  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module enable {{ item }} --force"
   with_items: "{{ ceph_mgr_modules }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:

--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -17,6 +17,8 @@
   command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} --format json mgr module ls"
   register: enabled_ceph_mgr_modules
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  when:
+    - ceph_release_num[ceph_release] >= ceph_release_num['luminous']
 
 - name: disable ceph mgr enabled modules
   command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module disable {{ item }}"
@@ -26,8 +28,11 @@
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
     - not enabled_ceph_mgr_modules.get('skipped')
+    - ceph_release_num[ceph_release] >= ceph_release_num['luminous']
 
 - name: add modules to ceph-mgr
   command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module enable {{ item }}"
   with_items: "{{ ceph_mgr_modules }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  when:
+    - ceph_release_num[ceph_release] >= ceph_release_num['luminous']

--- a/roles/ceph-mon/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-mon/tasks/check_mandatory_vars.yml
@@ -5,7 +5,7 @@
   when:
     - monitor_interface == 'interface'
     - monitor_address == '0.0.0.0'
-    - monitor_address_block | length == 0
+    - monitor_address_block == 'subnet'
 
 - name: make sure pg num is set for cephfs pools
   fail:

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -41,7 +41,7 @@
     - not containerized_deployment_with_kv
     - ip_version == 'ipv4'
     - hostvars[groups[mon_group_name][0]]['monitor_address_block'] is defined
-    - hostvars[groups[mon_group_name][0]]['monitor_address_block'] | length > 0
+    - hostvars[groups[mon_group_name][0]]['monitor_address_block'] != 'subnet'
 
 - name: ipv6 - force peer addition as potential bootstrap peer for cluster bringup - monitor_interface
   command: docker exec ceph-mon-{{ ansible_hostname }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['ansible_' + monitor_interface].ipv6[0].address }}]
@@ -71,7 +71,7 @@
     - not containerized_deployment_with_kv
     - ip_version == 'ipv6'
     - hostvars[groups[mon_group_name][0]]['monitor_address_block'] is defined
-    - hostvars[groups[mon_group_name][0]]['monitor_address_block'] | length > 0
+    - hostvars[groups[mon_group_name][0]]['monitor_address_block'] != 'subnet'
 
 - name: include fetch_configs.yml
   include: fetch_configs.yml

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -29,7 +29,7 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
   --net=host \
   {% endif -%}
   -e IP_VERSION={{ ip_version[-1:] }} \
-  {% if monitor_address_block | length > 0 %}
+  {% if monitor_address_block != 'subnet' %}
     {% if ip_version == 'ipv4' -%}
   -e MON_IP={{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }} \
     {% elif ip_version == 'ipv6' -%}

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -2,6 +2,12 @@
 # You can override default vars defined in defaults/main.yml here,
 # but I would advice to use host or group vars instead
 
+raw_journal_devices: "{{ dedicated_devices }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+raw_multi_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+dmcrytpt_journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+dmcrypt_dedicated_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+
 
 ###########
 # GENERAL #
@@ -79,7 +85,7 @@ osd_auto_discovery: false
 
 # Encrypt your OSD device using dmcrypt
 # If set to True, no matter which osd_objecstore and osd_scenario you use the data will be encrypted
-dmcrypt: false
+dmcrypt: "{{ True if dmcrytpt_journal_collocation or dmcrypt_dedicated_journal else False }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
 # I. First scenario: collocated
@@ -102,7 +108,7 @@ dmcrypt: false
 # /dev/sda2: PARTLABEL="ceph block" PARTUUID="e6ca3e1d-4702-4569-abfa-e285de328e9d"
 #
 
-osd_scenario: dummy
+osd_scenario: "{{ 'collocated' if journal_collocation or dmcrytpt_journal_collocation else 'non-collocated' if raw_multi_journal or dmcrypt_dedicated_journal else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 valid_osd_scenarios:
   - collocated
   - non-collocated

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -21,27 +21,45 @@ ExecStart=/usr/bin/docker run --rm --net=host \
   -e KV_IP={{ kv_endpoint }} \
   -e KV_PORT={{ kv_port }} \
   {% endif -%}
-  {% if radosgw_address_block | length > 0 %}
-    {% if ip_version == 'ipv4' -%}
+{% if hostvars[inventory_hostname]['radosgw_address_block'] is defined and hostvars[inventory_hostname]['radosgw_address_block'] != 'subnet' %}
+    {% if ip_version == 'ipv4' %}
   -e RGW_CIVETWEB_IP={{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }} \
-    {% elif ip_version == 'ipv6' -%}
+    {% elif ip_version == 'ipv6' %}
   -e RGW_CIVETWEB_IP=[{{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}] \
-    {% endif -%}
-  {% elif hostvars[inventory_hostname]['radosgw_address'] is defined and hostvars[inventory_hostname]['radosgw_address'] != '0.0.0.0' -%}
-    {% if ip_version == 'ipv4' -%}
+    {% endif %}
+{% elif radosgw_address_block is defined and radosgw_address_block != 'subnet' -%}
+    {% if ip_version == 'ipv4' %}
+  -e RGW_CIVETWEB_IP={{ ['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }} \
+    {% elif ip_version == 'ipv6' %}
+  -e RGW_CIVETWEB_IP=[{{ ['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}] \
+    {% endif %}
+{% elif hostvars[inventory_hostname]['radosgw_address'] is defined and hostvars[inventory_hostname]['radosgw_address'] != 'address' -%}
+    {% if ip_version == 'ipv4' %}
   -e RGW_CIVETWEB_IP={{ hostvars[inventory_hostname]['radosgw_address'] }} \
-    {% elif ip_version == 'ipv6' -%}
+    {% elif ip_version == 'ipv6' %}
   -e RGW_CIVETWEB_IP=[{{ hostvars[inventory_hostname]['radosgw_address'] }}] \
-    {% endif -%}
-  {% else -%}
+    {% endif %}
+{% elif radosgw_address is defined and radosgw_address != 'address' -%}
+    {% if ip_version == 'ipv4' %}
+  -e RGW_CIVETWEB_IP={{ radosgw_address }} \
+    {% elif ip_version == 'ipv6' %}
+  -e RGW_CIVETWEB_IP=[{{ radosgw_address }}] \
+    {% endif %}
+{% elif hostvars[inventory_hostname]['radosgw_interface'] is defined -%}
     {% set interface = 'ansible_' + hostvars[inventory_hostname]['radosgw_interface'] %}
-      {% if ip_version == 'ipv6' -%}
-  -e RGW_CIVETWEB_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
-      {% elif ip_version == 'ipv4' -%}
+    {% if ip_version == 'ipv4' %}
   -e RGW_CIVETWEB_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
-      {% endif -%}
-  {% endif -%}
-
+    {% elif ip_version == 'ipv6' %}
+  -e RGW_CIVETWEB_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
+    {% endif %}
+{% else %}
+    {% set interface = 'ansible_' + radosgw_interface %}
+    {% if ip_version == 'ipv4' %}
+  -e RGW_CIVETWEB_IP={{ [interface][ip_version]['address'] }} \
+    {% elif ip_version == 'ipv6' %}
+  -e RGW_CIVETWEB_IP=[{{ [interface][ip_version][0]['address'] }}] \
+    {% endif %}
+{% endif %}
   -v /etc/localtime:/etc/localtime:ro \
   -e CEPH_DAEMON=RGW \
   -e CLUSTER={{ cluster }} \


### PR DESCRIPTION
stable-3.0 brought numerous changes in ceph-ansible variables, this PR
aims to maintain backward compatibility for someone running stable-2.2
upgrading to stable-3.0 but keeps its groups_vars untouched.
We will then determine the right options to make sure the upgrade works
but we are expecting that new variables should be used.

We will drop this in a near future, maybe 3.1 or 3.2.

Closes: https://github.com/ceph/ceph-ansible/issues/1834

Signed-off-by: Sébastien Han <seb@redhat.com>