### PR TITLE
Convert interface names to underscores for facts

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -51,14 +51,14 @@ mon host = {% if nb_mon > 0 %}
         [{{ hostvars[host]['monitor_address'] }}]
       {%- endif %}
     {%- elif hostvars[host]['monitor_interface'] is defined -%}
-      {% set interface = 'ansible_' + hostvars[host]['monitor_interface'] %}
+      {% set interface = 'ansible_' + (hostvars[host]['monitor_interface'] | replace('-', '_')) %}
       {% if ip_version == 'ipv4' -%}
         {{ hostvars[host][interface][ip_version]['address'] }}
       {%- elif ip_version == 'ipv6' -%}
         [{{ hostvars[host][interface][ip_version][0]['address'] }}]
       {%- endif %}
     {%- else -%}
-      {% set interface = 'ansible_' + monitor_interface %}
+      {% set interface = 'ansible_' + (monitor_interface | replace('-', '_')) %}
       {% if ip_version == 'ipv4' -%}
         {{ hostvars[host][interface][ip_version]['address'] }}
       {%- elif ip_version == 'ipv6' -%}
@@ -89,14 +89,14 @@ mon host = {% if nb_mon > 0 %}
         [{{ hostvars[host]['monitor_address'] }}]
       {%- endif %}
     {%- elif hostvars[host]['monitor_interface'] is defined -%}
-      {% set interface = 'ansible_' + hostvars[host]['monitor_interface'] %}
+      {% set interface = 'ansible_' + (hostvars[host]['monitor_interface'] | replace('-', '_')) %}
       {% if ip_version == 'ipv4' -%}
         {{ hostvars[host][interface][ip_version]['address'] }}
       {%- elif ip_version == 'ipv6' -%}
         [{{ hostvars[host][interface][ip_version][0]['address'] }}]
       {%- endif %}
     {%- else -%}
-      {% set interface = 'ansible_' + monitor_interface %}
+      {% set interface = 'ansible_' + (monitor_interface | replace('-', '_')) %}
       {% if ip_version == 'ipv4' -%}
         {{ hostvars[host][interface][ip_version]['address'] }}
       {%- elif ip_version == 'ipv6' -%}
@@ -195,14 +195,14 @@ rgw frontends = civetweb port={{ radosgw_address }}:{{ radosgw_civetweb_port }} 
 rgw frontends = civetweb port=[{{ radosgw_address }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% endif %}
 {% elif hostvars[host]['radosgw_interface'] is defined -%}
-    {% set interface='ansible_' + hostvars[host]['radosgw_interface'] %}
+    {% set interface='ansible_' + (hostvars[host]['radosgw_interface'] | replace('-', '_')) %}
     {% if ip_version == 'ipv4' %}
 rgw frontends = civetweb port={{ hostvars[host][interface][ip_version]['address'] }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% elif ip_version == 'ipv6' %}
 rgw frontends = civetweb port=[{{ hostvars[host][interface][ip_version][0]['address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% endif %}
 {% else %}
-    {% set interface='ansible_' + radosgw_interface %}
+    {% set interface='ansible_' + (radosgw_interface | replace('-', '_')) %}
     {% if ip_version == 'ipv4' %}
 rgw frontends = civetweb port={{ hostvars[host][interface][ip_version]['address'] }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% elif ip_version == 'ipv6' %}

--- a/roles/ceph-defaults/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_rgw_daemon.sh.j2
@@ -33,14 +33,14 @@ RGW_IP={{ radosgw_address }} \
 RGW_IP=[{{ radosgw_address }}] \
     {% endif %}
 {% elif hostvars[inventory_hostname]['radosgw_interface'] is defined -%}
-    {% set interface = 'ansible_' + hostvars[inventory_hostname]['radosgw_interface'] %}
+    {% set interface = 'ansible_' + (hostvars[inventory_hostname]['radosgw_interface'] | replace('-', '_')) %}
     {% if ip_version == 'ipv4' %}
 RGW_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
     {% elif ip_version == 'ipv6' %}
 RGW_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
     {% endif %}
 {% else %}
-    {% set interface = 'ansible_' + radosgw_interface %}
+    {% set interface = 'ansible_' + (radosgw_interface | replace('-', '_')) %}
     {% if ip_version == 'ipv4' %}
 RGW_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
     {% elif ip_version == 'ipv6' %}

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -42,14 +42,14 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
   -e MON_IP=[{{ hostvars[inventory_hostname]['monitor_address'] }}] \
     {% endif -%}
 {% elif hostvars[inventory_hostname]['monitor_interface'] is defined %}
-    {% set interface = 'ansible_' + hostvars[inventory_hostname]['monitor_interface'] %}
+    {% set interface = 'ansible_' + (hostvars[inventory_hostname]['monitor_interface'] | replace('-', '_')) %}
     {% if ip_version == 'ipv4' -%}
   -e MON_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
     {% elif ip_version == 'ipv6' -%}
   -e MON_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
     {% endif -%}
 {% else %}
-    {% set interface = 'ansible_' + monitor_interface %}
+    {% set interface = 'ansible_' + (monitor_interface | replace('-', '_')) %}
     {% if ip_version == 'ipv4' -%}
   -e MON_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
     {% elif ip_version == 'ipv6' -%}

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -46,14 +46,14 @@ ExecStart=/usr/bin/docker run --rm --net=host \
   -e RGW_CIVETWEB_IP=[{{ radosgw_address }}] \
     {% endif %}
 {% elif hostvars[inventory_hostname]['radosgw_interface'] is defined -%}
-    {% set interface = 'ansible_' + hostvars[inventory_hostname]['radosgw_interface'] %}
+    {% set interface = 'ansible_' + (hostvars[inventory_hostname]['radosgw_interface'] | replace('-', '_')) %}
     {% if ip_version == 'ipv4' %}
   -e RGW_CIVETWEB_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
     {% elif ip_version == 'ipv6' %}
   -e RGW_CIVETWEB_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
     {% endif %}
 {% else %}
-    {% set interface = 'ansible_' + radosgw_interface %}
+    {% set interface = 'ansible_' + (radosgw_interface | replace('-', '_')) %}
     {% if ip_version == 'ipv4' %}
   -e RGW_CIVETWEB_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
     {% elif ip_version == 'ipv6' %}


### PR DESCRIPTION
If a deployer uses an interface name with a dash/hyphen in it, such
as `br-storage` for the monitor_interface group_var, the `ceph.conf.j2`
template fails to find the right facts. It looks for
`ansible_br-storage` but only `ansible_br_storage` exists.

This patch converts the interface name to underscores when the
template does the fact lookup.