### PR TITLE
tests: split purge_cluster, followup on a53aa9e

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -277,7 +277,7 @@
 
   - name: disable ceph osd service
     service:
-      name: "ceph-osd@{{ item }}"
+      name: "{{ item }}"
       state: stopped
       enabled: no
     with_items: "{{ osd_units.stdout_lines }}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = {dev,jewel,luminous,rhcs}-{ansible2.2,ansible2.3}-{xenial_cluster,centos7_cluster,docker_cluster,purge_cluster,purge_dmcrypt,update_dmcrypt,update_cluster,cluster,purge_docker_cluster,update_docker_cluster,switch_to_containers}
-  {dev,luminous}-{ansible2.2,ansible2.3}-{filestore_osds_non_container,filestore_osds_container,bluestore_osds_container,bluestore_osds_non_container,lvm_osds,purge_lvm_osds,shrink_mon,shrink_osd,shrink_mon_container,shrink_osd_container,docker_cluster_collocation}
+envlist = {dev,jewel,luminous,rhcs}-{ansible2.2,ansible2.3}-{xenial_cluster,centos7_cluster,docker_cluster,update_cluster,cluster,update_docker_cluster,switch_to_containers,purge_filestore_osds_container,purge_filestore_osds_non_container,purge_cluster_non_container,purge_cluster_container}
+  {dev,luminous}-{ansible2.2,ansible2.3}-{filestore_osds_non_container,filestore_osds_container,bluestore_osds_container,bluestore_osds_non_container,lvm_osds,purge_lvm_osds,shrink_mon,shrink_osd,shrink_mon_container,shrink_osd_container,docker_cluster_collocation,purge_bluestore_osds_non_container,purge_bluestore_osds_container}
 
 skipsdist = True
 
@@ -129,8 +129,13 @@ setenv=
   docker_cluster: PLAYBOOK = site-docker.yml.sample
   docker_cluster_collocation: PLAYBOOK = site-docker.yml.sample
   update_docker_cluster: PLAYBOOK = site-docker.yml.sample
-  purge_docker_cluster: PLAYBOOK = site-docker.yml.sample
-  purge_docker_cluster: PURGE_PLAYBOOK = purge-docker-cluster.yml
+  purge_cluster_container: PLAYBOOK = site-docker.yml.sample
+  purge_cluster_container: PURGE_PLAYBOOK = purge-docker-cluster.yml
+  purge_bluestore_osds_container: PLAYBOOK = site-docker.yml.sample
+  purge_bluestore_osds_container: PURGE_PLAYBOOK = purge-docker-cluster.yml
+  purge_filestore_osds_container: PLAYBOOK = site-docker.yml.sample
+  purge_filestore_osds_container: PURGE_PLAYBOOK = purge-docker-cluster.yml
+
   filestore_osds_container: PLAYBOOK = site-docker.yml.sample
   bluestore_osds_container: PLAYBOOK = site-docker.yml.sample
   shrink_mon_container: PLAYBOOK = site-docker.yml.sample
@@ -169,9 +174,12 @@ changedir=
   docker_cluster: {toxinidir}/tests/functional/centos/7/docker
   docker_cluster_collocation: {toxinidir}/tests/functional/centos/7/docker-collocation
   update_docker_cluster: {toxinidir}/tests/functional/centos/7/docker
-  purge_docker_cluster: {toxinidir}/tests/functional/centos/7/docker
-  purge_cluster: {toxinidir}/tests/functional/centos/7/bs-osds-non-container
-  update_dmcrypt: {toxinidir}/tests/functional/centos/7/bs-osds-non-container
+  purge_filestore_osds_container: {toxinidir}/tests/functional/centos/7/fs-osds-container
+  purge_bluestore_osds_container: {toxinidir}/tests/functional/centos/7/bs-osds-container
+  purge_filestore_osds_non_container: {toxinidir}/tests/functional/centos/7/fs-osds-non-container
+  purge_bluestore_osds_non_container: {toxinidir}/tests/functional/centos/7/bs-osds-non-container
+  purge_cluster_non_container: {toxinidir}/tests/functional/centos/7/cluster
+  purge_cluster_container: {toxinidir}/tests/functional/centos/7/docker
   update_cluster: {toxinidir}/tests/functional/centos/7/cluster
   switch_to_containers: {toxinidir}/tests/functional/centos/7/cluster
   lvm_osds: {toxinidir}/tests/functional/centos/7/lvm-osds
@@ -226,12 +234,14 @@ commands=
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} " \
       --extra-vars @ceph-override.json
 
-  purge_cluster: {[purge]commands}
+  purge_cluster_non_container: {[purge]commands}
+  purge_cluster_container: {[purge]commands}
+  purge_filestore_osds_non_container: {[purge]commands}
+  purge_bluestore_osds_non_container: {[purge]commands}
+  purge_filestore_osds_container: {[purge]commands}
+  purge_bluestore_osds_container: {[purge]commands}
   purge_lvm_osds: {[purge-lvm]commands}
-  purge_dmcrypt: {[purge]commands}
-  purge_docker_cluster: {[purge]commands}
   switch_to_containers: {[switch-to-containers]commands}
-  update_dmcrypt: {[update]commands}
   update_cluster: {[update]commands}
   update_docker_cluster: {[update]commands}
   shrink_mon: {[shrink-mon]commands}


### PR DESCRIPTION
- split purge_cluster because we need to test filestore and bluestore
scenarios.
- clean some leftover.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>