### PR TITLE
Typo fix for radosgw@ systemd file

### DIFF
--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -2,7 +2,7 @@
 - name: ensure systemd service override directory exists
   file:
     state: directory
-    path: "/etc/systemd/system/ceph-rgw@.service.d/"
+    path: "/etc/systemd/system/ceph-radosgw@.service.d/"
   when:
     - ceph_rgw_systemd_overrides is defined
 


### PR DESCRIPTION
systemd script for radosgw is radosgw@ not rgw@, the directory needs to
match the path.