### PR TITLE
Add option to use jemalloc for Debian

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -460,6 +460,12 @@ dummy:
 #  - { name: vm.swappiness, value: 10 }
 #  - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }
 
+# For Debian & Red Hat/CentOS installs set jemalloc as the memory allocator for Ceph.
+# jemalloc is generally faster for small IO workloads and when
+# ceph-osd is backed by SSDs. However, memory usage is usally higher.
+# Don't enable this if using osd_objectstorage: bluestore.
+#ceph_jemalloc_enabled: false
+
 
 ##########
 # DOCKER #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -460,6 +460,12 @@ ceph_repository: rhcs
 #  - { name: vm.swappiness, value: 10 }
 #  - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }
 
+# For Debian & Red Hat/CentOS installs set jemalloc as the memory allocator for Ceph.
+# jemalloc is generally faster for small IO workloads and when
+# ceph-osd is backed by SSDs. However, memory usage is usally higher.
+# Don't enable this if using osd_objectstorage: bluestore.
+#ceph_jemalloc_enabled: false
+
 
 ##########
 # DOCKER #

--- a/roles/ceph-common/tasks/configure_memory_allocator.yml
+++ b/roles/ceph-common/tasks/configure_memory_allocator.yml
@@ -1,0 +1,50 @@
+---
+- name: install jemalloc for debian
+  apt:
+    name: "libjemalloc1"
+    update_cache: no
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - ansible_os_family == 'Debian'
+
+- name: install jemalloc for redhat
+  package:
+    name: "jemalloc"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - ansible_os_family == 'RedHat'
+
+- name: configure LD_PRELOAD for jemalloc for debian
+  lineinfile:
+    dest: "{{ etc_default_ceph.stat.isdir | ternary('/etc/default/ceph/ceph', '/etc/default/ceph') }}"
+    insertafter: EOF
+    create: yes
+    regexp: "^LD_PRELOAD="
+    line: "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
+  when:
+    - etc_default_ceph.stat.exists
+    - ansible_os_family == 'Debian'
+  notify:
+    - restart ceph mons
+    - restart ceph osds
+    - restart ceph mdss
+    - restart ceph rgws
+    - restart ceph mgrs
+    - restart ceph rbdmirrors
+
+- name: configure LD_PRELOAD for jemalloc for redhat
+  lineinfile:
+    dest: "/etc/sysconfig/ceph"
+    insertafter: EOF
+    create: yes
+    regexp: "^LD_PRELOAD="
+    line: "LD_PRELOAD=/usr/lib64/libjemalloc.so.1"
+  when:
+    - ansible_os_family == 'RedHat'
+  notify:
+    - restart ceph mons
+    - restart ceph osds
+    - restart ceph mdss
+    - restart ceph rgws
+    - restart ceph mgrs
+    - restart ceph rbdmirrors

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -90,3 +90,10 @@
 
 - name: include configure_cluster_name.yml
   include: configure_cluster_name.yml
+
+- name: include configure_memory_allocator.yml
+  include: configure_memory_allocator.yml
+  when:
+    - osd_objectstore != 'bluestore'
+    - (ceph_origin == 'repository' or ceph_origin == 'distro')
+    - ceph_jemalloc_enabled

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -452,6 +452,12 @@ os_tuning_params:
   - { name: vm.swappiness, value: 10 }
   - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }
 
+# For Debian & Red Hat/CentOS installs set jemalloc as the memory allocator for Ceph.
+# jemalloc is generally faster for small IO workloads and when
+# ceph-osd is backed by SSDs. However, memory usage is usally higher.
+# Don't enable this if using osd_objectstorage: bluestore.
+ceph_jemalloc_enabled: false
+
 
 ##########
 # DOCKER #


### PR DESCRIPTION
Use "ceph_jemalloc_enabled" to enable jemalloc as the default memory
allocator for Ceph on Debian installs. This defaults to false, so no
change to existing deploys, but can be set to install and configure
jemalloc as the default memory allocator.

If the LD_PRELOAD line is changed in /etc/default/ceph it will cause a
restart of the ceph services so that jemalloc is in use.