### PR TITLE
Issue/2092

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -460,6 +460,11 @@ dummy:
 #  - { name: vm.swappiness, value: 10 }
 #  - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }
 
+# For Debian & Red Hat/CentOS installs set TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES
+# Set this to a byte value (e.g. 134217728)
+# A value of 0 will leave the package default.
+#ceph_tcmalloc_max_total_thread_cache: 0
+
 
 ##########
 # DOCKER #

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -149,7 +149,7 @@ dummy:
 #   - /dev/sdg
 #
 # This will result in the following mapping:
-# - /dev/sda will have /dev/sdf1 as journal
+# - /dev/sda will have /dev/sdf1 as a journal
 # - /dev/sdb will have /dev/sdf2 as a journal
 # - /dev/sdc will have /dev/sdg1 as a journal
 # - /dev/sdd will have /dev/sdg2 as a journal

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -460,6 +460,11 @@ ceph_repository: rhcs
 #  - { name: vm.swappiness, value: 10 }
 #  - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }
 
+# For Debian & Red Hat/CentOS installs set TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES
+# Set this to a byte value (e.g. 134217728)
+# A value of 0 will leave the package default.
+#ceph_tcmalloc_max_total_thread_cache: 0
+
 
 ##########
 # DOCKER #

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -277,7 +277,7 @@
 
   - name: disable ceph osd service
     service:
-      name: "ceph-osd@{{ item }}"
+      name: "{{ item }}"
       state: stopped
       enabled: no
     with_items: "{{ osd_units.stdout_lines }}"

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -70,6 +70,16 @@
     docker_exec_client_cmd:
   when: docker_exec_client_cmd == 'ceph'
 
+- name: chmod key(s)
+  file:
+    path: "/etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
+    mode: "{{ item.mode|default(omit) }}" # if mode not in list, uses mode from ps umask
+  with_items: "{{ keys }}"
+  when:
+    - cephx
+    - keys | length > 0
+    - keys.mode is defined
+
 - name: setfacl for key(s)
   acl:
     path: "/etc/ceph/{{ cluster }}.{{ item.0.name }}.keyring"
@@ -79,15 +89,6 @@
     - "{{ keys }}"
     - acls
     - skip_missing: true
-  when:
-    - cephx
-    - keys | length > 0
-
-- name: chmod key(s)
-  file:
-    path: "/etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
-    mode: "{{ item.mode }}"
-  with_items: "{{ keys }}"
   when:
     - cephx
     - keys | length > 0

--- a/roles/ceph-common/tasks/configure_cluster_name.yml
+++ b/roles/ceph-common/tasks/configure_cluster_name.yml
@@ -5,6 +5,7 @@
     insertafter: EOF
     create: yes
     line: "CLUSTER={{ cluster }}"
+    regexp: "^CLUSTER="
   when:
     - ansible_os_family == "RedHat"
 
@@ -32,6 +33,7 @@
     dest: /etc/default/ceph
     insertafter: EOF
     create: yes
+    regexp: "^CLUSTER="
     line: "CLUSTER={{ cluster }}"
   when:
     - ansible_os_family == "Debian"
@@ -43,6 +45,7 @@
     dest: /etc/default/ceph/ceph
     insertafter: EOF
     create: yes
+    regexp: "^CLUSTER="
     line: "CLUSTER={{ cluster }}"
   when:
     - ansible_os_family == "Debian"

--- a/roles/ceph-common/tasks/configure_memory_allocator.yml
+++ b/roles/ceph-common/tasks/configure_memory_allocator.yml
@@ -1,0 +1,25 @@
+---
+- name: configure TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES for debian
+  lineinfile:
+    dest: "{{ etc_default_ceph.stat.isdir | ternary('/etc/default/ceph/ceph', '/etc/default/ceph') }}"
+    insertafter: EOF
+    create: yes
+    regexp: "^TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES="
+    line: "TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }}"
+  when:
+    - ansible_os_family == 'Debian'
+    - etc_default_ceph.stat.exists
+  notify:
+    - restart ceph osds
+
+- name: configure TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES for redhat
+  lineinfile:
+    dest: "/etc/sysconfig/ceph"
+    insertafter: EOF
+    create: yes
+    regexp: "^TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES="
+    line: "TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }}"
+  when:
+    - ansible_os_family == 'RedHat'
+  notify:
+    - restart ceph osds

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -90,3 +90,10 @@
 
 - name: include configure_cluster_name.yml
   include: configure_cluster_name.yml
+
+- name: include configure_memory_allocator.yml
+  include: configure_memory_allocator.yml
+  when:
+    - (ceph_tcmalloc_max_total_thread_cache | int) > 0
+    - osd_objectstore == 'filestore'
+    - (ceph_origin == 'repository' or ceph_origin == 'distro')

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -200,7 +200,7 @@ rgw frontends = civetweb port=[{{ ['ansible_' + radosgw_interface][ip_version][0
 
 {% if groups[nfs_group_name] is defined %}
 {% if nfs_group_name in group_names %}
-{% if inventory_hostname in groups.get(nfs_group_name, []) %}
+{% if inventory_hostname in groups.get(nfs_group_name, []) and inventory_hostname not in groups.get(rgw_group_name, []) %}
 {% for host in groups[nfs_group_name] %}
 {% if nfs_obj_gw %}
 {% if hostvars[host]['ansible_hostname'] is defined %}

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -452,6 +452,11 @@ os_tuning_params:
   - { name: vm.swappiness, value: 10 }
   - { name: vm.min_free_kbytes, value: "{{ vm_min_free_kbytes }}" }
 
+# For Debian & Red Hat/CentOS installs set TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES
+# Set this to a byte value (e.g. 134217728)
+# A value of 0 will leave the package default.
+ceph_tcmalloc_max_total_thread_cache: 0
+
 
 ##########
 # DOCKER #

--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -50,6 +50,15 @@
     - openstack_config
     - item.0 != groups[mon_group_name] | last
 
+- name: chmod openstack key(s)
+  file:
+    path: "/etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
+    mode: "{{ item.mode|default(omit) }}" # if mode not in list, uses mode from ps umask
+  with_items: "{{ openstack_keys }}"
+  when:
+    - openstack_config
+    - cephx
+    
 - name: setfacl for openstack key(s)
   acl:
     path: "/etc/ceph/{{ cluster }}.{{ item.0.name }}.keyring"
@@ -59,15 +68,6 @@
     - "{{ openstack_keys }}"
     - acls
     - skip_missing: true
-  when:
-    - openstack_config
-    - cephx
-
-- name: chmod openstack key(s)
-  file:
-    path: "/etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
-    mode: "{{ item.mode }}"
-  with_items: "{{ openstack_keys }}"
   when:
     - openstack_config
     - cephx

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -141,7 +141,7 @@ valid_osd_scenarios:
 #   - /dev/sdg
 #
 # This will result in the following mapping:
-# - /dev/sda will have /dev/sdf1 as journal
+# - /dev/sda will have /dev/sdf1 as a journal
 # - /dev/sdb will have /dev/sdf2 as a journal
 # - /dev/sdc will have /dev/sdg1 as a journal
 # - /dev/sdd will have /dev/sdg2 as a journal

--- a/roles/ceph-osd/tasks/check_mandatory_vars.yml
+++ b/roles/ceph-osd/tasks/check_mandatory_vars.yml
@@ -26,7 +26,6 @@
   when:
     - osd_group_name is defined
     - osd_group_name in group_names
-    - not containerized_deployment
     - osd_scenario == 'dummy'
 
 - name: make sure a valid osd scenario was chosen
@@ -35,7 +34,6 @@
   when:
     - osd_group_name is defined
     - osd_group_name in group_names
-    - not containerized_deployment
     - not osd_scenario in valid_osd_scenarios
 
 - name: verify devices have been provided
@@ -103,7 +101,6 @@
   when:
     - osd_group_name is defined
     - osd_group_name in group_names
-    - not containerized_deployment
     - osd_scenario == 'non-collocated'
     - dedicated_devices|length == 0
       or devices|length == 0
@@ -114,7 +111,6 @@
   when:
     - osd_group_name is defined
     - osd_group_name in group_names
-    - not containerized_deployment
     - osd_scenario == 'non-collocated'
     - dedicated_devices is string
     - dedicated_devices|length == 0
@@ -126,6 +122,5 @@
   when:
     - osd_group_name is defined
     - osd_group_name in group_names
-    - not containerized_deployment
     - osd_objectstore == 'bluestore'
     - ceph_release_num[ceph_release] < ceph_release_num.luminous

--- a/roles/ceph-osd/tasks/docker/start_docker_osd.yml
+++ b/roles/ceph-osd/tasks/docker/start_docker_osd.yml
@@ -10,6 +10,14 @@
   when:
     - ceph_docker_on_openstack
 
+- name: test if the container image has the disk_list function
+  command: docker run --entrypoint=stat {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} disk_list.sh
+  changed_when: false
+  failed_when: false
+  register: disk_list
+  when:
+    - ceph_release_num[ceph_release] < ceph_release_num.kraken
+
 - name: generate ceph osd docker run script
   become: true
   template:

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -5,12 +5,23 @@
 #############
 # FUNCTIONS #
 #############
-
-
+{% if disk_list.get("rc", 1) == 0 -%}
 function expose_partitions () {
 DOCKER_ENV=$(docker run --name expose_partitions_${1} --privileged=true -v /dev/:/dev/ -v /etc/ceph:/etc/ceph -e CLUSTER={{ cluster }} -e OSD_DEVICE=/dev/${1} {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} disk_list)
   docker rm -f expose_partitions_${1}
 }
+{% else -%}
+# NOTE(leseb): maintains backwards compatibility with old ceph-docker Jewel images
+# Jewel images prior to https://github.com/ceph/ceph-docker/pull/797
+REGEX="[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+function expose_partitions {
+  local partition
+  if docker logs ceph-osd-prepare-{{ ansible_hostname }}-devdev${1} |& grep -Eo "$partition is GPT partition"; then
+    part=$(docker logs ceph-osd-prepare-{{ ansible_hostname }}-devdev${1} |& grep "$partition is GPT partition" | grep -Eo /dev/disk/by-partuuid/${REGEX} | uniq)
+    DOCKER_ENV="$DOCKER_ENV -e OSD_JOURNAL=$part"
+  fi
+}
+{% endif -%}
 
 expose_partitions "$1"
 

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -73,6 +73,9 @@ expose_partitions "$1"
   {% endif -%}
   -e CLUSTER={{ cluster }} \
   -e OSD_DEVICE=/dev/${1} \
+  {% if (ceph_tcmalloc_max_total_thread_cache | int) > 0 and osd_objectstore == 'filestore' -%}
+  -e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }} \
+  {% endif -%}
   -e CEPH_DAEMON=OSD_CEPH_DISK_ACTIVATE \
   {{ ceph_osd_docker_extra_env }} \
   --name=ceph-osd-{{ ansible_hostname }}-${1} \

--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -2,7 +2,7 @@
 - name: ensure systemd service override directory exists
   file:
     state: directory
-    path: "/etc/systemd/system/ceph-rgw@.service.d/"
+    path: "/etc/systemd/system/ceph-radosgw@.service.d/"
   when:
     - ceph_rgw_systemd_overrides is defined
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = {dev,jewel,luminous,rhcs}-{ansible2.2,ansible2.3}-{xenial_cluster,centos7_cluster,docker_cluster,purge_cluster,purge_dmcrypt,update_dmcrypt,update_cluster,cluster,purge_docker_cluster,update_docker_cluster,switch_to_containers}
-  {dev,luminous}-{ansible2.2,ansible2.3}-{filestore_osds_non_container,filestore_osds_container,bluestore_osds_container,bluestore_osds_non_container,lvm_osds,purge_lvm_osds,shrink_mon,shrink_osd,shrink_mon_container,shrink_osd_container,docker_cluster_collocation}
+envlist = {dev,jewel,luminous,rhcs}-{ansible2.2,ansible2.3}-{xenial_cluster,centos7_cluster,docker_cluster,update_cluster,cluster,update_docker_cluster,switch_to_containers,purge_filestore_osds_container,purge_filestore_osds_non_container,purge_cluster_non_container,purge_cluster_container}
+  {dev,luminous}-{ansible2.2,ansible2.3}-{filestore_osds_non_container,filestore_osds_container,bluestore_osds_container,bluestore_osds_non_container,lvm_osds,purge_lvm_osds,shrink_mon,shrink_osd,shrink_mon_container,shrink_osd_container,docker_cluster_collocation,purge_bluestore_osds_non_container,purge_bluestore_osds_container}
 
 skipsdist = True
 
@@ -129,8 +129,13 @@ setenv=
   docker_cluster: PLAYBOOK = site-docker.yml.sample
   docker_cluster_collocation: PLAYBOOK = site-docker.yml.sample
   update_docker_cluster: PLAYBOOK = site-docker.yml.sample
-  purge_docker_cluster: PLAYBOOK = site-docker.yml.sample
-  purge_docker_cluster: PURGE_PLAYBOOK = purge-docker-cluster.yml
+  purge_cluster_container: PLAYBOOK = site-docker.yml.sample
+  purge_cluster_container: PURGE_PLAYBOOK = purge-docker-cluster.yml
+  purge_bluestore_osds_container: PLAYBOOK = site-docker.yml.sample
+  purge_bluestore_osds_container: PURGE_PLAYBOOK = purge-docker-cluster.yml
+  purge_filestore_osds_container: PLAYBOOK = site-docker.yml.sample
+  purge_filestore_osds_container: PURGE_PLAYBOOK = purge-docker-cluster.yml
+
   filestore_osds_container: PLAYBOOK = site-docker.yml.sample
   bluestore_osds_container: PLAYBOOK = site-docker.yml.sample
   shrink_mon_container: PLAYBOOK = site-docker.yml.sample
@@ -169,9 +174,12 @@ changedir=
   docker_cluster: {toxinidir}/tests/functional/centos/7/docker
   docker_cluster_collocation: {toxinidir}/tests/functional/centos/7/docker-collocation
   update_docker_cluster: {toxinidir}/tests/functional/centos/7/docker
-  purge_docker_cluster: {toxinidir}/tests/functional/centos/7/docker
-  purge_cluster: {toxinidir}/tests/functional/centos/7/bs-osds-non-container
-  update_dmcrypt: {toxinidir}/tests/functional/centos/7/bs-osds-non-container
+  purge_filestore_osds_container: {toxinidir}/tests/functional/centos/7/fs-osds-container
+  purge_bluestore_osds_container: {toxinidir}/tests/functional/centos/7/bs-osds-container
+  purge_filestore_osds_non_container: {toxinidir}/tests/functional/centos/7/fs-osds-non-container
+  purge_bluestore_osds_non_container: {toxinidir}/tests/functional/centos/7/bs-osds-non-container
+  purge_cluster_non_container: {toxinidir}/tests/functional/centos/7/cluster
+  purge_cluster_container: {toxinidir}/tests/functional/centos/7/docker
   update_cluster: {toxinidir}/tests/functional/centos/7/cluster
   switch_to_containers: {toxinidir}/tests/functional/centos/7/cluster
   lvm_osds: {toxinidir}/tests/functional/centos/7/lvm-osds
@@ -226,12 +234,14 @@ commands=
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} " \
       --extra-vars @ceph-override.json
 
-  purge_cluster: {[purge]commands}
+  purge_cluster_non_container: {[purge]commands}
+  purge_cluster_container: {[purge]commands}
+  purge_filestore_osds_non_container: {[purge]commands}
+  purge_bluestore_osds_non_container: {[purge]commands}
+  purge_filestore_osds_container: {[purge]commands}
+  purge_bluestore_osds_container: {[purge]commands}
   purge_lvm_osds: {[purge-lvm]commands}
-  purge_dmcrypt: {[purge]commands}
-  purge_docker_cluster: {[purge]commands}
   switch_to_containers: {[switch-to-containers]commands}
-  update_dmcrypt: {[update]commands}
   update_cluster: {[update]commands}
   update_docker_cluster: {[update]commands}
   shrink_mon: {[shrink-mon]commands}


### PR DESCRIPTION
Make acls and mode parameters of opentack_keys optional

Only chmod or setfacl the requested keyring(s) in the opentack_keys data structure when the mode or acls keys of that data structure exist.

User may specify four permission combinations for the keyring file(s): 1. only set ACL, 2. only set mode, 3. set neither mode nor ACL, 4. set mode and then ACL.

Fixes: #2092