### PR TITLE
Make acls and mode parameters of opentack_keys optional

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -70,6 +70,15 @@
     docker_exec_client_cmd:
   when: docker_exec_client_cmd == 'ceph'
 
+- name: chmod key(s)
+  file:
+    path: "/etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
+    mode: "{{ item.mode|default(omit) }}" # if mode not in list, uses mode from ps umask
+  with_items: "{{ keys }}"
+  when:
+    - cephx
+    - keys | length > 0
+
 - name: setfacl for key(s)
   acl:
     path: "/etc/ceph/{{ cluster }}.{{ item.0.name }}.keyring"
@@ -79,15 +88,6 @@
     - "{{ keys }}"
     - acls
     - skip_missing: true
-  when:
-    - cephx
-    - keys | length > 0
-
-- name: chmod key(s)
-  file:
-    path: "/etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
-    mode: "{{ item.mode }}"
-  with_items: "{{ keys }}"
   when:
     - cephx
     - keys | length > 0

--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -50,6 +50,15 @@
     - openstack_config
     - item.0 != groups[mon_group_name] | last
 
+- name: chmod openstack key(s)
+  file:
+    path: "/etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
+    mode: "{{ item.mode|default(omit) }}" # if mode not in list, uses mode from ps umask
+  with_items: "{{ openstack_keys }}"
+  when:
+    - openstack_config
+    - cephx
+    
 - name: setfacl for openstack key(s)
   acl:
     path: "/etc/ceph/{{ cluster }}.{{ item.0.name }}.keyring"
@@ -59,15 +68,6 @@
     - "{{ openstack_keys }}"
     - acls
     - skip_missing: true
-  when:
-    - openstack_config
-    - cephx
-
-- name: chmod openstack key(s)
-  file:
-    path: "/etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
-    mode: "{{ item.mode }}"
-  with_items: "{{ openstack_keys }}"
   when:
     - openstack_config
     - cephx


### PR DESCRIPTION
Only chmod or setfacl the requested keyring(s) in the
opentack_keys data structure when the mode or acls keys
of that data structure exist.

User may specify four permission combinations for the
keyring file(s): 1. only set ACL, 2. only set mode,
3. set neither mode nor ACL, 4. set mode and then ACL.

Fixes: #2092