### PR TITLE
DNM [skip ci] update: fix nfs update for jewel

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -521,7 +521,6 @@
       when:
         - containerized_deployment
 
-
 - name: upgrade ceph nfs node
 
   vars:
@@ -539,8 +538,7 @@
         name: nfs-ganesha
         state: stopped
         enabled: yes
-      when:
-        - not containerized_deployment
+      failed_when: false
 
   roles:
     - ceph-defaults

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def node(host, request):
     docker = ansible_vars.get("docker")
     osd_auto_discovery = ansible_vars.get("osd_auto_discovery")
     lvm_scenario = ansible_vars.get("osd_scenario") == 'lvm'
+    actual_ceph_release = host.ansible('command', 'ceph --version', check=False)['stdout'].split(' ')[4]
     ceph_release_num = {
       'jewel': 10,
       'kraken': 11,
@@ -48,10 +49,10 @@ def node(host, request):
     if node_type == "nfss" and ceph_stable_release == "jewel":
         pytest.skip("nfs nodes can not be tested with ceph release jewel")
 
-    if request.node.get_marker("from_luminous") and ceph_release_num[ceph_stable_release] < ceph_release_num['luminous']:
+    if request.node.get_marker("from_luminous") and ceph_release_num[actual_ceph_release] < ceph_release_num['luminous']:
         pytest.skip("This test is only valid for releases starting from Luminous and above")
 
-    if request.node.get_marker("before_luminous") and ceph_release_num[ceph_stable_release] >= ceph_release_num['luminous']:
+    if request.node.get_marker("before_luminous") and ceph_release_num[actual_ceph_release] >= ceph_release_num['luminous']:
         pytest.skip("This test is only valid for release before Luminous")
 
     journal_collocation_test = ansible_vars.get("osd_scenario") == "collocated"


### PR DESCRIPTION
We can't stop a service which doesn't exist since prior to luminous we
don't run ceph-nfs.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>