### PR TITLE
default: remove dup variable

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -105,9 +105,8 @@ dummy:
 # INSTALL #
 ###########
 #ceph_rhcs_cdn_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
-#ceph_repository_type: "{{ 'cdn' if ceph_rhcs_cdn_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_repository_type: "{{ 'cdn' if ceph_rhcs_cdn_install else 'iso' if ceph_rhcs_iso_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #ceph_rhcs_iso_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
-#ceph_repository_type: "{{ 'iso' if ceph_rhcs_iso_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #ceph_rhcs: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 #ceph_stable: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 #ceph_dev: False # backward compatibility with stable-2.2, will disappear in stable 3.1
@@ -178,7 +177,6 @@ dummy:
 #
 #
 #ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(2) }}"
-#ceph_repository_type: dummy
 #valid_ceph_repository_type:
 #  - cdn
 #  - iso

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -105,9 +105,8 @@ fetch_directory: ~/ceph-ansible-keys
 # INSTALL #
 ###########
 #ceph_rhcs_cdn_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
-#ceph_repository_type: "{{ 'cdn' if ceph_rhcs_cdn_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#ceph_repository_type: "{{ 'cdn' if ceph_rhcs_cdn_install else 'iso' if ceph_rhcs_iso_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #ceph_rhcs_iso_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
-#ceph_repository_type: "{{ 'iso' if ceph_rhcs_iso_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #ceph_rhcs: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 #ceph_stable: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 #ceph_dev: False # backward compatibility with stable-2.2, will disappear in stable 3.1
@@ -178,7 +177,6 @@ ceph_repository: rhcs
 #
 #
 #ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(2) }}"
-#ceph_repository_type: dummy
 #valid_ceph_repository_type:
 #  - cdn
 #  - iso

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -97,9 +97,8 @@ ceph_use_distro_backports: false # DEBIAN ONLY
 # INSTALL #
 ###########
 ceph_rhcs_cdn_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
-ceph_repository_type: "{{ 'cdn' if ceph_rhcs_cdn_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+ceph_repository_type: "{{ 'cdn' if ceph_rhcs_cdn_install else 'iso' if ceph_rhcs_iso_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 ceph_rhcs_iso_install: False # backward compatibility with stable-2.2, will disappear in stable 3.1
-ceph_repository_type: "{{ 'iso' if ceph_rhcs_iso_install else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 ceph_rhcs: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 ceph_stable: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 ceph_dev: False # backward compatibility with stable-2.2, will disappear in stable 3.1
@@ -170,7 +169,6 @@ ceph_stable_redhat_distro: el7
 #
 #
 ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(2) }}"
-ceph_repository_type: dummy
 valid_ceph_repository_type:
   - cdn
   - iso


### PR DESCRIPTION
ceph_repository_type was declared multiple times. This commit fixes
this.

Signed-off-by: Sébastien Han <seb@redhat.com>