### PR TITLE
test: when creating the /dev/sdc2 partition specify label as gpt

### DIFF
--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -43,8 +43,6 @@
         part_start: 0%
         part_end: 50%
         unit: '%'
-        # this is a brand-new, unlabeled disk, so add the label
-        # only for the first partition
         label: gpt
         state: present
 
@@ -56,6 +54,7 @@
         part_end: 100%
         unit: '%'
         state: present
+        label: gpt
 
     - name: create journals vg from /dev/sdc2
       lvg:


### PR DESCRIPTION
ansible==2.4 requires that label be set to gpt, or it will be defaulted
to msdos.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>