### PR TITLE
Fix: the ansible version for the stable-3.0 branch

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,7 +66,7 @@ The ``master`` branch should be considered experimental and used with caution.
   ``2.1`` and ``2.2.2``.
 
 - ``stable-3.0`` Support for ceph versions ``jewel`` and ``luminous``. This branch supports ansible versions
-  ``2.2`` and ``2.4.1``.
+  ``2.3.1``, ``2.3.2`` and ``2.4.1``.
 
 - ``master`` Support for ceph versions ``jewel``, and ``luminous``. This branch supports ansible version ``2.4.1``.
 


### PR DESCRIPTION
In my env, only ansible version 2.3.1 and 2.3.2 can run the stable-3.0 branch ,but ansible 2.2