### PR TITLE
FIX: run restart scripts in `noexec` /tmp

### DIFF
--- a/roles/ceph-defaults/handlers/main.yml
+++ b/roles/ceph-defaults/handlers/main.yml
@@ -18,7 +18,7 @@
     - inventory_hostname in play_hosts
 
 - name: restart ceph mon daemon(s) - non container
-  command: /tmp/restart_mon_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_mon_daemon.sh
   listen: "restart ceph mons"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
@@ -32,7 +32,7 @@
   delegate_to: "{{ item }}"
 
 - name: restart ceph mon daemon(s) - container
-  command: /tmp/restart_mon_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_mon_daemon.sh
   listen: "restart ceph mons"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
@@ -61,7 +61,7 @@
     - inventory_hostname in play_hosts
 
 - name: restart ceph osds daemon(s) - non container
-  command: /tmp/restart_osd_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_osd_daemon.sh
   listen: "restart ceph osds"
   when:
     - osd_group_name in group_names
@@ -79,7 +79,7 @@
   delegate_to: "{{ item }}"
 
 - name: restart ceph osds daemon(s) - container
-  command: /tmp/restart_osd_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_osd_daemon.sh
   listen: "restart ceph osds"
   when:
     # We do not want to run these checks on initial deployment (`socket_osd_container_stat.results[n].rc == 0`)
@@ -108,7 +108,7 @@
     - inventory_hostname in play_hosts
 
 - name: restart ceph mds daemon(s) - non container
-  command: /tmp/restart_mds_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_mds_daemon.sh
   listen: "restart ceph mdss"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
@@ -122,7 +122,7 @@
   delegate_to: "{{ item }}"
 
 - name: restart ceph mds daemon(s) - container
-  command: /tmp/restart_mds_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_mds_daemon.sh
   listen: "restart ceph mdss"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
@@ -148,7 +148,7 @@
     - inventory_hostname in play_hosts
 
 - name: restart ceph rgw daemon(s) - non container
-  command: /tmp/restart_rgw_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_rgw_daemon.sh
   listen: "restart ceph rgws"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
@@ -162,7 +162,7 @@
   delegate_to: "{{ item }}"
 
 - name: restart ceph rgw daemon(s) - container
-  command: /tmp/restart_rgw_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_rgw_daemon.sh
   listen: "restart ceph rgws"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
@@ -188,7 +188,7 @@
     - inventory_hostname in play_hosts
 
 - name: restart ceph nfs daemon(s) - non container
-  command: /tmp/restart_nfs_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_nfs_daemon.sh
   listen: "restart ceph nfss"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
@@ -202,7 +202,7 @@
   delegate_to: "{{ item }}"
 
 - name: restart ceph nfs daemon(s) - container
-  command: /tmp/restart_nfs_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_nfs_daemon.sh
   listen: "restart ceph nfss"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
@@ -228,7 +228,7 @@
     - inventory_hostname in play_hosts
 
 - name: restart ceph rbd mirror daemon(s) - non container
-  command: /tmp/restart_rbd_mirror_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_rbd_mirror_daemon.sh
   listen: "restart ceph rbdmirrors"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
@@ -242,7 +242,7 @@
   delegate_to: "{{ item }}"
 
 - name: restart ceph rbd mirror daemon(s) - container
-  command: /tmp/restart_rbd_mirror_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_rbd_mirror_daemon.sh
   listen: "restart ceph rbdmirrors"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
@@ -268,7 +268,7 @@
     - inventory_hostname in play_hosts
 
 - name: restart ceph mgr daemon(s) - non container
-  command: /tmp/restart_mgr_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_mgr_daemon.sh
   listen: "restart ceph mgrs"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
@@ -282,7 +282,7 @@
   delegate_to: "{{ item }}"
 
 - name: restart ceph mgr daemon(s) - container
-  command: /tmp/restart_mgr_daemon.sh
+  command: /usr/bin/env bash /tmp/restart_mgr_daemon.sh
   listen: "restart ceph mgrs"
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)


### PR DESCRIPTION
- One can not run scripts directly in place, that mounted with `noexec`
option. But one can run scripts as arguments for `bash/sh`.

Signed-off-by: Arano-kai <captcha.is.evil@gmail.com>