### PR TITLE
osd: skip some set_fact when osd_scenario=lvm

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -133,6 +133,7 @@
   when:
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
+    - osd_scenario != 'lvm'
 
 - name: set_fact build devices from resolved symlinks
   set_fact:
@@ -141,6 +142,7 @@
   when:
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
+    - osd_scenario != 'lvm'
 
 - name: set_fact build final devices list
   set_fact:
@@ -148,3 +150,4 @@
   when:
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
+    - osd_scenario != 'lvm'


### PR DESCRIPTION
these tasks are not needed when using `osd_scenario: lvm`

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1509230

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>