### PR TITLE
osd: fix crush location for non-containerized deployment

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -1,4 +1,8 @@
 ---
+- name: include osd_fragment.yml
+  include: osd_fragment.yml
+  when: crush_location
+
 - name: get osd id
   shell: |
     ls /var/lib/ceph/osd/ | sed 's/.*-//'


### PR DESCRIPTION
crush location only set for containerized deployment

Signed-off-by: yaoning <yaoning@unitedstack.com>