### PR TITLE
tests: re-add missing param in tox

### DIFF
--- a/tests/functional/centos/7/docker-collocation/ceph-override.json
+++ b/tests/functional/centos/7/docker-collocation/ceph-override.json
@@ -1,0 +1,1 @@
+../cluster/ceph-override.json

--- a/tox.ini
+++ b/tox.ini
@@ -126,6 +126,7 @@ setenv=
   # only available for ansible >= 2.2
   ANSIBLE_STDOUT_CALLBACK = debug
   docker_cluster: PLAYBOOK = site-docker.yml.sample
+  docker_cluster_collocation: PLAYBOOK = site-docker.yml.sample
   update_docker_cluster: PLAYBOOK = site-docker.yml.sample
   purge_docker_cluster: PLAYBOOK = site-docker.yml.sample
   purge_docker_cluster: PURGE_PLAYBOOK = purge-docker-cluster.yml


### PR DESCRIPTION
this line has been removed by mistake in a53aa9e.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 93f0856770ca1cee7628f906c06f94ee77c8be7e)