### PR TITLE
config: fix config generation

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -98,9 +98,9 @@ mon host = {% if nb_mon > 0 %}
     {%- else -%}
       {% set interface = 'ansible_' + monitor_interface %}
       {% if ip_version == 'ipv4' -%}
-        {{ [interface][ip_version]['address'] }}
+        {{ hostvars[host][interface][ip_version]['address'] }}
       {%- elif ip_version == 'ipv6' -%}
-        [{{ [interface][ip_version][0]['address'] }}]
+        [{{ hostvars[host][interface][ip_version][0]['address'] }}]
       {%- endif %}
     {%- endif %}
     {% if not loop.last -%},{%- endif %}
@@ -195,16 +195,18 @@ rgw frontends = civetweb port={{ radosgw_address }}:{{ radosgw_civetweb_port }} 
 rgw frontends = civetweb port=[{{ radosgw_address }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% endif %}
 {% elif hostvars[host]['radosgw_interface'] is defined -%}
+    {% set interface='ansible_' + hostvars[host]['radosgw_interface'] %}
     {% if ip_version == 'ipv4' %}
-rgw frontends = civetweb port={{ hostvars[host]['ansible_' + hostvars[host]['radosgw_interface']][ip_version]['address'] }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+rgw frontends = civetweb port={{ hostvars[host][interface][ip_version]['address'] }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% elif ip_version == 'ipv6' %}
-rgw frontends = civetweb port=[{{ hostvars[host]['ansible_' + hostvars[host]['radosgw_interface']][ip_version][0]['address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+rgw frontends = civetweb port=[{{ hostvars[host][interface][ip_version][0]['address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% endif %}
 {% else %}
+    {% set interface='ansible_' + radosgw_interface %}
     {% if ip_version == 'ipv4' %}
-rgw frontends = civetweb port={{ ['ansible_' + radosgw_interface][ip_version]['address'] }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+rgw frontends = civetweb port={{ hostvars[host][interface][ip_version]['address'] }}:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% elif ip_version == 'ipv6' %}
-rgw frontends = civetweb port=[{{ ['ansible_' + radosgw_interface][ip_version][0]['address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
+rgw frontends = civetweb port=[{{ hostvars[host][interface][ip_version][0]['address'] }}]:{{ radosgw_civetweb_port }} {{ radosgw_civetweb_options }}
     {% endif %}
 {% endif %}
 {% endif %}

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -51,9 +51,9 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
 {% else %}
     {% set interface = 'ansible_' + monitor_interface %}
     {% if ip_version == 'ipv4' -%}
-  -e MON_IP={{ [interface][ip_version]['address'] }} \
+  -e MON_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
     {% elif ip_version == 'ipv6' -%}
-  -e MON_IP=[{{ [interface][ip_version][0]['address'] }}] \
+  -e MON_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
     {% endif -%}
 {%- endif %}
   -e CLUSTER={{ cluster }} \

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -55,9 +55,9 @@ ExecStart=/usr/bin/docker run --rm --net=host \
 {% else %}
     {% set interface = 'ansible_' + radosgw_interface %}
     {% if ip_version == 'ipv4' %}
-  -e RGW_CIVETWEB_IP={{ [interface][ip_version]['address'] }} \
+  -e RGW_CIVETWEB_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
     {% elif ip_version == 'ipv6' %}
-  -e RGW_CIVETWEB_IP=[{{ [interface][ip_version][0]['address'] }}] \
+  -e RGW_CIVETWEB_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
     {% endif %}
 {% endif %}
   -v /etc/localtime:/etc/localtime:ro \


### PR DESCRIPTION
The path to the fact is not correct.
In any case, we will retrieve the IP address in hostvars, the variable
is the way we get the interface name according where it has been set
(eg.: inventory host file vs. group_vars/)

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1510906

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>