### PR TITLE
Add openSUSE Leap 42.3 support

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -80,6 +80,12 @@ dummy:
 #  - hdparm
 #  - python-setuptools
 
+#suse_package_dependencies:
+#  - python-pycurl
+#  - python-xml
+#  - hdparm
+#  - python-setuptools
+
 # Whether or not to install the ceph-test package.
 #ceph_test: false
 
@@ -116,7 +122,7 @@ dummy:
 # ORIGIN SOURCE
 #
 # Choose between:
-# - 'repository' means that you will get ceph installed through a new repository. Later below choose between 'community', 'rhcs' or 'dev'
+# - 'repository' means that you will get ceph installed through a new repository. Later below choose between 'community', 'rhcs', 'dev' or 'obs'
 # - 'distro' means that no separate repo file will be added
 #  you will get whatever version of Ceph is included in your Linux distro.
 # 'local' means that the ceph binaries will be copied over from the local machine
@@ -134,6 +140,7 @@ dummy:
 #  - dev
 #  - uca
 #  - custom
+#  - obs
 
 
 # REPOSITORY: COMMUNITY VERSION
@@ -201,6 +208,15 @@ dummy:
 #ceph_stable_openstack_release_uca: liberty
 #ceph_stable_release_uca: "{{ansible_lsb.codename}}-updates/{{ceph_stable_openstack_release_uca}}"
 
+# REPOSITORY: openSUSE OBS
+#
+# Enabled when ceph_repository == 'obs'
+#
+# This allows the install of Ceph from the openSUSE OBS repository. The OBS repository
+# usually has newer Ceph releases than the normal distro repository.
+#
+#
+#ceph_obs_repo: "https://download.opensuse.org/repositories/filesystems:/ceph:/luminous/openSUSE_Leap_{{ ansible_distribution_version }}/"
 
 # REPOSITORY: DEV
 #
@@ -497,9 +513,9 @@ dummy:
 # do not ever change this here
 #rolling_update: false
 
-
 #####################
 # Docker pull retry #
 #####################
 #docker_pull_retry: 3
 #docker_pull_timeout: "300s"
+

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -80,6 +80,12 @@ fetch_directory: ~/ceph-ansible-keys
 #  - hdparm
 #  - python-setuptools
 
+#suse_package_dependencies:
+#  - python-pycurl
+#  - python-xml
+#  - hdparm
+#  - python-setuptools
+
 # Whether or not to install the ceph-test package.
 #ceph_test: false
 
@@ -116,7 +122,7 @@ fetch_directory: ~/ceph-ansible-keys
 # ORIGIN SOURCE
 #
 # Choose between:
-# - 'repository' means that you will get ceph installed through a new repository. Later below choose between 'community', 'rhcs' or 'dev'
+# - 'repository' means that you will get ceph installed through a new repository. Later below choose between 'community', 'rhcs', 'dev' or 'obs'
 # - 'distro' means that no separate repo file will be added
 #  you will get whatever version of Ceph is included in your Linux distro.
 # 'local' means that the ceph binaries will be copied over from the local machine
@@ -134,6 +140,7 @@ ceph_repository: rhcs
 #  - dev
 #  - uca
 #  - custom
+#  - obs
 
 
 # REPOSITORY: COMMUNITY VERSION
@@ -201,6 +208,15 @@ ceph_repository: rhcs
 #ceph_stable_openstack_release_uca: liberty
 #ceph_stable_release_uca: "{{ansible_lsb.codename}}-updates/{{ceph_stable_openstack_release_uca}}"
 
+# REPOSITORY: openSUSE OBS
+#
+# Enabled when ceph_repository == 'obs'
+#
+# This allows the install of Ceph from the openSUSE OBS repository. The OBS repository
+# usually has newer Ceph releases than the normal distro repository.
+#
+#
+#ceph_obs_repo: "https://download.opensuse.org/repositories/filesystems:/ceph:/luminous/openSUSE_Leap_{{ ansible_distribution_version }}/"
 
 # REPOSITORY: DEV
 #
@@ -497,9 +513,9 @@ ceph_repository: rhcs
 # do not ever change this here
 #rolling_update: false
 
-
 #####################
 # Docker pull retry #
 #####################
 #docker_pull_retry: 3
 #docker_pull_timeout: "300s"
+

--- a/roles/ceph-agent/meta/main.yml
+++ b/roles/ceph-agent/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-client/meta/main.yml
+++ b/roles/ceph-client/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-common/meta/main.yml
+++ b/roles/ceph-common/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -28,7 +28,7 @@
     msg: "make sure ceph_stable_release ( {{ ceph_stable_release }} ) is set to a release name (e.g: luminous), http://docs.ceph.com/docs/master/release-notes/"
   when:
     - ceph_stable_release == 'dummy'
-    - ceph_repository not in ['rhcs', 'dev']
+    - ceph_repository not in ['rhcs', 'dev', 'obs']
   tags:
     - package-install
 
@@ -38,7 +38,7 @@
   when:
     - ceph_stable_release not in ceph_release_num
     - ceph_origin == 'repository'
-    - ceph_repository not in ['rhcs', 'dev']
+    - ceph_repository not in ['rhcs', 'dev', 'obs']
   tags:
     - package-install
 

--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -27,6 +27,7 @@
   fail:
     msg: "make sure ceph_stable_release ( {{ ceph_stable_release }} ) is set to a release name (e.g: luminous), http://docs.ceph.com/docs/master/release-notes/"
   when:
+    - ceph_origin != 'distro'
     - ceph_stable_release == 'dummy'
     - ceph_repository not in ['rhcs', 'dev', 'obs']
   tags:

--- a/roles/ceph-common/tasks/checks/check_system.yml
+++ b/roles/ceph-common/tasks/checks/check_system.yml
@@ -15,7 +15,7 @@
   fail:
     msg: "Distribution not supported {{ ansible_os_family }}"
   when:
-    - ansible_os_family not in ['Debian', 'RedHat', 'ClearLinux']
+    - ansible_os_family not in ['Debian', 'RedHat', 'ClearLinux', 'Suse']
 
 - name: fail on unsupported distribution for red hat ceph storage
   fail:
@@ -51,6 +51,13 @@
   when:
     - ceph_repository == 'uca'
     - ansible_distribution != 'Ubuntu'
+
+- name: fail on unsupported openSUSE distribution
+  fail:
+    msg: "Distribution not supported: {{ ansible_distribution }}"
+  when:
+    - ansible_distribution == 'openSUSE Leap'
+    - ansible_distribution_version | version_compare('42.3', '<')
 
 - name: fail on unsupported ansible version
   fail:

--- a/roles/ceph-common/tasks/configure_cluster_name.yml
+++ b/roles/ceph-common/tasks/configure_cluster_name.yml
@@ -7,7 +7,7 @@
     line: "CLUSTER={{ cluster }}"
     regexp: "^CLUSTER="
   when:
-    - ansible_os_family == "RedHat"
+    - ansible_os_family in ["RedHat", "Suse"]
 
 # NOTE(leseb): we are performing the following check
 # to ensure any Jewel installation will not fail.

--- a/roles/ceph-common/tasks/installs/configure_suse_repository_installation.yml
+++ b/roles/ceph-common/tasks/installs/configure_suse_repository_installation.yml
@@ -1,0 +1,5 @@
+---
+- name: include suse_obs_repository.yml
+  include: suse_obs_repository.yml
+  when:
+    - ceph_repository == 'obs'

--- a/roles/ceph-common/tasks/installs/install_on_suse.yml
+++ b/roles/ceph-common/tasks/installs/install_on_suse.yml
@@ -1,0 +1,24 @@
+---
+# SUSE only supports the following:
+# - ceph_origin == 'distro'
+# - ceph_origin == 'repository' and ceph_repository == 'obs'
+- name: Check for supported installation method on suse
+  fail:
+    msg: "Unsupported installation method origin:{{ ceph_origin }} repo:{{ ceph_repository }}'"
+  when:
+    - ceph_origin != 'distro' or (ceph_origin == 'repository' and ceph_repository != 'obs')
+
+- name: include configure_suse_repository_installation.yml
+  include: configure_suse_repository_installation.yml
+  when:
+    - ceph_origin == 'repository'
+
+- name: install dependencies
+  zypper:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items: "{{ suse_package_dependencies }}"
+
+- name: include install_suse_packages.yml
+  include: install_suse_packages.yml

--- a/roles/ceph-common/tasks/installs/install_suse_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_suse_packages.yml
@@ -1,0 +1,54 @@
+---
+- name: install suse dependencies
+  package:
+    name: "{{ suse_package_dependencies }}"
+    state: present
+  when:
+    - ansible_distribution == 'Suse'
+
+- name: install suse ceph-common
+  package:
+    name: "ceph-common"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+
+- name: install suse ceph-mon package
+  package:
+    name: "ceph-mon"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - mon_group_name in group_names
+
+- name: install suse ceph-osd package
+  package:
+    name: "ceph-osd"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - osd_group_name in group_names
+
+- name: install suse ceph-fuse package
+  package:
+    name: "ceph-fuse"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - client_group_name in group_names
+
+- name: install suse ceph-base package
+  package:
+    name: "ceph-base"
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - client_group_name in group_names
+
+- name: install suse ceph-test package
+  package:
+    name: ceph-test
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - ceph_test
+
+- name: install suse ceph-radosgw package
+  package:
+    name: ceph-radosgw
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - rgw_group_name in group_names

--- a/roles/ceph-common/tasks/installs/suse_obs_repository.yml
+++ b/roles/ceph-common/tasks/installs/suse_obs_repository.yml
@@ -1,0 +1,8 @@
+---
+- name: configure openSUSE ceph OBS repository
+  zypper_repository:
+    name: "OBS:filesystems:ceph"
+    state: present
+    uri: "{{ ceph_obs_repo }}"
+    auto_import_keys: yes
+    autorefresh: yes

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -28,6 +28,15 @@
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 
+- name: include installs/install_on_suse.yml
+  include: installs/install_on_suse.yml
+  when:
+    - ansible_os_family == 'Suse'
+  tags:
+    - package-install
+  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
+  static: False
+
 - name: include installs/install_on_debian.yml
   include: installs/install_on_debian.yml
   when:
@@ -46,10 +55,18 @@
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 
-- name: include ntp setup tasks
-  include: "misc/ntp_{{ ansible_os_family | lower }}.yml"
+- name: include ntp debian setup tasks
+  include: "misc/ntp_debian.yml"
   when:
-    - ansible_os_family in ['RedHat', 'Debian']
+    - ansible_os_family == 'Debian'
+    - ntp_service_enabled
+  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
+  static: False
+
+- name: include ntp rpm setup tasks
+  include: "misc/ntp_rpm.yml"
+  when:
+    - ansible_os_family in ['RedHat', 'Suse']
     - ntp_service_enabled
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False

--- a/roles/ceph-common/tasks/misc/ntp_rpm.yml
+++ b/roles/ceph-common/tasks/misc/ntp_rpm.yml
@@ -1,5 +1,5 @@
 ---
-- name: install ntp on redhat
+- name: install ntp
   package:
     name: ntp
     state: present

--- a/roles/ceph-config/meta/main.yml
+++ b/roles/ceph-config/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -72,6 +72,12 @@ redhat_package_dependencies:
   - hdparm
   - python-setuptools
 
+suse_package_dependencies:
+  - python-pycurl
+  - python-xml
+  - hdparm
+  - python-setuptools
+
 # Whether or not to install the ceph-test package.
 ceph_test: false
 
@@ -108,7 +114,7 @@ ceph_custom: False # backward compatibility with stable-2.2, will disappear in s
 # ORIGIN SOURCE
 #
 # Choose between:
-# - 'repository' means that you will get ceph installed through a new repository. Later below choose between 'community', 'rhcs' or 'dev'
+# - 'repository' means that you will get ceph installed through a new repository. Later below choose between 'community', 'rhcs', 'dev' or 'obs'
 # - 'distro' means that no separate repo file will be added
 #  you will get whatever version of Ceph is included in your Linux distro.
 # 'local' means that the ceph binaries will be copied over from the local machine
@@ -126,6 +132,7 @@ valid_ceph_repository:
   - dev
   - uca
   - custom
+  - obs
 
 
 # REPOSITORY: COMMUNITY VERSION
@@ -193,6 +200,15 @@ ceph_rhcs_cdn_debian_repo_version: "/3-release/" # for GA, later for updates use
 #ceph_stable_openstack_release_uca: liberty
 #ceph_stable_release_uca: "{{ansible_lsb.codename}}-updates/{{ceph_stable_openstack_release_uca}}"
 
+# REPOSITORY: openSUSE OBS
+#
+# Enabled when ceph_repository == 'obs'
+#
+# This allows the install of Ceph from the openSUSE OBS repository. The OBS repository
+# usually has newer Ceph releases than the normal distro repository.
+#
+#
+#ceph_obs_repo: "https://download.opensuse.org/repositories/filesystems:/ceph:/luminous/openSUSE_Leap_{{ ansible_distribution_version }}/"
 
 # REPOSITORY: DEV
 #

--- a/roles/ceph-docker-common/meta/main.yml
+++ b/roles/ceph-docker-common/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-docker-common/tasks/checks/check_ntp_rpm.yml
+++ b/roles/ceph-docker-common/tasks/checks/check_ntp_rpm.yml
@@ -1,5 +1,5 @@
 ---
-- name: check ntp installation on redhat
+- name: check ntp installation on redhat or suse
   command: rpm -q ntp
   args:
     warn: no
@@ -8,9 +8,9 @@
   check_mode: no
   changed_when: false
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_os_family in ['RedHat', 'Suse']
 
-- name: install ntp on redhat
+- name: install ntp on redhat or suse
   package:
     name: ntp
     state: present

--- a/roles/ceph-docker-common/tasks/main.yml
+++ b/roles/ceph-docker-common/tasks/main.yml
@@ -75,11 +75,11 @@
     - ansible_os_family == 'RedHat'
     - ntp_service_enabled
 
-- name: include misc/ntp_redhat.yml
-  include: misc/ntp_redhat.yml
+- name: include misc/ntp_rpm.yml
+  include: misc/ntp_rpm.yml
   when:
     - not is_atomic
-    - ansible_os_family == 'RedHat'
+    - ansible_os_family in ['RedHat', 'Suse']
     - ntp_service_enabled
 
 - name: include misc/ntp_debian.yml

--- a/roles/ceph-docker-common/tasks/misc/ntp_rpm.yml
+++ b/roles/ceph-docker-common/tasks/misc/ntp_rpm.yml
@@ -1,8 +1,8 @@
 ---
-- name: include ../checks/check_ntp_redhat.yml
-  include: ../checks/check_ntp_redhat.yml
+- name: include ../checks/check_ntp_rpm.yml
+  include: ../checks/check_ntp_rpm.yml
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_os_family in ['RedHat', 'Suse']
 
 - name: start the ntp service
   service:

--- a/roles/ceph-fetch-keys/meta/main.yml
+++ b/roles/ceph-fetch-keys/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-mds/meta/main.yml
+++ b/roles/ceph-mds/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-mgr/meta/main.yml
+++ b/roles/ceph-mgr/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-mon/meta/main.yml
+++ b/roles/ceph-mon/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-nfs/meta/main.yml
+++ b/roles/ceph-nfs/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -113,7 +113,7 @@
   when:
     - (ceph_origin == 'repository' or ceph_origin == 'distro')
     - ceph_repository != 'rhcs'
-    - ansible_os_family == 'Debian'
+    - ansible_os_family in ['Debian', 'Suse']
     - nfs_file_gw
 
 - name: install nfs rgw gateway
@@ -125,7 +125,7 @@
   when:
     - (ceph_origin == 'repository' or ceph_origin == 'distro')
     - ceph_repository != 'rhcs'
-    - ansible_os_family == 'Debian'
+    - ansible_os_family in ['Debian', 'Suse']
     - nfs_obj_gw
 
 # debian_rhcs installation

--- a/roles/ceph-osd/meta/main.yml
+++ b/roles/ceph-osd/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-rbd-mirror/meta/main.yml
+++ b/roles/ceph-rbd-mirror/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-restapi/meta/main.yml
+++ b/roles/ceph-restapi/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/roles/ceph-rgw/meta/main.yml
+++ b/roles/ceph-rgw/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: opensuse
+      versions:
+        - 42.3
   categories:
     - system
 dependencies: []

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -43,6 +43,12 @@
       when:
         - systempython2.stat.exists is undefined or systempython2.stat.exists == false
 
+    - name: install python2 for opensuse
+      raw: sudo zypper -n install python-base creates=/usr/bin/python2.7
+      ignore_errors: yes
+      when:
+        - systempython2.stat.exists is undefined or systempython2.stat.exists == false
+
     - name: gather facts
       setup:
       when:

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -43,6 +43,7 @@ disks: [ '/dev/sdb', '/dev/sdc' ]
 #
 # Ubuntu: ceph/ubuntu-xenial or bento/ubuntu-16.04 or ubuntu/trusty64 or ubuntu/wily64
 # CentOS: bento/centos-7.1 or puppetlabs/centos-7.0-64-puppet
+# openSUSE: opensuse/openSUSE-42.3-x86_64
 # libvirt CentOS: centos/7
 # parallels Ubuntu: parallels/ubuntu-14.04
 # Debian: deb/jessie-amd64 - be careful the storage controller is named 'SATA Controller'


### PR DESCRIPTION
This PR adds support for openSUSE Leap 42.3 support. The Ceph packages can either be installed from the official repositories or from the OBS one.