### PR TITLE
purge-docker-cluster: ensure old logs are removed

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -437,6 +437,21 @@
     tags:
       remove_img
 
+  - name: include vars from group_vars/osds.yml
+    include_vars:
+      file: "{{ item }}"
+    with_first_found:
+      - files:
+        - "{{ playbook_dir }}/group_vars/osds"
+        - "{{ playbook_dir }}/group_vars/osds.yml"
+        skip: true
+
+  - name: ensure all osd_disk_prepare logs are removed
+    file:
+      path: "{{ item }}"
+      state: absent
+    with_fileglob:
+      - "{{ ceph_osd_docker_run_script_path | default('/usr/share') }}/ceph-osd-prepare-*.log"
 
 - name: purge ceph mon cluster
 


### PR DESCRIPTION
purge-docker-cluster must remove all osd_disk_prepare logs in
`{{ ceph_osd_docker_run_script_path }}`, otherwise if you purge your
cluster and try to redeploy it, osds will fail to start since because it
will try to retrieve find a partition uuid which doesn't exist.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1510470

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>