### PR TITLE
[skip ci] osd: always run disk_list test

### DIFF
--- a/roles/ceph-osd/tasks/docker/start_docker_osd.yml
+++ b/roles/ceph-osd/tasks/docker/start_docker_osd.yml
@@ -15,8 +15,6 @@
   changed_when: false
   failed_when: false
   register: disk_list
-  when:
-    - ceph_release_num[ceph_release] < ceph_release_num.kraken
 
 - name: generate ceph osd docker run script
   become: true

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -5,7 +5,7 @@
 #############
 # FUNCTIONS #
 #############
-{% if disk_list.get("rc", 1) == 0 -%}
+{% if disk_list.get('rc') == 0 -%}
 function expose_partitions () {
 DOCKER_ENV=$(docker run --rm --name expose_partitions_${1} --privileged=true -v /dev/:/dev/ -v /etc/ceph:/etc/ceph -e CLUSTER={{ cluster }} -e OSD_DEVICE=/dev/${1} {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} disk_list)
   docker rm -f expose_partitions_${1}


### PR DESCRIPTION
there is no need to have a condition on this task, this test should be
always run since the result will be interpreted later.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 591d77220e4e8fef12faf4312ec977c3e175ed09)