### PR TITLE
osd: avoid using non desired loop device in autodiscovery

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -26,6 +26,7 @@
     - osd_auto_discovery
     - ansible_devices is defined
     - item.value.removable == "0"
+    - item.value.sectors != "0"
     - item.value.partitions|count == 0
     - item.value.holders|count == 0
     - "'dm-' not in item.key"


### PR DESCRIPTION
This will prevent ceph-ansible from using a loop device while it
shouldn't in auto_discovery mode.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 43975a7332795fb85a92101b8049c2854598b4e5)