### PR TITLE
tests: set CEPH_STABLE_RELEASE in ceph-build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -144,9 +144,7 @@ setenv=
   shrink_osd_container: PLAYBOOK = site-docker.yml.sample
 
   rhcs: CEPH_STABLE_RELEASE = luminous
-  jewel: CEPH_STABLE_RELEASE = jewel
   jewel: UPDATE_CEPH_STABLE_RELEASE = luminous
-  luminous: CEPH_STABLE_RELEASE = luminous
   luminous: UPDATE_CEPH_STABLE_RELEASE = luminous
   luminous: UPDATE_CEPH_DOCKER_IMAGE_TAG = tag-build-master-luminous-ubuntu-16.04
   lvm_osds: CEPH_STABLE_RELEASE = luminous


### PR DESCRIPTION
`CEPH_STABLE_RELEASE` needs to bet set in ceph-build according
to ceph/ceph-ansible#2165

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>