### PR TITLE
[backport][stable-3.0] tests: remove OSD_FORCE_ZAP variable from tests

### DIFF
--- a/roles/ceph-osd/tasks/build_devices.yml
+++ b/roles/ceph-osd/tasks/build_devices.yml
@@ -1,0 +1,37 @@
+---
+- name: set_fact devices generate device list when osd_auto_discovery
+  set_fact:
+    devices: "{{ devices | default([]) + [ item.key | regex_replace('^', '/dev/') ] }}"
+  with_dict: "{{ ansible_devices }}"
+  when:
+    - osd_auto_discovery
+    - ansible_devices is defined
+    - item.value.removable == "0"
+    - item.value.sectors != "0"
+    - item.value.partitions|count == 0
+    - item.value.holders|count == 0
+    - "'dm-' not in item.key"
+
+- name: resolve dedicated device link(s)
+  command: readlink -f {{ item }}
+  changed_when: false
+  with_items: "{{ dedicated_devices }}"
+  register: dedicated_devices_prepare_canonicalize
+  when:
+    - osd_scenario == 'non-collocated'
+    - not osd_auto_discovery
+
+- name: set_fact build dedicated_devices from resolved symlinks
+  set_fact:
+    dedicated_devices_tmp: "{{ dedicated_devices_tmp | default([]) + [ item.stdout ] }}"
+  with_items: "{{ dedicated_devices_prepare_canonicalize.results }}"
+  when:
+    - osd_scenario == 'non-collocated'
+    - not osd_auto_discovery
+
+- name: set_fact build final dedicated_devices list
+  set_fact:
+    dedicated_devices: "{{ dedicated_devices_tmp | reject('search','/dev/disk') | list }}"
+  when:
+    - osd_scenario == 'non-collocated'
+    - not osd_auto_discovery

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -18,23 +18,8 @@
 - name: include ceph_disk_cli_options_facts.yml
   include: ceph_disk_cli_options_facts.yml
 
-- name: set_fact devices generate device list when osd_auto_discovery
-  set_fact:
-    devices: "{{ devices | default([]) + [ item.key | regex_replace('^', '/dev/') ] }}"
-  with_dict: "{{ ansible_devices }}"
-  when:
-    - osd_auto_discovery
-    - ansible_devices is defined
-    - item.value.removable == "0"
-    - item.value.sectors != "0"
-    - item.value.partitions|count == 0
-    - item.value.holders|count == 0
-    - "'dm-' not in item.key"
-
-- name: include check_devices.yml
-  include: check_devices.yml
-  when:
-    - not osd_auto_discovery
+- name: include build_devices.yml
+  include: build_devices.yml
 
 - name: check if a partition named 'ceph' exists
   shell: "parted --script {{ item }} print | egrep -sq '^ 1.*ceph'"

--- a/tests/functional/centos/7/bs-osds-container/group_vars/all.yml
+++ b/tests/functional/centos/7/bs-osds-container/group_vars/all.yml
@@ -6,7 +6,7 @@ cluster: test
 monitor_interface: eth1
 public_network: "192.168.35.0/24"
 cluster_network: "192.168.36.0/24"
-ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }} -e OSD_FORCE_ZAP=1
+ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }}
 ceph_conf_overrides:
   global:
     osd_pool_default_size: 1

--- a/tests/functional/centos/7/docker-collocation/group_vars/all
+++ b/tests/functional/centos/7/docker-collocation/group_vars/all
@@ -15,7 +15,7 @@ cluster_network: "192.168.16.0/24"
 osd_scenario: collocated
 ceph_rgw_civetweb_port: 8080
 osd_objectstore: filestore
-ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }} -e OSD_FORCE_ZAP=1
+ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }}
 devices:
   - /dev/sda
   - /dev/sdb

--- a/tests/functional/centos/7/docker/group_vars/all
+++ b/tests/functional/centos/7/docker/group_vars/all
@@ -15,7 +15,7 @@ cluster_network: "192.168.18.0/24"
 osd_scenario: collocated
 ceph_rgw_civetweb_port: 8080
 osd_objectstore: filestore
-ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }} -e OSD_FORCE_ZAP=1
+ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }}
 devices:
   - '/dev/disk/by-id/ata-QEMU_HARDDISK_QM00001'
   - /dev/sdb

--- a/tests/functional/centos/7/fs-osds-container/group_vars/all.yml
+++ b/tests/functional/centos/7/fs-osds-container/group_vars/all.yml
@@ -6,7 +6,7 @@ cluster: test
 monitor_interface: eth1
 public_network: "192.168.55.0/24"
 cluster_network: "192.168.56.0/24"
-ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }} -e OSD_FORCE_ZAP=1
+ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }}
 ceph_conf_overrides:
   global:
     osd_pool_default_size: 1


### PR DESCRIPTION
according to ceph/ceph-container#840, this variable is no longer needed.

backport of #2170 

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit aa0b1ed11872ea6f69f69b4a376b13ae5d6e12e0)