### PR TITLE
Set permissions and ACLs of OpenStack keys on all ceph-mons

### DIFF
--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -50,24 +50,25 @@
     - openstack_config
     - item.0 != groups[mon_group_name] | last
 
-- name: chmod openstack key(s)
+- name: chmod openstack key(s) on the other mons and this mon
   file:
-    path: "/etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
-    mode: "{{ item.mode|default(omit) }}" # if mode not in list, uses mode from ps umask
-  with_items: "{{ openstack_keys }}"
+    path: "/etc/ceph/{{ cluster }}.{{ item.1.name }}.keyring"
+    mode: "{{ item.1.mode|default(omit) }}" # if mode not in list, uses mode from ps umask
+  with_nested:
+    - "{{ groups[mon_group_name] }}"
+    - "{{ openstack_keys }}"
+  delegate_to: "{{ item.0 }}"
   when:
     - openstack_config
     - cephx
-    
-- name: setfacl for openstack key(s)
-  acl:
-    path: "/etc/ceph/{{ cluster }}.{{ item.0.name }}.keyring"
-    entry: "{{ item.1 }}"
-    state: present
-  with_subelements:
+
+- name: setfacl for openstack key(s) on the other mons and this mon
+  command: "setfacl -m {{ item.1.acls | join(',') }} /etc/ceph/{{ cluster }}.{{ item.1.name }}.keyring"
+  with_nested:
+    - "{{ groups[mon_group_name] }}"
     - "{{ openstack_keys }}"
-    - acls
-    - skip_missing: true
+  delegate_to: "{{ item.0 }}"
   when:
+    - item.1.acls | length > 0
     - openstack_config
     - cephx


### PR DESCRIPTION
If ceph-ansible deploys a Ceph cluster with "openstack_config: true"
and sets the openstack_keys map to have certain ACLs or permissions,
the requested ACLs or permissions are only set on one of the monitor
nodes [2] when they should be set on all of them.

This patch solves [3] the above issue by having the chmod and setfacl
tasks iterate the list of mon nodes (including the mon node that the
task was delegated to) to apply the chmod of setfacl to the keys in
openstack_keys.

[1]
```
openstack_keys:
  - { name: client.openstack, key: "$(ceph-authtool --gen-print-key)", mon_cap: "allow r", osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool=images, allow rwx pool=vms, allow rwx pool=volumes, allow rwx pool=backups", mode: "0600", acls: ["u:nova:r--", "u:cinder:r--", "u:glance:r--", "u:gnocchi:r--"] }
```
[2]
```
$ ansible mons -m shell -b -a "ls -l /etc/ceph/ceph.client.openstack.keyring ; getfacl /etc/ceph/ceph.client.openstack.keyring"
192.168.1.26 | SUCCESS | rc=0 >>
-rw-r-----+ 1 root root 253 Nov  3 20:30 /etc/ceph/ceph.client.openstack.keyring
user::rw-
user:glance:r--
user:nova:r--
user:cinder:r--
user:gnocchi:r--
group::---
mask::r--
other::---getfacl: Removing leading '/' from absolute path names

192.168.1.29 | SUCCESS | rc=0 >>
-rw-r--r--. 1 root root 253 Nov  3 20:30 /etc/ceph/ceph.client.openstack.keyring
user::rw-
group::r--
other::r--getfacl: Removing leading '/' from absolute path names

192.168.1.23 | SUCCESS | rc=0 >>
-rw-r--r--. 1 root root 253 Nov  3 20:30 /etc/ceph/ceph.client.openstack.keyring
user::rw-
group::r--
other::r--getfacl: Removing leading '/' from absolute path names

$
```
[3]
```
(undercloud) [stack@hci-director ceph-ansible]$ ansible mons -m shell -b -a "ls -l /etc/ceph/ceph.client.openstack.keyring ; getfacl /etc/ceph/ceph.client.openstack.keyring"
192.168.1.25 | SUCCESS | rc=0 >>
-rw-r-----+ 1 root root 253 Nov 14 01:12 /etc/ceph/ceph.client.openstack.keyring
user::rw-
user:glance:r--
user:nova:r--
user:cinder:r--
user:gnocchi:r--
group::---
mask::r--
other::---getfacl: Removing leading '/' from absolute path names

192.168.1.29 | SUCCESS | rc=0 >>
-rw-r-----+ 1 root root 253 Nov 14 01:12 /etc/ceph/ceph.client.openstack.keyring
user::rw-
user:glance:r--
user:nova:r--
user:cinder:r--
user:gnocchi:r--
group::---
mask::r--
other::---getfacl: Removing leading '/' from absolute path names

192.168.1.27 | SUCCESS | rc=0 >>
-rw-r-----+ 1 root root 253 Nov 14 01:12 /etc/ceph/ceph.client.openstack.keyring
user::rw-
user:glance:r--
user:nova:r--
user:cinder:r--
user:gnocchi:r--
group::---
mask::r--
other::---getfacl: Removing leading '/' from absolute path names

(undercloud) [stack@hci-director ceph-ansible]$
```