### PR TITLE
fix: ganesha conf file path

### DIFF
--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -10,7 +10,7 @@
 - name: generate ganesha configuration file
   action: config_template
   args:
-    src: "{{ lookup('env', 'ANSIBLE_ROLES_PATH') | default (playbook_dir + '/roles', true) }}/ceph-nfs/templates/ganesha.conf.j2"
+    src: "ganesha.conf.j2"
     dest: /etc/ganesha/ganesha.conf
     owner: "root"
     group: "root"
@@ -43,7 +43,7 @@
 - name: generate systemd unit file
   become: true
   template:
-    src: "{{ role_path }}/templates/ceph-nfs.service.j2"
+    src: "ceph-nfs.service.j2"
     dest: /etc/systemd/system/ceph-nfs@.service
     owner: "root"
     group: "root"


### PR DESCRIPTION
The default path is the role's templates dir, so the prefix is not needed.
Same as the ceph-config role，