### PR TITLE
rbd: enable ceph-rbd-mirror.target on releases prior to luminous

### DIFF
--- a/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
@@ -26,15 +26,6 @@
   when:
     - ceph_release_num[ceph_release] < ceph_release_num.luminous
 
-- name: enable ceph-rbd-mirror.target on jewel
-  systemd:
-    name: "ceph-rbd-mirror.target"
-    state: started
-    enabled: yes
-  changed_when: false
-  when:
-    - ceph_release_num[ceph_release] < ceph_release_num.luminous
-
 - name: stop and remove the generic rbd-mirror service instance
   service:
     name: "ceph-rbd-mirror@{{ ceph_rbd_mirror_local_user }}"
@@ -48,12 +39,13 @@
 # The upstream fix is: https://github.com/ceph/ceph/pull/17969
 # It's affecting, ceph version 12.2.0 (32ce2a3ae5239ee33d6150705cdb24d43bab910c) luminous (rc) and before
 - name: enable ceph-rbd-mirror.target
-  service:
+  systemd:
     name: "ceph-rbd-mirror.target"
+    state: started
     enabled: yes
   changed_when: false
   when:
-    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
+    - ceph_release_num[ceph_release] <= ceph_release_num.luminous
 
 - name: start and add the rbd-mirror service instance
   service:


### PR DESCRIPTION
when `ceph-rbd-mirror.target` is not enabled, the service won't start
after a reboot because there is a dependency between these two units.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>