### PR TITLE
purge-docker: remove osd disk prepare logs

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -446,12 +446,18 @@
         - "{{ playbook_dir }}/group_vars/osds.yml"
         skip: true
 
+  - name: find all osd_disk_prepare logs
+    find:
+      paths: "{{ ceph_osd_docker_run_script_path | default('/usr/share') }}"
+      pattern: "ceph-osd-prepare-*.log"
+    register: osd_disk_prepare_logs
+
   - name: ensure all osd_disk_prepare logs are removed
     file:
-      path: "{{ item }}"
+      path: "{{ item.path }}"
       state: absent
-    with_fileglob:
-      - "{{ ceph_osd_docker_run_script_path | default('/usr/share') }}/ceph-osd-prepare-*.log"
+    with_items:
+      - "{{ osd_disk_prepare_logs.files }}"
 
 - name: purge ceph mon cluster
 


### PR DESCRIPTION
`with_fileglob` loops over files on the machine that runs the playbook.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>