### PR TITLE
purge-cluster: remove usage of `with_fileglob`

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -661,12 +661,18 @@
     register: check_for_running_ceph
     failed_when: check_for_running_ceph.rc == 0
 
+  - name: find ceph systemd unit files to remove
+    find:
+      paths: "/etc/systemd/system"
+      pattern: "ceph*"
+    register: systemd_files
+
   - name: remove ceph systemd unit files
     file:
-      path: "{{ item }}"
+      path: "{{ item.path }}"
       state: absent
-    with_fileglob: /etc/systemd/system/ceph*
-    changed_when: false
+    with_items:
+      - "{{ systemd_files.files }}"
     when: ansible_service_mgr == 'systemd'
 
 


### PR DESCRIPTION
`with_fileglob` loops over files on the machine where ansible-playbook
is being run. Here, we want to iterate over files on the remote machine

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>