### PR TITLE
Make openstack_keys param support no acls list

### DIFF
--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -69,6 +69,6 @@
     - "{{ openstack_keys }}"
   delegate_to: "{{ item.0 }}"
   when:
-    - item.1.acls | length > 0
+    - item.1.get('acls', []) | length > 0
     - openstack_config
     - cephx


### PR DESCRIPTION
A recent change [1] required that the openstack_keys
param always containe an acls list. However, it's
possible it might not contain that list. Thus, this
param sets a default for that list to be empty if it
is not in the structure as defined by the user.

[1] d65cbaa53952269ec9a2e76fca8203ce7ad22c2b