### PR TITLE
crush: create rack type buckets and build crush tree according to {{ …

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -70,6 +70,9 @@ dummy:
 #  - "{{ crush_rule_hdd }}"
 #  - "{{ crush_rule_ssd }}"
 
+# Caution: this will create crush roots and racks according to {{ osd_crush_location }}
+# and will move hosts into them which might lead to significant data movement in the cluster!
+#create_crush_tree: false
 
 #############
 # OPENSTACK #

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -62,6 +62,9 @@ crush_rules:
   - "{{ crush_rule_hdd }}"
   - "{{ crush_rule_ssd }}"
 
+# Caution: this will create crush roots and racks according to {{ osd_crush_location }}
+# and will move hosts into them which might lead to significant data movement in the cluster!
+create_crush_tree: false
 
 #############
 # OPENSTACK #

--- a/roles/ceph-mon/tasks/crush_rules.yml
+++ b/roles/ceph-mon/tasks/crush_rules.yml
@@ -5,6 +5,31 @@
   changed_when: false
   failed_when: false
   run_once: true
+  when: create_crush_tree
+
+- name: create rack type buckets needed for configured crush rules
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd crush add-bucket {{ hostvars[item]['ceph_crush_rack']|default('default_rack_' + hostvars[item]['ceph_crush_root']) }} rack"
+  with_items: "{{ groups[osd_group_name] }}"
+  changed_when: false
+  failed_when: false
+  run_once: true
+  when: create_crush_tree
+
+- name: move rack type buckets to created corresponding crush roots
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd crush move {{ hostvars[item]['ceph_crush_rack']|default('default_rack_' + hostvars[item]['ceph_crush_root']) }} root={{ hostvars[item]['ceph_crush_root'] }}"
+  with_items: "{{ groups[osd_group_name] }}"
+  changed_when: false
+  failed_when: false
+  run_once: true
+  when: create_crush_tree
+
+- name: move host type buckets to rack type ones
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd crush move {{ hostvars[item]['ansible_hostname'] }} rack={{ hostvars[item]['ceph_crush_rack']|default('default_rack_' + hostvars[item]['ceph_crush_root']) }}"
+  with_items: "{{ groups[osd_group_name] }}"
+  changed_when: false
+  failed_when: false
+  run_once: true
+  when: create_crush_tree
 
 - name: create configured crush rules
   command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-simple {{ item.name }} {{ item.root }} {{ item.type }}"


### PR DESCRIPTION
…osd_crush_location }}.

Currently, we can define crush location for each host but only crush roots and crush rules are created. This commit automates other routines for a complete solution:
  1) Creates rack type crush buckets defined in {{ ceph_crush_rack }} of each osd host. If it's not defined by user then a rack named 'default_rack_{{ ceph_crush_root  }}' would be added and used in next steps.
  2) Move rack type crush buckets defined in {{ ceph_crush_rack }} into crush roots defined in {{ ceph_crush_root }} of each osd host.
  3) Move hosts defined in {{ ceph_crush_rack }} into crush roots defined in {{ ceph_crush_root }} of each osd host.

Signed-off-by: Eduard Egorov <eduard.egorov@icl-services.com>