### PR TITLE
osd: ensure a gpt label is set on device

### DIFF
--- a/roles/ceph-osd/tasks/check_gpt.yml
+++ b/roles/ceph-osd/tasks/check_gpt.yml
@@ -1,0 +1,19 @@
+---
+- name: check the partition status of the osd disks
+  command: "parted --script {{ item }} print"
+  with_items:
+    - "{{ devices }}"
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  register: osd_partition_status_results
+
+- name: create gpt disk label
+  command: parted --script {{ item.1 }} mklabel gpt
+  with_together:
+    - "{{ osd_partition_status_results.results }}"
+    - "{{ devices }}"
+  changed_when: false
+  when:
+    - not item.0.get("skipped")
+    - item.0.get("rc", 0) != 0

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -36,6 +36,9 @@
     - containerized_deployment
     - not containerized_deployment_with_kv
 
+- name: include check_gpt.yml
+  include: check_gpt.yml
+
 - name: include scenarios/collocated.yml
   include: scenarios/collocated.yml
   when:


### PR DESCRIPTION
ceph-disk prepare will fail on jewel if a GPT label is not present on
device.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>