### PR TITLE
osd: remove leftover and fix a typo

### DIFF
--- a/roles/ceph-osd/tasks/pre_requisite.yml
+++ b/roles/ceph-osd/tasks/pre_requisite.yml
@@ -1,14 +1,5 @@
 ---
-- name: enable extras repo for centos
-  ini_file:
-    dest: /etc/yum.repos.d/CentOS-Base.repo
-    section: extras
-    option: enabled
-    value: 1
-  when:
-    - ansible_distribution == 'CentOS'
-
-- name: install rependencies
+- name: install dependencies
   package:
     name: parted
     state: present


### PR DESCRIPTION
This task was originally needed to fix a docker installation issue
(see: #1030). This has been fixed, therefore it can be removed.

Fixes: #2199

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>