### PR TITLE
purge-cluster: remove usage of `with_fileglob`

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -661,12 +661,18 @@
     register: check_for_running_ceph
     failed_when: check_for_running_ceph.rc == 0
 
+  - name: find ceph systemd unit files to remove
+    find:
+      paths: "/etc/systemd/system"
+      pattern: "ceph*"
+    register: systemd_files
+
   - name: remove ceph systemd unit files
     file:
-      path: "{{ item }}"
+      path: "{{ item.path }}"
       state: absent
-    with_fileglob: /etc/systemd/system/ceph*
-    changed_when: false
+    with_items:
+      - "{{ systemd_files.files }}"
     when: ansible_service_mgr == 'systemd'
 
 


### PR DESCRIPTION
`with_fileglob` loops over files on the machine where ansible-playbook
is being run.

Backport of #2185 

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 947766e294cf8b18eb551a8093b0bbdca7610858)