### PR TITLE
common: install ceph-common on all the machines

### DIFF
--- a/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
@@ -1,4 +1,9 @@
 ---
+- name: install red hat storage ceph-common for debian
+  apt:
+    pkg: ceph-common
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+
 - name: install red hat storage ceph mon for debian
   apt:
     name: ceph-mon
@@ -30,13 +35,6 @@
 - name: install red hat storage ceph-fuse client for debian
   apt:
     pkg: ceph-fuse
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install red hat storage ceph-common for debian
-  apt:
-    pkg: ceph-common
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - client_group_name in group_names


### PR DESCRIPTION
Since some daemons now install their own packages the task checking the
ceph version fails on Debian systems. So the 'ceph-common' package must
be installed on all the machines.

Signed-off-by: Sébastien Han <seb@redhat.com>