### PR TITLE
handlers: restart daemons only if docker is running

### DIFF
--- a/roles/ceph-defaults/handlers/main.yml
+++ b/roles/ceph-defaults/handlers/main.yml
@@ -38,6 +38,7 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - mon_group_name in group_names
     - containerized_deployment
+    - ceph_mon_container_stat.get('rc') == 0
     - inventory_hostname == groups.get(mon_group_name) | last
     - inventory_hostname in play_hosts
     - ceph_mon_container_stat.get('stdout_lines', [])|length != 0
@@ -86,6 +87,7 @@
     # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
     - osd_group_name in group_names
     - containerized_deployment
+    - ceph_osd_container_stat.get('rc') == 0
     - inventory_hostname == groups.get(osd_group_name) | last
     - ((crush_location is defined and crush_location) or ceph_osd_container_stat.get('stdout_lines', [])|length != 0)
     - handler_health_osd_check
@@ -128,6 +130,7 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - mds_group_name in group_names
     - containerized_deployment
+    - ceph_mds_container_stat.get('rc') == 0
     - inventory_hostname == groups.get(mds_group_name) | last
     - inventory_hostname in play_hosts
     - ceph_mds_container_stat.get('stdout_lines', [])|length != 0
@@ -168,6 +171,7 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - rgw_group_name in group_names
     - containerized_deployment
+    - ceph_rgw_container_stat.get('rc') == 0
     - inventory_hostname == groups.get(rgw_group_name) | last
     - inventory_hostname in play_hosts
     - ceph_rgw_container_stat.get('stdout_lines', [])|length != 0
@@ -208,6 +212,7 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - nfs_group_name in group_names
     - containerized_deployment
+    - ceph_nfs_container_stat.get('rc') == 0
     - inventory_hostname == groups.get(nfs_group_name) | last
     - inventory_hostname in play_hosts
     - ceph_nfs_container_stat.get('stdout_lines', [])|length != 0
@@ -248,6 +253,7 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - rbdmirror_group_name in group_names
     - containerized_deployment
+    - ceph_rbd_mirror_container_stat.get('rc') == 0
     - inventory_hostname == groups.get(rbdmirror_group_name) | last
     - inventory_hostname in play_hosts
     - ceph_rbd_mirror_container_stat.get('stdout_lines', [])|length != 0
@@ -288,6 +294,7 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - mgr_group_name in group_names
     - containerized_deployment
+    - ceph_mgr_container_stat.get('rc') == 0
     - inventory_hostname == groups.get(mgr_group_name) | last
     - inventory_hostname in play_hosts
     - ceph_mgr_container_stat.get('stdout_lines', [])|length != 0


### PR DESCRIPTION
In case where docker CLI is available but docker is not running, we
don't want to trigger the restart of the daemons.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1510555

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>