### PR TITLE
Add support for using loopback devices as OSDs

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -3,7 +3,7 @@
 # partition.
 
 - name: activate osd(s) when device is a disk
-  command: ceph-disk activate {{ item | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
+  command: ceph-disk activate "{{ item | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\1p') | regex_replace('^(\/dev\/loop[0-9]{1})$', '\1p') }}1"
   with_items:
     - "{{ devices|unique }}"
   changed_when: false
@@ -13,7 +13,7 @@
     - not dmcrypt
 
 - name: activate osd(s) when device is a disk (dmcrypt)
-  command: ceph-disk activate --dmcrypt {{ item | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\\1p') }}1
+  command: ceph-disk activate --dmcrypt "{{ item | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\1p') | regex_replace('^(\/dev\/loop[0-9]{1})$', '\1p') }}1"
   with_items:
     - "{{ devices|unique }}"
   changed_when: false


### PR DESCRIPTION
This is particularly useful in CI environments where you dont have
the option of adding extra devices or volumes to the host. It is also
a simple change to support loopback devices.