### PR TITLE
ceph-osd: respect nvme partitions when device is a disk.

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -3,7 +3,7 @@
 # partition.
 
 - name: activate osd(s) when device is a disk
-  command: ceph-disk activate "{{ item | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\1p') | regex_replace('^(\/dev\/loop[0-9]{1})$', '\1p') }}1"
+  command: ceph-disk activate "{{ item }}{%- if 'nvme' in item or 'cciss' in item or 'loop' in item %}{{ 'p' }}{%- endif %}{{ '1' }}"
   with_items:
     - "{{ devices|unique }}"
   changed_when: false
@@ -12,8 +12,9 @@
     - not osd_auto_discovery
     - not dmcrypt
 
+
 - name: activate osd(s) when device is a disk (dmcrypt)
-  command: ceph-disk activate --dmcrypt "{{ item | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\1p') | regex_replace('^(\/dev\/loop[0-9]{1})$', '\1p') }}1"
+  command: ceph-disk activate --dmcrypt "{{ item }}{%- if 'nvme' in item or 'cciss' in item or 'loop' in item %}{{ 'p' }}{%- endif %}{{ '1' }}"
   with_items:
     - "{{ devices|unique }}"
   changed_when: false


### PR DESCRIPTION
Bugfix fo #2206.
I was found that partition number is hardcoded to task, but for ata devices partition number is only number. For nvme device needed prefix 'p' before partition number.


Test:
```yaml
---
- hosts: localhost
  gather_facts: false
  vars:
    devices:
    - '/dev/sda'
    - '/dev/sdb'
    - '/dev/nvme0n1'
    - '/dev/nvme0n2'
  tasks:
  - name: Test nvme for 2206
    command: echo "{{ item | regex_replace('^(\/dev\/cciss\/c[0-9]{1}d[0-9]{1})$', '\1p') | regex_replace('^(\/dev\/loop[0-9]{1})$', '\1p') }}
                   {%- if 'nvme' in item %}{{ 'p1' }}{% else %}{{ '1' }}{% endif %}"
    with_items:
    - "{{ vars['devices'] | unique }}"
    register: result
    loop_control:
      label: "{{ 'Device is: ' ~ item ~ ', device with partition is: ' ~ result.stdout_lines[0] }}"
```

Result:

```python
PLAY [localhost] *************************************************************************************************************************************

TASK [Test nvme for 2206] ****************************************************************************************************************************
changed: [localhost] => (item=Device is: /dev/sda, device with partition is: /dev/sda1)
changed: [localhost] => (item=Device is: /dev/sdb, device with partition is: /dev/sdb1)
changed: [localhost] => (item=Device is: /dev/nvme0n1, device with partition is: /dev/nvme0n1p1)
changed: [localhost] => (item=Device is: /dev/nvme0n2, device with partition is: /dev/nvme0n2p1)

PLAY RECAP *******************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0   
```