### PR TITLE
purge: fix bug on 'wait_for' task

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -213,7 +213,7 @@
 
   - name: wait for server to boot
     become: false
-    local_action: wait_for port=22 host={{ inventory_hostname }} state=started delay=10 timeout=500
+    local_action: wait_for port=22 host={{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }} state=started delay=10 timeout=500
 
   - name: remove data
     file:


### PR DESCRIPTION
this task hangs because `{{ inventory_hostname }}` doesn't resolv to an
actual ip address.
Using `hostvars[inventory_hostname]['ansible_default_ipv4']['address']`
should fix this because it will reach the node with its actual IP
address.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>