### PR TITLE
[stable-3.0]Add information about current branch to index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,7 +65,8 @@ The ``master`` branch should be considered experimental and used with caution.
 - ``stable-2.2`` Support for ceph versions ``jewel`` and ``kraken``. This branch supports ansible versions
   ``2.1`` and ``2.2.2``.
 
-- ``master`` Support for ceph versions ``jewel``, ``kraken`` and ``luminous``. This branch supports ansible version ``2.3.1``.
+- ``stable-3.0`` Support for ceph versions ``jewel`` and ``luminous``. This branch supports ansible versions
+  ``2.3.1``, ``2.3.2`` and ``2.4.1``.
 
 Configuration and Usage
 =======================


### PR DESCRIPTION
It turns out that index.rst contains outdated information about
master branch and doesn't contain information about current branch
(stable-3.0). This patch fixes this issue.