### PR TITLE
WIP: osd: Create multiple OSDs per device

### DIFF
--- a/infrastructure-playbooks/prepare-multiple-osds-per-disk.yml
+++ b/infrastructure-playbooks/prepare-multiple-osds-per-disk.yml
@@ -1,0 +1,135 @@
+---
+# This playbook prepares any drives to host more than one OSD.
+# We know that currently a single OSD hosted on a NVMe can not take advantage of the entire device.
+# As a result, hosting multiple OSDs help taking the best out your NVMe drive.
+#
+# To use:
+# Define "osds_per_device" in group_vars/osds.yml
+# This will automatically partition your devices into equally-sized partitions
+#
+
+- name: confirm whether user really meant to partition devices
+  hosts: localhost
+  gather_facts: false
+
+  vars_prompt:
+    - name: ireallymeanit
+      prompt: Are you sure you want to partition your devices?
+      default: 'no'
+      private: no
+
+  tasks:
+    - name: exit playbook, if user did not mean to partition any device(s)
+      fail:
+        msg: "Exiting prepare-multiple-osd-per-disk playbook, no device(s) was/were partitioned...
+         To prepare your drives, either say 'yes' on the prompt or 
+         use `-e ireallymeanit=yes` on the command line when invoking the playbook"
+      when: ireallymeanit != 'yes'
+
+- name: prepare multi-osd devices
+  vars:
+    osd_group_name: osds
+    osds_per_device: 0
+    journal_size: "{{ 5120|default('journal_size') }}"
+  hosts:
+    - "{{ osd_group_name|default('osds') }}"
+  
+  tasks:
+    - include_vars: ../roles/ceph-common/defaults/main.yml
+    - include_vars: ../group_vars/all.yml
+    - include_vars: ../group_vars/osds.yml
+
+    - name: exit playbook, if no number of OSDs per device were given
+      fail:
+        msg: "Specify how many OSDs you wish to host on each device!"
+      when: osds_per_device == 0
+
+    - name: exit playbook, if no devices are defined
+      fail:
+        msg: "Give me a device list! As a dictionary"
+      when: devices|length == 0
+
+    - name: test if sgdisk command exist
+      shell: "command -v sgdisk"
+      changed_when: false
+      failed_when: false
+      register: sgdisk_command
+      
+    - name: exit playbook, if sgdisk is not installed
+      fail:
+        msg: "The sgdisk command is not available, please install it :("
+      run_once: true
+      when: sgdisk_command.rc != 0
+
+    - name: check the partition status of the device(s)
+      shell: "parted --script {{ item }} print > /dev/null 2>&1"
+      with_items: "{{ devices|default([])|unique }}"
+      changed_when: false
+      failed_when: false
+      register: devices_partition_status
+
+    - name: check if a partition named 'ceph' exists
+      shell: "parted --script {{ item }} print | egrep -sq '^ 1.*ceph'"
+      with_items: "{{ devices }}"
+      changed_when: false
+      failed_when: false
+      register: parted_results
+
+    - name: fix partitions gpt header or labels of the journal devices
+      shell: "sgdisk --zap-all --clear --mbrtogpt -- {{ item.1 }} && sgdisk --zap-all --clear --mbrtogpt -- {{ item.2 }}"
+      with_together:
+        - "{{ devices_partition_status.results }}"
+        - "{{ devices|default([])|unique }}"
+        - "{{ dedicated_devices|default([])|unique }}"
+      changed_when: false
+      when: item.0.rc != 1
+
+    - name: exit playbook, if Ceph partition exists
+      fail:
+        msg: "Looks like a Ceph partition is present, would you like to remove it so we can proceed?"
+      with_items: "{{parted_results.results}}"
+      when: item.get("rc", 0) != 1
+
+    - name: get disk size in GiB
+      shell: "parted {{ item }} unit GiB print  | grep Disk | grep -v Flags | awk {'print $3'} | egrep -o '[0-9]+'"
+      with_items: "{{ devices|default([])|unique }}"
+      changed_when: false
+      failed_when: false
+      register: devices_size
+
+    - name: calculate collocated OSD partition size in GiB
+      set_fact:
+        osd_size: "{{ osd_size | default([]) + [ ((item.stdout|int - (journal_size|int / 1024) * osds_per_device) / osds_per_device)|round(0,'floor')|int ]  }}"
+      with_items: "{{ devices_size.results }}"
+      when:
+        - osd_scenario == 'collocated'
+
+    - name: calculate non-collocated OSD partition size in GiB
+      set_fact:
+        osd_size: "{{ osd_size | default([]) + [ (item.stdout|int / osds_per_device)|round(0,'floor')|int ]  }}"
+      with_items: "{{ devices_size.results }}"
+      when:
+        - osd_scenario == 'non-collocated'
+
+    - name: partition collocated journals
+      shell: "for i in `seq 1 {{ osds_per_device }}`;do sgdisk -n 0:0:+{{ (journal_size|int / 1024)|round(0)|int }}G -t 0:F802 -c 0:\"ceph journal\" {{ item.1 }};done"
+      with_together:
+        - "{{ osd_size|default([]) }}"
+        - "{{ devices|default([])|unique }}"
+      when:
+        - osd_scenario == 'collocated'
+
+    - name: partition non-collocated journals
+      shell: "for i in `seq 1 {{ osds_per_device }}`;do sgdisk -n 0:0:+{{ (journal_size|int / 1024)|round(0)|int }}G -t 0:F802 -c 0:\"ceph journal\" {{ item.1 }};done"
+      with_together:
+        - "{{ osd_size|default([]) }}"
+        - "{{ dedicated_devices|default([]) }}"
+      when:
+        - osd_scenario == 'non-collocated'
+
+    - name: partition OSDs
+      shell: "for i in `seq 1 {{ osds_per_device }}`;do sgdisk -n 0:0:+{{ item.0 }}G -t 0:F800 -c 0:\"ceph data\" {{ item.1 }};done"
+      with_together:
+        - "{{ osd_size|default([]) }}"
+        - "{{ devices|default([])|unique }}"
+

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -7,7 +7,7 @@ journal_collocation: False # backward compatibility with stable-2.2, will disapp
 raw_multi_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 dmcrypt_journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 dmcrypt_dedicated_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
-
+osds_per_device: 1
 
 ###########
 # GENERAL #

--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -22,6 +22,16 @@
     - not osd_auto_discovery
     - dmcrypt
 
+- name: activate osd(s) when device is a partition
+  command: ceph-disk activate {{ item }}
+  with_items:
+    - "{{ osd_data_partitions.stdout_lines }}"
+  when:
+    - not osd_auto_discovery
+    - not dmcrypt
+    - osds_per_device > 1
+  register: activate_osd_disk
+
 # NOTE (leseb): we must do this because of
 # https://github.com/ansible/ansible/issues/4297
 - name: set_fact combined_activate_osd_disk_results

--- a/roles/ceph-osd/tasks/build_devices.yml
+++ b/roles/ceph-osd/tasks/build_devices.yml
@@ -35,3 +35,36 @@
   when:
     - osd_scenario == 'non-collocated'
     - not osd_auto_discovery
+
+- name: get OSD journal partitions
+  shell: blkid | awk '/ceph journal"/ { sub (":", "", $1); print $1 }'
+  when:
+    - osds_per_device > 1
+    - osd_objectstore == 'filestore'
+  failed_when: false
+  register: osd_journal_partitions
+
+- name: get OSD block partitions
+  shell: blkid | awk '/ceph block"/ { sub (":", "", $1); print $1 }'
+  when:
+    - osds_per_device > 1
+    - osd_objectstore == 'bluestore'
+  failed_when: false
+  register: osd_block_partitions
+
+- name: get OSD db partitions
+  shell: blkid | awk '/ceph block.db"/ { sub (":", "", $1); print $1 }'
+  when:
+    - osds_per_device > 1
+    - osd_objectstore == 'bluestore'
+  failed_when: false
+  register: osd_db_partitions
+
+- name: get OSD wal partitions
+  shell: blkid | awk '/ceph block.wal"/ { sub (":", "", $1); print $1 }'
+  when:
+    - osds_per_device > 1
+    - osd_objectstore == 'bluestore'
+  failed_when: false
+  register: osd_wal_partitions
+  

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -62,6 +62,11 @@
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 
+# need to probe for multi-osd disks
+- name: partprobe devices before activating
+  shell: partprobe
+  register: partprobe_results
+
 - name: include activate_osds.yml
   include: activate_osds.yml
   when:

--- a/roles/ceph-osd/tasks/scenarios/collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/collocated.yml
@@ -60,3 +60,13 @@
     - not containerized_deployment
     - not item.0.get("skipped")
     - item.0.get("rc", 0) != 0
+
+- name: manually prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) with collocated multi-osd data and journal(s)
+  command: "ceph-disk prepare {{ ceph_disk_cli_options }} {{ item.0 }} {{ item.1 }} "
+  with_together:
+    - "{{ osd_data_partitions.stdout_lines }}"
+    - "{{ osd_journal_partitions.stdout_lines }}"
+  when:
+    - osds_per_device > 1
+    - not containerized_deployment
+    - osd_objectstore == 'filestore'

--- a/roles/ceph-osd/tasks/scenarios/non-collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/non-collocated.yml
@@ -60,6 +60,16 @@
     - not item.0.get("skipped")
     - item.0.get("rc", 0) != 0
 
+- name: prepare ceph "{{ osd_objectstore }}" non-containerisze multi-osd disk(s) non-collocated
+  command: "ceph-disk prepare {{ ceph_disk_cli_options }} {{ item.0 }} {{ item.1 }} "
+  with_together:
+    - "{{ osd_data_partitions.stdout_lines }}"
+    - "{{ osd_journal_partitions.stdout_lines }}"
+  when:
+    - osds_per_device > 1
+    - not containerized_deployment
+    - osd_objectstore == 'filestore'
+
 - name: prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) non-collocated
   command: "ceph-disk prepare {{ ceph_disk_cli_options }} {{ item.1 }} {{ item.2 }}"
   with_together:

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -10,7 +10,7 @@
   failed_when: false
   check_mode: no
   register: osd_id
-  until: osd_id.stdout_lines|length == devices|unique|length
+  until: osd_id.stdout_lines|length == (devices|unique|length|int * osds_per_device|int) or osd_id.stdout_lines|length == devices|unique|length
   retries: 10
 
 - name: ensure systemd service override directory exists


### PR DESCRIPTION
This brings back the support to create OSDs on partitions instead of raw devices. This is needed to take advantage of the parallelism of faster media such as SATA SSD and NVMe SSD. I built the partitioning portion off of PR #1067 and added a new variable called "osds_per_device". Setting this value > 1 in group_var/osds.yml will trigger most of the multi-OSD scenarios. **Currently, only non-containerized Filestore OSDs are supported.**

Closes: #2126 and #1064

Signed-off-by: Orlando Moreno <orlando.moreno@intel.com>