### PR TITLE
Set tighter permissions on keyrings when containerized

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -151,3 +151,17 @@
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
     - osd_scenario != 'lvm'
+
+- name: set_fact ceph_uid for Debian based system
+  set_fact:
+    ceph_uid: 64045
+  when:
+    - containerized_deployment
+    - ceph_docker_image_tag | match("latest") or ceph_docker_image_tag | search("ubuntu")
+
+- name: set_fact ceph_uid for Red Hat based system
+  set_fact:
+    ceph_uid: 167
+  when:
+    - containerized_deployment
+    - ceph_docker_image_tag | search("centos") or ceph_docker_image | search("rhceph") or ceph_docker_image_tag | search("fedora")

--- a/roles/ceph-mgr/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mgr/tasks/docker/copy_configs.yml
@@ -14,7 +14,21 @@
   always_run: true
   register: statconfig
 
-- name: try to fetch ceph config and keys
+- name: try to fetch ceph keys
+  copy:
+    src: "{{ fetch_directory }}/{{ fsid }}/{{ item.0 }}"
+    dest: "{{ item.0 }}"
+    owner: "{{ ceph_uid }}"
+    mode: 0600
+  changed_when: false
+  with_together:
+    - "{{ ceph_config_keys }}"
+    - "{{ statconfig.results }}"
+  when:
+    - item.1.stat.exists == true
+    - item.0 | search("keyring")
+
+- name: try to fetch ceph config
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}/{{ item.0 }}"
     dest: "{{ item.0 }}"
@@ -25,7 +39,9 @@
   with_together:
     - "{{ ceph_config_keys }}"
     - "{{ statconfig.results }}"
-  when: item.1.stat.exists == true
+  when:
+    - item.1.stat.exists == true
+    - not (item.0 | search("keyring"))
 
 - name: "copy mgr key to /var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring"
   command: cp /etc/ceph/{{ cluster }}.mgr.{{ ansible_hostname }}.keyring /var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring

--- a/roles/ceph-mon/tasks/docker/copy_configs.yml
+++ b/roles/ceph-mon/tasks/docker/copy_configs.yml
@@ -49,7 +49,21 @@
   register: statconfig
   always_run: true
 
-- name: try to copy ceph config and keys
+- name: try to copy ceph keys
+  copy:
+    src: "{{ fetch_directory }}/{{ fsid }}/{{ item.0 }}"
+    dest: "{{ item.0 }}"
+    owner: "{{ ceph_uid }}"
+    mode: 0600
+  changed_when: false
+  with_together:
+    - "{{ ceph_config_keys }}"
+    - "{{ statconfig.results }}"
+  when:
+    - item.1.stat.exists == true
+    - item.0 | search("keyring")
+
+- name: try to copy ceph config
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}/{{ item.0 }}"
     dest: "{{ item.0 }}"
@@ -62,6 +76,7 @@
     - "{{ statconfig.results }}"
   when:
     - item.1.stat.exists == true
+    - not (item.0 | search("keyring"))
 
 - name: set selinux permissions
   shell: |


### PR DESCRIPTION
During a containerized deployment, set the permissions
of ceph.client.admin.keyring and other keyrings to
chmod 600 and chown it to ceph.

(cherry picked from commit ffae294288c3f4d1570094bc7cec2abd35fc67c3)