### PR TITLE
defaults: fix CI issue with ceph_uid fact

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -157,7 +157,7 @@
     ceph_uid: 64045
   when:
     - containerized_deployment
-    - ceph_docker_image_tag | match("latest") or ceph_docker_image_tag | search("ubuntu")
+    - ceph_docker_image_tag | search("latest") or ceph_docker_image_tag | search("ubuntu")
 
 - name: set_fact ceph_uid for Red Hat based system
   set_fact:


### PR DESCRIPTION
The CI complains because of `ceph_uid` fact which doesn't exist since
the docker image tag used in the CI doesn't match with this condition.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>