### PR TITLE
Revert "tests: set CEPH_STABLE_RELEASE in ceph-build"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -142,6 +142,7 @@ setenv=
   shrink_osd_container: PLAYBOOK = site-docker.yml.sample
 
   rhcs: CEPH_STABLE_RELEASE = luminous
+  jewel: CEPH_STABLE_RELEASE = jewel
   jewel: UPDATE_CEPH_STABLE_RELEASE = luminous
   jewel: UPDATE_CEPH_DOCKER_IMAGE_TAG = tag-build-master-luminous-ubuntu-16.04
   luminous: CEPH_STABLE_RELEASE = luminous


### PR DESCRIPTION
This reverts commit 7a1d7d92ff4d6f38be9f11f4c26909b361b58f99.

(cherry picked from commit 73a20e9b50f9212f4e610ae021b23c8e010e9991)

backport of #2236 