### PR TITLE
Rename fact docker_version to ceph_docker_version

### DIFF
--- a/roles/ceph-docker-common/tasks/main.yml
+++ b/roles/ceph-docker-common/tasks/main.yml
@@ -39,11 +39,11 @@
   command: docker --version
   changed_when: false
   check_mode: no
-  register: docker_version
+  register: ceph_docker_version
 
-- name: set_fact docker_version docker_version.stdout.split
+- name: set_fact ceph_docker_version ceph_docker_version.stdout.split
   set_fact:
-    docker_version: "{{ docker_version.stdout.split(' ')[2] }}"
+    ceph_docker_version: "{{ ceph_docker_version.stdout.split(' ')[2] }}"
 
 # Only include 'checks.yml' when :
 # we are deploying containers without kv AND host is either a mon OR a nfs OR an osd,

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -8,7 +8,7 @@ ExecStartPre=-/usr/bin/docker stop ceph-mds-{{ ansible_hostname }}
 ExecStartPre=-/usr/bin/docker rm ceph-mds-{{ ansible_hostname }}
 ExecStart=/usr/bin/docker run --rm --net=host \
   --memory={{ ceph_mds_docker_memory_limit }} \
-  {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
+  {% if ceph_docker_version.split('.')[0] | version_compare('13', '>=') -%}
   --cpus={{ ceph_mds_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_mds_docker_cpu_limit * 100000 }} \

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -8,7 +8,7 @@ ExecStartPre=-/usr/bin/docker stop ceph-mgr-{{ ansible_hostname }}
 ExecStartPre=-/usr/bin/docker rm ceph-mgr-{{ ansible_hostname }}
 ExecStart=/usr/bin/docker run --rm --net=host \
   --memory={{ ceph_mgr_docker_memory_limit }} \
-  {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
+  {% if ceph_docker_version.split('.')[0] | version_compare('13', '>=') -%}
   --cpus={{ ceph_mgr_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_mgr_docker_cpu_limit * 100000 }} \

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -8,7 +8,7 @@ ExecStartPre=-/usr/bin/docker rm ceph-mon-%i
 ExecStartPre=$(command -v mkdir) -p /etc/ceph /var/lib/ceph/mon
 ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
   --memory={{ ceph_mon_docker_memory_limit }} \
-{% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
+{% if ceph_docker_version.split('.')[0] | version_compare('13', '>=') -%}
   --cpus={{ ceph_mon_docker_cpu_limit }} \
 {% else -%}
   --cpu-quota={{ ceph_mon_docker_cpu_limit * 100000 }} \

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -49,7 +49,7 @@ expose_partitions "$1"
   --privileged=true \
   --pid=host \
   --memory={{ ceph_osd_docker_memory_limit }} \
-  {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
+  {% if ceph_docker_version.split('.')[0] | version_compare('13', '>=') -%}
   --cpus={{ ceph_osd_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_osd_docker_cpu_limit * 100000 }} \

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -8,7 +8,7 @@ ExecStartPre=-/usr/bin/docker stop ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStartPre=-/usr/bin/docker rm ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStart=/usr/bin/docker run --rm --net=host \
   --memory={{ ceph_rbd_mirror_docker_memory_limit }} \
-  {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
+  {% if ceph_docker_version.split('.')[0] | version_compare('13', '>=') -%}
   --cpus={{ ceph_rbd_mirror_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_rbd_mirror_docker_cpu_limit * 100000 }} \

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -8,7 +8,7 @@ ExecStartPre=-/usr/bin/docker stop ceph-rgw-{{ ansible_hostname }}
 ExecStartPre=-/usr/bin/docker rm ceph-rgw-{{ ansible_hostname }}
 ExecStart=/usr/bin/docker run --rm --net=host \
   --memory={{ ceph_rgw_docker_memory_limit }} \
-  {% if docker_version.split('.')[0] | version_compare('13', '>=') -%}
+  {% if ceph_docker_version.split('.')[0] | version_compare('13', '>=') -%}
   --cpus={{ ceph_rgw_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_rgw_docker_cpu_limit * 100000 }} \


### PR DESCRIPTION
The name docker_version is very generic and is also used by other
roles. As a result, there may be name conflicts. To avoid this a
ceph_ prefix should be used for this fact. Since it is an internal
fact renaming is not a problem.