### PR TITLE
Make sure the ceph user and group is always present

### DIFF
--- a/roles/ceph-common/tasks/create_ceph_user_and_group.yml
+++ b/roles/ceph-common/tasks/create_ceph_user_and_group.yml
@@ -1,0 +1,8 @@
+---
+- name: create user group ceph
+  group:
+    name: 'ceph'
+
+- name: create user ceph
+  user:
+    name: 'ceph'

--- a/roles/ceph-common/tasks/installs/configure_redhat_local_installation.yml
+++ b/roles/ceph-common/tasks/installs/configure_redhat_local_installation.yml
@@ -36,11 +36,3 @@
   synchronize:
     src: "{{ceph_installation_dir}}/"
     dest: "/"
-
-- name: create user group ceph
-  group:
-    name: 'ceph'
-
-- name: create user ceph
-  user:
-    name: 'ceph'

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -98,6 +98,9 @@
     - ceph_current_fsid.rc == 0
     - mon_group_name in group_names
 
+- name: include create_ceph_user_and_group.yml
+  include: create_ceph_user_and_group.yml
+
 - name: include create_ceph_initial_dirs.yml
   include: create_ceph_initial_dirs.yml
 


### PR DESCRIPTION
Some installation types do not have ceph user or Group. This change
ensures that user and group are always present and created if this
is not the case.

Closes: ceph/ceph-ansible#2250