### PR TITLE
docker: add missing condition for selinux tasks

### DIFF
--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -8,6 +8,7 @@
   changed_when: false
   when:
     - containerized_deployment
+    - ansible_os_family == 'RedHat'
     - sestatus is defined
     - sestatus.stdout != 'Disabled'
 

--- a/roles/ceph-mds/tasks/containerized.yml
+++ b/roles/ceph-mds/tasks/containerized.yml
@@ -37,7 +37,9 @@
     - "{{ ceph_conf_key_directory }}"
     - /var/lib/ceph
   changed_when: false
-  when: sestatus.stdout != 'Disabled'
+  when:
+    - ansible_os_family == 'RedHat'
+    - sestatus.stdout != 'Disabled'
 
 - name: generate systemd unit file
   become: true


### PR DESCRIPTION
on `client` and `mds` roles, it tries to set selinux even on non rhel
based distributions.`

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>