### PR TITLE
default: look for the right return code on socket stat in-use

### DIFF
--- a/roles/ceph-defaults/tasks/check_socket_non_container.yml
+++ b/roles/ceph-defaults/tasks/check_socket_non_container.yml
@@ -25,7 +25,7 @@
   when:
     - inventory_hostname in groups.get(mon_group_name, [])
     - mon_socket_stat.rc == 0
-    - mon_socket.rc != 0
+    - mon_socket.rc == 1
 
 - name: check for a ceph osd socket
   shell: |
@@ -54,7 +54,7 @@
   when:
     - inventory_hostname in groups.get(osd_group_name, [])
     - osd_socket_stat.rc == 0
-    - osd_socket.rc != 0
+    - osd_socket.rc == 1
 
 - name: check for a ceph mds socket
   shell: |
@@ -83,7 +83,7 @@
   when:
     - inventory_hostname in groups.get(mds_group_name, [])
     - mds_socket_stat.rc == 0
-    - mds_socket.rc != 0
+    - mds_socket.rc == 1
 
 - name: check for a ceph rgw socket
   shell: |
@@ -112,7 +112,7 @@
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])
     - rgw_socket_stat.rc == 0
-    - rgw_socket.rc != 0
+    - rgw_socket.rc == 1
 
 - name: check for a ceph mgr socket
   shell: |
@@ -141,7 +141,7 @@
   when:
     - inventory_hostname in groups.get(mgr_group_name, [])
     - mgr_socket_stat.rc == 0
-    - mgr_socket.rc != 0
+    - mgr_socket.rc == 1
 
 - name: check for a ceph rbd mirror socket
   shell: |
@@ -170,7 +170,7 @@
   when:
     - inventory_hostname in groups.get(rbdmirror_group_name, [])
     - rbd_mirror_socket_stat.rc == 0
-    - rbd_mirror_socket.rc != 0
+    - rbd_mirror_socket.rc == 1
 
 - name: check for a ceph nfs ganesha socket
   command: stat --printf=%n /var/run/ganesha.pid
@@ -198,4 +198,4 @@
   when:
     - inventory_hostname in groups.get(nfs_group_name, [])
     - nfs_socket_stat.rc == 0
-    - nfs_socket.rc != 0
+    - nfs_socket.rc == 1


### PR DESCRIPTION
As reported in https://github.com/ceph/ceph-ansible/issues/2254, the
check with fuser is not ideal. If fuser is not available the return code
is 127. Here we want to make sure that we looking for the correct return
code, so 1.

Closes: https://github.com/ceph/ceph-ansible/issues/2254
Signed-off-by: Sébastien Han <seb@redhat.com>