### PR TITLE
roles: ceph-mgr: Install the ceph-mgr package on SUSE

### DIFF
--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -1,10 +1,10 @@
 ---
-- name: install redhat ceph-mgr package
+- name: install ceph-mgr package on RedHat or SUSE
   package:
     name: ceph-mgr
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_os_family in ['RedHat', 'Suse']
 
 - name: install ceph mgr for debian
   apt:


### PR DESCRIPTION
The ceph-mgr package name is identical to RedHat so add the SUSE family
to the existing task.