### PR TITLE
rolling_update: do not require root to answer question

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -16,6 +16,7 @@
 
 - name: confirm whether user really meant to upgrade the cluster
   hosts: localhost
+  become: false
   vars:
     - mgr_group_name: mgrs
 


### PR DESCRIPTION
There is no need to ask for root on the local action. This will prompt
for a password the current user is not part of sudoers. That's
  unnecessary anyways.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1516947
Signed-off-by: Sébastien Han <seb@redhat.com>