### PR TITLE
rgw: fix multisite tasks execution when 'rgw_multisite' variable is n…

### DIFF
--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -37,7 +37,7 @@
   include: multisite/main.yml
   when:
     - rgw_zone is defined
-    - rgw_multisite
+    - rgw_multisite | default(False)
     - ceph_release_num[ceph_release] >= ceph_release_num.jewel
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False


### PR DESCRIPTION
…ot defined.

Multi-site playbooks are included even if 'rgw_multisite' variable is not defined anywhere. Since README-MULTISITE.md states that this variable should be added to RGW group variable for turning on multi-site feature, I assumes it should be off by default.

Repro steps: define rgw_zone variable for the host (doesn't make much sense at the moment but sill it should not cause this behavior in my opinion).

Signed-off-by: Eduard Egorov <eduard.egorov@icl-services.com>