### PR TITLE
site-docker: ability to disable fact sharing

### DIFF
--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -13,14 +13,26 @@
   - clients
   - iscsigws
   - mgrs
+
   gather_facts: false
   become: True
+
+  vars:
+    delegate_facts_host: True
+
   pre_tasks:
+    - name: gather facts
+      setup:
+      when:
+        - not delegate_facts_host | bool
+
     - name: gather and delegate facts
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['all'] }}"
+      when:
+        - delegate_facts_host | bool
 
     - name: check if it is atomic host
       stat:


### PR DESCRIPTION
When deploying with Ansible at large scale, the delegate_facts method
consumes a lot of memory on the host that is running Ansible. This can
cause various issues like memory exhaustion on that machine.
You can now run Ansible with "-e delegate_facts_host=False" to disable
the fact sharing.

Signed-off-by: Sébastien Han <seb@redhat.com>