### PR TITLE
osd: skip devices marked as '/dev/dead'

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -11,7 +11,7 @@
   when:
     - not osd_auto_discovery
     - not dmcrypt
-
+    - item != '/dev/dead'
 
 - name: activate osd(s) when device is a disk (dmcrypt)
   command: ceph-disk activate --dmcrypt "{{ item }}{%- if 'nvme' in item or 'cciss' in item or 'loop' in item %}{{ 'p' }}{%- endif %}{{ '1' }}"
@@ -22,6 +22,7 @@
   when:
     - not osd_auto_discovery
     - dmcrypt
+    - item != '/dev/dead'
 
 # NOTE (leseb): we must do this because of
 # https://github.com/ansible/ansible/issues/4297


### PR DESCRIPTION
On a non-collocated scenario, if a drive is faulty we can't really
remove it from the list of 'devices' without messing up or having to
re-arrange the order of the 'dedicated_devices'. We want to keep this
device list ordered. This will prevent the activation failing on a
device that we know is failing but we can't remove it yet to not mess up
the dedicated_devices mapping with devices.

Signed-off-by: Sébastien Han <seb@redhat.com>