### PR TITLE
fix jewel scenarios on container

### DIFF
--- a/tests/functional/centos/7/bs-osds-container/group_vars/all.yml
+++ b/tests/functional/centos/7/bs-osds-container/group_vars/all.yml
@@ -6,7 +6,8 @@ cluster: test
 monitor_interface: eth1
 public_network: "192.168.35.0/24"
 cluster_network: "192.168.36.0/24"
-ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }}
+# OSD_FORCE_ZAP is only for Jewel, the function does not exist anymore on Luminous and above
+ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }} -e OSD_FORCE_ZAP=1
 ceph_conf_overrides:
   global:
     osd_pool_default_size: 1

--- a/tests/functional/centos/7/docker-collocation/group_vars/all
+++ b/tests/functional/centos/7/docker-collocation/group_vars/all
@@ -15,7 +15,8 @@ cluster_network: "192.168.16.0/24"
 osd_scenario: collocated
 ceph_rgw_civetweb_port: 8080
 osd_objectstore: filestore
-ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }}
+# OSD_FORCE_ZAP is only for Jewel, the function does not exist anymore on Luminous and above
+ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }} -e OSD_FORCE_ZAP=1
 devices:
   - /dev/sda
   - /dev/sdb

--- a/tests/functional/centos/7/docker/group_vars/all
+++ b/tests/functional/centos/7/docker/group_vars/all
@@ -15,7 +15,8 @@ cluster_network: "192.168.18.0/24"
 osd_scenario: collocated
 ceph_rgw_civetweb_port: 8080
 osd_objectstore: filestore
-ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }}
+# OSD_FORCE_ZAP is only for Jewel, the function does not exist anymore on Luminous and above
+ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }} -e OSD_FORCE_ZAP=1
 devices:
   - '/dev/disk/by-id/ata-QEMU_HARDDISK_QM00001'
   - /dev/sdb

--- a/tests/functional/centos/7/fs-osds-container/group_vars/all.yml
+++ b/tests/functional/centos/7/fs-osds-container/group_vars/all.yml
@@ -6,7 +6,8 @@ cluster: test
 monitor_interface: eth1
 public_network: "192.168.55.0/24"
 cluster_network: "192.168.56.0/24"
-ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }}
+# OSD_FORCE_ZAP is only for Jewel, the function does not exist anymore on Luminous and above
+ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }} -e OSD_FORCE_ZAP=1
 ceph_conf_overrides:
   global:
     osd_pool_default_size: 1


### PR DESCRIPTION
When deploying Jewel from master we still need to enable this code since
the container image has such check. This check still exists because
ceph-disk is not able to create a GPT label on a drive that does not
have one.

Signed-off-by: Sébastien Han <seb@redhat.com>