### PR TITLE
mon: always run ceph-create-keys

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -1,8 +1,6 @@
 ---
 - name: collect admin and bootstrap keys
   command: ceph-create-keys --cluster {{ cluster }} -i {{ monitor_name }} -t 30
-  args:
-    creates: /etc/ceph/{{ cluster }}.client.admin.keyring
   changed_when: false
   check_mode: no
   when:


### PR DESCRIPTION
ceph-create-keys is idempotent so it's not an issue to run it each time
we play ansible. This also fix issues where the 'creates' arg skips the
task and no keys get generated on newer version, e.g during an upgrade.

Closes: https://github.com/ceph/ceph-ansible/issues/2228
Signed-off-by: Sébastien Han <seb@redhat.com>