### PR TITLE
rgw: disable legacy rgw service unit

### DIFF
--- a/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
+++ b/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
@@ -9,7 +9,7 @@
     mode: "0644"
 
 # For backward compatibility
-- name: disable old systemd unit ('ceph-rgw@') if present
+- name: disable old systemd unit ('ceph-rgw@'|'ceph-radosgw@radosgw.'|'ceph-radosgw@') if present
   systemd:
     name: "{{ item }}"
     state: stopped
@@ -18,6 +18,7 @@
   with_items:
     - "ceph-rgw@{{ ansible_hostname }}"
     - "ceph-radosgw@{{ ansible_hostname }}.service"
+    - "ceph-radosgw@radosgw.{{ ansible_hostname }}.service"
   ignore_errors: true
 
 - name: systemd start rgw container


### PR DESCRIPTION
When upgrading from OSP11 to OSP12 container, ceph-ansible attempts to
disable the RGW service provided by the overcloud image. The task
attempts to stop/disable ceph-rgw@{{ ansible-hostname }} and
ceph-radosgw@{{ ansible-hostname }}.service. The actual service name is
ceph-radosgw@radosgw.$name

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1525209
Signed-off-by: Sébastien Han <seb@redhat.com>