### PR TITLE
osd: set ceph_osd_docker_run_script_path to /etc/ceph

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -281,7 +281,7 @@ dummy:
 # ACTIVATE DEVICE
 #
 #ceph_osd_docker_extra_env:
-#ceph_osd_docker_run_script_path: "/usr/share" # script called by systemd to run the docker command
+#ceph_osd_docker_run_script_path: "/etc/ceph" # script called by systemd to run the docker command
 
 
 ###########

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -448,7 +448,7 @@
 
   - name: find all osd_disk_prepare logs
     find:
-      paths: "{{ ceph_osd_docker_run_script_path | default('/usr/share') }}"
+      paths: "{{ ceph_osd_docker_run_script_path | default('/etc/ceph') }}"
       pattern: "ceph-osd-prepare-*.log"
     register: osd_disk_prepare_logs
 

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -273,7 +273,7 @@ ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }}
 # ACTIVATE DEVICE
 #
 ceph_osd_docker_extra_env:
-ceph_osd_docker_run_script_path: "/usr/share" # script called by systemd to run the docker command
+ceph_osd_docker_run_script_path: "/etc/ceph" # script called by systemd to run the docker command
 
 
 ###########

--- a/tests/functional/centos/7/docker-collocation/group_vars/all
+++ b/tests/functional/centos/7/docker-collocation/group_vars/all
@@ -20,7 +20,6 @@ ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }} -e OSD_FORCE
 devices:
   - /dev/sda
   - /dev/sdb
-ceph_osd_docker_run_script_path: /var/tmp
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:

--- a/tests/functional/centos/7/docker/group_vars/all
+++ b/tests/functional/centos/7/docker/group_vars/all
@@ -20,7 +20,6 @@ ceph_osd_docker_prepare_env: -e OSD_JOURNAL_SIZE={{ journal_size }} -e OSD_FORCE
 devices:
   - '/dev/disk/by-id/ata-QEMU_HARDDISK_QM00001'
   - /dev/sdb
-ceph_osd_docker_run_script_path: /var/tmp
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:


### PR DESCRIPTION
The current default for the variable ceph_osd_docker_run_script_path is
/usr/share. /usr is not writable on Atomic Host and cause the playbook
to stop. So it's better to have a default location that works for all
the distro.

Closes: https://github.com/ceph/ceph-ansible/issues/2088
Signed-off-by: Sébastien Han <seb@redhat.com>