### PR TITLE
tests: fixes to allow for stable-3.0 nightly testing of jewel

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -535,11 +535,15 @@
   become: True
 
   pre_tasks:
+    # failed_when: false is here so that if we upgrade
+    # from a version of ceph that does not have nfs-ganesha
+    # then this task will not fail
     - name: stop ceph nfs
       systemd:
         name: nfs-ganesha
         state: stopped
         enabled: yes
+      failed_when: false
       when:
         - not containerized_deployment
 

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -148,11 +148,15 @@
   become: true
 
   pre_tasks:
+    # failed_when: false is here because if we're
+    # working with a jewel cluster then ceph mgr
+    # will not exist
     - name: stop non-containerized ceph mgr(s)
       service:
         name: "ceph-mgr@{{ ansible_hostname }}"
         state: stopped
         enabled: no
+      failed_when: false
 
     - set_fact:
         ceph_uid: 64045

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -441,11 +441,15 @@
   become: true
 
   pre_tasks:
+    # failed_when: false is here because if we're
+    # working with a jewel cluster then ceph nfs
+    # will not exist
     - name: stop non-containerized ceph nfs(s)
       service:
         name: nfs-ganesha
         state: stopped
         enabled: no
+      failed_when: false
 
     - set_fact:
         ceph_uid: 64045

--- a/tox.ini
+++ b/tox.ini
@@ -146,6 +146,7 @@ setenv=
   rhcs: CEPH_STABLE_RELEASE = luminous
   jewel: CEPH_STABLE_RELEASE = jewel
   jewel: UPDATE_CEPH_STABLE_RELEASE = luminous
+  jewel: UPDATE_CEPH_DOCKER_IMAGE_TAG = tag-build-master-luminous-ubuntu-16.04
   luminous: CEPH_STABLE_RELEASE = luminous
   luminous: UPDATE_CEPH_STABLE_RELEASE = luminous
   luminous: UPDATE_CEPH_DOCKER_IMAGE_TAG = tag-build-master-luminous-ubuntu-16.04


### PR DESCRIPTION
This fixes a few things related to our nightly tests with ``stable-3.0`` that deploy jewel clusters.

- when updating a jewel cluster ignore failures related to stopping ``nfs-ganesha`` 
- when switching a jewel cluster to containers ignore ``nfs`` and ``mgr``  service failures
- explicitly set ``UPDATE_CEPH_DOCKER_IMAGE_TAG`` for jewel tests so they upgrade to luminous and not latest.

These are really only an issue because we've setup our tests to work with both jewel and luminous.