### PR TITLE
containers: bump memory limit

### DIFF
--- a/group_vars/mdss.yml.sample
+++ b/group_vars/mdss.yml.sample
@@ -27,7 +27,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
-#ceph_mds_docker_memory_limit: 1g
+#ceph_mds_docker_memory_limit: 4g
 #ceph_mds_docker_cpu_limit: 1
 
 # we currently for MDS_NAME to hostname because of a bug in ceph-docker

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -260,7 +260,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
-#ceph_osd_docker_memory_limit: 1g
+#ceph_osd_docker_memory_limit: 3g
 #ceph_osd_docker_cpu_limit: 1
 
 # The next two variables are undefined, and thus, unused by default.

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -19,7 +19,7 @@ copy_admin_key: false
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
-ceph_mds_docker_memory_limit: 1g
+ceph_mds_docker_memory_limit: 4g
 ceph_mds_docker_cpu_limit: 1
 
 # we currently for MDS_NAME to hostname because of a bug in ceph-docker

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -252,7 +252,7 @@ ceph_config_keys: [] # DON'T TOUCH ME
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
-ceph_osd_docker_memory_limit: 1g
+ceph_osd_docker_memory_limit: 3g
 ceph_osd_docker_cpu_limit: 1
 
 # The next two variables are undefined, and thus, unused by default.


### PR DESCRIPTION
A default value of 4GB for MDS is more appropriate and 3GB for OSD also.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1531607
Signed-off-by: Sébastien Han <seb@redhat.com>