### PR TITLE
osd: change default for ceph_osd_docker_memory_limit

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -260,7 +260,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
-#ceph_osd_docker_memory_limit: 1g
+#ceph_osd_docker_memory_limit: 3g
 #ceph_osd_docker_cpu_limit: 1
 
 # The next two variables are undefined, and thus, unused by default.

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -252,7 +252,7 @@ ceph_config_keys: [] # DON'T TOUCH ME
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
-ceph_osd_docker_memory_limit: 1g
+ceph_osd_docker_memory_limit: 3g
 ceph_osd_docker_cpu_limit: 1
 
 # The next two variables are undefined, and thus, unused by default.


### PR DESCRIPTION
According to the documentation [1], we should change this default from 1g to
3g for OSD daemons.

[1] https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html-single/red_hat_ceph_storage_hardware_guide/index#intel_hardware_guide

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>