### PR TITLE
mon: use crush rules for non-container too

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -76,11 +76,6 @@
     - ceph_release_num[ceph_release] > ceph_release_num.jewel
   with_items: "{{ groups.get(mgr_group_name, []) }}"
 
-- name: crush_rules.yml
-  include: crush_rules.yml
-  when:
-    - crush_rule_config
-
 - name: find ceph keys
   shell: ls -1 /etc/ceph/*.keyring
   changed_when: false

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -22,6 +22,11 @@
   # this avoids the bug mentioned here: https://github.com/ansible/ansible/issues/18206
   static: no
 
+- name: crush_rules.yml
+  include: crush_rules.yml
+  when:
+    - crush_rule_config
+
 - name: include secure_cluster.yml
   include: secure_cluster.yml
   when:


### PR DESCRIPTION
There is no reasons why we can't use crush rules when deploying
containers. So moving the inlcude in the main.yml so it can be called.

Signed-off-by: Sébastien Han <seb@redhat.com>