### PR TITLE
container: change the way we force no logs inside the container

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -74,6 +74,7 @@ mon host = {% if nb_mon > 0 %}
 
 {% if containerized_deployment %}
 fsid = {{ fsid }}
+log file = /dev/null
 mon host = {% if nb_mon > 0 %}
 {% for host in groups[mon_group_name] -%}
     {% if monitor_address_block != 'subnet' %}

--- a/roles/ceph-docker-common/defaults/main.yml
+++ b/roles/ceph-docker-common/defaults/main.yml
@@ -1,4 +1,1 @@
 ---
-ceph_conf_overrides:
-  global:
-    log_file: /dev/null


### PR DESCRIPTION
Previously we were using ceph_conf_overrides however this doesn't play
nice for softwares like TripleO that uses ceph_conf_overrides inside its
own code. For now, and since this is the only occurence of this, we can
ensure no logs through the ceph conf template.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1532619
Signed-off-by: Sébastien Han <seb@redhat.com>