### PR TITLE
ceph-volume: adds a crush_device_class option for lvm_volumes

### DIFF
--- a/docs/source/osds/scenarios.rst
+++ b/docs/source/osds/scenarios.rst
@@ -205,6 +205,7 @@ The following keys are accepted for a ``filestore`` deployment:
 * ``data_vg`` (not required if ``data`` is a raw device or partition)
 * ``journal``
 * ``journal_vg`` (not required if ``journal`` is a partition and not a logical volume)
+* ``crush_device_class`` (optional, sets the crush device class for the OSD)
 
 The ``journal`` key represents the logical volume name or partition that will be used for your OSD journal.
 
@@ -217,6 +218,7 @@ For example, a configuration to use the ``lvm`` osd scenario would look like::
         data_vg: vg1
         journal: journal-lv1
         journal_vg: vg2
+        crush_device_class: foo
       - data: data-lv2
         journal: /dev/sda
         data_vg: vg1
@@ -245,6 +247,7 @@ The following keys are accepted for a ``bluestore`` deployment:
 * ``db_vg`` (optional for ``block.db``)
 * ``wal`` (optional for ``block.wal``)
 * ``wal_vg`` (optional for ``block.wal``)
+* ``crush_device_class`` (optional, sets the crush device class for the OSD)
 
 A ``bluestore`` lvm deployment, for all four different combinations supported
 could look like::
@@ -254,6 +257,7 @@ could look like::
     lvm_volumes:
       - data: data-lv1
         data_vg: vg1
+        crush_device_class: foo
       - data: data-lv2
         data_vg: vg1
         wal: wal-lv1

--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -73,6 +73,10 @@ options:
             - If wal is a lv, this must be the name of the volume group it belongs to.
             - Only applicable if objectstore is 'bluestore'.
         required: false
+    crush_device_class:
+        description:
+            - Will set the crush device class for the OSD.
+        required: false
 
 
 author:
@@ -142,6 +146,7 @@ def run_module():
         db_vg=dict(type='str', required=False),
         wal=dict(type='str', required=False),
         wal_vg=dict(type='str', required=False),
+        crush_device_class=dict(type='str', required=False),
     )
 
     module = AnsibleModule(
@@ -160,6 +165,7 @@ def run_module():
     db_vg = module.params.get('db_vg', None)
     wal = module.params.get('wal', None)
     wal_vg = module.params.get('wal_vg', None)
+    crush_device_class = module.params.get('crush_device_class', None)
 
     cmd = [
         'ceph-volume',
@@ -185,6 +191,9 @@ def run_module():
     if wal:
         wal = get_wal(wal, wal_vg)
         cmd.extend(["--block.wal", wal])
+
+    if crush_device_class:
+        cmd.extend(["--crush-device-class", crush_device_class])
 
     result = dict(
         changed=False,

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -205,6 +205,7 @@ bluestore_wal_devices: "{{ dedicated_devices }}"
 #     data_vg: vg1
 #     journal: journal-lv1
 #     journal_vg: vg2
+#     crush_device_class: foo
 #   - data: data-lv2
 #     journal: /dev/sda1
 #     data_vg: vg1
@@ -226,6 +227,7 @@ bluestore_wal_devices: "{{ dedicated_devices }}"
 #     data_vg: vg1
 #     wal: wal-lv1
 #     wal_vg: vg1
+#     crush_device_class: foo
 #   - data: data-lv2
 #     db: db-lv2
 #     db_vg: vg2

--- a/roles/ceph-osd/tasks/scenarios/lvm.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm.yml
@@ -12,6 +12,7 @@
     db_vg: "{{ item.db_vg|default(omit) }}"
     wal: "{{ item.wal|default(omit) }}"
     wal_vg: "{{ item.wal_vg|default(omit) }}"
+    crush_device_class: "{{ item.crush_device_class|default(omit) }}"
   environment:
     CEPH_VOLUME_DEBUG: 1
   with_items: "{{ lvm_volumes }}"

--- a/tests/functional/centos/7/bs-lvm-osds/group_vars/all
+++ b/tests/functional/centos/7/bs-lvm-osds/group_vars/all
@@ -13,6 +13,7 @@ copy_admin_key: true
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group
+    crush_device_class: test
   - data: data-lv2
     data_vg: test_group
     db: journal1

--- a/tests/functional/centos/7/lvm-osds/group_vars/all
+++ b/tests/functional/centos/7/lvm-osds/group_vars/all
@@ -16,6 +16,7 @@ lvm_volumes:
   - data: data-lv1
     journal: /dev/sdc1
     data_vg: test_group
+    crush_device_class: test
   - data: data-lv2
     journal: journal1
     data_vg: test_group


### PR DESCRIPTION
A ``--crush-device-class`` feature is currently in development for ``ceph-volume``, but we need this in place first so that we can test the PR that introduces ``--crush-device-class``.