### PR TITLE
ntp: followup cleanup

### DIFF
--- a/roles/ceph-common/tasks/checks/check_ntp_atomic.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_atomic.yml
@@ -1,6 +1,0 @@
----
-- name: check ntp installation on atomic
-  command: rpm -q chrony
-  ignore_errors: true
-  always_run: true
-  changed_when: false

--- a/roles/ceph-common/tasks/checks/check_ntp_debian.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_debian.yml
@@ -1,12 +1,4 @@
 ---
-- name: check ntp installation on debian
-  command: dpkg -s ntp
-  ignore_errors: true
-  always_run: true
-  changed_when: false
-  when:
-    - ansible_os_family == 'Debian'
-
 - name: install ntp on debian
   package:
     name: ntp

--- a/roles/ceph-common/tasks/checks/check_ntp_redhat.yml
+++ b/roles/ceph-common/tasks/checks/check_ntp_redhat.yml
@@ -1,12 +1,4 @@
 ---
-- name: check ntp installation on redhat
-  command: rpm -q ntp
-  ignore_errors: true
-  always_run: true
-  changed_when: false
-  when:
-    - ansible_os_family == 'RedHat'
-
 - name: install ntp on redhat
   package:
     name: ntp

--- a/roles/ceph-docker-common/tasks/checks/check_ntp_atomic.yml
+++ b/roles/ceph-docker-common/tasks/checks/check_ntp_atomic.yml
@@ -1,6 +1,0 @@
----
-- name: check ntp installation on atomic
-  command: rpm -q chrony
-  ignore_errors: true
-  always_run: true
-  changed_when: false

--- a/roles/ceph-docker-common/tasks/checks/check_ntp_debian.yml
+++ b/roles/ceph-docker-common/tasks/checks/check_ntp_debian.yml
@@ -1,12 +1,4 @@
 ---
-- name: check ntp installation on debian
-  command: dpkg -s ntp
-  ignore_errors: true
-  always_run: true
-  changed_when: false
-  when:
-    - ansible_os_family == 'Debian'
-
 - name: install ntp on debian
   package:
     name: ntp

--- a/roles/ceph-docker-common/tasks/checks/check_ntp_redhat.yml
+++ b/roles/ceph-docker-common/tasks/checks/check_ntp_redhat.yml
@@ -1,12 +1,4 @@
 ---
-- name: check ntp installation on redhat
-  command: rpm -q ntp
-  ignore_errors: true
-  always_run: true
-  changed_when: false
-  when:
-    - ansible_os_family == 'RedHat'
-
 - name: install ntp on redhat
   package:
     name: ntp

--- a/roles/ceph-docker-common/tasks/misc/ntp_atomic.yml
+++ b/roles/ceph-docker-common/tasks/misc/ntp_atomic.yml
@@ -1,8 +1,4 @@
 ---
-- name: include ../checks/check_ntp_atomic.yml
-  include: ../checks/check_ntp_atomic.yml
-  when: is_atomic
-
 - name: start the ntp service
   service:
     name: chronyd


### PR DESCRIPTION
Checking if ntp is present is not needed anymore, these tasks are not
used anymore. So let's remove them

Signed-off-by: Sébastien Han <seb@redhat.com>