### PR TITLE
rolling update: add mgr exception for jewel minor updates

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -19,6 +19,7 @@
   become: false
   vars:
     - mgr_group_name: mgrs
+    - jewel_minor_update: False
 
   vars_prompt:
     - name: ireallymeanit
@@ -40,6 +41,7 @@
       fail:
         msg: "Please add a mgr host to your inventory."
       when:
+        - not jewel_minor_update
         - groups.get(mgr_group_name, []) | length == 0
 
 


### PR DESCRIPTION
When update from a minor Jewel version to another, the playbook will
fail on the task "fail if no mgr host is present in the inventory".
This now can be worked around by running Ansible with_items

-e jewel_minor_update=true

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1535382
Signed-off-by: Sébastien Han <seb@redhat.com>