### PR TITLE
Skip devices that used as backed for other devices

### DIFF
--- a/roles/ceph-osd/tasks/build_devices.yml
+++ b/roles/ceph-osd/tasks/build_devices.yml
@@ -9,6 +9,7 @@
     - item.value.removable == "0"
     - item.value.sectors != "0"
     - item.value.partitions|count == 0
+    - item.value.links.masters|count == 0
     - item.value.holders|count == 0
     - "'dm-' not in item.key"
 


### PR DESCRIPTION
Devices that used as backed for logical layers (dmraid, bcache, LVM , etc) have "masters" in Ansible "devices" fact. This patch skip such devices on initial lookup.
