### PR TITLE
rgw: disable legacy unit

### DIFF
--- a/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
+++ b/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
@@ -21,6 +21,7 @@
     - "ceph-rgw@{{ ansible_hostname }}"
     - "ceph-radosgw@{{ ansible_hostname }}.service"
     - "ceph-radosgw@radosgw.{{ ansible_hostname }}.service"
+    - ceph-radosgw@radosgw.gateway.service
   ignore_errors: true
 
 - name: systemd start rgw container


### PR DESCRIPTION
Some systems that were deployed with old tools can leave units named
"ceph-radosgw@radosgw.gateway.service". As a consequence, they will
prevent the new unit to start.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1509584
Signed-off-by: Sébastien Han <seb@redhat.com>