### PR TITLE
tests: remove crush_device_class from lvm tests

### DIFF
--- a/tests/functional/centos/7/bs-lvm-osds/group_vars/all
+++ b/tests/functional/centos/7/bs-lvm-osds/group_vars/all
@@ -13,7 +13,6 @@ copy_admin_key: true
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group
-    crush_device_class: test
   - data: data-lv2
     data_vg: test_group
     db: journal1

--- a/tests/functional/centos/7/lvm-osds/group_vars/all
+++ b/tests/functional/centos/7/lvm-osds/group_vars/all
@@ -16,7 +16,6 @@ lvm_volumes:
   - data: data-lv1
     journal: /dev/sdc1
     data_vg: test_group
-    crush_device_class: test
   - data: data-lv2
     journal: journal1
     data_vg: test_group


### PR DESCRIPTION
The --crush-device-class flag for ceph-volume is not available in luminous so lets
remove this testing option for now until it's more widely available.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>