### PR TITLE
Skipping backend devices

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -213,6 +213,7 @@ dummy:
 #     data_vg: vg1
 #     journal: journal-lv1
 #     journal_vg: vg2
+#     crush_device_class: foo
 #   - data: data-lv2
 #     journal: /dev/sda1
 #     data_vg: vg1
@@ -234,6 +235,7 @@ dummy:
 #     data_vg: vg1
 #     wal: wal-lv1
 #     wal_vg: vg1
+#     crush_device_class: foo
 #   - data: data-lv2
 #     db: db-lv2
 #     db_vg: vg2

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -29,7 +29,7 @@ dummy:
 #  mimic: 13
 
 # Directory to fetch cluster fsid, keys etc...
-fetch_directory: ~/ceph-ansible-keys
+#fetch_directory: fetch/
 
 # The 'cluster' variable determines the name of the cluster.
 # Changing the default value to something else means that you will
@@ -135,14 +135,14 @@ fetch_directory: ~/ceph-ansible-keys
 # - 'distro' means that no separate repo file will be added
 #  you will get whatever version of Ceph is included in your Linux distro.
 # 'local' means that the ceph binaries will be copied over from the local machine
-ceph_origin: repository
+#ceph_origin: "{{ 'repository' if ceph_rhcs or ceph_stable or ceph_dev or ceph_stable_uca or ceph_custom else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #valid_ceph_origins:
 #  - repository
 #  - distro
 #  - local
 
 
-ceph_repository: rhcs
+#ceph_repository: "{{ 'community' if ceph_stable else 'rhcs' if ceph_rhcs else 'dev' if ceph_dev else 'uca' if ceph_stable_uca else 'custom' if ceph_custom else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #valid_ceph_repository:
 #  - community
 #  - rhcs

--- a/roles/ceph-osd/tasks/build_devices.yml
+++ b/roles/ceph-osd/tasks/build_devices.yml
@@ -9,6 +9,7 @@
     - item.value.removable == "0"
     - item.value.sectors != "0"
     - item.value.partitions|count == 0
+    - item.value.links.masters|count == 0
     - item.value.holders|count == 0
     - "'dm-' not in item.key"
 


### PR DESCRIPTION
Devices that used as backed for logical layers (dmraid, bcache, LVM , etc) have "masters" in Ansible "devices" fact. This patch skip such devices on initial lookup.