### PR TITLE
osd: fix a typo in roles/ceph-osd/defaults/main.yml

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -13,7 +13,7 @@ dummy:
 #raw_journal_devices: "{{ dedicated_devices }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 #raw_multi_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
-#dmcrytpt_journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+#dmcrypt_journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 #dmcrypt_dedicated_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
@@ -93,7 +93,7 @@ dummy:
 
 # Encrypt your OSD device using dmcrypt
 # If set to True, no matter which osd_objecstore and osd_scenario you use the data will be encrypted
-#dmcrypt: "{{ True if dmcrytpt_journal_collocation or dmcrypt_dedicated_journal else False }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#dmcrypt: "{{ True if dmcrypt_journal_collocation or dmcrypt_dedicated_journal else False }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
 # I. First scenario: collocated
@@ -116,7 +116,7 @@ dummy:
 # /dev/sda2: PARTLABEL="ceph block" PARTUUID="e6ca3e1d-4702-4569-abfa-e285de328e9d"
 #
 
-#osd_scenario: "{{ 'collocated' if journal_collocation or dmcrytpt_journal_collocation else 'non-collocated' if raw_multi_journal or dmcrypt_dedicated_journal else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#osd_scenario: "{{ 'collocated' if journal_collocation or dmcrypt_journal_collocation else 'non-collocated' if raw_multi_journal or dmcrypt_dedicated_journal else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #valid_osd_scenarios:
 #  - collocated
 #  - non-collocated

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -5,7 +5,7 @@
 raw_journal_devices: "{{ dedicated_devices }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 raw_multi_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
-dmcrytpt_journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
+dmcrypt_journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 dmcrypt_dedicated_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
@@ -85,7 +85,7 @@ osd_auto_discovery: false
 
 # Encrypt your OSD device using dmcrypt
 # If set to True, no matter which osd_objecstore and osd_scenario you use the data will be encrypted
-dmcrypt: "{{ True if dmcrytpt_journal_collocation or dmcrypt_dedicated_journal else False }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+dmcrypt: "{{ True if dmcrypt_journal_collocation or dmcrypt_dedicated_journal else False }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
 # I. First scenario: collocated
@@ -108,7 +108,7 @@ dmcrypt: "{{ True if dmcrytpt_journal_collocation or dmcrypt_dedicated_journal e
 # /dev/sda2: PARTLABEL="ceph block" PARTUUID="e6ca3e1d-4702-4569-abfa-e285de328e9d"
 #
 
-osd_scenario: "{{ 'collocated' if journal_collocation or dmcrytpt_journal_collocation else 'non-collocated' if raw_multi_journal or dmcrypt_dedicated_journal else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+osd_scenario: "{{ 'collocated' if journal_collocation or dmcrypt_journal_collocation else 'non-collocated' if raw_multi_journal or dmcrypt_dedicated_journal else 'dummy' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 valid_osd_scenarios:
   - collocated
   - non-collocated


### PR DESCRIPTION
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 39b584e540570ef79af98c3c23fdce90f02a701c)

backport of #2143 

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1536098