### PR TITLE
ceph-volume: adds dmcrypt support

### DIFF
--- a/docs/source/osds/scenarios.rst
+++ b/docs/source/osds/scenarios.rst
@@ -176,6 +176,9 @@ mappings for devices to be deployed. It is a list of dictionaries which expects
 a volume name and a volume group for logical volumes, but can also accept
 a partition in the case of ``filestore`` for the ``journal``.
 
+This scenario supports encrypting your OSDs by setting ``dmcrypt: True``. If set,
+all OSDs defined in ``lvm_volumes`` will be encrypted.
+
 The ``data`` key represents the logical volume name, raw device or partition that is to be used for your
 OSD data.  The ``data_vg`` key represents the volume group name that your
 ``data`` logical volume resides on. This key is required for purging of OSDs
@@ -230,6 +233,18 @@ For example, a configuration to use the ``lvm`` osd scenario would look like::
       - data: /dev/sda1
         journal: journal-lv1
         journal_vg: vg2
+
+For example, a configuration to use the ``lvm`` osd scenario with encryption would look like::
+
+    osd_objectstore: filestore
+    osd_scenario: lvm
+    dmcrypt: True
+    lvm_volumes:
+      - data: data-lv1
+        data_vg: vg1
+        journal: journal-lv1
+        journal_vg: vg2
+        crush_device_class: foo
 
 
 ``bluestore``

--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -77,6 +77,10 @@ options:
         description:
             - Will set the crush device class for the OSD.
         required: false
+    dmcrypt:
+        description:
+            - If set to True the OSD will be encrypted with dmcrypt.
+        required: false
 
 
 author:
@@ -147,6 +151,7 @@ def run_module():
         wal=dict(type='str', required=False),
         wal_vg=dict(type='str', required=False),
         crush_device_class=dict(type='str', required=False),
+        dmcrypt=dict(type='bool', required=False, default=False),
     )
 
     module = AnsibleModule(
@@ -166,6 +171,7 @@ def run_module():
     wal = module.params.get('wal', None)
     wal_vg = module.params.get('wal_vg', None)
     crush_device_class = module.params.get('crush_device_class', None)
+    dmcrypt = module.params['dmcrypt']
 
     cmd = [
         'ceph-volume',
@@ -194,6 +200,9 @@ def run_module():
 
     if crush_device_class:
         cmd.extend(["--crush-device-class", crush_device_class])
+
+    if dmcrypt:
+        cmd.append("--dmcrypt")
 
     result = dict(
         changed=False,

--- a/roles/ceph-osd/tasks/scenarios/lvm.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm.yml
@@ -13,6 +13,7 @@
     wal: "{{ item.wal|default(omit) }}"
     wal_vg: "{{ item.wal_vg|default(omit) }}"
     crush_device_class: "{{ item.crush_device_class|default(omit) }}"
+    dmcrypt: "{{ dmcrypt|default(omit) }}"
   environment:
     CEPH_VOLUME_DEBUG: 1
   with_items: "{{ lvm_volumes }}"


### PR DESCRIPTION
dmcrypt support in ``ceph-volume`` is coming shortly, this PR adds that to our ``ceph_volume`` module. I didn't enable this in any of of the CI scenarios yet though so all of our existing lvm tests should still pass. We need this feature in now though so that we can test with ``ceph-ansible`` as this feature is developed.