### PR TITLE
osds: change default value for `dedicated_devices`

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -10,7 +10,7 @@ dummy:
 # You can override default vars defined in defaults/main.yml here,
 # but I would advice to use host or group vars instead
 
-#raw_journal_devices: "{{ dedicated_devices }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+#raw_journal_devices: [] # backward compatibility with stable-2.2, will disappear in stable 3.1
 #journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 #raw_multi_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 #dmcrypt_journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
@@ -175,7 +175,7 @@ dummy:
 # /dev/sdb: PTTYPE="gpt"
 # /dev/sdb1: PARTLABEL="ceph block.db" PARTUUID="af5b2d74-4c08-42cf-be57-7248c739e217"
 # /dev/sdb2: PARTLABEL="ceph block.wal" PARTUUID="af3f8327-9aa9-4c2b-a497-cf0fe96d126a"
-#dedicated_devices: []
+#dedicated_devices: "{{ raw_journal_devices if raw_multi_journal or dmcrypt_dedicated_journal else [] }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
 # More device granularity for Bluestore

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -2,7 +2,7 @@
 # You can override default vars defined in defaults/main.yml here,
 # but I would advice to use host or group vars instead
 
-raw_journal_devices: "{{ dedicated_devices }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
+raw_journal_devices: [] # backward compatibility with stable-2.2, will disappear in stable 3.1
 journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 raw_multi_journal: False # backward compatibility with stable-2.2, will disappear in stable 3.1
 dmcrypt_journal_collocation: False # backward compatibility with stable-2.2, will disappear in stable 3.1
@@ -167,7 +167,7 @@ valid_osd_scenarios:
 # /dev/sdb: PTTYPE="gpt"
 # /dev/sdb1: PARTLABEL="ceph block.db" PARTUUID="af5b2d74-4c08-42cf-be57-7248c739e217"
 # /dev/sdb2: PARTLABEL="ceph block.wal" PARTUUID="af3f8327-9aa9-4c2b-a497-cf0fe96d126a"
-dedicated_devices: []
+dedicated_devices: "{{ raw_journal_devices if raw_multi_journal or dmcrypt_dedicated_journal else [] }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 
 
 # More device granularity for Bluestore


### PR DESCRIPTION
This is to keep backward compatibility with stable-2.2 and satisfy the
check "verify dedicated devices have been provided" in
`check_mandatory_vars.yml`. This check is looking for
`dedicated_devices` so we need to default it's value to
`raw_journal_devices` when `raw_multi_journal` is set to `True`.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1536098

Backport of #2338 

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 9306a1789c95e5abb77260dde4d9cc3df900959f)