### PR TITLE
ansible: set ssh retry option to 5

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -19,3 +19,6 @@ timeout = 30
 [ssh_connection]
 # see: https://github.com/ansible/ansible/issues/11536
 control_path = %(directory)s/%%h-%%r-%%p
+
+# Option to retry failed ssh executions if the failure is encountered in ssh itself
+retries = 5


### PR DESCRIPTION
We noticed that sometime, ceph-ansible can fail with error :

`Failed to connect to the host via ssh:`

It can occurs after the task `restart firewalld` has been played.

Setting `retries` to 5 should prevent from unexcepted ssh failure.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>