### PR TITLE
defaults: avoid getting stuck (ceph --connect-timeout)

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -22,7 +22,7 @@
 # because it blindly picks a mon, which may be down because
 # of the rolling update
 - name: is ceph running already?
-  command: "{{ docker_exec_cmd }} ceph --connect-timeout 3 --cluster {{ cluster }} fsid"
+  command: "timeout 5 {{ docker_exec_cmd }} ceph --cluster {{ cluster }} fsid"
   changed_when: false
   failed_when: false
   check_mode: no


### PR DESCRIPTION
Sometime the playbook gets stuck because even with `--connect-timeout=`
option, the connexion to the existing ceph cluster never timeout.

As a workaround, using `timeout` command provided by coreutils will
actually timeout if we can't connect to the cluster.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>