### PR TITLE
ceph-common: Don't check for ceph_stable_release for distro packages

### DIFF
--- a/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
+++ b/roles/ceph-common/tasks/checks/check_mandatory_vars.yml
@@ -27,6 +27,7 @@
   fail:
     msg: "make sure ceph_stable_release ( {{ ceph_stable_release }} ) is set to a release name (e.g: luminous), http://docs.ceph.com/docs/master/release-notes/"
   when:
+    - ceph_origin != 'distro'
     - ceph_stable_release == 'dummy'
     - ceph_repository not in ['rhcs', 'dev']
   tags:


### PR DESCRIPTION
When we consume the distribution packages, we don't have the choise on
which version to install, so we shouldn't require that variable to be
set. Distributions normally provide only one version of Ceph in the
official repositories so we get whatever they provide.

Signed-off-by: Markos Chandras <mchandras@suse.de>
(cherry picked from commit dd6ee72547a4eca22c8c9b8691b910c2cfa821d3)