### PR TITLE
upgrade: skip luminous tasks for jewel minor update

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -363,11 +363,15 @@
       command: "{{ docker_exec_cmd_update_osd|default('') }} ceph --cluster {{ cluster }} versions"
       register: ceph_versions
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      when:
+        - not jewel_minor_update
 
     - name: set_fact ceph_versions_osd
       set_fact:
         ceph_versions_osd: "{{ (ceph_versions.stdout|from_json).osd }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      when:
+        - not jewel_minor_update
 
     # length == 1 means there is a single osds versions entry
     # thus all the osds are running the same version
@@ -375,8 +379,9 @@
       command: "{{ docker_exec_cmd_update_osd|default('') }} ceph --cluster {{ cluster }} osd require-osd-release luminous"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       when:
-        - (ceph_versions.stdout|from_json).osd | length == 1
+        - (ceph_versions.get('stdout', '{}')|from_json).get('osd', {}) | length == 1
         - ceph_versions_osd | string | search("ceph version 12")
+        - not jewel_minor_update
 
 
 - name: upgrade ceph mdss cluster


### PR DESCRIPTION
These tasks are needed only when upgrading to luminous.
They are not needed in Jewel minor upgrade and by the way, they fail because
`ceph versions` command doesn't exist.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1535382

(cherry picked from commit c7ec12d49ca3c3f936f4c7a34ef15c042ab0f699)
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>