### PR TITLE
config: add host-specific ceph_conf_overrides evaluation and generation.

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -13,19 +13,28 @@
       - /etc/ceph/ceph.d/
 
   - name: template ceph_conf_overrides
-    local_action: copy content="{{ ceph_conf_overrides }}" dest="{{ fetch_directory }}/ceph_conf_overrides_temp"
-    become: false
-    run_once: true
+    copy:
+      content: "{{ ceph_conf_overrides }}"
+      dest: "/tmp/ceph_conf_overrides_temp_{{ ansible_hostname }}"
+
+  - name: copy tmp template file for ceph_conf_overrides to the ansible server
+    fetch:
+      src: "/tmp/ceph_conf_overrides_temp_{{ ansible_hostname }}"
+      dest: "{{ fetch_directory }}/{{ fsid }}/ceph_conf_overrides_temp_{{ ansible_hostname }}"
+      flat: yes
 
   - name: get rendered ceph_conf_overrides
-    local_action: set_fact ceph_conf_overrides_rendered="{{ lookup('template', '{{ fetch_directory }}/ceph_conf_overrides_temp') | from_yaml }}"
-    become: false
-    run_once: true
+    set_fact:
+      ceph_conf_overrides_rendered: "{{ lookup('template', '{{ fetch_directory }}/{{ fsid }}/ceph_conf_overrides_temp_{{ ansible_hostname }}') | from_yaml }}"
 
   - name: remove tmp template file for ceph_conf_overrides
-    local_action: file path="{{ fetch_directory }}/ceph_conf_overrides_temp" state=absent
+    file:
+      path: "/tmp/ceph_conf_overrides_temp_{{ ansible_hostname }}"
+      state: absent
+
+  - name: remove tmp template file for ceph_conf_overrides (localhost)
+    local_action: file path="{{ fetch_directory }}/{{ fsid }}/ceph_conf_overrides_temp_{{ ansible_hostname }}" state=absent
     become: false
-    run_once: true
 
   - name: "generate ceph configuration file: {{ cluster }}.conf"
     action: config_template


### PR DESCRIPTION
This allows us to use host-specific variables in ceph_conf_overrides variable. For example, this fixes usage of such variables (e.g. 'nss db path' having {{ ansible_hostname }} inside) in ceph_conf_overrides for rados gateway configuration (see profiles/rgw-keystone-v3) - issue #2157.

Signed-off-by: Eduard Egorov <eduard.egorov@icl-services.com>
(cherry picked from commit 93e9f3723bb4bcf8004bbcea3213d72d11588899)