### PR TITLE
Add default for radosgw_keystone_ssl

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -387,6 +387,7 @@ dummy:
 #radosgw_address: "{{ '0.0.0.0' if rgw_containerized_deployment else 'address' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #radosgw_address_block: subnet
 #radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
+#radosgw_keystone_ssl: false # activate this when using keystone PKI keys
 # Rados Gateway options
 #email_address: foo@bar.com
 

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -387,6 +387,7 @@ ceph_repository: rhcs
 #radosgw_address: "{{ '0.0.0.0' if rgw_containerized_deployment else 'address' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 #radosgw_address_block: subnet
 #radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
+#radosgw_keystone_ssl: false # activate this when using keystone PKI keys
 # Rados Gateway options
 #email_address: foo@bar.com
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -379,6 +379,7 @@ radosgw_interface: interface
 radosgw_address: "{{ '0.0.0.0' if rgw_containerized_deployment else 'address' }}" # backward compatibility with stable-2.2, will disappear in stable 3.1
 radosgw_address_block: subnet
 radosgw_keystone: false # activate OpenStack Keystone options full detail here: http://ceph.com/docs/master/radosgw/keystone/
+radosgw_keystone_ssl: false # activate this when using keystone PKI keys
 # Rados Gateway options
 email_address: foo@bar.com
 


### PR DESCRIPTION
This should default to False. The default for Keystone is not to use PKI
keys, additionally, anybody using this setting had to have been manually
setting it before.

Fixes: #2111