### PR TITLE
Do not search osd ids if ceph-volume

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -12,6 +12,8 @@
   register: osd_id
   until: osd_id.stdout_lines|length == devices|unique|length
   retries: 10
+  when:
+    - osd_scenario != 'lvm'
 
 - name: ensure systemd service override directory exists
   file:


### PR DESCRIPTION
The 'get osd id' task goes through all the 10 times (and its respective
timeouts) to make sure that the number of OSDs in the osd directory
match the number of devices.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1537103