### PR TITLE
purge: fix resolve parent device task

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -349,7 +349,7 @@
                                  ceph_wal_partition_to_erase_path.get('stdout_lines', []) }}"
 
   - name: resolve parent device
-    shell: $(lsblk --nodeps -no pkname "{{ item }}")
+    command: lsblk --nodeps -no pkname "{{ item }}"
     register: tmp_resolved_parent_device
     with_items:
       - "{{ combined_devices_list }}"


### PR DESCRIPTION
This is a typo caused by leftover.
It was previously written like this :
`shell: echo /dev/$(lsblk -no pkname "{{ item }}") }}")`
and has been rewritten to :
`shell: $(lsblk --nodeps -no pkname "{{ item }}") }}")`
because we are appending later the '/dev/' in the next task.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1540137

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>