### PR TITLE
Check for docker sockets named after both _hostname or _fqdn

### DIFF
--- a/roles/ceph-mds/tasks/containerized.yml
+++ b/roles/ceph-mds/tasks/containerized.yml
@@ -63,7 +63,7 @@
   changed_when: false
 
 - name: wait for mds socket to exist
-  command: "{{ docker_exec_cmd }} stat /var/run/ceph/{{ cluster }}-mds.{{ ansible_hostname }}.asok"
+  command: "{{ docker_exec_cmd }} sh -c 'stat /var/run/ceph/{{ cluster }}-mds.{{ ansible_hostname }}.asok || stat /var/run/ceph/{{ cluster }}-mds.{{ ansible_fqdn }}.asok'"
   register: multi_mds_socket
   retries: 5
   delay: 15

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -7,7 +7,7 @@
   include: start_docker_monitor.yml
 
 - name: wait for monitor socket to exist
-  command: docker exec ceph-mon-{{ ansible_hostname }} stat /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok
+  command: "docker exec ceph-mon-{{ ansible_hostname }} sh -c 'stat /var/run/ceph/{{ cluster }}-mon.{{ ansible_hostname }}.asok || stat /var/run/ceph/{{ cluster }}-mon.{{ ansible_fqdn }}.asok'"
   register: monitor_socket
   retries: 5
   delay: 15


### PR DESCRIPTION
While hostname -f will always return an hostname including its
domain part and -s without the domain part, the behavior when
no arguments are given can include or not include the domain part
depending on how the system is configured; the socket name might
not match the instance name then.