### PR TITLE
purge-docker: fix ceph-osd-zap name container

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -368,7 +368,7 @@
       {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
       zap_device
     with_items:
-      - "{{ combined_devices_list }}"
+      - "{{ resolved_parent_device }}"
 
   - name: wait until the zap containers die
     shell: |
@@ -385,7 +385,7 @@
       name: "ceph-osd-zap-{{ ansible_hostname }}-{{ item }}"
       state: absent
     with_items:
-      - "{{ combined_devices_list }}"
+      - "{{ resolved_parent_device }}"
 
   - name: remove ceph osd service
     file:


### PR DESCRIPTION
the `zap ceph osd disks` task should iter on `resolved_parent_device`
instead of `combined_devices_list` which contain only the base device
name (vs. full path name in `combined_devices_list`).

this fixes the issue where docker complain about container name because
of illegal characters such as `/` :
```
"/usr/bin/docker-current: Error response from daemon: Invalid container
name (ceph-osd-zap-magna074-/dev/sdb1), only [a-zA-Z0-9][a-zA-Z0-9_.-]
are allowed.","See '/usr/bin/docker-current run --help'."
""
```

having the the basename of the device path is enough for the container
name.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1540137

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 3b2f6c34e42eae4033a209d819620211dc68c34b)