### PR TITLE
mon: Fixed crush_rule_config for containerised deployment.

### DIFF
--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -22,11 +22,6 @@
   # this avoids the bug mentioned here: https://github.com/ansible/ansible/issues/18206
   static: no
 
-- name: crush_rules.yml
-  include: crush_rules.yml
-  when:
-    - crush_rule_config
-
 - name: include secure_cluster.yml
   include: secure_cluster.yml
   when:
@@ -36,6 +31,12 @@
 - name: include docker/main.yml
   include: docker/main.yml
   when: containerized_deployment
+
+- name: crush_rules.yml
+  include: crush_rules.yml
+  when:
+    - crush_rule_config
+    - inventory_hostname == groups.get(mon_group_name) | last
 
 - name: include set_osd_pool_default_pg_num.yml
   include: set_osd_pool_default_pg_num.yml


### PR DESCRIPTION
Was called too early, container was not yet started so the commands failed.
Moved the section after include docker/main.yml

Signed-off-by: Greg Charot <gcharot@redhat.com>
(cherry picked from commit a6d1922a2e70c36036ff130dc6b6b942101379ba)