### PR TITLE
Add support for multipath disks

### DIFF
--- a/roles/ceph-osd/tasks/activate_osds.yml
+++ b/roles/ceph-osd/tasks/activate_osds.yml
@@ -3,7 +3,7 @@
 # partition.
 
 - name: activate osd(s) when device is a disk
-  command: ceph-disk activate "{{ item }}{%- if 'nvme' in item or 'cciss' in item or 'loop' in item %}{{ 'p' }}{%- endif %}{{ '1' }}"
+  command: ceph-disk activate "{{ item }}{%- if 'nvme' in item or 'cciss' in item or 'loop' in item %}{{ 'p' }}{%- endif %}{%- if 'mpath' in item %}{{ '-part' }}{%- endif %}{{ '1' }}"
   with_items:
     - "{{ devices|unique }}"
   changed_when: false
@@ -14,7 +14,7 @@
 
 
 - name: activate osd(s) when device is a disk (dmcrypt)
-  command: ceph-disk activate --dmcrypt "{{ item }}{%- if 'nvme' in item or 'cciss' in item or 'loop' in item %}{{ 'p' }}{%- endif %}{{ '1' }}"
+  command: ceph-disk activate --dmcrypt "{{ item }}{%- if 'nvme' in item or 'cciss' in item or 'loop' in item %}{{ 'p' }}{%- endif %}{%- if 'mpath' in item %}{{ '-part' }}{%- endif %}{{ '1' }}"
   with_items:
     - "{{ devices|unique }}"
   changed_when: false


### PR DESCRIPTION
Add support for using multipath disks as OSDs. This requires ceph-ansible knowing how the multipath disk partition names are formatted.