### PR TITLE
default: define 'osd_scenario' variable

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -151,7 +151,7 @@
   when:
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
-    - osd_scenario != 'lvm'
+    - osd_scenario|default('dummy') != 'lvm'
 
 - name: set_fact build devices from resolved symlinks
   set_fact:
@@ -160,7 +160,7 @@
   when:
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
-    - osd_scenario != 'lvm'
+    - osd_scenario|default('dummy') != 'lvm'
 
 - name: set_fact build final devices list
   set_fact:
@@ -168,7 +168,7 @@
   when:
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
-    - osd_scenario != 'lvm'
+    - osd_scenario|default('dummy') != 'lvm'
 
 - name: set_fact ceph_uid for Debian based system
   set_fact:


### PR DESCRIPTION
osd_scenario does not exist in the ceph-default role so if we try to
play ceph-default on an OSD node, the playbook will fail with undefined
variable.

Signed-off-by: Sébastien Han <seb@redhat.com>