### PR TITLE
site: ability to only generate a ceph.conf on the machines

### DIFF
--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -67,9 +67,9 @@
   become: True
   gather_facts: false
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-docker-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-mon
   serial: 1 # MUST be '1' WHEN DEPLOYING MONITORS ON DOCKER CONTAINERS
 
@@ -77,70 +77,70 @@
   become: True
   gather_facts: false
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-docker-common
-    - { role: ceph-config, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - { role: ceph-config, tags: ['ceph_update_config'], when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
     - { role: ceph-mgr, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 
 - hosts: osds
   become: True
   gather_facts: false
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-docker-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-osd
 
 - hosts: mdss
   become: True
   gather_facts: false
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-docker-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-mds
 
 - hosts: rgws
   become: True
   gather_facts: false
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-docker-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-rgw
 
 - hosts: nfss
   become: True
   gather_facts: false
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-docker-common
-    - { role: ceph-config, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - { role: ceph-config, tags: ['ceph_update_config'], when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
     - { role: ceph-nfs, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 
 - hosts: rbdmirrors
   become: True
   gather_facts: false
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-docker-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-rbd-mirror
 
 - hosts: restapis
   become: True
   gather_facts: false
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-docker-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-restapi
 
 - hosts: clients
   become: True
   gather_facts: false
   roles:
-  - ceph-defaults
-  - ceph-docker-common
-  - ceph-config
-  - ceph-client
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
+    - ceph-docker-common
+    - { role: ceph-config, tags: ['ceph_update_config'] }
+    - ceph-client

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -72,98 +72,98 @@
   gather_facts: false
   become: True
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-mon
 
 - hosts: mgrs
   gather_facts: false
   become: True
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-common
-    - { role: ceph-config, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - { role: ceph-config, tags: ['ceph_update_config'], when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
     - { role: ceph-mgr, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 
 - hosts: agents
   gather_facts: false
   become: True
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-agent
 
 - hosts: osds
   gather_facts: false
   become: True
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-osd
 
 - hosts: mdss
   gather_facts: false
   become: True
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-mds
 
 - hosts: rgws
   gather_facts: false
   become: True
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-rgw
 
 - hosts: nfss
   gather_facts: false
   become: True
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-common
-    - { role: ceph-config, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - { role: ceph-config, tags: ['ceph_update_config'], when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
     - { role: ceph-nfs, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 
 - hosts: restapis
   gather_facts: false
   become: True
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-restapi
 
 - hosts: rbdmirrors
   gather_facts: false
   become: True
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-rbd-mirror
 
 - hosts: clients
   gather_facts: false
   become: True
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-common
-    - ceph-config
+    - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-client
 
 - hosts: iscsi-gws
   gather_facts: false
   become: True
   roles:
-    - ceph-defaults
+    - { role: ceph-defaults, tags: ['ceph_update_config'] }
     - ceph-common
-    - { role: ceph-config, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - { role: ceph-config, tags: ['ceph_update_config'], when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
     - { role: ceph-iscsi-gw, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
 


### PR DESCRIPTION
Now by running the playbook like this:

ansible-playbook site.yml --tags='ceph_update_config'

You can only generate a ceph configuration file on the nodes.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1543434
Signed-off-by: Sébastien Han <seb@redhat.com>