### PR TITLE
infra: do not include host_vars/* in take-over-existing-cluster.yml

### DIFF
--- a/infrastructure-playbooks/take-over-existing-cluster.yml
+++ b/infrastructure-playbooks/take-over-existing-cluster.yml
@@ -16,7 +16,6 @@
   vars_files:
     - roles/ceph-defaults/defaults/main.yml
     - group_vars/all.yml
-    - "host_vars/{{ ansible_hostname }}.yml"
   roles:
     - ceph-defaults
     - ceph-fetch-keys
@@ -38,7 +37,6 @@
   tasks:
     - include_vars: roles/ceph-defaults/defaults/main.yml
     - include_vars: group_vars/all.yml
-    - include_vars: "host_vars/{{ ansible_hostname }}.yml"
 
     - name: get the name of the existing ceph cluster
       shell: |


### PR DESCRIPTION
These are better collected by ansible automatically. This would also
fail if the host_var file didn't exist.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>