### PR TITLE
Backport of 2386

### DIFF
--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -5,6 +5,14 @@
   changed_when: false
   failed_when: false
 
+- name: assign rbd application to pool(s)
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd pool application enable {{ item.name }} rbd"
+  with_items: "{{ openstack_pools | unique }}"
+  changed_when: false
+  failed_when: false
+  when:
+    - ceph_release_num[ceph_release] >= ceph_release_num['luminous']
+
 # A future version could use "--caps CAPSFILE"
 # which will set all of capabilities associated with a given key, for all subsystems
 - name: create openstack key(s)


### PR DESCRIPTION
Since Luminous we need to set the application tag for each pool,
otherwise a CEPH_WARNING is generated when the pools are in use.

We should assign the OpenStack pools to their default which would be
"rbd". When updating to Luminous this would happen automatically to the
vms, images, backups and volumes pools, but for new deploys this is not
the case.