### PR TITLE
rolling update: fix undefined jewel_minor_update failure

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -335,6 +335,8 @@
 
 
 - name: unset osd flags
+  vars:
+    - jewel_minor_update: False
 
   hosts:
     - "{{ mon_group_name|default('mons') }}"


### PR DESCRIPTION
Variables set at the play level with ``vars`` do
not carry over into the next play in the playbook.

The var jewel_minor_update was set in a previous play but
used in this one and was failing because it was not defined.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1544029

Signed-off-by: Andrew Schoen <aschoen@redhat.com>