### PR TITLE
client: use `ceph_uid` fact to set uid/gid on admin key

### DIFF
--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -20,7 +20,7 @@
     - sestatus is defined
     - sestatus.stdout != 'Disabled'
 
-- name: copy ceph admin keyring
+- name: copy ceph admin keyring when non containerized deployment
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.client.admin.keyring"
     dest: "/etc/ceph/"
@@ -28,5 +28,18 @@
     group: "ceph"
     mode: "0600"
   when:
+    - not containerized_deployment
+    - cephx
+    - copy_admin_key
+
+- name: copy ceph admin keyring when containerized deployment
+  copy:
+    src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.client.admin.keyring"
+    dest: "/etc/ceph/"
+    owner: "{{ ceph_uid }}"
+    group: "{{ ceph_uid }}"
+    mode: "0600"
+  when:
+    - containerized_deployment
     - cephx
     - copy_admin_key


### PR DESCRIPTION
That task is failing on containerized deployment because `ceph:ceph`
doesn't exist.
The idea here is to use the `{{ ceph_uid }}` to set the ownerships for
the admin keyring when containerized_deployment.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1540578

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>