### PR TITLE
Remove redundant task to check if atomic

### DIFF
--- a/roles/ceph-docker-common/tasks/main.yml
+++ b/roles/ceph-docker-common/tasks/main.yml
@@ -5,18 +5,6 @@
 - name: include check_mandatory_vars.yml
   include: check_mandatory_vars.yml
 
-- name: check if it is atomic host
-  stat:
-    path: /run/ostree-booted
-  register: stat_ostree
-  check_mode: no
-
-- name: set_fact is_atomic
-  set_fact:
-    is_atomic: '{{ stat_ostree.stat.exists }}'
-  tags:
-    - always
-
 - name: include pre_requisites/prerequisites.yml
   include: pre_requisites/prerequisites.yml
   when:

--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -43,24 +43,24 @@
 
     - name: set_fact is_atomic
       set_fact:
-        atomic: '{{ stat_ostree.stat.exists }}'
+        is_atomic: '{{ stat_ostree.stat.exists }}'
       tags:
         - always
 
   roles:
     - { role: ceph-defaults,
         tags: [with_pkg, fetch_container_image],
-        when: "(containerized_deployment | bool) and not (atomic | bool)" }
+        when: "(containerized_deployment | bool) and not (is_atomic | bool)" }
     - { role: ceph-docker-common,
         tags: [with_pkg, fetch_container_image],
-        when: "(containerized_deployment | bool) and not (atomic | bool)" }
+        when: "(containerized_deployment | bool) and not (is_atomic | bool)" }
 
   post_tasks:
     - name: "pull {{ ceph_docker_image }} image"
       command: "docker pull {{ ceph_docker_registry}}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       changed_when: false
       when:
-        - atomic
+        - is_atomic
         - (ceph_docker_dev_image is undefined or not ceph_docker_dev_image)
 
 - hosts: mons


### PR DESCRIPTION
This fact is already set in site-docker.yml so there's no need to check
it again in ceph-docker-common

Signed-off-by: Paul Bourke <paul.bourke@oracle.com>