### PR TITLE
[TEST] Test setting up correct systemd file for nfs-ganesha

### DIFF
--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -68,6 +68,13 @@
   notify:
     - restart ceph nfss
 
+- name: copy over nfs-ganesha-lock.service file
+  shell: "cp /lib/systemd/system/nfs-ganesha-lock.service.debian8 /lib/systemd/system/nfs-ganesha-lock.service"
+  when:
+    - ansible_distribution == 'Ubuntu'
+    - not containerized_deployment
+    - ceph_nfs_enable_service
+
 - name: systemd start nfs container
   systemd:
     name: ceph-nfs@{{ ceph_nfs_service_suffix | default(ansible_hostname) }}


### PR DESCRIPTION
Don't merge this.
Test to see if we copy over the nfs-ganesha-lock.service.debian8 file
properly, whether the Xenial CI job will work.

The upstream download.ceph.com nfs-ganesha package should be fixed for
xenial (which is in progress).