### PR TITLE
Adjust /etc/updatedb.conf to not parse /var/lib/ceph

### DIFF
--- a/roles/ceph-common/tasks/misc/system_tuning.yml
+++ b/roles/ceph-common/tasks/misc/system_tuning.yml
@@ -6,6 +6,15 @@
   when:
     - osd_objectstore == 'filestore'
 
+- name: disable osd directory path in updatedb.conf
+  replace:
+    dest: /etc/updatedb.conf
+    regexp: '^(PRUNEPATHS(?!.*/var/lib/ceph).*)"$'
+    replace: '\1 /var/lib/ceph"'
+  failed_when: false
+  when:
+    - osd_objectstore == 'filestore'
+
 - name: create tmpfiles.d directory
   file:
     path: "/etc/tmpfiles.d"


### PR DESCRIPTION
Using updatedb -e doesnt make a permanent change, but will updatedb
without the passed path.

To make this change more permanent we should update the
/etc/updatedb.conf file to include /var/lib/ceph.