### PR TITLE
remove kernel.pid_max

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -476,7 +476,6 @@ dummy:
 
 #disable_transparent_hugepage: true
 #os_tuning_params:
-#  - { name: kernel.pid_max, value: 4194303 }
 #  - { name: fs.file-max, value: 26234859 }
 #  - { name: vm.zone_reclaim_mode, value: 0 }
 #  - { name: vm.swappiness, value: 10 }

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -476,7 +476,6 @@ ceph_repository: rhcs
 
 #disable_transparent_hugepage: true
 #os_tuning_params:
-#  - { name: kernel.pid_max, value: 4194303 }
 #  - { name: fs.file-max, value: 26234859 }
 #  - { name: vm.zone_reclaim_mode, value: 0 }
 #  - { name: vm.swappiness, value: 10 }

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -468,7 +468,6 @@ ceph_conf_overrides: {}
 
 disable_transparent_hugepage: true
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
   - { name: vm.zone_reclaim_mode, value: 0 }
   - { name: vm.swappiness, value: 10 }

--- a/tests/functional/centos/7/bs-lvm-osds/group_vars/all
+++ b/tests/functional/centos/7/bs-lvm-osds/group_vars/all
@@ -18,7 +18,6 @@ lvm_volumes:
     db: journal1
     db_vg: journals
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:

--- a/tests/functional/centos/7/bs-lvm-osds/vagrant_variables.yml
+++ b/tests/functional/centos/7/bs-lvm-osds/vagrant_variables.yml
@@ -70,5 +70,4 @@ vagrant_disable_synced_folder: true
 # vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/centos/7/bs-osds-container/group_vars/osds.yml
+++ b/tests/functional/centos/7/bs-osds-container/group_vars/osds.yml
@@ -1,4 +1,3 @@
 ---
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/centos/7/bs-osds-container/vagrant_variables.yml
+++ b/tests/functional/centos/7/bs-osds-container/vagrant_variables.yml
@@ -70,5 +70,4 @@ vagrant_disable_synced_folder: true
 # vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/centos/7/bs-osds-non-container/group_vars/osds.yml
+++ b/tests/functional/centos/7/bs-osds-non-container/group_vars/osds.yml
@@ -1,4 +1,3 @@
 ---
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/centos/7/bs-osds-non-container/vagrant_variables.yml
+++ b/tests/functional/centos/7/bs-osds-non-container/vagrant_variables.yml
@@ -70,5 +70,4 @@ vagrant_disable_synced_folder: true
 # vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/centos/7/cluster/group_vars/all
+++ b/tests/functional/centos/7/cluster/group_vars/all
@@ -16,7 +16,6 @@ dedicated_devices:
   - '/dev/sdc'
 osd_scenario: non-collocated
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
 user_config: True
 openstack_config: True

--- a/tests/functional/centos/7/cluster/group_vars/osds
+++ b/tests/functional/centos/7/cluster/group_vars/osds
@@ -1,5 +1,4 @@
 ---
 copy_admin_key: true
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/centos/7/cluster/vagrant_variables.yml
+++ b/tests/functional/centos/7/cluster/vagrant_variables.yml
@@ -70,7 +70,6 @@ vagrant_disable_synced_folder: true
 # vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
 
 # VM prefix name, need to match the hostname

--- a/tests/functional/centos/7/fs-osds-container/group_vars/osds.yml
+++ b/tests/functional/centos/7/fs-osds-container/group_vars/osds.yml
@@ -1,4 +1,3 @@
 ---
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/centos/7/fs-osds-container/vagrant_variables.yml
+++ b/tests/functional/centos/7/fs-osds-container/vagrant_variables.yml
@@ -70,5 +70,4 @@ vagrant_disable_synced_folder: true
 # vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/centos/7/fs-osds-non-container/group_vars/osds.yml
+++ b/tests/functional/centos/7/fs-osds-non-container/group_vars/osds.yml
@@ -1,4 +1,3 @@
 ---
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/centos/7/fs-osds-non-container/vagrant_variables.yml
+++ b/tests/functional/centos/7/fs-osds-non-container/vagrant_variables.yml
@@ -70,5 +70,4 @@ vagrant_disable_synced_folder: true
 # vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/centos/7/lvm-osds/group_vars/all
+++ b/tests/functional/centos/7/lvm-osds/group_vars/all
@@ -21,7 +21,6 @@ lvm_volumes:
     data_vg: test_group
     journal_vg: journals
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:

--- a/tests/functional/centos/7/lvm-osds/vagrant_variables.yml
+++ b/tests/functional/centos/7/lvm-osds/vagrant_variables.yml
@@ -70,5 +70,4 @@ vagrant_disable_synced_folder: true
 # vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/ubuntu/16.04/cluster/group_vars/all
+++ b/tests/functional/ubuntu/16.04/cluster/group_vars/all
@@ -16,7 +16,6 @@ dedicated_devices:
   - '/dev/sdc'
 osd_scenario: non-collocated
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:

--- a/tests/functional/ubuntu/16.04/cluster/group_vars/osds
+++ b/tests/functional/ubuntu/16.04/cluster/group_vars/osds
@@ -1,4 +1,3 @@
 ---
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/ubuntu/16.04/cluster/vagrant_variables.yml
+++ b/tests/functional/ubuntu/16.04/cluster/vagrant_variables.yml
@@ -70,5 +70,4 @@ vagrant_disable_synced_folder: true
 # vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/vagrant_variables.yml.linode
+++ b/vagrant_variables.yml.linode
@@ -37,5 +37,4 @@ restapi: true
 # vagrant_sync_dir: /home/vagrant/sync
 
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -62,7 +62,6 @@ vagrant_sync_dir: /home/vagrant/sync
 # vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
 
 os_tuning_params:
-  - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }
 
 # Debug mode, runs Ansible with -vvvv


### PR DESCRIPTION
This is now managed by Ceph packages.

See: https://github.com/ceph/ceph/pull/18544/files

http://tracker.ceph.com/issues/21929

Closes: https://github.com/ceph/ceph-ansible/issues/2410

Signed-off-by: Sébastien Han <seb@redhat.com>