### PR TITLE
Make rule_name optional when defining items in openstack_pools

### DIFF
--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -1,6 +1,6 @@
 ---
 - name: create openstack pool(s)
-  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pg_num }} {{ item.rule_name }}"
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pg_num }} {{ item.rule_name|default('') }}"
   with_items: "{{ openstack_pools | unique }}"
   changed_when: false
   failed_when: false


### PR DESCRIPTION
Previously it was necessary to provide a value (eventually an
empty string) for the "rule_name" key for each item in
openstack_pools. This change makes that optional and defaults to
empty string when not given.