### PR TITLE
mds: fix ansible_service_mgr typo

### DIFF
--- a/roles/ceph-mds/tasks/non_containerized.yml
+++ b/roles/ceph-mds/tasks/non_containerized.yml
@@ -67,7 +67,7 @@
     path: "/etc/systemd/system/ceph-mds@.service.d/"
   when:
     - ceph_mds_systemd_overrides is defined
-    - ansible_server_mgr == 'systemd'
+    - ansible_service_mgr == 'systemd'
 
 - name: add ceph-mds systemd service overrides
   config_template:


### PR DESCRIPTION
Fix typo on when test for ansible_service_mgr == systemd