### PR TITLE
[backport] mds: fix ansible_service_mgr typo

### DIFF
--- a/roles/ceph-mds/tasks/non_containerized.yml
+++ b/roles/ceph-mds/tasks/non_containerized.yml
@@ -67,7 +67,7 @@
     path: "/etc/systemd/system/ceph-mds@.service.d/"
   when:
     - ceph_mds_systemd_overrides is defined
-    - ansible_server_mgr == 'systemd'
+    - ansible_service_mgr == 'systemd'
 
 - name: add ceph-mds systemd service overrides
   config_template:


### PR DESCRIPTION
This commit fixes a typo introduced by 4671b9e74e657988137f6723ef12e38c66d9cd40

(cherry picked from commit 1e1b26ca4d6f4ede84756003b9ffad851530e956)

Backport of #2416 