### PR TITLE
tests: make CI jobs using 'ansible.cfg'

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -122,6 +122,7 @@ passenv=*
 sitepackages=True
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_CONFIG = -F {toxinidir}/ansible.cfg
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
   ANSIBLE_CALLBACK_WHITELIST = profile_tasks
   # only available for ansible >= 2.2


### PR DESCRIPTION
The jobs launches by the CI are not using 'ansible.cfg'.
There are some parameters that should avoid SSH failure that we are used
to see in the CI so far.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>