### PR TITLE
Adds handy ceph aliases whe containerized installations.

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -469,6 +469,10 @@
     tags:
       remove_img
 
+  - name: remove ceph aliases
+    file:
+      path: /etc/profile.d/ceph-aliases.sh
+      state: absent
 
 - name: remove installed packages
 

--- a/roles/ceph-mon/tasks/docker/configure_ceph_command_aliases.yml
+++ b/roles/ceph-mon/tasks/docker/configure_ceph_command_aliases.yml
@@ -1,0 +1,8 @@
+---
+- name: configure ceph profile.d aliases
+  template:
+    src: ceph-aliases.sh.j2
+    dest: "/etc/profile.d/ceph-aliases.sh"
+    mode: 0755
+    owner: root
+    group: root

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -6,6 +6,9 @@
 - name: include start_docker_monitor.yml
   include: start_docker_monitor.yml
 
+- name: include configure_ceph_command_aliases.yml
+  include: configure_ceph_command_aliases.yml
+
 - name: wait for monitor socket to exist
   command: "docker exec ceph-mon-{{ ansible_hostname }} sh -c 'stat /var/run/ceph/{{ cluster }}-mon.{{ ansible_hostname }}.asok || stat /var/run/ceph/{{ cluster }}-mon.{{ ansible_fqdn }}.asok'"
   register: monitor_socket

--- a/roles/ceph-mon/templates/ceph-aliases.sh.j2
+++ b/roles/ceph-mon/templates/ceph-aliases.sh.j2
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Sets up handy aliases for ceph.
+ceph() {
+  sudo {{ docker_exec_cmd }} ceph --cluster {{ cluster }} ${@}
+}
+
+radosgw-admin() {
+  sudo {{ docker_exec_cmd }} radosgw-admin --cluster {{ cluster }} ${@}
+}
+
+rados() {
+  sudo {{ docker_exec_cmd }} rados --cluster {{ cluster }} ${@}
+}
+
+rbd() {
+  sudo {{ docker_exec_cmd }} rbd --cluster {{ cluster }} ${@}
+}


### PR DESCRIPTION
Same approach as openshift-ansible with etcdctl:
* https://github.com/openshift/openshift-ansible/blob/release-3.7/roles/etcd/tasks/auxiliary/drop_etcdctl.yml
* https://github.com/openshift/openshift-ansible/blob/release-3.7/roles/etcd/etcdctl.sh

Adds some ceph aliases to /etc/profile.d/ceph-aliases.sh so we can run ceph cli commands: ceph, radosgw-admin, rados and rbd directly from the host, without having to do "sudo docker exec ...".