### PR TITLE
client: fix pgs num for client pool creation

### DIFF
--- a/group_vars/clients.yml.sample
+++ b/group_vars/clients.yml.sample
@@ -15,8 +15,8 @@ dummy:
 
 #user_config: false
 #pools:
-#  - { name: test, pgs: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}" }
-#  - { name: test2, pgs: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}" }
+#  - { name: test, pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
+#  - { name: test2, pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
 
 # Can add `mds_cap` attribute to override the default value which is '' for mds capabilities.
 # To have have ansible setfacl the generated key for $user, set the acls var like so:

--- a/roles/ceph-client/defaults/main.yml
+++ b/roles/ceph-client/defaults/main.yml
@@ -7,8 +7,8 @@ copy_admin_key: false
 
 user_config: false
 pools:
-  - { name: test, pgs: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}" }
-  - { name: test2, pgs: "{{ ceph_conf_overrides.global.osd_pool_default_pg_num }}" }
+  - { name: test, pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
+  - { name: test2, pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
 
 # Can add `mds_cap` attribute to override the default value which is '' for mds capabilities.
 # To have have ansible setfacl the generated key for $user, set the acls var like so:

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -46,12 +46,11 @@
     - copy_admin_key
 
 - name: create pools
-  command: "{{ docker_exec_client_cmd }} --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pgs }}"
+  command: "{{ docker_exec_client_cmd }} --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.get('pgs', hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num']) }}"
   with_items: "{{ pools }}"
   changed_when: false
   failed_when: false
   when:
-    - ceph_conf_overrides.get('global', {}).get('osd_pool_default_pg_num', False) != False
     - pools | length > 0
     - copy_admin_key
 


### PR DESCRIPTION
`ceph_conf_overrides.global.osd_pool_default_pg_num` shouldn't be a
mandatory variable since we can set it in `keys` dict.
It's too much to have to define both.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>