### PR TITLE
Makes use of docker_exec_cmd in ceph-mon role.

### DIFF
--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -7,14 +7,14 @@
   include: start_docker_monitor.yml
 
 - name: wait for monitor socket to exist
-  command: "docker exec ceph-mon-{{ ansible_hostname }} sh -c 'stat /var/run/ceph/{{ cluster }}-mon.{{ ansible_hostname }}.asok || stat /var/run/ceph/{{ cluster }}-mon.{{ ansible_fqdn }}.asok'"
+  command: "{{ docker_exec_cmd }} sh -c 'stat /var/run/ceph/{{ cluster }}-mon.{{ ansible_hostname }}.asok || stat /var/run/ceph/{{ cluster }}-mon.{{ ansible_fqdn }}.asok'"
   register: monitor_socket
   retries: 5
   delay: 15
   until: monitor_socket.rc == 0
 
 - name: ipv4 - force peer addition as potential bootstrap peer for cluster bringup - monitor_interface
-  command: docker exec ceph-mon-{{ ansible_hostname }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[groups[mon_group_name][0]]['ansible_' + monitor_interface].ipv4.address }}
+  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[groups[mon_group_name][0]]['ansible_' + monitor_interface].ipv4.address }}"
   changed_when: false
   failed_when: false
   when:
@@ -24,7 +24,7 @@
     - hostvars[groups[mon_group_name][0]]['monitor_interface'] != 'interface'
 
 - name: ipv4 - force peer addition as potential bootstrap peer for cluster bringup - monitor_address
-  command: docker exec ceph-mon-{{ ansible_hostname }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[groups[mon_group_name][0]]['monitor_address'] }}
+  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[groups[mon_group_name][0]]['monitor_address'] }}"
   changed_when: false
   failed_when: false
   when:
@@ -34,7 +34,7 @@
     - hostvars[groups[mon_group_name][0]]['monitor_address'] != '0.0.0.0'
 
 - name: ipv4 - force peer addition as potential bootstrap peer for cluster bringup - monitor_address_block
-  command: docker exec ceph-mon-{{ ansible_hostname }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[groups[mon_group_name][0]]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}
+  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[groups[mon_group_name][0]]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}"
   changed_when: false
   failed_when: false
   when:
@@ -44,7 +44,7 @@
     - hostvars[groups[mon_group_name][0]]['monitor_address_block'] != 'subnet'
 
 - name: ipv6 - force peer addition as potential bootstrap peer for cluster bringup - monitor_interface
-  command: docker exec ceph-mon-{{ ansible_hostname }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['ansible_' + monitor_interface].ipv6[0].address }}]
+  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['ansible_' + monitor_interface].ipv6[0].address }}]"
   changed_when: false
   failed_when: false
   when:
@@ -54,7 +54,7 @@
     - hostvars[groups[mon_group_name][0]]['monitor_interface'] != 'interface'
 
 - name: ipv6 - force peer addition as potential bootstrap peer for cluster bringup - monitor_address
-  command: docker exec ceph-mon-{{ ansible_hostname }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['monitor_address'] }}]
+  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['monitor_address'] }}]"
   changed_when: false
   failed_when: false
   when:
@@ -64,7 +64,7 @@
     - hostvars[groups[mon_group_name][0]]['monitor_address'] != '0.0.0.0'
 
 - name: ipv6 - force peer addition as potential bootstrap peer for cluster bringup - monitor_address_block
-  command: docker exec ceph-mon-{{ ansible_hostname }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}]
+  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}]"
   changed_when: false
   failed_when: false
   when:
@@ -78,7 +78,7 @@
   when: not containerized_deployment_with_kv
 
 - name: create ceph rest api keyring when mon is containerized
-  command: docker exec ceph-mon-{{ ansible_hostname }} ceph --cluster {{ cluster }} auth get-or-create client.restapi osd 'allow *' mon 'allow *' -o /etc/ceph/{{ cluster }}.client.restapi.keyring
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} auth get-or-create client.restapi osd 'allow *' mon 'allow *' -o /etc/ceph/{{ cluster }}.client.restapi.keyring"
   args:
      creates: "{{ ceph_conf_key_directory }}/{{ cluster }}.client.restapi.keyring"
   changed_when: false
@@ -91,7 +91,7 @@
 
 - block:
   - name: create ceph mgr keyring(s) when mon is containerized
-    command: docker exec ceph-mon-{{ ansible_hostname }} ceph --cluster {{ cluster }} auth get-or-create mgr.{{ hostvars[item]['ansible_hostname'] }} mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o /etc/ceph/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring
+    command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} auth get-or-create mgr.{{ hostvars[item]['ansible_hostname'] }} mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o /etc/ceph/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
     args:
       creates: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
     changed_when: false


### PR DESCRIPTION
Keeps consistency inside the role and among roles.
Makes the code more readable.