### PR TITLE
Remove vars that are no longer used

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -369,8 +369,6 @@ dummy:
 
 ## Rados Gateway options
 #
-#radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
-#radosgw_resolve_cname: false # enable for radosgw to resolve DNS CNAME based bucket names
 #radosgw_civetweb_port: 8080
 #radosgw_civetweb_num_threads: 100
 # For additional civetweb configuration options available such as SSL, logging,

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -369,8 +369,6 @@ ceph_repository: rhcs
 
 ## Rados Gateway options
 #
-#radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
-#radosgw_resolve_cname: false # enable for radosgw to resolve DNS CNAME based bucket names
 #radosgw_civetweb_port: 8080
 #radosgw_civetweb_num_threads: 100
 # For additional civetweb configuration options available such as SSL, logging,

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -361,8 +361,6 @@ mds_max_mds: 3
 
 ## Rados Gateway options
 #
-#radosgw_dns_name: your.subdomain.tld # subdomains used by radosgw. See http://ceph.com/docs/master/radosgw/config/#enabling-subdomain-s3-calls
-radosgw_resolve_cname: false # enable for radosgw to resolve DNS CNAME based bucket names
 radosgw_civetweb_port: 8080
 radosgw_civetweb_num_threads: 100
 # For additional civetweb configuration options available such as SSL, logging,


### PR DESCRIPTION
As part of fcba2c801a122b7ce8ec6a5c27a70bc19589d177 these vars were
removed and no longer do anything:

radosgw_dns_name
radosgw_resolve_cname

This patch removes them from the group_vars files and defaults/main.yml