### PR TITLE
[skip ci] Mons: add devices classes option to the crush rule creation task.

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -52,18 +52,24 @@ dummy:
 ###############
 # CRUSH RULES #
 ###############
+# Set crush_rule_config to true (default is false) if you want ceph-ansible to configure extra crush rules for you.
 #crush_rule_config: false
 
+# Define your rules and enable them with the "crush_rules:" list
+# If crush_rule_config is set to true and crush_rules is not overwritten by the user then the following rules will be configured:
+
 #crush_rule_hdd:
-#  name: HDD
-#  root: HDD
-#  type: host
-#  default: false
+#  name: HDD  # Name of the crush rule
+#  root: HDD  # Crush root the rule you take.
+#  type: host  # Reaplication failure domain
+#  device_class: ""  # Should this rule target a specific device class ?
+#  default: false  # Should this rule be the default for new pools ? Only ONE default rule max.
 
 #crush_rule_ssd:
 #  name: SSD
 #  root: SSD
 #  type: host
+#  device_class: ""
 #  default: false
 
 #crush_rules:

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -44,18 +44,24 @@ cephfs_pools:
 ###############
 # CRUSH RULES #
 ###############
+# Set crush_rule_config to true (default is false) if you want ceph-ansible to configure extra crush rules for you.
 crush_rule_config: false
 
+# Define your rules and enable them with the "crush_rules:" list
+# If crush_rule_config is set to true and crush_rules is not overwritten by the user then the following rules will be configured:
+
 crush_rule_hdd:
-  name: HDD
-  root: HDD
-  type: host
-  default: false
+  name: HDD  # Name of the crush rule
+  root: HDD  # Crush root the rule you take.
+  type: host  # Reaplication failure domain
+  device_class: ""  # Should this rule target a specific device class ?
+  default: false  # Should this rule be the default for new pools ? Only ONE default rule max.
 
 crush_rule_ssd:
   name: SSD
   root: SSD
   type: host
+  device_class: ""
   default: false
 
 crush_rules:

--- a/roles/ceph-mon/tasks/crush_rules.yml
+++ b/roles/ceph-mon/tasks/crush_rules.yml
@@ -12,7 +12,7 @@
     - hostvars[item]['osd_crush_location'] is defined
 
 - name: create configured crush rules
-  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-simple {{ item.name }} {{ item.root }} {{ item.type }}"
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-replicated {{ item.name }} {{ item.root }} {{ item.type }} {{ item.device_class | default('') }}"
   with_items: "{{ crush_rules | unique }}"
   changed_when: false
   when:

--- a/tests/functional/centos/7/cluster/group_vars/mons
+++ b/tests/functional/centos/7/cluster/group_vars/mons
@@ -10,6 +10,7 @@ crush_rule_hdd:
   root: HDD
   type: host
   default: true
+  device_class: hdd
 crush_rules:
   - "{{ crush_rule_hdd }}"
 


### PR DESCRIPTION
use device_class: to define the device class the rule should use.
Default is to do not use it (empty string)
Added some comments on how to enable and create custom crush rules.

Signed-off-by: Sébastien Han <seb@redhat.com>
Co-authored-by: Greg Charot <gcharot@redhat.com>