### PR TITLE
adds a new ceph_volume_zap module

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -328,23 +328,52 @@
     failed_when: false
     register: ceph_lockbox_partition_to_erase_path
 
-  # this should go away once 'ceph-volume lvm zap' is available
-  - name: remove osd logical volumes
-    command: "lvremove -f {{ item.data_vg }}/{{ item.data }}"
+  - name: zap osd data devices
+    ceph_volume_zap:
+      device: "{{ item.data }}"
+      device_vg: "{{ item.data_vg|default(omit) }}"
+      destroy: true
     with_items: "{{ lvm_volumes }}"
+    environment:
+      CEPH_VOLUME_DEBUG: 1
     when:
       - osd_scenario == "lvm"
 
-  # this should go away once 'ceph-volume lvm zap' is available
-  - name: remove osd lvm journals
-    command: "lvremove -f {{ item.journal_vg }}/{{ item.journal }}"
+  - name: zap osd journal devices
+    ceph_volume_zap:
+      device: "{{ item.journal}}"
+      device_vg: "{{ item.journal_vg|default(omit) }}"
+      destroy: true
     with_items: "{{ lvm_volumes }}"
-    # journals might be logical volumes, but they could also be
-    # devices so fail silently if this doesn't work
-    failed_when: false
+    environment:
+      CEPH_VOLUME_DEBUG: 1
     when:
       - osd_scenario == "lvm"
-      - item.journal_vg is defined
+      - item.journal is defined
+
+  - name: zap osd wal devices
+    ceph_volume_zap:
+      device: "{{ item.wal }}"
+      device_vg: "{{ item.wal_vg|default(omit) }}"
+      destroy: true
+    with_items: "{{ lvm_volumes }}"
+    environment:
+      CEPH_VOLUME_DEBUG: 1
+    when:
+      - osd_scenario == "lvm"
+      - item.wal is defined
+
+  - name: zap osd db devices
+    ceph_volume_zap:
+      device: "{{ item.db }}"
+      device_vg: "{{ item.db_vg|default(omit) }}"
+      destroy: true
+    with_items: "{{ lvm_volumes }}"
+    environment:
+      CEPH_VOLUME_DEBUG: 1
+    when:
+      - osd_scenario == "lvm"
+      - item.db is defined
 
   - name: get ceph block partitions
     shell: |

--- a/library/ceph_volume_zap.py
+++ b/library/ceph_volume_zap.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python
+import datetime
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ceph_volume_zap
+
+short_description: Zap devices used by ceph OSDs with ceph-volume
+
+description:
+    - Using the ceph-volume utility available in Ceph this module
+      can be used to zap devices used by ceph OSDs.
+    - These devices, partitions or logicial volumes can then be reused.
+    - All partitions and logical volumes will be kept intact.
+
+options:
+    device:
+        description:
+            - The logical volume name, device or partition to zap.
+        required: true
+    device_vg:
+        description:
+            - If device is a lv, this must be the name of the volume group it belongs to.
+        required: false
+    destroy:
+        description:
+            - If set to True any logical volumes existing on a given device or partition will be destroyed.
+        required: false
+        default: true
+
+
+author:
+    - Andrew Schoen (@andrewschoen)
+'''
+
+EXAMPLES = '''
+- name: zap a raw device
+  ceph_volume_zap:
+    device: /dev/sdc
+    destroy: True
+
+- name: zap a partition
+  ceph_volume_zap:
+    device: /dev/sdc1
+    destroy: True
+
+- name: zap a logical volume
+  ceph_volume_zap:
+    device: lv1
+    device_vg: vg_name
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def get_device(device, device_vg):
+    if device_vg:
+        device = "{0}/{1}".format(device_vg, device)
+    return device
+
+
+def run_module():
+    module_args = dict(
+        device=dict(type='str', required=True),
+        device_vg=dict(type='str', required=False),
+        destroy=dict(type='bool', required=False, default=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    device = module.params['device']
+    device_vg = module.params.get('device_vg', None)
+    destroy = module.params['destroy']
+
+    cmd = [
+        'ceph-volume',
+        'lvm',
+        'zap',
+    ]
+
+    device_to_zap = get_device(device, device_vg)
+    cmd.append(device_to_zap)
+
+    if destroy:
+        cmd.append("--destroy")
+
+    result = dict(
+        changed=False,
+        cmd=cmd,
+        stdout='',
+        stderr='',
+        rc='',
+        start='',
+        end='',
+        delta='',
+    )
+
+    if module.check_mode:
+        return result
+
+    startd = datetime.datetime.now()
+
+    rc, out, err = module.run_command(cmd, encoding=None)
+
+    endd = datetime.datetime.now()
+    delta = endd - startd
+
+    result = dict(
+        cmd=cmd,
+        stdout=out.rstrip(b"\r\n"),
+        stderr=err.rstrip(b"\r\n"),
+        rc=rc,
+        start=str(startd),
+        end=str(endd),
+        delta=str(delta),
+        changed=True,
+    )
+
+    if rc != 0:
+        module.fail_json(msg='non-zero return code', **result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/library/test_ceph_volume_zap.py
+++ b/library/test_ceph_volume_zap.py
@@ -1,0 +1,12 @@
+from . import ceph_volume_zap
+
+
+class TestCephVolumeZapModule(object):
+
+    def test_device_no_vg(self):
+        result = ceph_volume_zap.get_device("/dev/sda", None)
+        assert result == "/dev/sda"
+
+    def test_device_with_vg(self):
+        result = ceph_volume_zap.get_device("data-lv", "data-vg")
+        assert result == "data-vg/data-lv"

--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -21,21 +21,6 @@
       command: lvcreate --yes -l 50%FREE -n data-lv2 test_group
       failed_when: false
 
-    # purge-cluster.yml does not properly destroy partitions
-    # used for lvm osd journals, this ensures they are removed
-    # for that testing scenario
-    - name: remove /dev/sdc1 if it exists
-      parted:
-        device: /dev/sdc
-        number: 1
-        state: absent
-
-    - name: remove /dev/sdc2 if it exists
-      parted:
-        device: /dev/sdc
-        number: 2
-        state: absent
-
     - name: partition /dev/sdc for journals
       parted:
         device: /dev/sdc


### PR DESCRIPTION
This module is used in ``purge-cluster.yml`` to zap devices, partitions and logical volumes that were used by ``ceph-volume`` previously so that they can be reused.

fixes: #2337