### PR TITLE
[WIP] Cleanup fsid generation

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -28,7 +28,7 @@ dummy:
 #  luminous: 12
 #  mimic: 13
 
-# Directory to fetch cluster fsid, keys etc...
+# Directory to fetch cluster keys etc...
 #fetch_directory: fetch/
 
 # The 'cluster' variable determines the name of the cluster.
@@ -276,10 +276,10 @@ dummy:
 ## Ceph options
 #
 # Each cluster requires a unique, consistent filesystem ID. By
-# default, the playbook generates one for you and stores it in a file
-# in `fetch_directory`. If you want to customize how the fsid is
-# generated, you may find it useful to disable fsid generation to
-# avoid cluttering up your ansible repo. If you set `generate_fsid` to
+# default, the playbook generates one for you and stores it as a
+# variable. If you want to customize how the fsid is generated,
+# you may find it useful to disable fsid generation to avoid
+# cluttering up your ansible repo. If you set `generate_fsid` to
 # false, you *must* generate `fsid` in another way.
 # ACTIVATE THE FSID VARIABLE FOR NON-VAGRANT DEPLOYMENT
 #fsid: "{{ cluster_uuid.stdout }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -28,7 +28,7 @@ dummy:
 #  luminous: 12
 #  mimic: 13
 
-# Directory to fetch cluster fsid, keys etc...
+# Directory to fetch cluster keys etc...
 fetch_directory: ~/ceph-ansible-keys
 
 # The 'cluster' variable determines the name of the cluster.
@@ -276,10 +276,10 @@ ceph_repository: rhcs
 ## Ceph options
 #
 # Each cluster requires a unique, consistent filesystem ID. By
-# default, the playbook generates one for you and stores it in a file
-# in `fetch_directory`. If you want to customize how the fsid is
-# generated, you may find it useful to disable fsid generation to
-# avoid cluttering up your ansible repo. If you set `generate_fsid` to
+# default, the playbook generates one for you and stores it as a
+# variable. If you want to customize how the fsid is generated,
+# you may find it useful to disable fsid generation to avoid
+# cluttering up your ansible repo. If you set `generate_fsid` to
 # false, you *must* generate `fsid` in another way.
 # ACTIVATE THE FSID VARIABLE FOR NON-VAGRANT DEPLOYMENT
 #fsid: "{{ cluster_uuid.stdout }}"

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -78,28 +78,6 @@
           ((groups.get(nfs_group_name, []) | length > 0)
             and (inventory_hostname == groups.get(nfs_group_name, [])[0])))
 
-  - name: generate cluster uuid
-    local_action:
-      module: shell
-        python -c 'import uuid; print(str(uuid.uuid4()))' | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
-      creates: "{{ fetch_directory }}/ceph_cluster_uuid.conf"
-    register: cluster_uuid
-    become: false
-    when:
-      - generate_fsid
-
-  - name: read cluster uuid if it already exists
-    local_action:
-      module: command
-        cat {{ fetch_directory }}/ceph_cluster_uuid.conf
-      removes: "{{ fetch_directory }}/ceph_cluster_uuid.conf"
-    changed_when: false
-    register: cluster_uuid
-    check_mode: no
-    become: false
-    when:
-      - generate_fsid
-
   - name: ensure /etc/ceph exists
     file:
       path: /etc/ceph
@@ -127,11 +105,5 @@
       - restart ceph rgws
       - restart ceph mgrs
       - restart ceph rbdmirrors
-
-  - name: set fsid fact when generate_fsid = true
-    set_fact:
-      fsid: "{{ cluster_uuid.stdout }}"
-    when:
-      - generate_fsid
   when:
     - containerized_deployment|bool

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -20,7 +20,7 @@ ceph_release_num:
   luminous: 12
   mimic: 13
 
-# Directory to fetch cluster fsid, keys etc...
+# Directory to fetch cluster keys etc...
 fetch_directory: fetch/
 
 # The 'cluster' variable determines the name of the cluster.
@@ -268,13 +268,13 @@ ceph_custom_repo: https://server.domain.com/ceph-custom-repo
 ## Ceph options
 #
 # Each cluster requires a unique, consistent filesystem ID. By
-# default, the playbook generates one for you and stores it in a file
-# in `fetch_directory`. If you want to customize how the fsid is
-# generated, you may find it useful to disable fsid generation to
-# avoid cluttering up your ansible repo. If you set `generate_fsid` to
+# default, the playbook generates one for you and stores it as a
+# variable. If you want to customize how the fsid is generated,
+# you may find it useful to disable fsid generation to avoid
+# cluttering up your ansible repo. If you set `generate_fsid` to
 # false, you *must* generate `fsid` in another way.
 # ACTIVATE THE FSID VARIABLE FOR NON-VAGRANT DEPLOYMENT
-fsid: "{{ cluster_uuid.stdout }}"
+#fsid: "{{ cluster_uuid.stdout }}"
 generate_fsid: true
 
 ceph_conf_key_directory: /etc/ceph

--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -18,19 +18,56 @@
   when:
     - containerized_deployment
 
-# this task shouldn't run in a rolling_update situation
-# because it blindly picks a mon, which may be down because
-# of the rolling update
+# for rolling updates we should delegate to not the current host if the
+# current host is mon_group_name[0] since it will be unavailable
 - name: is ceph running already?
   command: "timeout 5 {{ docker_exec_cmd }} ceph --cluster {{ cluster }} fsid"
   changed_when: false
   failed_when: false
   check_mode: no
   register: ceph_current_fsid
-  delegate_to: "{{ groups[mon_group_name][0] }}"
+  delegate_to: "{{ (inventory_hostname == groups[mon_group_name][0]) | ternary(groups[mon_group_name][-1], groups[mon_group_name][0]) }}"
+  run_once: true
+
+- name: debug var cluser_uuid
+  debug:
+    var: cluster_uuid
+
+- name: debug var ceph_current_fsid
+  debug:
+    var: ceph_current_fsid
+
+- name: debug var fsid
+  debug:
+    var: fsid
+
+- name: generate cluster fsid
+  local_action:
+    module: shell
+      python -c 'import uuid; print(str(uuid.uuid4()))'
+  register: cluster_uuid
+  run_once: true
+  become: false
   when:
-    - not rolling_update
-    - groups.get(mon_group_name, []) | length > 0
+    - generate_fsid
+    - ceph_current_fsid.rc != 0
+    - hostvars['localhost']['fsid'] is undefined
+
+- name: shares facts for cluster_uuid fsid and ceph_current_fsid
+  set_fact:
+    ceph_current_fsid: "{{ ceph_current_fsid }}"
+    fsid: "{{ (ceph_current_fsid.rc == 0) | ternary(ceph_current_fsid.stdout, cluster_uuid.stdout | default('')) }}"
+  delegate_to: localhost
+  run_once: true
+  when:
+    - generate_fsid or (ceph_current_fsid.rc == 0)
+
+- name: Set the fact locally
+  set_fact:
+    ceph_current_fsid: "{{ hostvars['localhost']['ceph_current_fsid'] }}"
+    fsid: "{{ hostvars['localhost']['fsid'] }}"
+  when:
+    - generate_fsid or (ceph_current_fsid.rc == 0)
 
 # We want this check to be run only on the first node
 - name: check if {{ fetch_directory }} directory exists
@@ -40,15 +77,6 @@
   become: false
   register: monitor_keyring_conf
   run_once: true
-
-# set this as a default when performing a rolling_update
-# so the rest of the tasks here will succeed
-- name: set_fact ceph_current_fsid rc 1
-  set_fact:
-    ceph_current_fsid:
-      rc: 1
-  when:
-    - rolling_update or groups.get(mon_group_name, []) | length == 0
 
 - name: create a local fetch directory if it does not exist
   local_action:
@@ -61,54 +89,10 @@
   when:
     - (cephx or generate_fsid)
 
-- name: set_fact fsid ceph_current_fsid.stdout
-  set_fact:
-    fsid: "{{ ceph_current_fsid.stdout }}"
-  when:
-    - ceph_current_fsid.rc == 0
-
 # Set ceph_release to ceph_stable by default
 - name: set_fact ceph_release ceph_stable_release
   set_fact:
     ceph_release: "{{ ceph_stable_release }}"
-
-- name: generate cluster fsid
-  local_action:
-    module: shell
-      python -c 'import uuid; print(str(uuid.uuid4()))' | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
-    creates: "{{ fetch_directory }}/ceph_cluster_uuid.conf"
-  register: cluster_uuid
-  become: false
-  when:
-    - generate_fsid
-    - ceph_current_fsid.rc != 0
-
-- name: reuse cluster fsid when cluster is already running
-  local_action:
-    module: shell
-      echo {{ fsid }} | tee {{ fetch_directory }}/ceph_cluster_uuid.conf
-    creates: "{{ fetch_directory }}/ceph_cluster_uuid.conf"
-  become: false
-  when:
-    - ceph_current_fsid.rc == 0
-
-- name: read cluster fsid if it already exists
-  local_action:
-    module: command
-      cat {{ fetch_directory }}/ceph_cluster_uuid.conf
-    removes: "{{ fetch_directory }}/ceph_cluster_uuid.conf"
-  changed_when: false
-  register: cluster_uuid
-  become: false
-  check_mode: no
-  when:
-    - generate_fsid
-
-- name: set_fact fsid
-  set_fact:
-    fsid: "{{ cluster_uuid.stdout }}"
-  when:
-    - generate_fsid
 
 - name: set_fact mds_name ansible_hostname
   set_fact:


### PR DESCRIPTION
The current approach makes fsid generation complicated by utilising a
file and fetch directory. If you delegate a set_fact to localhost it
will set the fact for all other hosts.

In this way we can set the fsid based on the running cluster (if it's
running), or generate it as before - but only perform this once and all
hosts can consume that setting.

Additionally - to allow this to run as part of the rolling updates, we
can run the task to check if ceph is running against either mons[0] or
mons[1] if we are currently using mons[0].