### PR TITLE
Fix config_template to consistently order sections

### DIFF
--- a/plugins/actions/_v1_config_template.py
+++ b/plugins/actions/_v1_config_template.py
@@ -26,7 +26,6 @@ from ansible import errors
 from ansible.runner.return_data import ReturnData
 from ansible import utils
 from ansible.utils import template
-from collections import OrderedDict
 
 CONFIG_TYPES = {
     'ini': 'return_config_overrides_ini',
@@ -145,14 +144,14 @@ class ConfigTemplateParser(ConfigParser.RawConfigParser):
     def write(self, fp):
         if self._defaults:
             fp.write("[%s]\n" % 'DEFAULT')
-            for key, value in OrderedDict(sorted(self._defaults.items())).items():
+            for key, value in sorted(self._defaults.items()):
                 self._write_check(fp, key=key, value=value)
             else:
                 fp.write("\n")
 
-        for section in self._sections:
+        for section in sorted(self._sections):
             fp.write("[%s]\n" % section)
-            for key, value in OrderedDict(sorted(self._sections[section].items())).items():
+            for key, value in sorted(self._sections[section].items()):
                 self._write_check(fp, key=key, value=value, section=True)
             else:
                 fp.write("\n")

--- a/plugins/actions/_v2_config_template.py
+++ b/plugins/actions/_v2_config_template.py
@@ -37,7 +37,6 @@ from ansible.plugins.action import ActionBase
 from ansible.utils.unicode import to_bytes, to_unicode
 from ansible import constants as C
 from ansible import errors
-from collections import OrderedDict
 
 CONFIG_TYPES = {
     'ini': 'return_config_overrides_ini',
@@ -173,14 +172,14 @@ class ConfigTemplateParser(ConfigParser.RawConfigParser):
     def write(self, fp):
         if self._defaults:
             fp.write("[%s]\n" % 'DEFAULT')
-            for key, value in OrderedDict(sorted(self._defaults.items())).items():
+            for key, value in sorted(self._defaults.items()):
                 self._write_check(fp, key=key, value=value)
             else:
                 fp.write("\n")
 
-        for section in self._sections:
+        for section in sorted(self._sections):
             fp.write("[%s]\n" % section)
-            for key, value in OrderedDict(sorted(self._sections[section].items())).items():
+            for key, value in sorted(self._sections[section].items()):
                 self._write_check(fp, key=key, value=value, section=True)
             else:
                 fp.write("\n")


### PR DESCRIPTION
In ec042219e64a321fa67fce0384af76eeb238c645 we added OrderedDict and
sorted to be able to preserve order for config_template k,v pairs inside
a section.

This patch adds a similar ordering for the sections themselves, which
could still change order and intiiate handler restarts.

OrderedDict isn't needed because we use .items() to return a list that
can then be sorted().

(cherry picked from commit fe4ba9d1353abb49775d5541060a55919978f45f)