### PR TITLE
ceph-defaults: set is_atomic variable

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -1,4 +1,13 @@
 ---
+- name: check if it is atomic host
+  stat:
+    path: /run/ostree-booted
+  register: stat_ostree
+
+- name: set_fact is_atomic
+  set_fact:
+    is_atomic: "{{ stat_ostree.stat.exists }}"
+
 - name: set_fact monitor_name ansible_hostname
   set_fact:
     monitor_name: "{{ ansible_hostname }}"


### PR DESCRIPTION
This variable is needed for containerized clusters and is required for
the ceph-docker-common role. Typically the is_atomic variable is set in
site-docker.yml.sample though so if ceph-docker-common is used outside
of that playbook it needs set in another way. Moving the creation of
this variable inside the role means playbooks don't need to worry
about setting it.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1558252

Signed-off-by: Andrew Schoen <aschoen@redhat.com>