### PR TITLE
Fix install of nfs-ganesha-ceph for Debian/SuSE

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -99,41 +99,33 @@
     - ceph_repository != 'rhcs'
     - ansible_os_family == 'Debian'
 
-# debian installation
-- name: install nfs cephfs gateway
-  package:
-    name: nfs-ganesha-ceph
-  when:
-    - (ceph_origin == 'repository' or ceph_origin == 'distro')
-    - ceph_repository != 'rhcs'
-    - ansible_os_family in ['Debian', 'Suse']
-    - nfs_file_gw
-
-- name: install nfs rgw gateway - suse
+- name: install nfs rgw/cephfs gateway - suse
   zypper:
-    name: "{{ item }}"
+    name: "{{ item.name }}"
     disable_gpg_check: yes
   with_items:
-    - nfs-ganesha-rgw
-    - radosgw
+    - { name: 'nfs-ganesha-rgw', install: "{{ nfs_obj_gw }}" }
+    - { name: 'radosgw', install: "{{ nfs_obj_gw }}" }
+    - { name: 'nfs-ganesha-ceph', install: "{{ nfs_file_gw }}" }
   when:
     - (ceph_origin == 'repository' or ceph_origin == 'distro')
     - ceph_repository != 'rhcs'
     - ansible_os_family == 'Suse'
-    - nfs_obj_gw
+    - item.install | bool
 
-- name: install nfs rgw gateway - debian
+- name: install nfs rgw/cephfs gateway - debian
   apt:
-    name: "{{ item }}"
+    name: "{{ item.name }}"
     allow_unauthenticated: yes
   with_items:
-    - nfs-ganesha-rgw
-    - radosgw
+    - { name: 'nfs-ganesha-rgw', install: "{{ nfs_obj_gw }}" }
+    - { name: 'radosgw', install: "{{ nfs_obj_gw }}" }
+    - { name: 'nfs-ganesha-ceph', install: "{{ nfs_file_gw }}" }
   when:
     - (ceph_origin == 'repository' or ceph_origin == 'distro')
     - ceph_repository != 'rhcs'
     - ansible_os_family == 'Debian'
-    - nfs_obj_gw
+    - item.install | bool
 
 # debian_rhcs installation
 - name: install red hat storage nfs gateway for debian


### PR DESCRIPTION
The Debian and SuSE installs for nfs-ganesha on the non-rhcs repository
requires you to allow_unauthenticated for Debian, and disable_gpg_check
for SuSE. The nfs-ganesha-rgw package already does this, but the
nfs-ganesha-ceph package will fail to install because of this same
issue.

This PR moves the installations to happen when the appropriate flags are
set to True (nfs_obj_gw & nfs_file_gw), but does it per distro (one for
SuSE and one for Debian) so that the appropriate flag can be passed to
ignore the GPG check.