### PR TITLE
setup cephx keys when not nfs_obj_gw

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -169,22 +169,22 @@
 # does not have the right selinux context to read ceph directories.
 - name: create rados gateway and ganesha directories
   file:
-    path: "{{ item }}"
+    path: "{{ item.name }}"
     state: directory
     owner: "ceph"
     group: "ceph"
     mode: "0755"
   with_items:
-    - /var/lib/ceph/bootstrap-rgw
-    - /var/lib/ceph/radosgw
-    - /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}
-    - "{{ rbd_client_admin_socket_path }}"
-    - /var/log/ceph
-    - /var/run/ceph/
+    - { name: "/var/lib/ceph/bootstrap-rgw", create: "{{ nfs_obj_gw }}" }
+    - { name: "/var/lib/ceph/radosgw", create: "{{ nfs_obj_gw }}" }
+    - { name: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}", create: "{{ nfs_obj_gw }}" }
+    - { name: "{{ rbd_client_admin_socket_path }}", create: "{{ nfs_obj_gw }}" }
+    - { name: "/var/log/ceph", create: true }
+    - { name: "/var/run/ceph", create: true }
   when:
-    - nfs_obj_gw
+    - item.create|bool
 
-- name: copy rados gateway bootstrap key
+- name: copy bootstrap cephx keys
   copy:
     src: "{{ fetch_directory }}/{{ fsid }}{{ item.name }}"
     dest: "{{ item.name }}"
@@ -192,10 +192,9 @@
     group: "ceph"
     mode: "0600"
   with_items:
-    - { name: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
+    - { name: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: "{{ nfs_obj_gw }}" }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
   when:
-    - nfs_obj_gw
     - cephx
     - item.copy_key|bool
 


### PR DESCRIPTION
Copy the admin key when configured nfs_file_gw (but not nfs_obj_gw). Also,
copy/setup RGW related directories only when configured as nfs_obj_gw.
[skip ci]
backport of : #2438 

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>
(cherry picked from commit 7f91547304349199bf10a636b4e10ccaf20a4212)