### PR TITLE
ceph-client: Reset docker_exec_client_cmd

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -36,6 +36,11 @@
     - not containerized_deployment
     - docker_exec_client_cmd == 'ceph-authtool'
 
+- name: set docker_exec_client_cmd for containers
+  set_fact:
+    docker_exec_client_cmd: docker run --rm -v /etc/ceph:/etc/ceph --entrypoint /usr/bin/{{ docker_exec_client_cmd_binary }} {{ ceph_docker_registry}}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+  when: containerized_deployment
+
 - name: check if key(s) already exist(s)
   command: "{{ docker_exec_client_cmd }} --cluster {{ cluster }} auth get {{ item.name }}"
   changed_when: false


### PR DESCRIPTION
If the docker_exec_client_cmd_binary changes (as it does here), then docker_exec_client_cmd must be set again.

Signed-off-by: Jeff McLamb <mclamb@gmail.com>