### PR TITLE
[skip ci] DNM Host vars validation

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -21,6 +21,7 @@ BuildRequires: python2-devel
 
 Requires: ansible >= 2.4.2.0
 Requires: python-netaddr
+Requires: python-notario
 
 %description
 Ansible playbooks for Ceph

--- a/library/validate
+++ b/library/validate
@@ -1,0 +1,4 @@
+# This is a placeholder file so that the ``validate`` action plugin can work.
+# An action plugin is prefered because that gets executed on the master. If at
+# some point the validation engine needs to run on remote nodes, then this
+# placeholder can implement the ``module`` part of the plugin.

--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -1,12 +1,9 @@
-import sys
-import os
 
 from ansible.plugins.action import ActionBase
 
 import notario
 from notario.exceptions import Invalid
-from notario.decorators import optional
-from notario.validators import types, recursive
+from notario.validators import types, chainable
 
 try:
     from __main__ import display
@@ -18,8 +15,10 @@ except ImportError:
 class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
-        # we must use hostvars, since task_vars will have un-processed variables
-        hostvars = task_vars['hostvars']
+        # we must use vars, since task_vars will have un-processed variables
+        host_vars = task_vars['vars']
+        display.warning(host_vars)
+        host = host_vars['ansible_hostname']
         mode = self._task.args.get('mode', 'permissive')
 
         self._supports_check_mode = False # XXX ?
@@ -28,31 +27,34 @@ class ActionModule(ActionBase):
         result = {}
         result['_ansible_verbose_always'] = True
 
-        for host, _vars in hostvars.items():
-            try:
-                notario.validate(_vars, install_options, defined_keys=True)
-                if _vars["ceph_origin"] == "repository":
-                    notario.validate(_vars, ceph_origin_repository, defined_keys=True)
+        try:
+            notario.validate(host_vars, install_options, defined_keys=True)
 
-                    if _vars["ceph_repository"] == "community":
-                        notario.validate(_vars, ceph_repository_community, defined_keys=True)
+            if host_vars["ceph_origin"] == "repository":
+                notario.validate(host_vars, ceph_origin_repository, defined_keys=True)
 
-                    if _vars["ceph_repository"] == "rhcs":
-                        notario.validate(_vars, ceph_repository_rhcs, defined_keys=True)
+                if host_vars["ceph_repository"] == "community":
+                    notario.validate(host_vars, ceph_repository_community, defined_keys=True)
 
+                if host_vars["ceph_repository"] == "rhcs":
+                    notario.validate(host_vars, ceph_repository_rhcs, defined_keys=True)
 
-            except Invalid as error:
-                display.vvvv("Notario Failure: %s" % str(error))
-                display.warning("[%s] Validation failed for variable: %s" % (host, error.path[0]))
-                msg = "Invalid variable assignment in host: %s\n" % host
-                msg += "    %s = %s\n" % (error.path[0], error.path[1])
-                msg += "    %s   %s\n" % (" " * len(str(error.path[0])), "^" * len(str(error.path[1])))
-                msg += "Reason: %s" % error.reason
-                result['failed'] = mode == 'strict'
-                result['msg'] = msg
-                result['stderr_lines'] = msg.split('\n')
+                if host_vars["ceph_repository"] == "dev":
+                    notario.validate(host_vars, ceph_repository_dev, defined_keys=True)
 
-            return result
+        except Invalid as error:
+            display.vvvv("Notario Failure: %s" % str(error))
+            display.warning(error)
+            display.warning("[%s] Validation failed for variable: %s" % (host, error.path))
+            msg = "Invalid variable assignment in host: %s\n" % host
+            msg += "    %s = %s\n" % (error.path[0], error.path[1])
+            msg += "    %s   %s\n" % (" " * len(str(error.path[0])), "^" * len(str(error.path[1])))
+            msg += "Reason: %s" % error.reason
+            result['failed'] = mode == 'strict'
+            result['msg'] = msg
+            result['stderr_lines'] = msg.split('\n')
+
+        return result
 
 # Schemas
 
@@ -78,19 +80,21 @@ install_options = (
     ('osd_objectstore', osd_objectstore_choices),
 )
 
-ceph_origin_repository = (
-    ("ceph_repository", ceph_repository_choices),
-
-)
+ceph_origin_repository = ("ceph_repository", ceph_repository_choices)
 
 ceph_repository_community = (
     ("ceph_mirror", types.string),
     ("ceph_stable_key", types.string),
-    ("ceph_stable_release", types.string),  # do we need to make sure this is not 'dummy'?
+    ("ceph_stable_release", types.string),
     ("ceph_stable_repo", types.string),
 )
 
 ceph_repository_rhcs = (
     ("ceph_repository_type", ceph_repository_type_choices),
-    ("ceph_rchs_version", types.string),  # FIXME: this might also be a integer
+    ("ceph_rhcs_version", chainable.AnyIn(types.string, types.integer)),
+)
+
+ceph_repository_dev = (
+    ("ceph_dev_branch", types.string),
+    ("ceph_dev_sha1", types.string),
 )

--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -1,0 +1,53 @@
+import sys
+import os
+
+from ansible.plugins.action import ActionBase
+
+import notario
+from notario.exceptions import Invalid
+from notario.decorators import optional
+from notario.validators import types, recursive
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        # we must use hostvars, since task_vars will have un-processed variables
+        hostvars = task_vars['hostvars']
+        mode = self._task.args.get('mode', 'permissive')
+
+        self._supports_check_mode = False # XXX ?
+        self._supports_async      = True
+
+        result = {}
+        result['_ansible_verbose_always'] = True
+
+        for host, _vars in hostvars.items():
+            try:
+                notario.validate(_vars, variables, defined_keys=True)
+            except Invalid as error:
+                display.vvvv("Notario Failure: %s" % str(error))
+                display.warning("[%s] Validation failed for variable: %s" % (host, error.path[-2]))
+                msg = "Invalid variable assignment in host: %s\n" % host
+                msg += "    %s = %s\n" % (error.path[-2], error.path[-1])
+                msg += "    %s   %s\n" % (" "*len(str(error.path[-2])), "^" *len(str(error.path[-1])))
+                msg += "Reason: %s" % error.reason
+                result['failed'] = mode == 'strict'
+                result['msg'] = msg
+                result['stderr_lines'] = msg.split('\n')
+
+            return result
+
+# Schemas
+
+variables = (
+    ('ceph_conf_key_directory', types.boolean),
+    (optional("nfs_file_gw"), types.boolean),
+    (optional("osd_containerized_deployment"), types.boolean),
+)

--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -23,20 +23,30 @@ class ActionModule(ActionBase):
         mode = self._task.args.get('mode', 'permissive')
 
         self._supports_check_mode = False # XXX ?
-        self._supports_async      = True
+        self._supports_async = True
 
         result = {}
         result['_ansible_verbose_always'] = True
 
         for host, _vars in hostvars.items():
             try:
-                notario.validate(_vars, variables, defined_keys=True)
+                notario.validate(_vars, install_options, defined_keys=True)
+                if _vars["ceph_origin"] == "repository":
+                    notario.validate(_vars, ceph_origin_repository, defined_keys=True)
+
+                    if _vars["ceph_repository"] == "community":
+                        notario.validate(_vars, ceph_repository_community, defined_keys=True)
+
+                    if _vars["ceph_repository"] == "rhcs":
+                        notario.validate(_vars, ceph_repository_rhcs, defined_keys=True)
+
+
             except Invalid as error:
                 display.vvvv("Notario Failure: %s" % str(error))
-                display.warning("[%s] Validation failed for variable: %s" % (host, error.path[-2]))
+                display.warning("[%s] Validation failed for variable: %s" % (host, error.path[0]))
                 msg = "Invalid variable assignment in host: %s\n" % host
-                msg += "    %s = %s\n" % (error.path[-2], error.path[-1])
-                msg += "    %s   %s\n" % (" "*len(str(error.path[-2])), "^" *len(str(error.path[-1])))
+                msg += "    %s = %s\n" % (error.path[0], error.path[1])
+                msg += "    %s   %s\n" % (" " * len(str(error.path[0])), "^" * len(str(error.path[1])))
                 msg += "Reason: %s" % error.reason
                 result['failed'] = mode == 'strict'
                 result['msg'] = msg
@@ -46,8 +56,41 @@ class ActionModule(ActionBase):
 
 # Schemas
 
-variables = (
-    ('ceph_conf_key_directory', types.boolean),
-    (optional("nfs_file_gw"), types.boolean),
-    (optional("osd_containerized_deployment"), types.boolean),
+
+def osd_objectstore_choices(value):
+    assert value in ['bluestore', 'filestore'], "osd_objectstore must be either 'bluestore' or 'filestore'"
+
+
+def ceph_origin_choices(value):
+    assert value in ['repository', 'distro', 'local'], "ceph_origin must be either 'repository', 'distro' or 'local'"
+
+
+def ceph_repository_choices(value):
+    assert value in ['community', 'rhcs', 'dev'], "ceph_repository must be either 'community', 'rhcs' or 'dev'"
+
+
+def ceph_repository_type_choices(value):
+    assert value in ['cdn', 'iso'], "ceph_repository_type must be either 'cdn' or 'iso'"
+
+
+install_options = (
+    ("ceph_origin", ceph_origin_choices),
+    ('osd_objectstore', osd_objectstore_choices),
+)
+
+ceph_origin_repository = (
+    ("ceph_repository", ceph_repository_choices),
+
+)
+
+ceph_repository_community = (
+    ("ceph_mirror", types.string),
+    ("ceph_stable_key", types.string),
+    ("ceph_stable_release", types.string),  # do we need to make sure this is not 'dummy'?
+    ("ceph_stable_repo", types.string),
+)
+
+ceph_repository_rhcs = (
+    ("ceph_repository_type", ceph_repository_type_choices),
+    ("ceph_rchs_version", types.string),  # FIXME: this might also be a integer
 )

--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -4,6 +4,7 @@ from ansible.plugins.action import ActionBase
 import notario
 from notario.exceptions import Invalid
 from notario.validators import types, chainable
+from notario.store import store as notario_store
 
 try:
     from __main__ import display
@@ -17,7 +18,6 @@ class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
         # we must use vars, since task_vars will have un-processed variables
         host_vars = task_vars['vars']
-        display.warning(host_vars)
         host = host_vars['ansible_hostname']
         mode = self._task.args.get('mode', 'permissive')
 
@@ -42,13 +42,21 @@ class ActionModule(ActionBase):
                 if host_vars["ceph_repository"] == "dev":
                     notario.validate(host_vars, ceph_repository_dev, defined_keys=True)
 
+            # store these values because one must be defined and the validation method
+            # will need access to all three through the store
+            notario_store["monitor_address"] = host_vars.get("monitor_address", None)
+            notario_store["monitor_address_block"] = host_vars.get("monitor_address_block", None)
+            notario_store["monitor_interface"] = host_vars.get("monitor_interface", None)
+
+            notario.validate(host_vars, monitor_options, defined_keys=True)
+
         except Invalid as error:
+            print host_vars
             display.vvvv("Notario Failure: %s" % str(error))
-            display.warning(error)
-            display.warning("[%s] Validation failed for variable: %s" % (host, error.path))
+            display.warning("[%s] Validation failed for variable: %s" % (host, error.path[0]))
             msg = "Invalid variable assignment in host: %s\n" % host
-            msg += "    %s = %s\n" % (error.path[0], error.path[1])
-            msg += "    %s   %s\n" % (" " * len(str(error.path[0])), "^" * len(str(error.path[1])))
+            msg += "    %s = %s\n" % (error.path, error.path)
+            msg += "    %s   %s\n" % (" " * len(str(error.path)), "^" * len(str(error.path)))
             msg += "Reason: %s" % error.reason
             result['failed'] = mode == 'strict'
             result['msg'] = msg
@@ -75,6 +83,20 @@ def ceph_repository_type_choices(value):
     assert value in ['cdn', 'iso'], "ceph_repository_type must be either 'cdn' or 'iso'"
 
 
+def validate_monitor_options(value):
+    """
+    Either monitor_address, monitor_address_block or monitor_interface must
+    be defined.
+    """
+    monitor_address_given = notario_store["monitor_address"] != "0.0.0.0"
+    monitor_address_block_given = notario_store["monitor_address_block"] != "subnet"
+    monitor_interface_given = notario_store["monitor_interface"] != "interface"
+
+    msg = "Either monitor_address, monitor_address_block or monitor_interface must be provided"
+
+    assert any(monitor_address_given, monitor_address_block_given, monitor_interface_given), msg
+
+
 install_options = (
     ("ceph_origin", ceph_origin_choices),
     ('osd_objectstore', osd_objectstore_choices),
@@ -98,3 +120,13 @@ ceph_repository_dev = (
     ("ceph_dev_branch", types.string),
     ("ceph_dev_sha1", types.string),
 )
+
+monitor_options = (
+    ("cluster_network", types.string),
+    ("fsid", types.string),
+    ("public_network", types.string),
+    ("monitor_address", validate_monitor_options),
+    ("monitor_address_block", validate_monitor_options),
+    ("monitor_interface", validate_monitor_options),
+)
+

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -68,6 +68,10 @@
         - ansible_distribution == 'Fedora'
         - ansible_distribution_major_version|int >= 23
 
+    - name: validate vars
+      validate:
+        mode: permissive
+
 - hosts: mons
   gather_facts: false
   become: True

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -68,9 +68,31 @@
         - ansible_distribution == 'Fedora'
         - ansible_distribution_major_version|int >= 23
 
+- hosts:
+  - mons
+  - agents
+  - osds
+  - mdss
+  - rgws
+  - nfss
+  - restapis
+  - rbdmirrors
+  - clients
+  - mgrs
+  - iscsi-gws
+
+  gather_facts: false
+
+  roles:
+    - ceph-defaults
+
+  tasks:
     - name: validate vars
       validate:
         mode: permissive
+
+    - fail:
+        msg: "failing for testing"
 
 - hosts: mons
   gather_facts: false

--- a/tests/requirements2.4.txt
+++ b/tests/requirements2.4.txt
@@ -2,3 +2,5 @@
 # testinfra < 1.7.1 does not work Ansible 2.4, see https://github.com/philpep/testinfra/issues/249
 testinfra==1.7.1
 pytest-xdist
+-e git://github.com/alfredodeza/notario.git#egg=notario
+ipdb


### PR DESCRIPTION
This (preview) pr is to demonstrate how validation could work in a way that addresses issue #2457 

It provides an "action plugin" that when called in a task, will validate against the host vars available.

It only has 3 items in the schema, since that is enough to demonstrate the use case. Here is some output on a few potential use cases.


Permissive mode, with `vvvv` flag and `ANSIBLE_STDOUT_CALLBACK=debug`, shows lots info, with the key that failed
and for what host (in this case, `local`)

    TASK [validate vars mode=permissive] *********************************************************************************
    task path: /Users/alfredo/tmp/validate/local.yml:8
    Notario Failure: -> ceph_conf_key_directory -> True did not pass validation against callable: string (not of type string)
     [WARNING]: [local] Validation failed for variable: ceph_conf_key_directory
    
    ok: [local] => {
        "changed": false,
        "failed": false
    }
    
    MSG:
    
    Invalid variable assignment in host: local
        ceph_conf_key_directory = True
                                  ^^^^
    Reason: not of type string
    
    META: ran handlers
    META: ran handlers


Strict mode makes the module fail:

    TASK [validate vars mode=strict] *************************************************************************************
    task path: /Users/alfredo/tmp/validate/local.yml:8
    Notario Failure: -> ceph_conf_key_directory -> True did not pass validation against callable: string (not of type string)
     [WARNING]: [local] Validation failed for variable: ceph_conf_key_directory
    
    fatal: [local]: FAILED! => {
        "changed": false,
        "failed": true
    }
    
    MSG:
    
    Invalid variable assignment in host: local
        ceph_conf_key_directory = True
                                  ^^^^
    Reason: not of type string
    
    

Without the `debug` mode for stdout, the formatting is kept by using `stderr_lines`:

    TASK [validate vars mode=strict] *************************************************************************************
    task path: /Users/alfredo/tmp/validate/local.yml:8
    Notario Failure: -> ceph_conf_key_directory -> True did not pass validation against callable: string (not of type string)
     [WARNING]: [local] Validation failed for variable: ceph_conf_key_directory
    
    fatal: [local]: FAILED! => {
        "changed": false,
        "failed": true,
        "msg": "Invalid variable assignment in host: local\n    ceph_conf_key_directory = True\n                              ^^^^\nReason: not of type string",
        "stderr_lines": [
            "Invalid variable assignment in host: local",
            "    ceph_conf_key_directory = True",
            "                              ^^^^",
            "Reason: not of type string"
        ]
    }
    

