### PR TITLE
cleanup osd.conf.j2

### DIFF
--- a/roles/ceph-osd/templates/osd.conf.j2
+++ b/roles/ceph-osd/templates/osd.conf.j2
@@ -1,2 +1,0 @@
-[osd.{{ item.stdout }}]
-osd crush location = {{ osd_crush_location }}


### PR DESCRIPTION
osd crush location is set by ceph_crush in the library,
osd.conf.j2 is not used any more.

Signed-off-by: Ning Yao <yaoning@unitedstack.com>