### PR TITLE
Refer to expected-num-ojects as expected_num_objects, not size

### DIFF
--- a/group_vars/clients.yml.sample
+++ b/group_vars/clients.yml.sample
@@ -21,7 +21,7 @@ dummy:
 #  rule_name: "replicated_rule"
 #  type: "replicated"
 #  erasure_profile: ""
-#  size: ""
+#  expected_num_objects: ""
 #test2:
 #  name: "test2"
 #  pg_num: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}"
@@ -29,7 +29,7 @@ dummy:
 #  rule_name: "replicated_rule"
 #  type: "replicated"
 #  erasure_profile: ""
-#  size: ""
+#  expected_num_objects: ""
 #pools:
 #  - "{{ test }}"
 #  - "{{ test2 }}"

--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -93,7 +93,7 @@ dummy:
 #  rule_name: "replicated_rule"
 #  type: "replicated"
 #  erasure_profile: ""
-#  size: ""
+#  expected_num_objects: ""
 #openstack_cinder_pool:
 #  name: "volumes"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -101,7 +101,7 @@ dummy:
 #  rule_name: "replicated_rule"
 #  type: "replicated"
 #  erasure_profile: ""
-#  size: ""
+#  expected_num_objects: ""
 #openstack_nova_pool:
 #  name: "vms"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -109,7 +109,7 @@ dummy:
 #  rule_name: "replicated_rule"
 #  type: "replicated"
 #  erasure_profile: ""
-#  size: ""
+#  expected_num_objects: ""
 #openstack_cinder_backup_pool:
 #  name: "backups"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -117,7 +117,7 @@ dummy:
 #  rule_name: "replicated_rule"
 #  type: "replicated"
 #  erasure_profile: ""
-#  size: ""
+#  expected_num_objects: ""
 #openstack_gnocchi_pool:
 #  name: "metrics"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -125,7 +125,7 @@ dummy:
 #  rule_name: "replicated_rule"
 #  type: "replicated"
 #  erasure_profile: ""
-#  size: ""
+#  expected_num_objects: ""
 
 #openstack_pools:
 #  - "{{ openstack_glance_pool }}"

--- a/roles/ceph-client/defaults/main.yml
+++ b/roles/ceph-client/defaults/main.yml
@@ -13,7 +13,7 @@ test:
   rule_name: "replicated_rule"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 test2:
   name: "test2"
   pg_num: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}"
@@ -21,7 +21,7 @@ test2:
   rule_name: "replicated_rule"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 pools:
   - "{{ test }}"
   - "{{ test2 }}"

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -56,7 +56,7 @@
     {%- if item.type | default("replicated") == 'erasure' and item.erasure_profile != '' %}
     {{ item.erasure_profile }}
     {%- endif %}
-    {{ item.size | default('') }}
+    {{ item.expected_num_objects | default('') }}
   with_items: "{{ pools }}"
   changed_when: false
   when:

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -85,7 +85,7 @@ openstack_glance_pool:
   rule_name: "replicated_rule"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 openstack_cinder_pool:
   name: "volumes"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -93,7 +93,7 @@ openstack_cinder_pool:
   rule_name: "replicated_rule"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 openstack_nova_pool:
   name: "vms"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -101,7 +101,7 @@ openstack_nova_pool:
   rule_name: "replicated_rule"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 openstack_cinder_backup_pool:
   name: "backups"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -109,7 +109,7 @@ openstack_cinder_backup_pool:
   rule_name: "replicated_rule"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 openstack_gnocchi_pool:
   name: "metrics"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -117,7 +117,7 @@ openstack_gnocchi_pool:
   rule_name: "replicated_rule"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 
 openstack_pools:
   - "{{ openstack_glance_pool }}"

--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -10,7 +10,7 @@
     {%- if item.type | default("replicated") == 'erasure' and item.erasure_profile != '' %}
     {{ item.erasure_profile }}
     {%- endif %}
-    {{ item.size | default('') }}
+    {{ item.expected_num_objects | default('') }}
   with_items: "{{ openstack_pools | unique }}"
   changed_when: false
 

--- a/tests/functional/centos/7/cluster/group_vars/clients
+++ b/tests/functional/centos/7/cluster/group_vars/clients
@@ -11,7 +11,7 @@ test:
   rule_name: "HDD"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 test2:
   name: "test2"
   pg_num: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}"
@@ -19,7 +19,7 @@ test2:
   rule_name: "HDD"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 pools:
   - "{{ test }}"
   - "{{ test2 }}"

--- a/tests/functional/centos/7/cluster/group_vars/mons
+++ b/tests/functional/centos/7/cluster/group_vars/mons
@@ -21,7 +21,7 @@ openstack_glance_pool:
   rule_name: "HDD"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 openstack_cinder_pool:
   name: "volumes"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -29,7 +29,7 @@ openstack_cinder_pool:
   rule_name: "HDD"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"

--- a/tests/functional/centos/7/docker-collocation/group_vars/clients
+++ b/tests/functional/centos/7/docker-collocation/group_vars/clients
@@ -10,7 +10,7 @@ test:
   rule_name: "HDD"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 test2:
   name: "test2"
   pg_num: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}"
@@ -18,7 +18,7 @@ test2:
   rule_name: "HDD"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 pools:
   - "{{ test }}"
   - "{{ test2 }}"

--- a/tests/functional/centos/7/docker/group_vars/clients
+++ b/tests/functional/centos/7/docker/group_vars/clients
@@ -10,7 +10,7 @@ test:
   rule_name: "HDD"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 test2:
   name: "test2"
   pg_num: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}"
@@ -18,7 +18,7 @@ test2:
   rule_name: "HDD"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 pools:
   - "{{ test }}"
   - "{{ test2 }}"

--- a/tests/functional/centos/7/docker/group_vars/mons
+++ b/tests/functional/centos/7/docker/group_vars/mons
@@ -21,7 +21,7 @@ openstack_glance_pool:
   rule_name: "HDD"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 openstack_cinder_pool:
   name: "volumes"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -29,7 +29,7 @@ openstack_cinder_pool:
   rule_name: "HDD"
   type: "replicated"
   erasure_profile: ""
-  size: ""
+  expected_num_objects: ""
 openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"


### PR DESCRIPTION
Follow up patch to PR 2432 [1] which replaces "size" (sorry if
the original bug used that term, which can be confusing) with
expected_num_objects as is used in the Ceph documentation [2].

[1] https://github.com/ceph/ceph-ansible/pull/2432/files
[2] http://docs.ceph.com/docs/jewel/rados/operations/pools