### PR TITLE
purge-docker: added conditionals needed to successfully re-run purge-docker-cluster.yml.

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -48,7 +48,6 @@
       ceph_docker_registry: "docker.io"
     when: ceph_docker_registry is not defined
 
-
 - name: purge ceph mds cluster
 
   hosts:
@@ -86,6 +85,7 @@
       force: yes
     tags:
       remove_img
+    ignore_errors: true
 
 - name: purge ceph mgr cluster
 
@@ -122,6 +122,7 @@
       force: yes
     tags:
       remove_img
+    ignore_errors: true
 
 - name: purge ceph rgw cluster
 
@@ -172,6 +173,7 @@
       force: yes
     tags:
       remove_img
+    ignore_errors: true
 
 
 - name: purge ceph rbd-mirror cluster
@@ -272,8 +274,9 @@
 
   - name: get all the running osds
     shell: |
-      systemctl list-units | grep "loaded active" | grep -oE "ceph-osd@([0-9]{1,2}|[a-z]+).service"
+      systemctl list-units | grep 'loaded[[:space:]]\+active' | grep -oE "ceph-osd@([0-9]{1,2}|[a-z]+).service"
     register: osd_units
+    ignore_errors: true
 
   - name: disable ceph osd service
     service:
@@ -285,10 +288,12 @@
   - name: get prepare container
     command: "docker ps -a -q --filter='name=ceph-osd-prepare'"
     register: prepare_containers
+    ignore_errors: true
 
   - name: remove ceph osd prepare container
     command: "docker rm -f {{ item }}"
     with_items: "{{ prepare_containers.stdout_lines }}"
+    ignore_errors: true
 
   # NOTE(leseb): hope someone will find a more elegant way one day...
   - name: see if encrypted partitions are present
@@ -401,6 +406,7 @@
       force: yes
     tags:
       remove_img
+    ignore_errors: true
 
   - name: include vars from group_vars/osds.yml
     include_vars:
@@ -468,6 +474,7 @@
       force: yes
     tags:
       remove_img
+    ignore_errors: true
 
   - name: remove ceph aliases
     file:
@@ -505,6 +512,7 @@
       state: stopped
       enabled: no
     when: not is_atomic
+    ignore_errors: true
 
   - name: remove docker-py on Debian
     pip:
@@ -677,5 +685,5 @@
 
   - name: purge fetch directory for localhost
     file:
-      path: "{{ fetch_directory }}"
+      path: "{{ fetch_directory }}/"
       state: absent


### PR DESCRIPTION
Added 'ignore_errors: true' to multiple tasks which run docker commands; even in cases where docker is no longer installed. Because of this, certain tasks in the purge-docker-cluster.yml will cause the playbook to fail if re-run and stop the purge. This leaves behind a dirty environment, and a playbook which can no longer be run.
Fix Regex line 275: Sometimes 'list-units' will output 4 spaces between loaded+active. The update will account for both scenarios.
purge fetch_directory: in other roles fetch_directory is hard linked ex.: "{{ fetch_directory }}"/"{{ somedir }}". That being said, fetch_directory will never have a trailing slash in the all.yml so this task was never being run(causing failures when trying to re-deploy).

Signed-off-by: Randy J. Martinez <ramartin@redhat.com>