### PR TITLE
ceph-mds: delete duplicate multimds container tasks

### DIFF
--- a/roles/ceph-mds/tasks/containerized.yml
+++ b/roles/ceph-mds/tasks/containerized.yml
@@ -68,16 +68,3 @@
   retries: 5
   delay: 15
   until: multi_mds_socket.rc == 0
-
-- name: enable multimds if requested when mon is containerized
-  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} fs set {{ cephfs }} allow_multimds true --yes-i-really-mean-it"
-  changed_when: false
-  when:
-    - mds_allow_multimds
-
-- name: set max_mds when mon is containerized
-  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} fs set {{ cephfs }} max_mds {{ mds_max_mds }}"
-  changed_when: false
-  when:
-    - mds_allow_multimds
-    - mds_max_mds > 1


### PR DESCRIPTION
This update will resolve `ceph-mds: deployment failure error['cephfs' is undefined.].`
See: `roles/ceph-mon/tasks/create_mds_filesystems.yml`. The same last two tasks are present there, and actually belong in that role since `"{{ cephfs }}"` gets defined in:
`roles/ceph-mon/defaults/main.yml`, and not `roles/ceph-mds/defaults/main.yml`

Signed-off-by: Randy J. Martinez <ramartin@redhat.com>