### PR TITLE
ceph-defaults: fix ceph_uid fact on container deployments

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -191,7 +191,14 @@
     ceph_uid: 167
   when:
     - containerized_deployment
-    - ceph_docker_image_tag | search("latest") or ceph_docker_image_tag | search("centos") or ceph_docker_image | search("rhceph")
+    - ceph_docker_image_tag | search("latest") or ceph_docker_image_tag | search("centos") or ceph_docker_image_tag | search("fedora")
+
+- name: set_fact ceph_uid for Red Hat
+  set_fact:
+    ceph_uid: 167
+  when:
+    - containerized_deployment
+    - ceph_docker_image | search("rhceph")
 
 - name: check if selinux is enabled
   command: getenforce
@@ -200,5 +207,3 @@
   check_mode: no
   when:
     - ansible_os_family == 'RedHat'
-
-


### PR DESCRIPTION
Red Hat is now using tags[3,latest] for image rhceph/rhceph-3-rhel7. Because of this, the ceph_uid conditional passes for Debian when 'ceph_docker_image_tag: latest' on RH family deployments. Updating the conditional to ansible_os_family solves the problem.

Signed-off-by: Randy J. Martinez <ramartin@redhat.com>