### PR TITLE
create keys and pools for client nodes only on first node

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -20,9 +20,11 @@
     creates: /etc/ceph/{{ cluster }}.{{ item.name }}.keyring
   with_items: "{{ keys }}"
   changed_when: false
+  run_once: true
   when:
     - cephx
     - keys | length > 0
+    - inventory_hostname in groups.get(client_group_name) | first
 
 - name: set docker_exec_client_cmd_binary to ceph
   set_fact:
@@ -36,14 +38,28 @@
     - not containerized_deployment
     - docker_exec_client_cmd == 'ceph-authtool'
 
+- name: slurp client key(s)
+  slurp:
+    src: "{{ ceph_conf_key_directory }}/{{ cluster }}.{{ item.name }}.keyring"
+  with_items:
+    - "{{ keys }}"
+  register: slurp_client_keys
+  run_once: true
+  when:
+    - cephx
+    - keys | length > 0
+    - inventory_hostname in groups.get(client_group_name) | first
+
 - name: check if key(s) already exist(s)
   command: "{{ docker_exec_client_cmd }} --cluster {{ cluster }} auth get {{ item.name }}"
   changed_when: false
   failed_when: false
   with_items: "{{ keys }}"
   register: keys_exist
+  run_once: true
   when:
     - copy_admin_key
+    - inventory_hostname in groups.get(client_group_name) | first
 
 - name: create pool(s)
   command: >
@@ -59,13 +75,16 @@
     {{ item.expected_num_objects | default('') }}
   with_items: "{{ pools }}"
   changed_when: false
+  run_once: true
   when:
     - pools | length > 0
     - copy_admin_key
+    - inventory_hostname in groups.get(client_group_name) | first
 
 - name: add key(s) to ceph
   command: "{{ docker_exec_client_cmd }} --cluster {{ cluster }} auth import -i /etc/ceph/{{ cluster }}.{{ item.0.name }}.keyring"
   changed_when: false
+  run_once: true
   with_together:
     - "{{ keys }}"
     - "{{ keys_exist.results | default([]) }}"
@@ -73,11 +92,22 @@
     - not item.1.get("skipped")
     - copy_admin_key
     - item.1.rc != 0
+    - inventory_hostname in groups.get(client_group_name) | first
 
 - name: put docker_exec_client_cmd back to normal with a none value
   set_fact:
     docker_exec_client_cmd:
   when: docker_exec_client_cmd == 'ceph'
+
+- name: get client keys
+  copy:
+    dest: "{{ item.source }}"
+    content: "{{ item.content | b64decode }}"
+  with_items:
+    - "{{ slurp_client_keys.results }}"
+  when:
+    - not item.get('skipped', False)
+    - not inventory_hostname == groups.get(client_group_name, []) | first
 
 - name: chmod key(s)
   file:

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -9,10 +9,7 @@
 
 - name: set selinux permissions
   shell: |
-    chcon -Rt svirt_sandbox_file_t {{ item }}
-  with_items:
-    - /etc/ceph
-    - /var/lib/ceph
+    chcon -Rt svirt_sandbox_file_t /etc/ceph
   changed_when: false
   when:
     - containerized_deployment

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -77,11 +77,9 @@
     file:
       path: /etc/ceph
       state: directory
-      owner: 'ceph'
-      group: 'ceph'
+      owner: "{{ ceph_uid }}"
+      group: "{{ ceph_uid }}"
       mode: 0755
-    when:
-      - groups.get(mon_group_name, []) | length == 0
 
   - name: "generate {{ cluster }}.conf configuration file"
     action: config_template

--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -66,7 +66,6 @@
     state: directory
   changed_when: false
   become: false
-  run_once: true
   when:
     - (cephx or generate_fsid)
 

--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -192,3 +192,11 @@
   when:
     - containerized_deployment
     - ceph_docker_image_tag | search("centos") or ceph_docker_image | search("rhceph") or ceph_docker_image_tag | search("fedora")
+
+- name: check if selinux is enabled
+  command: getenforce
+  register: sestatus
+  changed_when: false
+  check_mode: no
+  when:
+    - ansible_os_family == 'RedHat'

--- a/roles/ceph-docker-common/tasks/main.yml
+++ b/roles/ceph-docker-common/tasks/main.yml
@@ -98,8 +98,3 @@
 # # because it creates the directories needed by the latter.
 - name: include dirs_permissions.yml
   include: dirs_permissions.yml
-
-- name: include selinux.yml
-  include: selinux.yml
-  when:
-    - ansible_os_family == 'RedHat'

--- a/roles/ceph-docker-common/tasks/selinux.yml
+++ b/roles/ceph-docker-common/tasks/selinux.yml
@@ -1,6 +1,0 @@
----
-- name: check if selinux is enabled
-  command: getenforce
-  register: sestatus
-  changed_when: false
-  check_mode: no

--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -50,18 +50,16 @@
   roles:
     - { role: ceph-defaults,
         tags: [with_pkg, fetch_container_image],
-        when: "(containerized_deployment | bool) and not (is_atomic | bool)" }
+        when: "(((containerized_deployment | bool) and not (is_atomic | bool) and not (inventory_hostname in groups.get('clients', [False]))) or ((inventory_hostname == groups.get('clients', [False])|first) and (containerized_deployment | bool) and not (is_atomic | bool)))" }
     - { role: ceph-docker-common,
         tags: [with_pkg, fetch_container_image],
-        when: "(containerized_deployment | bool) and not (is_atomic | bool)" }
+        when: "(((containerized_deployment | bool) and not (is_atomic | bool) and not (inventory_hostname in groups.get('clients', [False]))) or ((inventory_hostname == groups.get('clients', [False])|first) and (containerized_deployment | bool) and not (is_atomic | bool)))" }
 
   post_tasks:
     - name: "pull {{ ceph_docker_image }} image"
       command: "docker pull {{ ceph_docker_registry}}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       changed_when: false
-      when:
-        - is_atomic
-        - (ceph_docker_dev_image is undefined or not ceph_docker_dev_image)
+      when: "((is_atomic and (ceph_docker_dev_image is undefined or not ceph_docker_dev_image) and not (inventory_hostname in groups.get('clients', [False]))) or (is_atomic and ((ceph_docker_dev_image is undefined) or not (ceph_docker_dev_image)) and (inventory_hostname == groups.get('clients', [False])|first)))"
 
 - hosts: mons
   tasks:
@@ -281,7 +279,7 @@
             start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
   roles:
     - { role: ceph-defaults, tags: ['ceph_update_config'] }
-    - ceph-docker-common
+    - { role: ceph-docker-common, when: "inventory_hostname == groups.get('clients', []) | first" }
     - { role: ceph-config, tags: ['ceph_update_config'] }
     - ceph-client
   post_tasks:


### PR DESCRIPTION
This PR aims to move the client pools and keys creation for from ceph-client to ceph-mon so we do not have to pull container image for client nodes.