### PR TITLE
nfs: ensure nfs-server server is stopped

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -223,3 +223,10 @@
     owner: "root"
     group: "root"
     mode: "0755"
+
+- name: stop nfs server service
+  systemd:
+    name: "{%- if ansible_os_family == 'RedHat' 'nfs-server' %}{%- endif %}{%- if ansible_os_family == 'Suse' 'nfsserver' %}{%- endif %}{%- if ansible_os_family == 'Debian' 'nfs-kernel-server' %}{%- endif %}"
+    state: stopped
+    enabled: no
+  ignore_errors: true


### PR DESCRIPTION
NFS-ganesha cannot start is the nfs-server service
is running. This commit stops nfs-server in case it
is running on a node before the nfs-ganesha service
starts up

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1508506

Signed-off-by: Ali Maredia <amaredia@redhat.com>