### PR TITLE
Deploying without managed monitors failed

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -26,6 +26,7 @@
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
     - containerized_deployment
+    - groups.get(mon_group_name, []) | length > 0
 
 # this task shouldn't run in a rolling_update situation
 # because it blindly picks a mon, which may be down because


### PR DESCRIPTION
Tripleo deployment failed when the monitors not manged
by tripleo itself with:
    FAILED! => {"msg": "list object has no element 0"}

The failing play item was introduced by
 f46217b69ae18317cb0c1cc3e391a0bca5767eb6 .

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1552327

Signed-off-by: Attila Fazekas <afazekas@redhat.com>