### PR TITLE
tox: use container latest tag for upgrades

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -184,14 +184,14 @@
     ceph_uid: 64045
   when:
     - containerized_deployment
-    - ceph_docker_image_tag | search("latest") or ceph_docker_image_tag | search("ubuntu")
+    - ceph_docker_image_tag | search("ubuntu")
 
 - name: set_fact ceph_uid for Red Hat based system
   set_fact:
     ceph_uid: 167
   when:
     - containerized_deployment
-    - ceph_docker_image_tag | search("centos") or ceph_docker_image | search("rhceph") or ceph_docker_image_tag | search("fedora")
+    - ceph_docker_image_tag | search("latest") or ceph_docker_image_tag | search("centos") or ceph_docker_image | search("rhceph")
 
 - name: check if selinux is enabled
   command: getenforce

--- a/tox.ini
+++ b/tox.ini
@@ -148,11 +148,12 @@ setenv=
 
   rhcs: CEPH_STABLE_RELEASE = luminous
   jewel: CEPH_STABLE_RELEASE = jewel
+  jewel: CEPH_DOCKER_IMAGE_TAG = latest-jewel
   jewel: UPDATE_CEPH_STABLE_RELEASE = luminous
-  jewel: UPDATE_CEPH_DOCKER_IMAGE_TAG = tag-build-master-luminous-ubuntu-16.04
+  jewel: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-luminous
   luminous: CEPH_STABLE_RELEASE = luminous
   luminous: UPDATE_CEPH_STABLE_RELEASE = luminous
-  luminous: UPDATE_CEPH_DOCKER_IMAGE_TAG = tag-build-master-luminous-ubuntu-16.04
+  luminous: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest  # Currently L is the latest stable release so it should point to 'latest'
   lvm_osds: CEPH_STABLE_RELEASE = luminous
   bluestore_lvm_osds: CEPH_STABLE_RELEASE = luminous
 deps=


### PR DESCRIPTION
Currently tag-build-master-luminous-ubuntu-16.04 is not used anymore.
Also now, 'latest' points to CentOS so we need to make that switch here
too.

We know have latest tags for each stable release so let's use them and
point tox at them to deploy the right version.

Signed-off-by: Sébastien Han <seb@redhat.com>