### PR TITLE
Fix MDS name in restart_mds_daemon script

### DIFF
--- a/roles/ceph-defaults/templates/restart_mds_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_mds_daemon.sh.j2
@@ -2,7 +2,7 @@
 
 RETRIES="{{ handler_health_mds_check_retries }}"
 DELAY="{{ handler_health_mds_check_delay }}"
-MDS_NAME="{{ ansible_hostname }}"
+MDS_NAME="{{ mds_name }}"
 SOCKET=/var/run/ceph/{{ cluster }}-mds.${MDS_NAME}.asok
 {% if containerized_deployment %}
 DOCKER_EXEC="docker exec ceph-mds-{{ ansible_hostname }}"


### PR DESCRIPTION
Make sure the `restart_mds_daemon` script is created with the correct MDS name.

Like for the monitors, the script should contain a short name or fully qualified domain name depending on variable settings.

For monitors, this is already ok:

https://github.com/ceph/ceph-ansible/blob/master/roles/ceph-defaults/tasks/facts.yml#L11-L21
https://github.com/ceph/ceph-ansible/blob/master/roles/ceph-defaults/templates/restart_mon_daemon.sh.j2#L5

For metadata servers this is not:
https://github.com/ceph/ceph-ansible/blob/master/roles/ceph-defaults/tasks/facts.yml#L122-L132
https://github.com/ceph/ceph-ansible/blob/master/roles/ceph-defaults/templates/restart_mds_daemon.sh.j2#L5