### PR TITLE
Remove deprecated allow_multimds

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -364,7 +364,6 @@ dummy:
 ## MDS options
 #
 #mds_use_fqdn: false # if set to true, the MDS name used will be the fqdn in the ceph.conf
-#mds_allow_multimds: false
 #mds_max_mds: 3
 
 ## Rados Gateway options

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -364,7 +364,6 @@ ceph_repository: rhcs
 ## MDS options
 #
 #mds_use_fqdn: false # if set to true, the MDS name used will be the fqdn in the ceph.conf
-#mds_allow_multimds: false
 #mds_max_mds: 3
 
 ## Rados Gateway options

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -356,7 +356,6 @@ filestore_xattr_use_omap: null
 ## MDS options
 #
 mds_use_fqdn: false # if set to true, the MDS name used will be the fqdn in the ceph.conf
-mds_allow_multimds: false
 mds_max_mds: 3
 
 ## Rados Gateway options

--- a/roles/ceph-mon/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mon/tasks/create_mds_filesystems.yml
@@ -22,12 +22,11 @@
   changed_when: false
   when:
     - ceph_release_num[ceph_release] >= ceph_release_num.jewel
-    - mds_allow_multimds
+    - ceph_release_num[ceph_release] < ceph_release_num.mimic
 
 - name: set max_mds
   command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} fs set {{ cephfs }} max_mds {{ mds_max_mds }}"
   changed_when: false
   when:
     - ceph_release_num[ceph_release] >= ceph_release_num.jewel
-    - mds_allow_multimds
     - mds_max_mds > 1


### PR DESCRIPTION
allow_multimds will be officially deprecated in Mimic, specify it
only for all versions of Ceph where it was declared stable. Going
forward, specify only max_mds.

Version checks should make this safe to merge.