### PR TITLE
common: upgrade/install ceph-test RPM first

### DIFF
--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -13,6 +13,13 @@
   when:
     - ansible_distribution == 'CentOS'
 
+- name: install redhat ceph-test package
+  package:
+    name: ceph-test
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - ceph_test
+
 - name: install redhat ceph-common
   package:
     name: "ceph-common"
@@ -45,13 +52,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - client_group_name in group_names
-
-- name: install redhat ceph-test package
-  package:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
 
 - name: install redhat ceph-radosgw package
   package:


### PR DESCRIPTION
Prior to this change, if a user had ceph-test-12.2.1 installed, and upgraded to ceph v12.2.3 or newer, the RPM upgrade process would fail.

The problem is that the ceph-test RPM did not depend on an exact version of ceph-common until v12.2.3.

In Ceph v12.2.3, ceph-{osdomap,kvstore,monstore}-tool binaries moved from ceph-test into ceph-base. When ceph-test is not yet up-to-date, Yum encounters package conflicts between the older ceph-test and newer ceph-base.

When all users have upgraded beyond Ceph < 12.2.3, this is no longer relevant.