### PR TITLE
Use the CentOS repo for Red Hat dev packages

### DIFF
--- a/roles/ceph-common/tasks/installs/redhat_dev_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_dev_repository.yml
@@ -1,7 +1,8 @@
 ---
 - name: fetch ceph red hat development repository
   uri:
-    url: https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/repo
+    # Use the centos repo since we don't currently have a dedicated red hat repo
+    url: https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/centos/{{ ansible_distribution_major_version }}/repo
     return_content: yes
   register: ceph_dev_yum_repo
 


### PR DESCRIPTION
No use even trying to use something that doesn't exist.

Signed-off-by: Zack Cerza <zack@redhat.com>