### PR TITLE
defaults: check only 1 time if there is a running cluster

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -37,6 +37,7 @@
   failed_when: false
   check_mode: no
   register: ceph_current_fsid
+  run_once: true
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
     - not rolling_update


### PR DESCRIPTION
There is no need to check for a running cluster n*nodes time in
`ceph-defaults` so let's add a `run_once: true` to save some resources
and time.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>