### PR TITLE
To support copy_admin_key 

### DIFF
--- a/roles/ceph-mds/tasks/containerized.yml
+++ b/roles/ceph-mds/tasks/containerized.yml
@@ -3,10 +3,23 @@
   set_fact:
     docker_exec_cmd: "docker exec ceph-mds-{{ ansible_hostname }}"
 
+- name: set_fact admin_keyring
+  set_fact:
+    admin_keyring:
+      - "/etc/ceph/{{ cluster }}.client.admin.keyring"
+  when:
+    - copy_admin_key
+
 - name: set_fact ceph_config_keys
   set_fact:
     ceph_config_keys:
       - /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring
+
+- name: merge ceph_config_keys and admin_keyring
+  set_fact:
+    ceph_config_keys: "{{ ceph_config_keys + admin_keyring }}"
+  when:
+    - copy_admin_key
 
 - name: stat for ceph config and keys
   local_action:

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -1,8 +1,21 @@
 ---
-- name: set config and keys paths
+- name: set_fact admin_keyring
+  set_fact:
+    admin_keyring:
+      - "/etc/ceph/{{ cluster }}.client.admin.keyring"
+  when:
+    - copy_admin_key
+
+- name: set_fact ceph_config_keys
   set_fact:
     ceph_config_keys:
       - /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring
+      
+ - name: merge ceph_config_keys and admin_keyring
+  set_fact:
+    ceph_config_keys: "{{ ceph_config_keys + admin_keyring }}"
+  when:
+    - copy_admin_key
 
 - name: stat for config and keys
   local_action:

--- a/roles/ceph-osd/tasks/copy_configs.yml
+++ b/roles/ceph-osd/tasks/copy_configs.yml
@@ -1,8 +1,21 @@
 ---
-- name: set config and keys paths
+- name: set_fact admin_keyring
+  set_fact:
+    admin_keyring:
+      - "/etc/ceph/{{ cluster }}.client.admin.keyring"
+  when:
+    - copy_admin_key
+
+- name: set_fact ceph_config_keys
   set_fact:
     ceph_config_keys:
       - /var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring
+
+- name: merge ceph_config_keys and admin_keyring
+  set_fact:
+    ceph_config_keys: "{{ ceph_config_keys + admin_keyring }}"
+  when:
+    - copy_admin_key
 
 - name: wait for ceph.conf and keys
   local_action:


### PR DESCRIPTION
With this patch, ceph-ansible will copy admin keyring to osd, mds, nfs nodes if copy_admin_key is set to true.
This also fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544720
(fixes  OSD - Both containerized and non containerized initialization, mds and nfs - only containerized scenario)