### PR TITLE
osd: do not do anything if the dev has a partition

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -26,14 +26,12 @@
 - name: include build_devices.yml
   include: build_devices.yml
 
-- name: check if a partition named 'ceph' exists
-  shell: "parted --script {{ item }} print | egrep -sq '^ 1.*ceph'"
-  with_items:
-    - "{{ devices }}"
-  changed_when: false
-  failed_when: false
-  check_mode: no
+- name: read information about the devices
+  parted:
+    device: "{{ item }}"
+    unit: MiB
   register: parted_results
+  with_items: "{{ devices }}"
 
 - name: include copy_configs.yml
   include: copy_configs.yml

--- a/roles/ceph-osd/tasks/scenarios/collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/collocated.yml
@@ -25,8 +25,7 @@
   when:
     - not osd_auto_discovery
     - containerized_deployment
-    - not item.0.get("skipped")
-    - item.0.get("rc", 0) != 0
+    - item.0.partitions|length == 0
 
 - name: automatic prepare ceph containerized osd disk collocated
   shell: |
@@ -58,5 +57,4 @@
     - "{{ devices }}"
   when:
     - not containerized_deployment
-    - not item.0.get("skipped")
-    - item.0.get("rc", 0) != 0
+    - item.0.partitions|length == 0

--- a/roles/ceph-osd/tasks/scenarios/non-collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/non-collocated.yml
@@ -27,8 +27,7 @@
   when:
     - containerized_deployment
     - osd_objectstore == 'filestore'
-    - not item.0.get("skipped")
-    - item.0.get("rc", 0) != 0
+    - item.0.partitions|length == 0
 
 - name: prepare ceph "{{ osd_objectstore }}" containerized osd disk(s) non-collocated with a dedicated device for db and wal
   shell: |
@@ -57,8 +56,7 @@
   when:
     - containerized_deployment
     - osd_objectstore == 'bluestore'
-    - not item.0.get("skipped")
-    - item.0.get("rc", 0) != 0
+    - item.0.partitions|length == 0
 
 - name: prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) non-collocated
   command: "ceph-disk prepare {{ ceph_disk_cli_options }} {{ item.1 }} {{ item.2 }}"
@@ -70,8 +68,7 @@
   when:
     - osd_objectstore == 'filestore'
     - not containerized_deployment
-    - not item.0.get("skipped")
-    - item.0.get("rc", 0) != 0
+    - item.0.partitions|length == 0
 
 - name: manually prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) with a dedicated device for db and wal
   command: "ceph-disk prepare {{ ceph_disk_cli_options }} --block.db {{ item.1 }} --block.wal {{ item.2 }} {{ item.3 }}"
@@ -83,5 +80,4 @@
   when:
     - osd_objectstore == 'bluestore'
     - not containerized_deployment
-    - not item.0.get("skipped")
-    - item.0.get("rc", 0) != 0
+    - item.0.partitions|length == 0


### PR DESCRIPTION
Regardless if the partition is 'ceph' or something else, we don't want
to be as strick as checking for a particular partition.
If the drive has a partition, we just don't do anything.

This solves the case where the server reboots, disks get a different
/dev/sda (node) allocation. In this case, prior to restarting the server
/dev/sda was an OSD, but now it's /dev/sdb and the other way around.
In such scenario, we will try to prepare the OSD and create a new
partition, so let's not mess around with devices that have partitions.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1498303
Signed-off-by: Sébastien Han <seb@redhat.com>