### PR TITLE
rgw: container add option to configure multi-site zone

### DIFF
--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -24,9 +24,9 @@ dummy:
 #rgw_pull_proto: "http"
 
 
-########
-#TUNING#
-########
+##########
+# TUNING #
+##########
 
 # To support buckets with a very large number of objects it's
 # important to split them into shards. We suggest about 100K
@@ -65,6 +65,14 @@ dummy:
 #ceph_rgw_docker_extra_env:
 #ceph_config_keys: [] # DON'T TOUCH ME
 #rgw_config_keys: "/" # DON'T TOUCH ME
+
+
+#############
+# MULTISITE #
+#############
+#rgw_multisite: false
+#rgw_zonegroup: ""
+#rgw_zone: ""
 
 
 ###########

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -16,9 +16,9 @@ rgw_pull_port: "{{ radosgw_civetweb_port }}"
 rgw_pull_proto: "http"
 
 
-########
-#TUNING#
-########
+##########
+# TUNING #
+##########
 
 # To support buckets with a very large number of objects it's
 # important to split them into shards. We suggest about 100K
@@ -57,6 +57,14 @@ ceph_rgw_docker_cpu_limit: 1
 ceph_rgw_docker_extra_env:
 ceph_config_keys: [] # DON'T TOUCH ME
 rgw_config_keys: "/" # DON'T TOUCH ME
+
+
+#############
+# MULTISITE #
+#############
+rgw_multisite: false
+rgw_zonegroup: ""
+rgw_zone: ""
 
 
 ###########

--- a/roles/ceph-rgw/tasks/docker/container_env_facts.yml
+++ b/roles/ceph-rgw/tasks/docker/container_env_facts.yml
@@ -1,0 +1,12 @@
+---
+- name: set_fact docker_env_args '-e RGW_ZONEGROUP={{ rgw_zonegroup }}'
+  set_fact:
+    docker_env_args: -e RGW_ZONEGROUP={{ rgw_zonegroup }}
+  when:
+    - rgw_zonegroup != ""
+
+- name: set_fact docker_env_args '-e RGW_ZONE={{ rgw_zone }}'
+  set_fact:
+    docker_env_args: "{{ docker_env_args | default ('') }} -e RGW_ZONE={{ rgw_zone }}"
+  when:
+    - rgw_zone != ""

--- a/roles/ceph-rgw/tasks/docker/main.yml
+++ b/roles/ceph-rgw/tasks/docker/main.yml
@@ -1,3 +1,8 @@
 ---
+- name: include container_env_facts.yml
+  include: container_env_facts.yml
+  when:
+    - containerized_deployment
+
 - name: include start_docker_rgw.yml
   include: start_docker_rgw.yml

--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: include multisite/main.yml
   include: multisite/main.yml
   when:
-    - rgw_zone is defined
+    - rgw_zone != ""
     - rgw_multisite
     - ceph_release_num[ceph_release] >= ceph_release_num.jewel
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)


### PR DESCRIPTION
You can now use RGW_ZONE and RGW_ZONEGROUP on each rgw host from your
inventory and assign them a value. Once the rgw container starts it'll
pick the info and add itself to the right zone.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1551637
Signed-off-by: Sébastien Han <seb@redhat.com>