### PR TITLE
[skip ci] 2527 bkp

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_rhcs_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_rhcs_repository.yml
@@ -1,4 +1,12 @@
 ---
+- name: set apt pinning for red hat ceph storage
+  template:
+    src: "{{ role_path }}/templates/rhcs.pref.j2"
+    dest: /etc/apt/preferences.d/rhcs.pref
+    owner: root
+    group: root
+    mode: 0644
+
 - name: include prerequisite_rhcs_iso_install_debian.yml
   include: prerequisite_rhcs_iso_install_debian.yml
   when:


### PR DESCRIPTION
When installing rhcs on Debian systems the red hat repos must have the
highest priority so we avoid packages conflicts and install the rhcs
version.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1565850
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit a98885a71ec63ff129d7001301a0323bfaadad8a)
Signed-off-by: Sébastien Han <seb@redhat.com>