### PR TITLE
client: add quotes to the dict values

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -40,6 +40,7 @@
     containerized: "{{ docker_exec_client_cmd | default('') }}"
     cluster: "{{ cluster }}"
     dest: "{{ ceph_conf_key_directory }}"
+    import_key: "{{ copy_admin_key }}"  # if the admin key is copied we assume the user wants to import the key in Ceph not only create it
   with_items: "{{ keys }}"
   run_once: true
   when:

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -1,7 +1,7 @@
 ---
 - name: set_fact keys_tmp - preserve backward compatibility after the introduction of the ceph_keys module
   set_fact:
-    keys_tmp: "{{ keys_tmp|default([]) + [ { 'key': item.key, 'name': item.name, 'caps': { 'mon': item.mon_cap, 'osd': item.osd_cap|default(''), 'mds': item.mds_cap|default(''), 'mgr': item.mgr_cap|default('') } , 'mode': item.mode } ] }}"
+    keys_tmp: "{{ keys_tmp|default([]) + [ { 'key': item.key, 'name': item.name, 'caps': { 'mon': item.mon_cap|quote, 'osd': item.osd_cap|default('')|quote, 'mds': item.mds_cap|default('')|quote, 'mgr': item.mgr_cap|default('')|quote } , 'mode': item.mode } ] }}"
   when:
     - item.get('mon_cap', None) # it's enough to assume we are running an old-fashionned syntax simply by checking the presence of mon_cap since every key needs this cap
   with_items: "{{ keys }}"


### PR DESCRIPTION
ceph-authtool does not support raw arguements so we have to quote caps
declaration like this allow 'bla bla' instead of allow bla bla

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1568157
Signed-off-by: Sébastien Han <seb@redhat.com>