### PR TITLE
[skip ci] shrink-osd: ability to shrink NVMe drives

### DIFF
--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -116,9 +116,11 @@
       when:
         - containerized_deployment
 
+    # if nvme then osd_to_kill_disks is nvme0n1, we need nvme0
+    # if ssd or hdd then osd_to_kill_disks is sda1, we need sda
     - name: stop osd services (container)
       service:
-        name: "ceph-osd@{{ item.0.stdout[:-1] | regex_replace('/dev/', '') }}"
+        name: "ceph-osd@{{ item.0.stdout[:-2] | regex_replace('/dev/', '') if 'nvme' in item.0.stdout else item.0.stdout[:-1] | regex_replace('/dev/', '') }}"
         state: stopped
         enabled: no
       with_together:


### PR DESCRIPTION
Now if the service name contains nvme we know we need to remove the last
2 character instead of 1.

If nvme then osd_to_kill_disks is nvme0n1, we need nvme0
If ssd or hdd then osd_to_kill_disks is sda1, we need sda

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1561456
Signed-off-by: Sébastien Han <seb@redhat.com>