### PR TITLE
Move apt cache update to individual task per role

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_community_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_community_repository.yml
@@ -8,4 +8,5 @@
   apt_repository:
     repo: "deb {{ ceph_stable_repo }} {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
     state: present
-  changed_when: false
+    update_cache: no
+  register: add_debian_apt_repo

--- a/roles/ceph-common/tasks/installs/debian_custom_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_custom_repository.yml
@@ -3,4 +3,5 @@
   apt_repository:
     repo: "deb {{ ceph_custom_repo }} {{ ansible_lsb.codename }} main"
     state: present
-  changed_when: false
+    update_cache: no
+  register: add_debian_apt_repo

--- a/roles/ceph-common/tasks/installs/debian_dev_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_dev_repository.yml
@@ -9,5 +9,5 @@
   apt_repository:
     repo: "{{ ceph_dev_deb_repo.content }}"
     state: present
-  changed_when: false
-
+    update_cache: no
+  register: add_debian_apt_repo

--- a/roles/ceph-common/tasks/installs/debian_uca_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_uca_repository.yml
@@ -7,4 +7,5 @@
   apt_repository:
     repo: "deb {{ ceph_stable_repo_uca }} {{ ceph_stable_release_uca }} main"
     state: present
-  changed_when: false
+    update_cache: no
+  register: add_debian_apt_repo

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -4,17 +4,28 @@
   when:
     - ceph_origin == 'repository'
 
+- name: update apt cache if a repo was added
+  apt:
+    update_cache: yes
+  register: update_apt_cache
+  retries: 5
+  delay: 2
+  until: update_apt_cache | success
+  when:
+    - add_debian_apt_repo is defined
+    - add_debian_apt_repo.changed | default(false)
+
+- name: update apt cache if cache_valid_time has expired
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+
 - name: install dependencies
   apt:
-    name: "{{ item }}"
+    name: "{{ debian_package_dependencies }}"
     state: present
     update_cache: yes
     cache_valid_time: 3600
-  with_items: "{{ debian_package_dependencies }}"
-
-- name: update apt cache
-  apt:
-    update_cache: yes
 
 - name: include install_debian_packages.yml
   include: install_debian_packages.yml

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install_debian.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install_debian.yml
@@ -6,24 +6,12 @@
 
 - name: enable red hat storage monitor repository for debian systems
   apt_repository:
-    repo: "deb {{ ceph_rhcs_cdn_debian_repo }}{{ ceph_rhcs_cdn_debian_repo_version }}/MON {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
+    repo: "deb {{ ceph_rhcs_cdn_debian_repo }}{{ ceph_rhcs_cdn_debian_repo_version }}/{{ item.repo }} {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
     state: present
-  changed_when: false
-  when:
-    - mon_group_name in group_names
-
-- name: enable red hat storage osd repository for debian systems
-  apt_repository:
-    repo: "deb {{ ceph_rhcs_cdn_debian_repo }}{{ ceph_rhcs_cdn_debian_repo_version }}/OSD {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
-    state: present
-  changed_when: false
-  when:
-    - osd_group_name in group_names
-
-- name: enable red hat storage rados gateway / mds repository for debian systems
-  apt_repository:
-    repo: "deb {{ ceph_rhcs_cdn_debian_repo }}{{ ceph_rhcs_cdn_debian_repo_version }}/Tools {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
-    state: present
-  changed_when: false
-  when:
-    - (rgw_group_name in group_names or mds_group_name in group_names)
+    update_cache: no
+  register: add_debian_apt_repo
+  with_items:
+    - { repo: "MON", configure: (mon_group_name in group_names) }
+    - { repo: "OSD", configure: (osd_group_name in group_names) }
+    - { repo: "Tools", configure: (rgw_group_name in group_names or mds_group_name in group_names) }
+  when: item.configure

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install_debian.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install_debian.yml
@@ -52,7 +52,8 @@
   apt_repository:
     repo: "deb file://{{ ceph_rhcs_repository_path }}/{{ item }} {{ ansible_lsb.codename }} main"
     state: present
-  changed_when: false
+    update_cache: no
+  register: add_debian_apt_repo
   with_items:
     - MON
     - OSD

--- a/roles/ceph-docker-common/tasks/pre_requisites/debian_prerequisites.yml
+++ b/roles/ceph-docker-common/tasks/pre_requisites/debian_prerequisites.yml
@@ -19,9 +19,20 @@
   apt_repository:
     repo: "{{ item }}"
     state: present
+    update_cache: no
+  register: add_docker_apt_repo
   with_items:
     - "deb https://apt.dockerproject.org/repo/ debian-{{ ansible_distribution_release }} main"
     - "deb http://http.us.debian.org/debian/ testing contrib main"
+
+- name: update apt cache
+  apt:
+    update_cache: yes
+  when: add_docker_apt_repo | changed
+  register: update_docker_apt_cache
+  until: update_docker_apt_cache | success
+  retries: 5
+  delay: 2
 
 - name: install pip from testing on debian
   package:

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -41,12 +41,27 @@
   apt_repository:
     repo: "deb {{ nfs_ganesha_stable_deb_repo }} {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
     state: present
-  changed_when: false
+    update_cache: no
+  register: add_ganesha_apt_repo
   when:
     - ansible_os_family == 'Debian'
     - nfs_ganesha_stable
     - ceph_origin == 'repository'
     - ceph_repository == 'community'
+
+- name: update apt cache
+  apt:
+    update_cache: yes
+  register: update_ganesha_apt_cache
+  retries: 5
+  delay: 2
+  until: update_ganesha_apt_cache | success
+  when:
+    - ansible_os_family == 'Debian'
+    - nfs_ganesha_stable
+    - ceph_origin == 'repository'
+    - ceph_repository == 'community'
+    - add_ganesha_apt_repo | changed
 
 - name: fetch nfs-ganesha development repository
   uri:


### PR DESCRIPTION
The apt-cache update can fail due to transient issues related to the
action being a network operation. To reduce the impact of these
transient failures this patch adds a retry to the update_cache task.

However, the apt_repository tasks which would perform an apt_update
won't retry the apt_update on a failure in the same way, as such this PR
moves the apt_update into an individual task, once per role.

Finally, the apt_repository tasks no longer have a changed_when: false,
and the apt_cache update is only performed once per role, if the
repositories change. Otherwise the cache is updated on the "apt" install
tasks if the cache_timeout has been reached.