### PR TITLE
Install Apt packages as a list

### DIFF
--- a/roles/ceph-common/tasks/installs/install_debian_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_packages.yml
@@ -1,29 +1,18 @@
 ---
-- name: install ceph for debian
+- name: set fact for packages that are always installed
+  set_fact:
+    _apt_deb_pkg_install_list: [ "ceph", "ceph-common" ]
+
+- name: generate list of packages to install
+  set_fact:
+    _apt_deb_pkg_install_list: "{{ _apt_deb_pkg_install_list }} + [ {{ item.pkg_name }} ]"
+  when: item.install
+  with_items:
+    - { pkg_name: "ceph-test", install: "{{ ceph_test }}" }
+    - { pkg_name: "radosgw", install: "{{ rgw_group_name in group_names }}" }
+
+- name: install ceph packages for debian
   apt:
-    name: "ceph"
-    update_cache: no
+    pkg: "{{ _apt_deb_pkg_install_list }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-
-- name: install ceph-common for debian
-  apt:
-    name: ceph-common
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-
-- name: install ceph-test for debian
-  apt:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-  when:
-    - ceph_test
-
-- name: install rados gateway for debian
-  apt:
-    name: radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    update_cache: yes
-  when:
-    - rgw_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
@@ -1,40 +1,20 @@
 ---
-- name: install red hat storage ceph-common for debian
-  apt:
-    pkg: ceph-common
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+- name: set fact for packages that are always installed
+  set_fact:
+    _apt_rhcs_pkg_install_list: [ "ceph-common" ]
 
-- name: install red hat storage ceph mon for debian
-  apt:
-    name: ceph-mon
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - mon_group_name in group_names
+- name: generate list of packages to install
+  set_fact:
+    _apt_rhcs_pkg_install_list: "{{ _apt_rhcs_pkg_install_list }} + [ {{ item.pkg_name }} ]"
+  when: item.install
+  with_items:
+    - { pkg_name: "ceph-mon", install: "{{ mon_group_name in group_names }}" }
+    - { pkg_name: "ceph-osd", install: "{{ osd_group_name in group_names }}" }
+    - { pkg_name: "ceph-test", install: "{{ ceph_test }}" }
+    - { pkg_name: "radosgw", install: "{{ rgw_group_name in group_names }}" }
+    - { pkg_name: "ceph-fuse", install: "{{ client_group_name in group_names }}" }
 
-- name: install red hat storage ceph osd for debian
+- name: install red hat storage ceph packages for debian
   apt:
-    name: ceph-osd
+    pkg: "{{ _apt_rhcs_pkg_install_list }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - osd_group_name in group_names
-
-- name: install ceph-test for debian
-  apt:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
-
-- name: install red hat storage radosgw for debian
-  apt:
-    name: radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - rgw_group_name in group_names
-
-- name: install red hat storage ceph-fuse client for debian
-  apt:
-    pkg: ceph-fuse
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -6,11 +6,10 @@
 
 - name: install dependencies
   apt:
-    name: "{{ item }}"
+    name: "{{ debian_package_dependencies }}"
     state: present
     update_cache: yes
     cache_valid_time: 3600
-  with_items: "{{ debian_package_dependencies }}"
 
 - name: update apt cache
   apt:


### PR DESCRIPTION
We can reduce the number of tasks required, and install all packages in
one go, rather than looping through them or installing them as
individual tasks. This will be more efficient since a list can be passed
to the apt install process.

This PR adds a list creation based on the conditionals used, and then
installs the packages in one go.