### PR TITLE
[skip ci] add .vscode/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/*
 .vagrant
 *.vdi
 *.keyring


### PR DESCRIPTION
I personally dev on vscode and I have some preferences to save when it
comes to running the python unit tests. So escaping this directory is
actually useful.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 3c4319ca4b5355d69b2925e916420f86d29ee524)
Signed-off-by: Sébastien Han <seb@redhat.com>