### PR TITLE
Install packages as a list

### DIFF
--- a/roles/ceph-common/tasks/installs/install_debian_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_packages.yml
@@ -1,29 +1,7 @@
 ---
 - name: install ceph for debian
   apt:
-    name: "ceph"
+    name: "{{ _ceph_pkgs_to_install }}"
     update_cache: no
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-
-- name: install ceph-common for debian
-  apt:
-    name: ceph-common
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-
-- name: install ceph-test for debian
-  apt:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-  when:
-    - ceph_test
-
-- name: install rados gateway for debian
-  apt:
-    name: radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    update_cache: yes
-  when:
-    - rgw_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
@@ -1,40 +1,5 @@
 ---
-- name: install red hat storage ceph-common for debian
+- name: install red hat storage ceph packages for debian
   apt:
-    pkg: ceph-common
+    pkg: "{{ _ceph_pkgs_to_install }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-
-- name: install red hat storage ceph mon for debian
-  apt:
-    name: ceph-mon
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - mon_group_name in group_names
-
-- name: install red hat storage ceph osd for debian
-  apt:
-    name: ceph-osd
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - osd_group_name in group_names
-
-- name: install ceph-test for debian
-  apt:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
-
-- name: install red hat storage radosgw for debian
-  apt:
-    name: radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - rgw_group_name in group_names
-
-- name: install red hat storage ceph-fuse client for debian
-  apt:
-    pkg: ceph-fuse
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -13,49 +13,7 @@
   when:
     - ansible_distribution == 'CentOS'
 
-- name: install redhat ceph-test package
+- name: install redhat ceph packages
   package:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
-
-- name: install redhat ceph-common
-  package:
-    name: "ceph-common"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-
-- name: install redhat ceph-mon package
-  package:
-    name: "ceph-mon"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - mon_group_name in group_names
-
-- name: install redhat ceph-osd package
-  package:
-    name: "ceph-osd"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - osd_group_name in group_names
-
-- name: install redhat ceph-fuse package
-  package:
-    name: "ceph-fuse"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install redhat ceph-base package
-  package:
-    name: "ceph-base"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install redhat ceph-radosgw package
-  package:
-    name: ceph-radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - rgw_group_name in group_names
+    name: "{{ _ceph_pkgs_to_install }}"
+    state: present

--- a/roles/ceph-common/tasks/installs/install_suse_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_suse_packages.yml
@@ -3,52 +3,8 @@
   package:
     name: "{{ suse_package_dependencies }}"
     state: present
-  when:
-    - ansible_distribution == 'Suse'
 
-- name: install suse ceph-common
+- name: install suse ceph packages
   package:
-    name: "ceph-common"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-
-- name: install suse ceph-mon package
-  package:
-    name: "ceph-mon"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - mon_group_name in group_names
-
-- name: install suse ceph-osd package
-  package:
-    name: "ceph-osd"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - osd_group_name in group_names
-
-- name: install suse ceph-fuse package
-  package:
-    name: "ceph-fuse"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install suse ceph-base package
-  package:
-    name: "ceph-base"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install suse ceph-test package
-  package:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
-
-- name: install suse ceph-radosgw package
-  package:
-    name: ceph-radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - rgw_group_name in group_names
+    name: "{{ _ceph_pkgs_to_install }}"
+    state: present

--- a/roles/ceph-common/vars/main.yml
+++ b/roles/ceph-common/vars/main.yml
@@ -1,0 +1,32 @@
+---
+_debian_ceph_pkgs:
+  - { name: "ceph", install: (ceph_repository != 'rhcs') }
+  - { name: "ceph-common", install: true }
+  - { name: "ceph-mon", install: ((ceph_repository == 'rhcs') and (mon_group_name in group_names)) }
+  - { name: "ceph-osd", install: ((ceph_repository == 'rhcs') and (osd_group_name in group_names)) }
+  - { name: "ceph-test", install: ceph-test }
+  - { name: "radosgw", install: (rgw_group_name in group_names) }
+  - { name: "ceph-fuse", install: ((ceph_repository == 'rhcs') and (client_group_name in group_names)) }
+
+_redhat_ceph_pkgs:
+  - { name: "ceph-test", install: ceph-test }
+  - { name: "ceph-common", install: true }
+  - { name: "ceph-mon", install: (mon_group_name in group_names) }
+  - { name: "ceph-osd", install: (osd_group_name in group_names) }
+  - { name: "ceph-fuse", install: (client_group_name in group_names) }
+  - { name: "ceph-base", install: (client_group_name in group_names) }
+  - { name: "ceph-radosgw", install: (rgw_group_name in group_names) }
+
+_distro_pkg_map:
+  "Debian": "{{ _debian_ceph_pkgs }}"
+  "RedHat": "{{ _redhat_ceph_pkgs }}"
+  "Suse": "{{ _redhat_ceph_pkgs }}"
+
+_ceph_pkgs_to_install: |-
+  {% set _packages = [] %}
+  {% for pkg in _distro_pkg_map[ansible_os_family] %}
+  {%   if (pkg['install']) %}
+  {%     set _ = _packages.append(pkg['name']) %}
+  {%   endif %}
+  {% endfor %}
+  {{ _packages }}


### PR DESCRIPTION
To make the package installation more efficient we should install
packages as a list rather than as individual tasks or using a
"with_items" loop. The package managers can handle a list passed to them
to install in one go.

In order to reduce the need for a task to sort the packages we can
create a var that will filter the packages and produce the list of
packages to install.