### PR TITLE
ceph-nfs: disable attribute caching

### DIFF
--- a/roles/ceph-nfs/templates/ganesha.conf.j2
+++ b/roles/ceph-nfs/templates/ganesha.conf.j2
@@ -13,6 +13,10 @@ NFS_Core_Param
 }
 
 {% if ceph_nfs_disable_caching or nfs_file_gw %}
+EXPORT_DEFAULTS {
+	Attr_Expiration_Time = 0;
+}
+
 CACHEINODE {
 	Dir_Max = 1;
 	Dir_Chunk = 0;


### PR DESCRIPTION
When 'ceph_nfs_disable_caching' is set to True, disable attribute
caching done by Ganesha for all Ganesha exports.

Signed-off-by: Ramana Raja <rraja@redhat.com>