### PR TITLE
[TEST2] Install packages as a list

### DIFF
--- a/roles/ceph-common/tasks/installs/install_debian_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_packages.yml
@@ -1,29 +1,19 @@
 ---
+- name: generate packages to install for debian
+  set_fact:
+    _debian_ceph_pkgs_to_install: [ "ceph", "ceph-common" ]
+
+- name: add packages to install per host
+  set_fact:
+    _debian_ceph_pkgs_to_install: "{{ _debian_ceph_pkgs_to_install + [ item.name ] }}"
+  when: item.install
+  with_items:
+    - { name: "ceph-test", install: ceph-test }
+    - { name: "radosgw", install: (rgw_group_name in group_names) }
+
 - name: install ceph for debian
   apt:
-    name: "ceph"
+    name: "{{ _debian_ceph_pkgs_to_install }}"
     update_cache: no
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-
-- name: install ceph-common for debian
-  apt:
-    name: ceph-common
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-
-- name: install ceph-test for debian
-  apt:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-  when:
-    - ceph_test
-
-- name: install rados gateway for debian
-  apt:
-    name: radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    update_cache: yes
-  when:
-    - rgw_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
@@ -1,40 +1,20 @@
 ---
-- name: install red hat storage ceph-common for debian
-  apt:
-    pkg: ceph-common
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+- name: generate packages to install for debian
+  set_fact:
+    _debian_rhcs_ceph_pkgs_to_install: [ "ceph-common" ]
 
-- name: install red hat storage ceph mon for debian
-  apt:
-    name: ceph-mon
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - mon_group_name in group_names
+- name: add packages to install per host
+  set_fact:
+    _debian_rhcs_ceph_pkgs_to_install: "{{ _debian_rhcs_ceph_pkgs_to_install + [ item.name ] }}"
+  when: item.install
+  with_items:
+    - { name: "ceph-mon", install: (mon_group_name in group_names) }
+    - { name: "ceph-osd", install: (osd_group_name in group_names) }
+    - { name: "ceph-test", install: ceph-test }
+    - { name: "radosgw", install: (rgw_group_name in group_names) }
+    - { name: "ceph-fuse", install: (client_group_name in group_names) }
 
-- name: install red hat storage ceph osd for debian
+- name: install red hat storage ceph packages for debian
   apt:
-    name: ceph-osd
+    pkg: "{{ _debian_rhcs_ceph_pkgs_to_install }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - osd_group_name in group_names
-
-- name: install ceph-test for debian
-  apt:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
-
-- name: install red hat storage radosgw for debian
-  apt:
-    name: radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - rgw_group_name in group_names
-
-- name: install red hat storage ceph-fuse client for debian
-  apt:
-    pkg: ceph-fuse
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -17,6 +17,8 @@
 
 - name: update apt cache if cache_valid_time has expired
   apt:
+    name: "{{ debian_package_dependencies }}"
+    state: present
     update_cache: yes
     cache_valid_time: 3600
 
@@ -24,8 +26,6 @@
   apt:
     name: "{{ debian_package_dependencies }}"
     state: present
-    update_cache: yes
-    cache_valid_time: 3600
 
 - name: include install_debian_packages.yml
   include: install_debian_packages.yml

--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -13,49 +13,23 @@
   when:
     - ansible_distribution == 'CentOS'
 
-- name: install redhat ceph-test package
-  package:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
+- name: generate packages to install for redhat
+  set_fact:
+    _redhat_ceph_pkgs_to_install: [ "ceph-common" ]
 
-- name: install redhat ceph-common
-  package:
-    name: "ceph-common"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+- name: add packages to install per host
+  set_fact:
+    _redhat_ceph_pkgs_to_install: "{{ _redhat_ceph_pkgs_to_install + [ item.name ] }}"
+  when: item.install
+  with_items:
+    - { name: "ceph-test", install: ceph-test }
+    - { name: "ceph-mon", install: (mon_group_name in group_names) }
+    - { name: "ceph-osd", install: (osd_group_name in group_names) }
+    - { name: "ceph-fuse", install: (client_group_name in group_names) }
+    - { name: "ceph-base", install: (client_group_name in group_names) }
+    - { name: "ceph-radosgw", install: (rgw_group_name in group_names) }
 
-- name: install redhat ceph-mon package
+- name: install redhat ceph packages
   package:
-    name: "ceph-mon"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - mon_group_name in group_names
-
-- name: install redhat ceph-osd package
-  package:
-    name: "ceph-osd"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - osd_group_name in group_names
-
-- name: install redhat ceph-fuse package
-  package:
-    name: "ceph-fuse"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install redhat ceph-base package
-  package:
-    name: "ceph-base"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install redhat ceph-radosgw package
-  package:
-    name: ceph-radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - rgw_group_name in group_names
+    name: "{{ _redhat_ceph_pkgs_to_install }}"
+    state: present

--- a/roles/ceph-common/tasks/installs/install_suse_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_suse_packages.yml
@@ -3,52 +3,25 @@
   package:
     name: "{{ suse_package_dependencies }}"
     state: present
-  when:
-    - ansible_distribution == 'Suse'
 
-- name: install suse ceph-common
-  package:
-    name: "ceph-common"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+- name: generate packages to install for redhat
+  set_fact:
+    _suse_ceph_pkgs_to_install: [ "ceph-common" ]
 
-- name: install suse ceph-mon package
-  package:
-    name: "ceph-mon"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - mon_group_name in group_names
+- name: add packages to install per host
+  set_fact:
+    _suse_ceph_pkgs_to_install: "{{ _suse_ceph_pkgs_to_install + [ item.name ] }}"
+  when: item.install
+  with_items:
+    - { name: "ceph-test", install: ceph-test }
+    - { name: "ceph-mon", install: (mon_group_name in group_names) }
+    - { name: "ceph-osd", install: (osd_group_name in group_names) }
+    - { name: "ceph-fuse", install: (client_group_name in group_names) }
+    - { name: "ceph-base", install: (client_group_name in group_names) }
+    - { name: "ceph-radosgw", install: (rgw_group_name in group_names) }
 
-- name: install suse ceph-osd package
-  package:
-    name: "ceph-osd"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - osd_group_name in group_names
 
-- name: install suse ceph-fuse package
+- name: install suse ceph packages
   package:
-    name: "ceph-fuse"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install suse ceph-base package
-  package:
-    name: "ceph-base"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install suse ceph-test package
-  package:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
-
-- name: install suse ceph-radosgw package
-  package:
-    name: ceph-radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - rgw_group_name in group_names
+    name: "{{ _suse_ceph_pkgs_to_install }}"
+    state: present


### PR DESCRIPTION
This is a test approach to see timing when generating the list as a task
and then installing once as part of a yum install, vs generating the
list in vars/main.yml - this will help us determine the time of the
actual install excluding the list generation and see if that is where
the time is being lost.

To make the package installation more efficient we should install
packages as a list rather than as individual tasks or using a
"with_items" loop. The package managers can handle a list passed to them
to install in one go.

In order to reduce the need for a task to sort the packages we can
create a var that will filter the packages and produce the list of
packages to install.