### PR TITLE
common: copy iso files if rolling_update

### DIFF
--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install.yml
@@ -34,7 +34,7 @@
 - name: copy red hat storage iso content for redhat systems
   shell: cp -r {{ ceph_rhcs_mount_path }}/* {{ ceph_rhcs_repository_path }}
   args:
-    creates: "{{ ceph_rhcs_repository_path }}/README"
+    creates: "{{ ceph_rhcs_repository_path+'/README' if not rolling_update else 'dummy' }}"
 
 - name: unmount red hat storage iso file for redhat systems
   mount:


### PR DESCRIPTION
If we are in a middle of an update we want to get the new package
version being installed so the task that copies the repo files should
not be skipped.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1572032
Signed-off-by: Sébastien Han <seb@redhat.com>