### PR TITLE
client: remove default value for pg_num in pools creation

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -78,8 +78,8 @@
   command: >
     {{ docker_exec_client_cmd | default('') }} ceph --cluster {{ cluster }}
     osd pool create {{ item.0.name }}
-    {{ item.0.get('pg_num', hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num']) }}
-    {{ item.0.pgp_num | default(item.0.pg_num) }}
+    {{ item.0.pg_num }}
+    {{ item.0.pgp_num }}
     {{ 'replicated_rule' if item.0.rule_name | default('replicated_rule') == '' else item.0.rule_name | default('replicated_rule') }}
     {{ 1 if item.0.type|default(1) == 'replicated' else 3 if item.0.type|default(1) == 'erasure' else item.0.type|default(1) }}
     {%- if (item.0.type | default("1") == '3' or item.0.type | default("1") == 'erasure') and item.0.erasure_profile != '' %}


### PR DESCRIPTION
trying to set the default value for pg_num to
`hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'])` will
break in case of external client nodes deployment.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>