### PR TITLE
[skip ci] rhcs: bump version to 3.0 for stable 3.1

### DIFF
--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -1,3 +1,4 @@
 ceph_repository: rhcs
 ceph_origin: repository
 fetch_directory: ~/ceph-ansible-keys
+ceph_rhcs_version: 3


### PR DESCRIPTION
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1519835
Signed-off-by: Sébastien Han <seb@redhat.com>