### PR TITLE
osd: clean legacy syntax in ceph-osd-run.sh.j2

### DIFF
--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -82,8 +82,7 @@ expose_partitions "$1"
   {% if ansible_distribution == 'Ubuntu' -%}
   --security-opt apparmor:unconfined \
   {% endif -%}
-  {% if not containerized_deployment_with_kv -%}
-  {% else -%}
+  {% if containerized_deployment_with_kv -%}
   -e KV_TYPE={{ kv_type }} \
   -e KV_IP={{ kv_endpoint }} \
   -e KV_PORT={{ kv_port }} \


### PR DESCRIPTION
Quick clean on a legacy syntax due to e0a264c7e

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>