### PR TITLE
mon: fix mgr keyring creation when upgrading from jewel

### DIFF
--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -94,8 +94,12 @@
     - not containerized_deployment_with_kv
 
 - block:
+  - name: get mons ips addr
+    command: "{{ docker_exec_cmd }} ceph-conf -c {{ ceph_conf_key_directory }}/{{ cluster }}.conf 'mon host'"
+    register: mons_ips
+
   - name: create ceph mgr keyring(s) when mon is containerized
-    command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} auth get-or-create mgr.{{ hostvars[item]['ansible_hostname'] }} mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o /etc/ceph/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
+    command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} -m {{ mons_ips.stdout.split(',')[0] }} auth get-or-create mgr.{{ hostvars[item]['ansible_hostname'] }} mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o /etc/ceph/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
     args:
       creates: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
     changed_when: false


### PR DESCRIPTION
On containerized deployment,
when upgrading from jewel to luminous, mgr keyring creation fails because the
command to create mgr keyring is executed on a container that is still
running jewel since the container is restarted later to run the new
image, therefore, it fails with bad entity error.

To get around this situation, we can delegate the command to create
these keyrings on the first monitor when we are running the playbook on the last monitor.
That way we ensure we will issue the command on a container that has
been well restarted with the new image.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1574995

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>