### PR TITLE
Makefile: bail out on unknown Git tag formats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,13 @@ ifneq (,$(findstring rc,$(VERSION)))
     RELEASE := 0.$(RC).$(RELEASE)
     VERSION := $(subst $(RC),,$(VERSION))
 endif
+
+ifneq (,$(shell echo $(VERSION) | grep [a-zA-Z]))
+    # If we still have alpha characters in our Git tag string, we don't know
+    # how to translate that into a sane RPM version/release. Bail out.
+    $(error cannot translate Git tag version $(VERSION) to an RPM NVR)
+endif
+
 NVR := $(NAME)-$(VERSION)-$(RELEASE).el7
 
 all: srpm


### PR DESCRIPTION
Prior to this change, if we created entirely new Git tags patterns like "3.2.0alpha" or "3.2.0foobar", the Makefile would incorrectly translate the Git tag name into a Name-Version-Release that would prevent upgrades to "newer" versions.

This happened for example in https://bugs.centos.org/view.php?id=14593, "Incorrect naming scheme for a build of ceph-ansible prevents subsequent updates to be installed"

If we encounter a new Git tag format that we cannot parse, pessimistically bail out early instead of trying to build an RPM.

The purpose of this safeguard is to prevent Jenkins from building RPMs that cannot be easily upgraded.