### PR TITLE
Install packages as a list

### DIFF
--- a/roles/ceph-common/tasks/installs/install_debian_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_packages.yml
@@ -1,29 +1,7 @@
 ---
 - name: install ceph for debian
   apt:
-    name: "ceph"
+    name: "{{ debian_ceph_pkgs | unique }}"
     update_cache: no
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-
-- name: install ceph-common for debian
-  apt:
-    name: ceph-common
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-
-- name: install ceph-test for debian
-  apt:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-  when:
-    - ceph_test
-
-- name: install rados gateway for debian
-  apt:
-    name: radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    update_cache: yes
-  when:
-    - rgw_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
@@ -1,40 +1,5 @@
 ---
-- name: install red hat storage ceph-common for debian
+- name: install red hat storage ceph packages for debian
   apt:
-    pkg: ceph-common
+    pkg: "{{ debian_ceph_pkgs | unique }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-
-- name: install red hat storage ceph mon for debian
-  apt:
-    name: ceph-mon
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - mon_group_name in group_names
-
-- name: install red hat storage ceph osd for debian
-  apt:
-    name: ceph-osd
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - osd_group_name in group_names
-
-- name: install ceph-test for debian
-  apt:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
-
-- name: install red hat storage radosgw for debian
-  apt:
-    name: radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - rgw_group_name in group_names
-
-- name: install red hat storage ceph-fuse client for debian
-  apt:
-    pkg: ceph-fuse
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names

--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -13,49 +13,7 @@
   when:
     - ansible_distribution == 'CentOS'
 
-- name: install redhat ceph-test package
+- name: install redhat ceph packages
   package:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
-
-- name: install redhat ceph-common
-  package:
-    name: "ceph-common"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-
-- name: install redhat ceph-mon package
-  package:
-    name: "ceph-mon"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - mon_group_name in group_names
-
-- name: install redhat ceph-osd package
-  package:
-    name: "ceph-osd"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - osd_group_name in group_names
-
-- name: install redhat ceph-fuse package
-  package:
-    name: "ceph-fuse"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install redhat ceph-base package
-  package:
-    name: "ceph-base"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install redhat ceph-radosgw package
-  package:
-    name: ceph-radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - rgw_group_name in group_names
+    name: "{{ redhat_ceph_pkgs | unique }}"
+    state: present

--- a/roles/ceph-common/tasks/installs/install_suse_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_suse_packages.yml
@@ -3,52 +3,8 @@
   package:
     name: "{{ suse_package_dependencies }}"
     state: present
-  when:
-    - ansible_distribution == 'Suse'
 
-- name: install suse ceph-common
+- name: install suse ceph packages
   package:
-    name: "ceph-common"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-
-- name: install suse ceph-mon package
-  package:
-    name: "ceph-mon"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - mon_group_name in group_names
-
-- name: install suse ceph-osd package
-  package:
-    name: "ceph-osd"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - osd_group_name in group_names
-
-- name: install suse ceph-fuse package
-  package:
-    name: "ceph-fuse"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install suse ceph-base package
-  package:
-    name: "ceph-base"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - client_group_name in group_names
-
-- name: install suse ceph-test package
-  package:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
-
-- name: install suse ceph-radosgw package
-  package:
-    name: ceph-radosgw
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - rgw_group_name in group_names
+    name: "{{ suse_ceph_pkgs | unique }}"
+    state: present

--- a/roles/ceph-common/vars/main.yml
+++ b/roles/ceph-common/vars/main.yml
@@ -1,0 +1,29 @@
+---
+# ceph-common is always installed, if a package isn't to be installed we replace
+# it with 'ceph-common' and run the install with the | unique filter.
+debian_ceph_pkgs:
+  - "{{ (ceph_repository != 'rhcs') | ternary('ceph', 'ceph-common') }}"
+  - "ceph-common"
+  - "{{ ((ceph_repository == 'rhcs') and (mon_group_name in group_names)) | ternary('ceph-mon', 'ceph-common') }}"
+  - "{{ ((ceph_repository == 'rhcs') and (osd_group_name in group_names)) | ternary('ceph-osd', 'ceph-common') }}"
+  - "{{ (ceph_test) | ternary('ceph-test', 'ceph-common') }}"
+  - "{{ (rgw_group_name in group_names) | ternary('radosgw', 'ceph-common') }}"
+  - "{{ ((ceph_repository == 'rhcs') and (client_group_name in group_names)) | ternary('ceph-fuse', 'ceph-common') }}"
+
+redhat_ceph_pkgs:
+  - "{{ (ceph_test) | ternary('ceph-test', 'ceph-common') }}"
+  - "ceph-common"
+  - "{{ (mon_group_name in group_names) | ternary('ceph-mon', 'ceph-common') }}"
+  - "{{ (osd_group_name in group_names) | ternary('ceph-osd', 'ceph-common') }}"
+  - "{{ (client_group_name in group_names) | ternary('ceph-fuse', 'ceph-common') }}"
+  - "{{ (client_group_name in group_names) | ternary('ceph-base', 'ceph-common') }}"
+  - "{{ (rgw_group_name in group_names) | ternary('ceph-radosgw', 'ceph-common') }}"
+
+suse_ceph_pkgs:
+  - "{{ (ceph_test) | ternary('ceph-test', 'ceph-common') }}"
+  - "ceph-common"
+  - "{{ (mon_group_name in group_names) | ternary('ceph-mon', 'ceph-common') }}"
+  - "{{ (osd_group_name in group_names) | ternary('ceph-osd', 'ceph-common') }}"
+  - "{{ (client_group_name in group_names) | ternary('ceph-fuse', 'ceph-common') }}"
+  - "{{ (client_group_name in group_names) | ternary('ceph-base', 'ceph-common') }}"
+  - "{{ (rgw_group_name in group_names) | ternary('ceph-radosgw', 'ceph-common') }}"


### PR DESCRIPTION
To make the package installation more efficient we should install
packages as a list rather than as individual tasks or using a
"with_items" loop. The package managers can handle a list passed to them
to install in one go.

We can use a specified list with the "omit" filter to indicate when
packages should be installed or not.