### PR TITLE
Backport #2574 to stable-3.1

### DIFF
--- a/roles/ceph-osd/tasks/system_tuning.yml
+++ b/roles/ceph-osd/tasks/system_tuning.yml
@@ -61,13 +61,7 @@
     sysctl_file: /etc/sysctl.d/ceph-tuning.conf
     sysctl_set: yes
     ignoreerrors: yes
-  with_items: "{{ os_tuning_params }}"
-
-- name: increase aio-max-nr for bluestore
-  sysctl:
-    name: fs.aio-max-nr
-    value: 1048576
-    sysctl_file: /etc/sysctl.d/ceph-tuning.conf
-    sysctl_set: yes
-  when:
-    - osd_objectstore == 'bluestore'
+  with_items:
+    - { name: "fs.aio-max-nr", value: "1048576", enable: (osd_objectstore == 'bluestore') }
+    - "{{ os_tuning_params }}"
+  when: item.enable | default(true)


### PR DESCRIPTION
The order of fs.aio-max-nr (which is hard-coded to 1048576) means that
if you set fs.aio-max-nr in os_tuning_params it will effectively be
ignored for bluestore scenarios.

To resolve this we should move the setting of fs.aio-max-nr above the
setting of os_tuning_params, in this way the operator can define the
value of fs.aio-max-nr to be something other than 1048576 if they want
to.

Additionally, we can make the sysctl settings happen in 1 task rather
than multiple.

(cherry picked from commit 08a2b58d39a687e25436afdf3fda1591d3be8ca1)