### PR TITLE
[skip ci] Makefile: add "make tag" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ NAME = ceph-ansible
 #  A "git describe" value of "v2.2.0" creates an NVR
 #  "ceph-ansible-2.2.0-1.el7"
 
-VERSION := $(shell git describe --tags --abbrev=0 --match 'v*' | sed 's/^v//')
+TAG := $(shell git describe --tags --abbrev=0 --match 'v*')
+VERSION := $(shell echo $(TAG) | sed 's/^v//')
 COMMIT := $(shell git rev-parse HEAD)
 SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
 RELEASE := $(shell git describe --tags --match 'v*' \
@@ -83,4 +84,23 @@ rpm: dist srpm
 	  --resultdir=. \
 	  --define "dist .el7"
 
-.PHONY: dist rpm srpm
+tag:
+	$(eval BRANCH := $(shell git rev-parse --abbrev-ref HEAD))
+	$(eval LASTNUM := $(shell echo $(TAG) \
+	                    | sed -E "s/.*[^0-9]([0-9]+)$$/\1/"))
+	$(eval NEXTNUM=$(shell echo $$(($(LASTNUM)+1))))
+	$(eval NEXTTAG=$(shell echo $(TAG) | sed "s/$(LASTNUM)$$/$(NEXTNUM)/"))
+	if [[ "$(TAG)" == $(git describe --tags --match 'v*') ]]; then \
+	    echo "$(SHORTCOMMIT) on $(BRANCH) is already tagged as $(TAG)"; \
+	    exit 1; \
+	fi
+	if [[ "$(BRANCH)" != "master" ]] && \
+	   ! [[ "$(BRANCH)" =~ ^stable- ]]; then \
+		echo Cannot tag $(BRANCH); \
+		exit 1; \
+	fi
+	@echo Tagging Git branch $(BRANCH)
+	git tag $(NEXTTAG)
+	@echo run \'git push origin $(NEXTTAG)\' to push to GitHub.
+
+.PHONY: dist rpm srpm tag


### PR DESCRIPTION
Add a new "make tag" command. This automates some common operations:

1) Automatically determine the next Git tag version number to create.
   For example:
   "3.2.0beta1 -> "3.2.0beta2"
   "3.2.0rc1 -> "3.2.0rc2"
   "3.2.0" -> "3.2.1"

2) Create the Git tag, and print instructions for the user to push it to
   GitHub.

3) Sanity check that HEAD is a stable-* branch or master (bail on
   everything else).

4) Sanity check that HEAD is not already tagged.

Note, we will still need to tag manually once each time we change the format, for example when moving from tagging "betas" to tagging "rcs", or "rcs" to "stable point releases".