### PR TITLE
mon: refactor of mgr key fetching

### DIFF
--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -106,27 +106,16 @@
       - not containerized_deployment_with_kv
     with_items: "{{ groups.get(mgr_group_name, []) }}"
 
-  - name: stat for ceph mgr key(s)
-    stat:
-      path: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
-    with_items: "{{ groups.get(mgr_group_name, []) }}"
-    changed_when: false
-    become: false
-    failed_when: false
-    register: stat_mgr_keys
-    check_mode: no
+  - name: fetch ceph mgr key(s)
+    fetch:
+      src: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
+      dest: "{{ fetch_directory }}/{{ fsid }}/{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
+      flat: yes
+    with_items:
+      - "{{ groups.get(mgr_group_name, []) }}"
     when:
       - "{{ groups.get(mgr_group_name, []) | length > 0 }}"
 
-  - name: fetch ceph mgr key(s)
-    fetch:
-      src: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item.item]['ansible_hostname'] }}.keyring"
-      dest: "{{ fetch_directory }}/{{ fsid }}/{{ item.stat.path }}"
-      flat: yes
-    with_items:
-      - "{{ stat_mgr_keys.results }}"
-    when:
-      - item.stat.exists == true
   when:
     - not rolling_update
     - inventory_hostname == groups[mon_group_name]|last


### PR DESCRIPTION
There is no need to stat for created mgr keyrings since they are created
anyway when deploying a ceph cluster > jewel.
We won't enter the block if ceph release is prior to luminous.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>