### PR TITLE
bkp of 2588: rolling_update: fix dest path for mgr keys fetching

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -192,7 +192,48 @@
   become: True
 
   pre_tasks:
-    # this task has a failed_when: false to handle the scenario where no mgr existed before the upgrade
+    - name: get current fsid
+      command: "ceph --cluster {{ cluster }} fsid"
+      register: cluster_uuid
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+
+    - name: non container | create ceph mgr keyring(s)
+      command: "ceph --cluster {{ cluster }} auth get-or-create mgr.{{ hostvars[item]['ansible_hostname'] }} mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o /etc/ceph/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
+      args:
+        creates: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
+      changed_when: false
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      with_items:
+        - "{{ groups.get(mgr_group_name, []) }}"
+      when:
+        - not containerized_deployment
+        - "{{ groups.get(mgr_group_name, []) | length > 0 }}"
+
+    - name: container | create ceph mgr keyring(s)
+      command: "docker exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph --cluster {{ cluster }} auth get-or-create mgr.{{ hostvars[item]['ansible_hostname'] }} mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o /etc/ceph/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
+      args:
+        creates: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
+      changed_when: false
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      with_items:
+        - "{{ groups.get(mgr_group_name, []) }}"
+      when:
+        - containerized_deployment
+        - "{{ groups.get(mgr_group_name, []) | length > 0 }}"
+
+    - name: fetch ceph mgr key(s)
+      fetch:
+        src: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
+        dest: "{{ fetch_directory }}/{{ fsid }}/{{ ceph_conf_key_directory }}/"
+        flat: yes
+        fail_on_missing: no
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      with_items:
+        - "{{ groups.get(mgr_group_name, []) }}"
+
+    # The following task has a failed_when: false
+    # to handle the scenario where no mgr existed before the upgrade
+    # or if we run a Ceph cluster before Luminous
     - name: stop ceph mgr
       systemd:
         name: ceph-mgr@{{ ansible_hostname }}


### PR DESCRIPTION
the role `ceph-mgr` that is played later in the playbook fails because
the destination path for the fetched keys is wrong.
This patch fix the destination path used in the task `fetch ceph mgr
key(s)` so there is no mismatch.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1574995

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 1b4c3f292d8779158ea445a8c9a11c8ed26abe11)
Signed-off-by: Sébastien Han <seb@redhat.com>