### PR TITLE
rolling_update: move osd flag section

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -179,6 +179,25 @@
       when:
         - containerized_deployment
 
+    - name: set osd flags
+      command: ceph --cluster {{ cluster }} osd set {{ item }}
+      with_items:
+        - noout
+        - noscrub
+        - nodeep-scrub
+      delegate_to: "{{ mon_host }}"
+      when: not containerized_deployment
+
+    - name: set containerized osd flags
+      command: |
+        docker exec ceph-mon-{{ hostvars[mon_host]['ansible_hostname'] }} ceph --cluster {{ cluster }} osd set {{ item }}
+      with_items:
+        - noout
+        - noscrub
+        - nodeep-scrub
+      delegate_to: "{{ mon_host }}"
+      when: containerized_deployment
+
 
 - name: upgrade ceph mgr node
 
@@ -269,25 +288,6 @@
         daemon_reload: yes
       when:
         - containerized_deployment
-
-    - name: set osd flags
-      command: ceph --cluster {{ cluster }} osd set {{ item }}
-      with_items:
-        - noout
-        - noscrub
-        - nodeep-scrub
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-      when: not containerized_deployment
-
-    - name: set containerized osd flags
-      command: |
-        docker exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph --cluster {{ cluster }} osd set {{ item }}
-      with_items:
-        - noout
-        - noscrub
-        - nodeep-scrub
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-      when: containerized_deployment
 
 
 - name: upgrade ceph osds cluster


### PR DESCRIPTION
During a minor update from a jewel to a higher jewel version (10.2.9 to
10.2.10 for example) osd flags don't get applied because they were done
in the mgr section which is skipped in jewel since this daemons does not
exist.
Moving the set flag section after all the mons have been updated solves
that problem.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1548071
Signed-off-by: Sébastien Han <seb@redhat.com>