### PR TITLE
Adds failure checking if OSD is not created

### DIFF
--- a/roles/ceph-osd/tasks/scenarios/collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/collocated.yml
@@ -1,4 +1,8 @@
 ---
+- name: set_fact osd_created
+  set_fact:
+    osd_created: False
+
 # use shell rather than docker module
 # to ensure osd disk prepare finishes before
 # starting the next task
@@ -26,6 +30,12 @@
     - not osd_auto_discovery
     - containerized_deployment
     - item.0.partitions|length == 0
+  register: osd
+
+- name: set_fact osd_created
+  set_fact:
+    osd_created: True
+  when: osd.changed
 
 - name: automatic prepare ceph containerized osd disk collocated
   shell: |
@@ -49,6 +59,12 @@
     - osd_auto_discovery
     - containerized_deployment
     - devices is defined
+  register: osd
+
+- name: set_fact osd_created
+  set_fact:
+    osd_created: True
+  when: osd.changed
 
 - name: manually prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) with collocated osd data and journal
   command: "ceph-disk prepare {{ ceph_disk_cli_options }} {{ item.1 }}"
@@ -57,4 +73,17 @@
     - "{{ devices }}"
   when:
     - not containerized_deployment
-    - item.0.partitions|length == 0
+  register: osd
+
+- name: set_fact osd_created
+  set_fact:
+    osd_created: True
+  when: osd.changed
+
+- name: fail if osd was never created
+  fail:
+    msg: >
+      OSD was never created. If using not using osd_auto_discovery, ensure the
+      specified devices do not have partitions. If using osd_auto_discovery,
+      check that suitable devices were found.
+  when: not osd_created

--- a/roles/ceph-osd/tasks/scenarios/non-collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/non-collocated.yml
@@ -1,4 +1,8 @@
 ---
+- name: set_fact osd_created
+  set_fact:
+    osd_created: False
+
 # use shell rather than docker module
 # to ensure osd disk prepare finishes before
 # starting the next task
@@ -28,6 +32,12 @@
     - containerized_deployment
     - osd_objectstore == 'filestore'
     - item.0.partitions|length == 0
+  register: osd
+
+- name: set_fact osd_created
+  set_fact:
+    osd_created: True
+  when: osd.changed
 
 - name: prepare ceph "{{ osd_objectstore }}" containerized osd disk(s) non-collocated with a dedicated device for db and wal
   shell: |
@@ -57,14 +67,25 @@
     - containerized_deployment
     - osd_objectstore == 'bluestore'
     - item.0.partitions|length == 0
+  register: osd
 
-- name: prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) non-collocated
-  command: "ceph-disk prepare {{ ceph_disk_cli_options }} {{ item.1 }} {{ item.2 }}"
-  with_together:
-    - "{{ parted_results.results | default([]) }}"
-    - "{{ devices }}"
-    - "{{ dedicated_devices }}"
-  changed_when: false
+- name: set_fact osd_created
+  set_fact:
+    osd_created: True
+  when: osd.changed
+
+- block:
+  - name: prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) non-collocated
+    command: "ceph-disk prepare {{ ceph_disk_cli_options }} {{ item.1 }} {{ item.2 }}"
+    with_together:
+      - "{{ parted_results.results | default([]) }}"
+      - "{{ devices }}"
+      - "{{ dedicated_devices }}"
+    changed_when: false
+
+  - name: set_fact osd_created
+    set_fact:
+      osd_created: True
   when:
     - osd_objectstore == 'filestore'
     - not containerized_deployment
@@ -81,3 +102,16 @@
     - osd_objectstore == 'bluestore'
     - not containerized_deployment
     - item.0.partitions|length == 0
+  register: osd
+
+- name: set_fact osd_created
+  set_fact:
+    osd_created: True
+  when: osd.changed
+
+- name: fail if osd was never created
+  fail:
+    msg: >
+      OSD was never created. Ensure the specified devices do not have
+      partitions.
+  when: not osd_created


### PR DESCRIPTION
There are several different types of OSD that may be created depending
on a users environment/settings.  However, in the case that no
conditions are met for OSD creation, ceph-ansible completes and no OSD
is created.

resolves #2598