### PR TITLE
[skip ci] ci: use nvme drives

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -520,6 +520,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
         lv.memory = MEMORY
         lv.random_hostname = true
+
+        # Test the host machine we are running on as an nvme drive
+        # Also make sure Intel IOMMU is enabled
+        # if so, then we expose it inside the guess using a PCI device passthrough
+        # we should probably check if the device is not accessed already...
+        if system "lspci | grep -sqo 'Non-Volatile memory controller: Intel Corporation PCIe Data Center SSD' && dmesg | grep -sq 'IOMMU'"
+          # Only do the passthrough on first OSD virtual machine
+          if i == "0"
+            # On our CI machines all the NVMEs have the same PCI slot 02:00.0
+            # So it's "safe" to hardcode it
+            libvirt.pci :bus => '0x02', :slot => '0x00', :function => '0x0'
+          end
+        end
       end
 
       # Parallels

--- a/tox.ini
+++ b/tox.ini
@@ -118,6 +118,9 @@ whitelist_externals =
     pip
     cp
     sleep
+    dd
+    sgdisk
+    true
 passenv=*
 sitepackages=True
 setenv=
@@ -266,3 +269,8 @@ commands=
   shrink_osd_container: {[shrink-osd]commands}
 
   vagrant destroy --force
+
+  # We might be running on a node with an NVME disk
+  # If that the case this drive has been used and must be purged for later deployments
+  sgdisk --zap-all --clear --mbrtogpt -g -- /dev/nvme0n1 || true
+  dd if=/dev/zero of=/dev/nvme0n1 bs=1M count=1024 oflag=direct || true


### PR DESCRIPTION
Our CI machines have an NVME drive each so let's use PCI passthrough to
expose them into only one of the OSD VM.

Signed-off-by: Sébastien Han <seb@redhat.com>