### PR TITLE
[skip ci] Adding mgr_vms variable

### DIFF
--- a/vagrant_variables.yml.atomic
+++ b/vagrant_variables.yml.atomic
@@ -11,6 +11,7 @@ nfs_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0
+mgr_vms: 0
 
 # Deploy RESTAPI on each of the Monitors
 #restapi: false


### PR DESCRIPTION
Missing this variable causes Vagrant fail to provision cluster.

@font @leseb 