### PR TITLE
[skip ci] defaults: restart_osd_daemon unit spaces

### DIFF
--- a/roles/ceph-defaults/templates/restart_osd_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_osd_daemon.sh.j2
@@ -61,7 +61,7 @@ get_docker_osd_id() {
 
 # For containerized deployments, the unit file looks like: ceph-osd@sda.service
 # For non-containerized deployments, the unit file looks like: ceph-osd@0.service
-for unit in $(systemctl list-units | grep "loaded active" | grep -oE "ceph-osd@([0-9]{1,2}|[a-z]+).service"); do
+for unit in $(systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-osd@([0-9]{1,2}|[a-z]+).service"); do
   # First, restart daemon(s)
   systemctl restart "${unit}"
   # We need to wait because it may take some time for the socket to actually exists


### PR DESCRIPTION
Extra space in systemctl list-units can cause restart_osd_daemon.sh to
fail

It looks like if you have more services enabled in the node space
between "loaded" and "active" get more space as compared to one space
given in command the command[1].

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1573317
Signed-off-by: Sébastien Han <seb@redhat.com>