### PR TITLE
ceph-validate: do not check ceph version on dev or rhcs installs

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -44,6 +44,7 @@
   when:
     - osd_group_name is defined
     - osd_group_name in group_names
+    - ceph_repository not in ['rhcs', 'dev']
     - not containerized_deployment
     - osd_scenario == "lvm"
     - ceph_release_num[ceph_release] < ceph_release_num.luminous
@@ -54,6 +55,7 @@
   when:
     - osd_group_name is defined
     - osd_group_name in group_names
+    - ceph_repository not in ['rhcs', 'dev']
     - osd_objectstore == 'bluestore'
     - ceph_release_num[ceph_release] < ceph_release_num.luminous
 


### PR DESCRIPTION
A dev or rhcs install does not require ceph_stable_release to be set and
instead generates that by looking at the installed ceph-version.
However, at this point in the playbook ceph may not have been installed
yet and ceph-common has not be run.

Fixes: https://github.com/ceph/ceph-ansible/issues/2618

Signed-off-by: Andrew Schoen <aschoen@redhat.com>