### PR TITLE
pin version of ansible to 2.4.2 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible>=2.4.2
+ansible~=2.4
 notario>=0.0.13
 netaddr>=0.7.19


### PR DESCRIPTION
This is the latest version that we support. If we don't pin this we
get a 2.5.x version installed that causes the playbook to fail in
various ways.

Fixes: https://github.com/ceph/ceph-ansible/issues/2631

Signed-off-by: Andrew Schoen <aschoen@redhat.com>