### PR TITLE
playbook: follow up on #2553

### DIFF
--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -25,7 +25,7 @@
     - name: gather facts
       setup:
       when:
-        - not delegate_facts_host | bool or inventory_hostname in groups.get('clients', [])
+        - not delegate_facts_host | bool
 
     - name: gather and delegate facts
       setup:


### PR DESCRIPTION
Since we fixed the `gather and delegate facts` task, this exception is
not needed anymore. It's a leftover that should be removed to save some
time when deploying a cluster with a large client number.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>