### PR TITLE
[skip ci] iscsi purge process needed sudo privileges

### DIFF
--- a/infrastructure-playbooks/purge-iscsi-gateways.yml
+++ b/infrastructure-playbooks/purge-iscsi-gateways.yml
@@ -21,6 +21,7 @@
 
 - name: Removing the gateway configuration
   hosts: iscsi-gws
+  become: yes
   vars:
     - igw_purge_type: "{{hostvars['localhost']['igw_purge_type']}}"
 
@@ -34,4 +35,3 @@
 
     - name: restart rbd-target-gw daemons
       service: name=rbd-target-gw state=restarted
-


### PR DESCRIPTION
Without the become:yes, the purge tasks fail with either access issues to the rados config object
or the log file in /var/log.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1549004