### PR TITLE
mds: move mds fs pools creation

### DIFF
--- a/roles/ceph-mds/tasks/main.yml
+++ b/roles/ceph-mds/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: include create_mds_filesystems.yml
+  include: create_mds_filesystems.yml
+  when:
+    - inventory_hostname == groups[mds_group_name] | first
+
 - name: set_fact docker_exec_cmd
   set_fact:
     docker_exec_cmd: "docker exec ceph-mds-{{ ansible_hostname }}"
@@ -7,11 +12,6 @@
 
 - name: include common.yml
   include: common.yml
-
-- name: include create_mds_filesystems.yml
-  include: create_mds_filesystems.yml
-  when:
-    - inventory_hostname == groups[mds_group_name] | first
 
 - name: non_containerized.yml
   include: non_containerized.yml


### PR DESCRIPTION
When collocating mds on monitor node, the cephpfs will fail
because `docker_exec_cmd` is reset to `ceph-mds-monXX` which is
incorrect because we need to delegate the task on `ceph-mon-monXX`.
In addition, it wouldn't have worked since `ceph-mds-monXX` container
isn't started yet.

Moving the task earlier in the `ceph-mds` role will fix this issue.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1578086

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>