### PR TITLE
python-netaddr is required to generate ceph.conf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansible>=2.4.2
 notario>=0.0.13
+netaddr>=0.7.19


### PR DESCRIPTION
ceph-config: add netaddr to python requirements

netaddr is required to generate ceph.conf, let's add this requirement in `requirements.txt`
