### PR TITLE
tests: fix broken symlink

### DIFF
--- a/tests/requirements2.5.txt
+++ b/tests/requirements2.5.txt
@@ -1,1 +1,1 @@
-tests/requirements2.4.txt
+requirements2.4.txt


### PR DESCRIPTION
`requirements2.5.txt` is pointing to `tests/requirements2.4.txt` while
it should point to `requirements2.4.txt` since they are in the same
directory.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>