### PR TITLE
tests: avoid yum failures

### DIFF
--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -22,3 +22,11 @@
         state: present
       when:
         - not is_atomic
+
+    - name: disable fastest mirror detection
+      ini_file:
+        path: /etc/yum/pluginconf.d/fastestmirror.conf
+        section: main
+        option: enabled
+        value: 0
+      when: ansible_distribution == 'CentOS'

--- a/tox.ini
+++ b/tox.ini
@@ -211,6 +211,8 @@ commands=
 
   rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
 
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/setup.yml
+
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
@@ -221,8 +223,6 @@ commands=
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
-
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/setup.yml
 
   # wait 2 minutes for services to be ready
   sleep 120


### PR DESCRIPTION
In the CI we can see at many times failures like following:

`Failure talking to yum: Cannot find a valid baseurl for repo:
base/7/x86_64`

It seems the fastest mirror detection is sometimes counterproductive and
leads yum to fail.

This has been added in the `setup.yml`.
This playbook was used until now only just before playing `testinfra`
and could be used before running ceph-ansible so we can add some
provisionning tasks.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>