### PR TITLE
mdss: do not make pg_num a mandatory params

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -352,8 +352,8 @@ dummy:
 #cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
 #cephfs_pools:
-#  - { name: "{{ cephfs_data }}", pgs: "" }
-#  - { name: "{{ cephfs_metadata }}", pgs: "" }
+#  - { name: "{{ cephfs_data }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
+#  - { name: "{{ cephfs_metadata }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
 
 ## OSD options
 #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -352,8 +352,8 @@ ceph_repository: rhcs
 #cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
 #cephfs_pools:
-#  - { name: "{{ cephfs_data }}", pgs: "" }
-#  - { name: "{{ cephfs_metadata }}", pgs: "" }
+#  - { name: "{{ cephfs_data }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
+#  - { name: "{{ cephfs_metadata }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
 
 ## OSD options
 #

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -344,8 +344,8 @@ cephfs_data: cephfs_data # name of the data pool for a given filesystem
 cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
 cephfs_pools:
-  - { name: "{{ cephfs_data }}", pgs: "" }
-  - { name: "{{ cephfs_metadata }}", pgs: "" }
+  - { name: "{{ cephfs_data }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
+  - { name: "{{ cephfs_metadata }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
 
 ## OSD options
 #

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -21,15 +21,6 @@
     - ceph_rhcs_cdn_debian_repo == 'https://customername:customerpasswd@rhcs.download.redhat.com'
     - ceph_repository not in ['rhcs', 'dev', 'obs']
 
-- name: make sure pg num is set for cephfs pools
-  fail:
-    msg: "You must set pg num for your cephfs pools, see the cephfs_pools variable."
-  with_items: "{{ cephfs_pools }}"
-  when:
-    - groups.get(mds_group_name, []) | length > 0
-    - mon_group_name in group_names
-    - item.pgs == ''
-
 - name: make sure journal_size configured
   debug:
     msg: "WARNING: journal_size is configured to {{ journal_size }}, which is less than 5GB. This is not recommended and can lead to severe issues."

--- a/tests/functional/centos/7/cluster/group_vars/all
+++ b/tests/functional/centos/7/cluster/group_vars/all
@@ -40,6 +40,3 @@ openstack_cinder_pool:
 openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"
-cephfs_pools:
-- { name: "{{ cephfs_data }}", pgs: "8" }
-- { name: "{{ cephfs_metadata }}", pgs: "8" }

--- a/tests/functional/centos/7/docker-collocation/group_vars/all
+++ b/tests/functional/centos/7/docker-collocation/group_vars/all
@@ -22,6 +22,3 @@ ceph_conf_overrides:
 devices:
   - /dev/sda
   - /dev/sdb
-cephfs_pools:
-  - { name: "{{ cephfs_data }}", pgs: "8" }
-  - { name: "{{ cephfs_metadata }}", pgs: "8" }

--- a/tests/functional/centos/7/docker/group_vars/all
+++ b/tests/functional/centos/7/docker/group_vars/all
@@ -41,6 +41,3 @@ openstack_cinder_pool:
 openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"
-cephfs_pools:
-  - { name: "{{ cephfs_data }}", pgs: "8" }
-  - { name: "{{ cephfs_metadata }}", pgs: "8" }

--- a/tests/functional/ubuntu/16.04/cluster/group_vars/all
+++ b/tests/functional/ubuntu/16.04/cluster/group_vars/all
@@ -28,6 +28,3 @@ nfs_ganesha_stable_branch: V2.5-stable
 nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 nfs_ganesha_dev: false
 nfs_ganesha_flavor: "ceph_master"
-cephfs_pools:
-  - { name: "{{ cephfs_data }}", pgs: "8" }
-  - { name: "{{ cephfs_metadata }}", pgs: "8" }


### PR DESCRIPTION
When playing ceph-mds role, mon nodes have set a fact with the default
pg num for osd pools, we can simply default to this value for cephfs
pools (`cephfs_pools` variable).

At the moment the variable definition for `cephfs_pools` looks like:

```
cephfs_pools:
  - { name: "{{ cephfs_data }}", pgs: "" }
  - { name: "{{ cephfs_metadata }}", pgs: "" }
```

and we have a task in `ceph-validate` to ensure `pgs` has been set to a
valid value.

We could simply avoid this check by setting the default value of `pgs`
to `hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num']` and
let to users the possibility to override this value.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1581164

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>