### PR TITLE
Rolling upgrades should use norebalance flag for OSDs

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -183,6 +183,7 @@
       command: ceph --cluster {{ cluster }} osd set {{ item }}
       with_items:
         - noout
+        - norebalance
         - noscrub
         - nodeep-scrub
       delegate_to: "{{ mon_host }}"
@@ -193,6 +194,7 @@
         docker exec ceph-mon-{{ hostvars[mon_host]['ansible_hostname'] }} ceph --cluster {{ cluster }} osd set {{ item }}
       with_items:
         - noout
+        - norebalance
         - noscrub
         - nodeep-scrub
       delegate_to: "{{ mon_host }}"
@@ -413,6 +415,7 @@
       command: "{{ docker_exec_cmd_update_osd|default('') }} ceph osd unset {{ item }} --cluster {{ cluster }}"
       with_items:
         - noout
+        - norebalance
         - noscrub
         - nodeep-scrub
       delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
Rolling upgrades should use norebalance flag for OSDs

The rolling upgrades playbook should have norebalance flag set for
OSDs upgrades to wait only for recovery.

Fixes: #2657 

Signed-off-by: vishal.kanaujia@flipkart.com