### PR TITLE
[skip ci] tests: avoid yum metalink failure

### DIFF
--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -20,7 +20,9 @@
         section: main
         option: enabled
         value: 0
-      when: ansible_distribution == 'CentOS'
+      when:
+        - ansible_distribution == 'CentOS'
+        - not is_atomic
 
     - name: update system
       command: yum update -y


### PR DESCRIPTION
We are seeing metalink issue regarding epel repository.
```
Failure talking to yum: Cannot retrieve metalink for repository: epel/x86_64.
Please verify its path and try again
```

Updating ca-certificates should prevent yum from this failure.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>