### PR TITLE
Makefile: followup on #2585

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ tag:
 	                    | sed -E "s/.*[^0-9]([0-9]+)$$/\1/"))
 	$(eval NEXTNUM=$(shell echo $$(($(LASTNUM)+1))))
 	$(eval NEXTTAG=$(shell echo $(TAG) | sed "s/$(LASTNUM)$$/$(NEXTNUM)/"))
-	if [[ "$(TAG)" == $(git describe --tags --match 'v*') ]]; then \
+	if [[ "$(TAG)" == "$(git describe --tags --match 'v*')" ]]; then \
 	    echo "$(SHORTCOMMIT) on $(BRANCH) is already tagged as $(TAG)"; \
 	    exit 1; \
 	fi


### PR DESCRIPTION
Fix a typo in `tag` target, double quote are missing here.

Without them, the `make tag` command fails like this:

```
if [[ "v3.0.35" ==  ]]; then \
            echo "e5f2df8 on stable-3.0 is already tagged as v3.0.35"; \
            exit 1; \
        fi
/bin/sh: -c: line 0: unexpected argument `]]' to conditional binary operator
/bin/sh: -c: line 0: syntax error near `;'
/bin/sh: -c: line 0: `if [[ "v3.0.35" ==  ]]; then     echo "e5f2df8 on stable-3.0 is already tagged as v3.0.35";     exit 1; fi'
make: *** [tag] Error 2
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>