### PR TITLE
tests: refact ci testing master

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,7 @@
 # These are Python requirements needed to run the functional tests
-testinfra==1.6.0
+testinfra
 pytest-xdist
+pytest==3.6.1
 notario>=0.0.13
+ansible~=2.5,<2.6
+netaddr

--- a/tests/requirements2.4.txt
+++ b/tests/requirements2.4.txt
@@ -1,6 +1,0 @@
-# These are Python requirements needed to run the functional tests
-# testinfra < 1.7.1 does not work Ansible 2.4, see https://github.com/philpep/testinfra/issues/249
-testinfra==1.7.1
-pytest-xdist
-pytest==3.6.1
-notario>=0.0.13

--- a/tests/requirements2.5.txt
+++ b/tests/requirements2.5.txt
@@ -1,1 +1,0 @@
-requirements2.4.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = {dev,jewel,luminous,rhcs}-{ansible2.2,ansible2.3,ansible2.4,ansible2.5}-{xenial_cluster,centos7_cluster,docker_cluster,update_cluster,cluster,update_docker_cluster,switch_to_containers,purge_filestore_osds_container,purge_filestore_osds_non_container,purge_cluster_non_container,purge_cluster_container,ooo_collocation}
-  {dev,luminous,rhcs}-{ansible2.3,ansible2.4,ansible2.5}-{filestore_osds_non_container,filestore_osds_container,bluestore_osds_container,bluestore_osds_non_container,bluestore_lvm_osds,lvm_osds,purge_lvm_osds,shrink_mon,shrink_osd,shrink_mon_container,shrink_osd_container,docker_cluster_collocation,purge_bluestore_osds_non_container,purge_bluestore_osds_container}
+envlist = {dev,jewel,luminous,mimic,rhcs}-{ansible2.2,ansible2.3,ansible2.4,ansible2.5}-{xenial_cluster,centos7_cluster,docker_cluster,update_cluster,cluster,update_docker_cluster,switch_to_containers,purge_filestore_osds_container,purge_filestore_osds_non_container,purge_cluster_non_container,purge_cluster_container,ooo_collocation}
+  {dev,luminous,mimic,rhcs}-{ansible2.3,ansible2.4,ansible2.5}-{filestore_osds_non_container,filestore_osds_container,bluestore_osds_container,bluestore_osds_non_container,bluestore_lvm_osds,lvm_osds,purge_lvm_osds,shrink_mon,shrink_osd,shrink_mon_container,shrink_osd_container,docker_cluster_collocation,purge_bluestore_osds_non_container,purge_bluestore_osds_container}
 
 skipsdist = True
 
@@ -158,6 +158,11 @@ setenv=
   luminous: CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-luminous
   luminous: UPDATE_CEPH_STABLE_RELEASE = luminous
   luminous: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest
+  mimic: CEPH_STABLE_RELEASE = mimic
+  mimic: CEPH_DOCKER_IMAGE_TAG = latest-mimic
+  mimic: CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis
+  mimic: UPDATE_CEPH_STABLE_RELEASE = mimic
+  mimic: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest
   lvm_osds: CEPH_STABLE_RELEASE = luminous
   bluestore_lvm_osds: CEPH_STABLE_RELEASE = luminous
 deps= -r{toxinidir}/tests/requirements.txt
@@ -211,7 +216,7 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:mimic} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \
@@ -238,7 +243,7 @@ commands=
       --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:mimic} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-bis} \

--- a/tox.ini
+++ b/tox.ini
@@ -160,16 +160,7 @@ setenv=
   luminous: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest
   lvm_osds: CEPH_STABLE_RELEASE = luminous
   bluestore_lvm_osds: CEPH_STABLE_RELEASE = luminous
-deps=
-  ansible2.2: ansible==2.2.3
-  ansible2.2: -r{toxinidir}/tests/requirements2.2.txt
-  ansible2.3: ansible==2.3.1
-  ansible2.3: -r{toxinidir}/tests/requirements2.2.txt
-  ansible2.4: ansible~=2.4,<2.5
-  ansible2.4: -r{toxinidir}/tests/requirements2.4.txt
-  ansible2.5: ansible~=2.5,<2.6
-  ansible2.5: -r{toxinidir}/tests/requirements2.5.txt
-  ooo_collocation: netaddr
+deps= -r{toxinidir}/tests/requirements.txt
 changedir=
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw xenial cluster using non-collocated OSD scenario
   xenial_cluster: {toxinidir}/tests/functional/ubuntu/16.04/cluster


### PR DESCRIPTION
We should test ceph-ansible against the latest ansible stable version on
master.

This commit also remove the pinning to 1.7.1 version of testinfra
because ansible 2.5 requires a newer version.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>