### PR TITLE
ceph-defaults: add the 14.x entry to ceph_release_num

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -27,6 +27,7 @@ dummy:
 #  kraken: 11
 #  luminous: 12
 #  mimic: 13
+#  nautilus: 14
 
 # Directory to fetch cluster fsid, keys etc...
 #fetch_directory: fetch/

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -27,6 +27,7 @@ dummy:
 #  kraken: 11
 #  luminous: 12
 #  mimic: 13
+#  nautilus: 14
 
 # Directory to fetch cluster fsid, keys etc...
 fetch_directory: ~/ceph-ansible-keys

--- a/roles/ceph-common/tasks/release-rhcs.yml
+++ b/roles/ceph-common/tasks/release-rhcs.yml
@@ -22,3 +22,9 @@
     ceph_release: mimic
   when:
     - ceph_version.split('.')[0] | version_compare('13', '==')
+
+- name: set_fact ceph_release nautilus
+  set_fact:
+    ceph_release: nautilus
+  when:
+    - ceph_version.split('.')[0] | version_compare('14', '==')

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -19,6 +19,7 @@ ceph_release_num:
   kraken: 11
   luminous: 12
   mimic: 13
+  nautilus: 14
 
 # Directory to fetch cluster fsid, keys etc...
 fetch_directory: fetch/

--- a/roles/ceph-docker-common/tasks/release.yml
+++ b/roles/ceph-docker-common/tasks/release.yml
@@ -22,3 +22,9 @@
     ceph_release: mimic
   when:
     - ceph_version.split('.')[0] | version_compare('13', '==')
+
+- name: set_fact ceph_release nautilus
+  set_fact:
+    ceph_release: nautilus
+  when:
+    - ceph_version.split('.')[0] | version_compare('14', '==')


### PR DESCRIPTION
The first 14.x tag has been cut so this needs to be added so that
version detection will still work on the master branch of ceph. I've
used the 'next' name here because at this time 14.x has not be named.

Fixes: https://github.com/ceph/ceph-ansible/issues/2671

Signed-off-by: Andrew Schoen <aschoen@redhat.com>