### PR TITLE
Backport "Fix template reference for ganesha.conf"

### DIFF
--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -25,7 +25,7 @@
 - name: generate ganesha configuration file
   action: config_template
   args:
-    src: "{{ lookup('env', 'ANSIBLE_ROLES_PATH') | default (playbook_dir + '/roles', true) }}/ceph-nfs/templates/ganesha.conf.j2"
+    src: "ganesha.conf.j2"
     dest: /etc/ganesha/ganesha.conf
     owner: "root"
     group: "root"


### PR DESCRIPTION
This is a backport of f45662e27023e034adac646ad814d19574fd2153 :
"We can simply reference the template name since it exists within the
role that we are calling. We don't need to check the ANSIBLE_ROLE_PATH
or playbooks directory for the file."

This is worth backporting because it breaks when the roles are placed in a subdirectory,
for example if ceph-ansible is checked out as a submodule of another projet.