### PR TITLE
mons: move set_fact of openstack_keys in ceph-osd

### DIFF
--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -37,19 +37,6 @@
 - name: include set_osd_pool_default_pg_num.yml
   include: set_osd_pool_default_pg_num.yml
 
-- name: set_fact openstack_keys_tmp - preserve backward compatibility after the introduction of the ceph_keys module
-  set_fact:
-    openstack_keys_tmp: "{{ openstack_keys_tmp|default([]) + [ { 'key': item.key, 'name': item.name, 'caps': { 'mon': item.mon_cap, 'osd': item.osd_cap|default(''), 'mds': item.mds_cap|default(''), 'mgr': item.mgr_cap|default('') } , 'mode': item.mode } ] }}"
-  with_items: "{{ openstack_keys }}"
-  when:
-    - item.get('mon_cap', None) # it's enough to assume we are running an old-fashionned syntax simply by checking the presence of mon_cap since every key needs this cap
-
-- name: set_fact keys - override keys_tmp with keys
-  set_fact:
-    openstack_keys: "{{ openstack_keys_tmp }}"
-  when:
-    - openstack_keys_tmp is defined
-
 - name: include calamari.yml
   include: calamari.yml
   when: calamari

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -81,6 +81,19 @@
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 
+- name: set_fact openstack_keys_tmp - preserve backward compatibility after the introduction of the ceph_keys module
+  set_fact:
+    openstack_keys_tmp: "{{ openstack_keys_tmp|default([]) + [ { 'key': item.key, 'name': item.name, 'caps': { 'mon': item.mon_cap, 'osd': item.osd_cap|default(''), 'mds': item.mds_cap|default(''), 'mgr': item.mgr_cap|default('') } , 'mode': item.mode } ] }}"
+  with_items: "{{ openstack_keys }}"
+  when:
+    - item.get('mon_cap', None) # it's enough to assume we are running an old-fashionned syntax simply by checking the presence of mon_cap since every key needs this cap
+
+- name: set_fact keys - override keys_tmp with keys
+  set_fact:
+    openstack_keys: "{{ openstack_keys_tmp }}"
+  when:
+    - openstack_keys_tmp is defined
+
 # Create the pools listed in openstack_pools
 - name: include openstack_config.yml
   include: openstack_config.yml


### PR DESCRIPTION
Since the openstack_config.yml has been moved to `ceph-osd` we must move
this `set_fact` in ceph-osd otherwise the tasks in
`openstack_config.yml` using `openstack_keys` will actually use the
defaults value from `ceph-defaults`.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1585139

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>