### PR TITLE
ceph-defaults: Enable local epel repository

### DIFF
--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -31,6 +31,34 @@
         value: 0
       when: ansible_distribution == 'CentOS'
 
+    - name: install epel
+      package:
+        name: epel-release
+        state: present
+      when:
+        - ansible_distribution == 'CentOS'
+        - not is_atomic
+
+    - name: enable local epel repository
+      ini_file:
+        path: /etc/yum.repos.d/epel.repo
+        section: epel
+        option: baseurl
+        value: http://apt-mirror.front.sepia.ceph.com/epel7/
+      when:
+        - ansible_distribution == 'CentOS'
+        - not is_atomic
+
+    - name: disable remote epel repository
+      ini_file:
+        path: /etc/yum.repos.d/epel.repo
+        section: epel
+        option: metalink
+        state: absent
+      when:
+        - ansible_distribution == 'CentOS'
+        - not is_atomic
+
     - name: resize logical volume for root partition to fill remaining free space
       command: lvresize -l +100%FREE /dev/atomicos/root
       when: is_atomic


### PR DESCRIPTION
During the tests, the remote epel repository is generating a lots of
errors leading to broken jobs (issue #2666)

This patch is about using a local repository instead of a random one.
To achieve that, we make a preliminary install of epel-release, remove
the metalink and enforce a baseurl to our local http mirror.

That should speed up the build process but also avoid the random errors
we face.

This patch is part of a patch series that tries to remove all possible yum failures.