### PR TITLE
ceph-common: add firewall rules for ceph-mgr

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -63,6 +63,7 @@ dummy:
 
 # Open ports on corresponding nodes if firewall is installed on it
 #ceph_mon_firewall_zone: public
+#ceph_mgr_firewall_zone: public
 #ceph_osd_firewall_zone: public
 #ceph_rgw_firewall_zone: public
 #ceph_mds_firewall_zone: public

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -63,6 +63,7 @@ fetch_directory: ~/ceph-ansible-keys
 
 # Open ports on corresponding nodes if firewall is installed on it
 #ceph_mon_firewall_zone: public
+#ceph_mgr_firewall_zone: public
 #ceph_osd_firewall_zone: public
 #ceph_rgw_firewall_zone: public
 #ceph_mds_firewall_zone: public

--- a/roles/ceph-common/tasks/misc/configure_firewall_rpm.yml
+++ b/roles/ceph-common/tasks/misc/configure_firewall_rpm.yml
@@ -25,6 +25,22 @@
   tags:
     - firewall
 
+- name: open manager ports
+  firewalld:
+    service: ceph
+    zone: "{{ ceph_mgr_firewall_zone }}"
+    permanent: true
+    immediate: false # if true then fails in case firewalld is stopped
+    state: enabled
+  notify: restart firewalld
+  when:
+    - ceph_release_num[ceph_release] >= ceph_release_num.luminous
+    - mgr_group_name is defined
+    - mgr_group_name in group_names
+    - firewalld_pkg_query.rc == 0
+  tags:
+    - firewall
+
 - name: open osd ports
   firewalld:
     service: ceph

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -55,6 +55,7 @@ check_firewall: False
 
 # Open ports on corresponding nodes if firewall is installed on it
 ceph_mon_firewall_zone: public
+ceph_mgr_firewall_zone: public
 ceph_osd_firewall_zone: public
 ceph_rgw_firewall_zone: public
 ceph_mds_firewall_zone: public


### PR DESCRIPTION
Prior to this commit the firewall tasks were not opening the ceph-mgr
ports. This would lead to unclean configuration since the ceph-mgr
daemons can not connect to the OSDs.
Thi commit opens the right ports on the ceph-mgr nodes to talk with the
OSDs.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1526400
Signed-off-by: Sébastien Han <seb@redhat.com>