### PR TITLE
ceph-common: move firewall checks after package installation

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -28,6 +28,7 @@ dummy:
 #  luminous: 12
 #  mimic: 13
 #  nautilus: 14
+#  dev: 99
 
 # Directory to fetch cluster fsid, keys etc...
 #fetch_directory: fetch/

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -28,6 +28,7 @@ dummy:
 #  luminous: 12
 #  mimic: 13
 #  nautilus: 14
+#  dev: 99
 
 # Directory to fetch cluster fsid, keys etc...
 fetch_directory: ~/ceph-ansible-keys

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -1,18 +1,4 @@
 ---
-- name: include checks/check_firewall.yml
-  include: checks/check_firewall.yml
-  when:
-    - check_firewall
-  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
-  static: False
-
-- name: include misc/configure_firewall_rpm.yml
-  include: misc/configure_firewall_rpm.yml
-  when:
-    - ansible_os_family in ['RedHat', 'Suse']
-  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
-  static: False
-
 - name: include installs/install_on_redhat.yml
   include: installs/install_on_redhat.yml
   when:
@@ -82,6 +68,20 @@
     - ceph_repository in ['rhcs', 'dev']
   tags:
     - always
+
+- name: include checks/check_firewall.yml
+  include: checks/check_firewall.yml
+  when:
+    - check_firewall
+  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
+  static: False
+
+- name: include misc/configure_firewall_rpm.yml
+  include: misc/configure_firewall_rpm.yml
+  when:
+    - ansible_os_family in ['RedHat', 'Suse']
+  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
+  static: False
 
 - name: include facts_mon_fsid.yml
   include: facts_mon_fsid.yml

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -20,6 +20,7 @@ ceph_release_num:
   luminous: 12
   mimic: 13
   nautilus: 14
+  dev: 99
 
 # Directory to fetch cluster fsid, keys etc...
 fetch_directory: fetch/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,8 @@ def node(host, request):
       'jewel': 10,
       'kraken': 11,
       'luminous': 12,
-      'mimic': 13
+      'mimic': 13,
+      'dev': 99
     }
     if not request.node.get_marker(node_type) and not request.node.get_marker('all'):
         pytest.skip("Not a valid test for node type: %s" % node_type)


### PR DESCRIPTION
We need to do this because on dev or rhcs installs ceph_stable_release
is not mandatory and the firewall check tasks have a task that is
conditional based off the installed version of ceph. If we perform those
checks after package install then they will not fail on dev or rhcs
installs.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>