### PR TITLE
ceph-mds: do not enable multimds on jewel

### DIFF
--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -25,8 +25,7 @@
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
-    - ceph_release_num[ceph_release] >= ceph_release_num.jewel
-    - ceph_release_num[ceph_release] < ceph_release_num.mimic
+    - ceph_release_num[ceph_release] == ceph_release_num.luminous
 
 - name: set max_mds
   command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} fs set {{ cephfs }} max_mds {{ mds_max_mds }}"


### PR DESCRIPTION
Multiple active MDS became stable in Luminous.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>