### PR TITLE
test: do not always copy admin key

### DIFF
--- a/tests/functional/centos/7/cluster/group_vars/osds
+++ b/tests/functional/centos/7/cluster/group_vars/osds
@@ -1,5 +1,4 @@
 ---
-copy_admin_key: true
 os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 osd_scenario: non-collocated

--- a/tox.ini
+++ b/tox.ini
@@ -145,6 +145,8 @@ setenv=
   shrink_mon_container: PLAYBOOK = site-docker.yml.sample
   shrink_mon_container: MON_TO_KILL = mon2
   shrink_osd_container: PLAYBOOK = site-docker.yml.sample
+  shrink_osd_container: COPY_ADMIN_KEY = True
+  shrink_osd: COPY_ADMIN_KEY = True
 
   rhcs: CEPH_STABLE_RELEASE = luminous
   jewel: CEPH_STABLE_RELEASE = jewel
@@ -222,6 +224,7 @@ commands=
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
+      copy_admin_key={env:COPY_ADMIN_KEY:False} \
   "
 
   # wait 2 minutes for services to be ready
@@ -247,7 +250,8 @@ commands=
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} " \
+      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
+      copy_admin_key={env:COPY_ADMIN_KEY:False} " \
       --extra-vars @ceph-override.json
 
   purge_cluster_non_container: {[purge]commands}


### PR DESCRIPTION
The admin key must be copied on the osd nodes only when we test the
shrink scenario. Shrink relies on ceph-disk commands that require the
admin key on the node where it's being executed.

Now we only copy the key when running on the shrink-osd scenario.

Signed-off-by: Sébastien Han <seb@redhat.com>