### PR TITLE
Generate a copy of ceph.conf locally

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -78,6 +78,8 @@ dummy:
 #ceph_rbdmirror_firewall_zone: public
 #ceph_iscsi_firewall_zone: public
 
+# Generate local ceph.conf in fetch directory
+#ceph_conf_local: false
 
 ############
 # PACKAGES #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -78,6 +78,8 @@ fetch_directory: ~/ceph-ansible-keys
 #ceph_rbdmirror_firewall_zone: public
 #ceph_iscsi_firewall_zone: public
 
+# Generate local ceph.conf in fetch directory
+#ceph_conf_local: false
 
 ############
 # PACKAGES #

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -26,6 +26,30 @@
       - restart ceph rgws
       - restart ceph mgrs
       - restart ceph rbdmirrors
+
+  - name: "ensure fetch directory exists"
+    run_once: true
+    become: false
+    local_action:
+      module: file
+      path: "{{ fetch_directory }}/{{ fsid }}/etc/ceph"
+      state: directory
+      mode: "0755"
+    when:
+      - ceph_conf_local
+
+  - name: "generate {{ cluster }}.conf configuration file locally"
+    local_action: config_template
+    become: false
+    run_once: true
+    args:
+      src: "ceph.conf.j2"
+      dest: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.conf"
+      config_overrides: "{{ ceph_conf_overrides }}"
+      config_type: ini
+    when:
+      - inventory_hostname in groups[mon_group_name]
+      - ceph_conf_local
   when:
     - not containerized_deployment|bool
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -70,6 +70,8 @@ ceph_restapi_firewall_zone: public
 ceph_rbdmirror_firewall_zone: public
 ceph_iscsi_firewall_zone: public
 
+# Generate local ceph.conf in fetch directory
+ceph_conf_local: false
 
 ############
 # PACKAGES #


### PR DESCRIPTION
Refers to #2697 

This change creates a copy of `ceph.conf` in ansible server.

Room for improvement:  a toggle flag to control this behavior.

@leseb What do you think?

Signed-off-by: Ha Phan <thanhha.work@gmail.com>