### PR TITLE
tests: skip disabling fastest mirror detection on atomic host

### DIFF
--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -29,7 +29,9 @@
         section: main
         option: enabled
         value: 0
-      when: ansible_distribution == 'CentOS'
+      when:
+        - ansible_distribution == 'CentOS'
+        - not is_atomic
 
     - name: install epel
       package:


### PR DESCRIPTION
There is no need to execute this task on atomic hosts.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>