### PR TITLE
tests: fix rgw tests

### DIFF
--- a/tests/functional/tests/rgw/test_rgw_tuning.py
+++ b/tests/functional/tests/rgw/test_rgw_tuning.py
@@ -11,7 +11,10 @@ class TestRGWs(object):
 
     @pytest.mark.no_docker
     def test_rgw_bucket_default_quota_is_applied(self, node, host):
-        radosgw_admin_cmd = "sudo radosgw-admin --cluster={} user create --uid=test --display-name Test".format(node["cluster_name"])
+        radosgw_admin_cmd = "sudo radosgw-admin --cluster={cluster} -n client.rgw.{hostname} --keyring /var/lib/ceph/radosgw/{cluster}-rgw.{hostname}/keyring user create --uid=test --display-name Test".format(
+            hostname=node["vars"]["inventory_hostname"],
+            cluster=node['cluster_name']
+        )
         radosgw_admin_output = host.check_output(radosgw_admin_cmd)
         radosgw_admin_output_json = json.loads(radosgw_admin_output)
         assert radosgw_admin_output_json["bucket_quota"]["enabled"] == True
@@ -19,7 +22,10 @@ class TestRGWs(object):
 
     @pytest.mark.no_docker
     def test_rgw_tuning_pools_are_set(self, node, host):
-        cmd = "sudo ceph --cluster={} --connect-timeout 5 osd dump".format(node["cluster_name"])
+        cmd = "sudo ceph --cluster={cluster} --connect-timeout 5 -n client.rgw.{hostname} --keyring /var/lib/ceph/radosgw/{cluster}-rgw.{hostname}/keyring osd dump".format(
+            hostname=node["vars"]["inventory_hostname"],
+            cluster=node['cluster_name']
+        )
         output = host.check_output(cmd)
         pools = node["vars"]["rgw_create_pools"]
         for pool_name, pg_num in pools.items():
@@ -31,7 +37,7 @@ class TestRGWs(object):
     def test_docker_rgw_tuning_pools_are_set(self, node, host):
         hostname = node["vars"]["inventory_hostname"]
         cluster = node['cluster_name']
-        cmd = "sudo docker exec ceph-rgw-{hostname} ceph --cluster={cluster} --connect-timeout 5 osd dump".format(
+        cmd = "sudo docker exec ceph-rgw-{hostname} ceph --cluster={cluster} -n client.rgw.{hostname} --connect-timeout 5 --keyring /var/lib/ceph/radosgw/{cluster}-rgw.{hostname}/keyring  osd dump".format(
             hostname=hostname,
             cluster=cluster
         )


### PR DESCRIPTION
41b4632 has introduced a change in functionnals tests.
Since the admin keyring isn't copied on rgw nodes anymore in tests, let's use
the rgw keyring to achieve them.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>