### PR TITLE
Backport: playbook: follow up on #2553 in stable-3.0

### DIFF
--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -27,7 +27,7 @@
     - name: gather facts
       setup:
       when:
-        - not delegate_facts_host | bool or inventory_hostname in groups.get('clients', [])
+        - not delegate_facts_host | bool
 
     - name: gather and delegate facts
       setup:


### PR DESCRIPTION
Since we fixed the `gather and delegate facts` task, this exception is
not needed anymore. It's a leftover that should be removed to save some
time when deploying a cluster with a large client number.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 828848017cefd981e14ca9e4690dd7d1320f0eef)