### PR TITLE
tests: add a dummy value for 'dev' release

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,8 @@ def node(host, request):
       'jewel': 10,
       'kraken': 11,
       'luminous': 12,
-      'mimic': 13
+      'mimic': 13,
+      'dev': 99
     }
     if not request.node.get_marker(node_type) and not request.node.get_marker('all'):
         pytest.skip("Not a valid test for node type: %s" % node_type)


### PR DESCRIPTION
Functional tests are broken when testing against 'dev' release (ceph).
Adding a dummy value here will fix them.

Typical error:

```
>       if request.node.get_marker("from_luminous") and ceph_release_num[ceph_stable_release] < ceph_release_num['luminous']:
E       KeyError: 'dev'
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>