### PR TITLE
client: use dummy created container when there is no mon in inventory

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -26,12 +26,6 @@
   run_once: true
   when: containerized_deployment
 
-- name: set docker_exec_client_cmd for containers
-  set_fact:
-    docker_exec_client_cmd: "docker exec ceph-create-keys"
-  run_once: true
-  when: containerized_deployment
-
 - name: set_fact delegated_node
   set_fact:
     delegated_node: "{{ groups[mon_group_name][0] if groups.get(mon_group_name, []) | length > 0 else inventory_hostname }}"
@@ -42,7 +36,7 @@
 
 - name: set_fact docker_exec_cmd
   set_fact:
-    docker_exec_cmd: "docker exec {% if groups.get(mon_group_name, []) | length > 0 -%} ceph-mon-{{ hostvars[delegated_node]['ansible_hostname'] }} {% else %} ceph-client-{{ hostvars[delegated_node]['ansible_hostname'] }} {% endif %}"
+    docker_exec_cmd: "docker exec {% if groups.get(mon_group_name, []) | length > 0 -%} ceph-mon-{{ hostvars[delegated_node]['ansible_hostname'] }} {% else %} ceph-create-keys {% endif %}"
   when:
     - containerized_deployment
 
@@ -52,13 +46,14 @@
     name: "{{ item.name }}"
     caps: "{{ item.caps }}"
     secret: "{{ item.key | default('') }}"
-    containerized: "{{ docker_exec_client_cmd | default('') }}"
+    containerized: "{{ docker_exec_cmd | default('') }}"
     cluster: "{{ cluster }}"
     dest: "{{ ceph_conf_key_directory }}"
     import_key: "{{ copy_admin_key }}"
     mode: "{{ item.mode|default(omit) }}"
   with_items: "{{ keys }}"
   run_once: true
+  delegate_to: "{{ delegated_node }}"
   when:
     - cephx
     - keys | length > 0
@@ -71,6 +66,7 @@
     - "{{ keys }}"
   register: slurp_client_keys
   run_once: true
+  delegate_to: "{{ delegated_node }}"
   when:
     - cephx
     - keys | length > 0


### PR DESCRIPTION
the `docker_exec_cmd` fact set in client role when there is no monitor
in inventory is wrong, `ceph-client-{{ hostname }}` is never created so
it will fail anyway.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>