### PR TITLE
osd: copy openstack keys over to all mon

### DIFF
--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -82,4 +82,4 @@
   when:
     - cephx
     - openstack_config
-    - item.0 != groups[mon_group_name] | last
+    - item.0 != groups[mon_group_name]


### PR DESCRIPTION
When configuring openstack, the created keyrings aren't copied over to
all monitors nodes.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1588093

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>