### PR TITLE
Backport: mon: copy openstack keys over to all mon in stable-3.0

### DIFF
--- a/roles/ceph-mon/tasks/openstack_config.yml
+++ b/roles/ceph-mon/tasks/openstack_config.yml
@@ -56,7 +56,7 @@
   when:
     - cephx
     - openstack_config
-    - item.0 != groups[mon_group_name] | last
+    - item.0 != groups[mon_group_name]
 
 - name: chmod openstack key(s) on the other mons and this mon
   file:


### PR DESCRIPTION
When configuring openstack, the created keyrings aren't copied over to
all monitors nodes.

This should have been backported from
433ecc7cbcc1ac91cab509dabe5c647d58c18c7f but this would implie too much
changes.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1588093

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>