### PR TITLE
tests: increase ssh timeout and retries in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -24,7 +24,7 @@ retry_files_enabled = False
 # This is the default SSH timeout to use on connection attempts
 # CI slaves are slow so by setting a higher value we can avoid the following error:
 # Timeout (12s) waiting for privilege escalation prompt:
-timeout = 30
+timeout = 60
 
 [ssh_connection]
 # see: https://github.com/ansible/ansible/issues/11536
@@ -33,4 +33,4 @@ ssh_args = -o ControlMaster=auto -o ControlPersist=600s
 pipelining = True 
 
 # Option to retry failed ssh executions if the failure is encountered in ssh itself
-retries = 5
+retries = 10


### PR DESCRIPTION
We see quite a few failures in the CI related to testing nodes losing
ssh connection. This modification allows ansible to retry more times and
wait longer before timing out. This seems to really affect testing
scenarios that use a large amount of testing nodes. The centos7_cluster
scenario specifically has 12 nodes and suffered from these failures
often.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>