### PR TITLE
tox: use latest ansible 2.4.x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -163,7 +163,7 @@ deps=
   ansible2.2: -r{toxinidir}/tests/requirements2.2.txt
   ansible2.3: ansible==2.3.1
   ansible2.3: -r{toxinidir}/tests/requirements2.2.txt
-  ansible2.4: ansible==2.4.2
+  ansible2.4: ansible~=2.4
   ansible2.4: -r{toxinidir}/tests/requirements2.4.txt
   ansible2.5: ansible==2.5.0
   ansible2.5: -r{toxinidir}/tests/requirements2.5.txt


### PR DESCRIPTION
Follow up on https://github.com/ceph/ceph-ansible/pull/2632 we want to
pin the latest version of the 2.4 Ansible release.

Signed-off-by: Sébastien Han <seb@redhat.com>