### PR TITLE
ceph-mon: Fix to run secure cluster only once in a run

### DIFF
--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -21,6 +21,8 @@
 
 - name: include secure_cluster.yml
   include: secure_cluster.yml
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
   when:
     - secure_cluster
     - not containerized_deployment


### PR DESCRIPTION
The current secure cluster play runs with all the monitors. The rerun
of this task is unnecessary and can be skipped.

Fixes: #2737

Signed-off-by: Vishal Kanaujia <vishal.kanaujia@flipkart.com>