### PR TITLE
ceph-osd: set 'openstack_keys_tmp' only when 'openstack_config' is defined.

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -86,6 +86,7 @@
     openstack_keys_tmp: "{{ openstack_keys_tmp|default([]) + [ { 'key': item.key, 'name': item.name, 'caps': { 'mon': item.mon_cap, 'osd': item.osd_cap|default(''), 'mds': item.mds_cap|default(''), 'mgr': item.mgr_cap|default('') } , 'mode': item.mode } ] }}"
   with_items: "{{ openstack_keys }}"
   when:
+    - openstack_config
     - item.get('mon_cap', None) # it's enough to assume we are running an old-fashionned syntax simply by checking the presence of mon_cap since every key needs this cap
 
 - name: set_fact keys - override keys_tmp with keys


### PR DESCRIPTION
If 'openstack_config' is false this task shouldn't be executed.