### PR TITLE
validate: be more explicit with error msg when notario isn't installed

### DIFF
--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -10,7 +10,7 @@ except ImportError:
 try:
     import notario
 except ImportError:
-    msg = "The python-notario library is missing. Please install it to continue."
+    msg = "The python-notario library is missing. Please install it on the node you are running ceph-ansible to continue."
     display.error(msg)
     raise SystemExit(msg)
 


### PR DESCRIPTION
This error message may be confusing and need to be more explicit on
where you have to install notario, indeed, people may think this library
must be installed on configured nodes while it must be installed on the
node you are running the playbook.

Fixes: #2649

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>