### PR TITLE
tests: increase memory to 1024Mb for centos7_cluster scenario

### DIFF
--- a/tests/functional/centos/7/cluster/vagrant_variables.yml
+++ b/tests/functional/centos/7/cluster/vagrant_variables.yml
@@ -27,7 +27,7 @@ cluster_subnet: 192.168.2
 
 # MEMORY
 # set 1024 for CentOS
-memory: 512
+memory: 1024
 
 # Ethernet interface name
 # use eth1 for libvirt and ubuntu precise, enp0s8 for CentOS and ubuntu xenial


### PR DESCRIPTION
we see more and more failure like `fatal: [mon0]: UNREACHABLE! => {}` in
`centos7_cluster` scenario, Since we have 30Gb RAM on hypervisors, we
can give monitors a bit more RAM. By the way, nodes on containerized cluster
testing scenario have already 1024Mb memory allocated.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>