### PR TITLE
rolling_update: remove the re-run of just the ceph-osd role

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -340,7 +340,6 @@
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-config
-    - ceph-osd
 
   post_tasks:
     - name: get osd numbers


### PR DESCRIPTION
Fixes: #2709

Since a rolling update is performed on an already configured cluster,
re-run of this roles is actually not required.

Signed-off-by: TamizharasiS <t.shanmugam@flipkart.com>