### PR TITLE
common: ability to enable/disable fw configuration

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -62,6 +62,11 @@ dummy:
 # want to set this to False to skip those checks.
 #check_firewall: False
 
+# If configure_firewall is true, then ansible will try to configure the
+# appropriate firewalling rules so that Ceph daemons can communicate
+# with each others.
+#configure_firewall: False
+
 # Open ports on corresponding nodes if firewall is installed on it
 #ceph_mon_firewall_zone: public
 #ceph_mgr_firewall_zone: public
@@ -72,6 +77,7 @@ dummy:
 #ceph_restapi_firewall_zone: public
 #ceph_rbdmirror_firewall_zone: public
 #ceph_iscsi_firewall_zone: public
+
 
 ############
 # PACKAGES #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -62,6 +62,11 @@ fetch_directory: ~/ceph-ansible-keys
 # want to set this to False to skip those checks.
 #check_firewall: False
 
+# If configure_firewall is true, then ansible will try to configure the
+# appropriate firewalling rules so that Ceph daemons can communicate
+# with each others.
+#configure_firewall: False
+
 # Open ports on corresponding nodes if firewall is installed on it
 #ceph_mon_firewall_zone: public
 #ceph_mgr_firewall_zone: public
@@ -72,6 +77,7 @@ fetch_directory: ~/ceph-ansible-keys
 #ceph_restapi_firewall_zone: public
 #ceph_rbdmirror_firewall_zone: public
 #ceph_iscsi_firewall_zone: public
+
 
 ############
 # PACKAGES #

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -79,6 +79,7 @@
 - name: include misc/configure_firewall_rpm.yml
   include: misc/configure_firewall_rpm.yml
   when:
+    - configure_firewall
     - ansible_os_family in ['RedHat', 'Suse']
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -54,6 +54,11 @@ mgr_group_name: mgrs
 # want to set this to False to skip those checks.
 check_firewall: False
 
+# If configure_firewall is true, then ansible will try to configure the
+# appropriate firewalling rules so that Ceph daemons can communicate
+# with each others.
+configure_firewall: False
+
 # Open ports on corresponding nodes if firewall is installed on it
 ceph_mon_firewall_zone: public
 ceph_mgr_firewall_zone: public
@@ -64,6 +69,7 @@ ceph_nfs_firewall_zone: public
 ceph_restapi_firewall_zone: public
 ceph_rbdmirror_firewall_zone: public
 ceph_iscsi_firewall_zone: public
+
 
 ############
 # PACKAGES #


### PR DESCRIPTION
Prior to this patch if you were running on a Red Hat system,
ceph-ansible would try to configure firewalld for you without the
operators's consent.
Now you can enable or disable the fw configuration by setting
configure_firewall to either true or false.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1589146
Signed-off-by: Sébastien Han <seb@redhat.com>