### PR TITLE
[skip ci] Backport of 2748 in stable-3.1

### DIFF
--- a/tests/functional/centos/7/cluster/vagrant_variables.yml
+++ b/tests/functional/centos/7/cluster/vagrant_variables.yml
@@ -27,7 +27,7 @@ cluster_subnet: 192.168.2
 
 # MEMORY
 # set 1024 for CentOS
-memory: 512
+memory: 1024
 
 # Ethernet interface name
 # use eth1 for libvirt and ubuntu precise, enp0s8 for CentOS and ubuntu xenial


### PR DESCRIPTION
Backport of #2748 in stable-3.1