### PR TITLE
Backport: common: ability to enable/disable fw configuration in stable-3.1

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -61,6 +61,11 @@ dummy:
 # want to set this to False to skip those checks.
 #check_firewall: False
 
+# If configure_firewall is true, then ansible will try to configure the
+# appropriate firewalling rules so that Ceph daemons can communicate
+# with each others.
+#configure_firewall: False
+
 # Open ports on corresponding nodes if firewall is installed on it
 #ceph_mon_firewall_zone: public
 #ceph_osd_firewall_zone: public
@@ -70,6 +75,7 @@ dummy:
 #ceph_restapi_firewall_zone: public
 #ceph_rbdmirror_firewall_zone: public
 #ceph_iscsi_firewall_zone: public
+
 
 ############
 # PACKAGES #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -61,6 +61,11 @@ fetch_directory: ~/ceph-ansible-keys
 # want to set this to False to skip those checks.
 #check_firewall: False
 
+# If configure_firewall is true, then ansible will try to configure the
+# appropriate firewalling rules so that Ceph daemons can communicate
+# with each others.
+#configure_firewall: False
+
 # Open ports on corresponding nodes if firewall is installed on it
 #ceph_mon_firewall_zone: public
 #ceph_osd_firewall_zone: public
@@ -70,6 +75,7 @@ fetch_directory: ~/ceph-ansible-keys
 #ceph_restapi_firewall_zone: public
 #ceph_rbdmirror_firewall_zone: public
 #ceph_iscsi_firewall_zone: public
+
 
 ############
 # PACKAGES #

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -89,6 +89,14 @@
   tags:
     - always
 
+- name: include misc/configure_firewall_rpm.yml
+  include: misc/configure_firewall_rpm.yml
+  when:
+    - configure_firewall
+    - ansible_os_family in ['RedHat', 'Suse']
+  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
+  static: False
+
 - name: include facts_mon_fsid.yml
   include: facts_mon_fsid.yml
   run_once: true

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -53,6 +53,11 @@ mgr_group_name: mgrs
 # want to set this to False to skip those checks.
 check_firewall: False
 
+# If configure_firewall is true, then ansible will try to configure the
+# appropriate firewalling rules so that Ceph daemons can communicate
+# with each others.
+configure_firewall: False
+
 # Open ports on corresponding nodes if firewall is installed on it
 ceph_mon_firewall_zone: public
 ceph_osd_firewall_zone: public
@@ -62,6 +67,7 @@ ceph_nfs_firewall_zone: public
 ceph_restapi_firewall_zone: public
 ceph_rbdmirror_firewall_zone: public
 ceph_iscsi_firewall_zone: public
+
 
 ############
 # PACKAGES #


### PR DESCRIPTION
Prior to this patch if you were running on a Red Hat system,
ceph-ansible would try to configure firewalld for you without the
operators's consent.
Now you can enable or disable the fw configuration by setting
configure_firewall to either true or false.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1589146
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 2e8412734a81077c2b11de316e08bbecbed2de96)