### PR TITLE
DNM: tests: test against ceph luminous when 'luminous' scenarios in stable-3.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -150,8 +150,9 @@ setenv=
   jewel: UPDATE_CEPH_STABLE_RELEASE = luminous
   jewel: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-luminous
   luminous: CEPH_STABLE_RELEASE = luminous
+  luminous: CEPH_DOCKER_IMAGE_TAG = latest-luminous
   luminous: UPDATE_CEPH_STABLE_RELEASE = luminous
-  luminous: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest  # Currently L is the latest stable release so it should point to 'latest'
+  luminous: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest
   lvm_osds: CEPH_STABLE_RELEASE = luminous
 deps=
   ansible2.2: ansible==2.2.3


### PR DESCRIPTION
since ceph-container image 'latest' ships ceph mimic, we must force
'luminous' scenarios to use 'latest-luminous' docker image tag.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>