### PR TITLE
tests: keep same ceph release during handlers/idempotency test

### DIFF
--- a/tests/functional/centos/7/cluster/ceph-override.json
+++ b/tests/functional/centos/7/cluster/ceph-override.json
@@ -5,6 +5,5 @@
 			"osd_pool_default_size": 1
 		}
 	},
-  "ceph_docker_image_tag": "latest-bis",
   "ceph_mon_docker_memory_limit": "2g"
 }

--- a/tox.ini
+++ b/tox.ini
@@ -150,6 +150,8 @@ setenv=
   jewel: UPDATE_CEPH_STABLE_RELEASE = luminous
   jewel: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-luminous
   luminous: CEPH_STABLE_RELEASE = luminous
+  luminous: CEPH_DOCKER_IMAGE_TAG = latest-luminous
+  luminous: CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-luminous
   luminous: UPDATE_CEPH_STABLE_RELEASE = luminous
   luminous: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest  # Currently L is the latest stable release so it should point to 'latest'
   lvm_osds: CEPH_STABLE_RELEASE = luminous
@@ -238,7 +240,7 @@ commands=
       ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-bis} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} " \
       --extra-vars @ceph-override.json


### PR DESCRIPTION
since `latest` points to `mimic`, we need to force the test to keep the
same ceph release when testing anything else than `mimic`.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 21894655a7eaf0db6c99a46955e0e8ebc59a83af)