### PR TITLE
common: start firewalld if configure_firewall

### DIFF
--- a/roles/ceph-common/tasks/misc/configure_firewall_rpm.yml
+++ b/roles/ceph-common/tasks/misc/configure_firewall_rpm.yml
@@ -10,6 +10,14 @@
   tags:
     - firewall
 
+- name: start firewalld
+  service:
+    name: firewalld
+    state: started
+    enabled: yes
+  when:
+    - firewalld_pkg_query.rc == 0
+
 - name: open monitor ports
   firewalld:
     service: ceph-mon


### PR DESCRIPTION
Currently we expect that if configure_firewall is set to True to have
firewalld enabled and running. Let's enforce that.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1589146
Signed-off-by: Sébastien Han <seb@redhat.com>