### PR TITLE
Backport: mon/osd: bump container memory limit in stable-3.0

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -118,7 +118,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mon_docker_extra_env' variable.
-#ceph_mon_docker_memory_limit: 1g
+#ceph_mon_docker_memory_limit: 3g
 #ceph_mon_docker_cpu_limit: 1
 
 # Use this variable to add extra env configuration to run your mon container.

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -235,7 +235,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
-#ceph_osd_docker_memory_limit: 3g
+#ceph_osd_docker_memory_limit: 5g
 #ceph_osd_docker_cpu_limit: 1
 
 # PREPARE DEVICE

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -110,7 +110,7 @@ openstack_keys:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mon_docker_extra_env' variable.
-ceph_mon_docker_memory_limit: 1g
+ceph_mon_docker_memory_limit: 3g
 ceph_mon_docker_cpu_limit: 1
 
 # Use this variable to add extra env configuration to run your mon container.

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -227,7 +227,7 @@ ceph_config_keys: [] # DON'T TOUCH ME
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
-ceph_osd_docker_memory_limit: 3g
+ceph_osd_docker_memory_limit: 5g
 ceph_osd_docker_cpu_limit: 1
 
 # PREPARE DEVICE


### PR DESCRIPTION
Backport of #2775 in stable-3.0

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1591876