### PR TITLE
reset failed count of ceph-mgr

### DIFF
--- a/roles/ceph-defaults/templates/restart_mgr_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_mgr_daemon.sh.j2
@@ -8,6 +8,7 @@ SOCKET=/var/run/ceph/{{ cluster }}-mgr.${MGR_NAME}.asok
 DOCKER_EXEC="docker exec ceph-mgr-{{ ansible_hostname }}"
 {% endif %}
 
+systemctl reset-failed ceph-mgr@${MGR_NAME}
 # First, restart the daemon
 systemctl restart ceph-mgr@${MGR_NAME}
 


### PR DESCRIPTION
Depending on your setup, ceph-mgr might get restarted multiple times.
When this is done to fast, systemd will prevent further restarts because of
configured limits in the ceph-mgr systemd unit file.

Resetting the failure count will prevent this problem. The reset is done before
the restart so in case of a real problem during the restart it still fails.

Fixes: #2768