### PR TITLE
tests: add more verbosity in testinfra

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands=
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
   # test that the cluster can be redeployed in a healthy state
-  testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
+  testinfra -ra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
 
 [purge-lvm]
 commands=
@@ -60,7 +60,7 @@ commands=
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
   # test that the cluster can be redeployed in a healthy state
-  testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
+  testinfra -ra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
 
 # extra commands for performing a rolling update
 # currently this hardcodes the release to kraken
@@ -109,7 +109,7 @@ commands=
       ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
   "
 
-  testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-switch-to-containers {toxinidir}/tests/functional/tests
+  testinfra -ra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-switch-to-containers {toxinidir}/tests/functional/tests
 
 [testenv]
 whitelist_externals =
@@ -232,7 +232,7 @@ commands=
   # wait 2 minutes for services to be ready
   sleep 120
   # test cluster state using ceph-ansible tests
-  testinfra -n 8 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
+  testinfra -ra -n 8 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
 
   # reboot all vms
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/reboot.yml
@@ -240,7 +240,7 @@ commands=
   # wait 2 minutes for services to be ready
   sleep 120
   # retest to ensure cluster came back up correctly after rebooting
-  testinfra -n 8 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
+  testinfra -ra -n 8 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
 
   # handlers/idempotency test
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} \


### PR DESCRIPTION
that may be helpful to know why a test has been skipped.

from pytest doc:

```
  -r chars              show extra test summary info as specified by chars
                        (f)ailed, (E)error, (s)skipped, (x)failed, (X)passed,
                        (p)passed, (P)passed with output, (a)all except pP.
                        Warnings are displayed at all times except when
                        --disable-warnings is set
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>