### PR TITLE
tests: fix *_has_correct_value tests

### DIFF
--- a/tests/functional/tests/mon/test_mons.py
+++ b/tests/functional/tests/mon/test_mons.py
@@ -1,5 +1,5 @@
 import pytest
-
+import re
 
 class TestMons(object):
 
@@ -31,11 +31,14 @@ class TestMons(object):
     def test_ceph_config_has_inital_members_line(self, node, File):
         assert File(node["conf_path"]).contains("^mon initial members = .*$")
 
-    def test_initial_members_line_has_correct_value(self, node, File):
-        mons = ",".join("%s" % host
-                        for host in node["vars"]["groups"]["mons"])
-        line = "mon initial members = {}".format(mons)
-        assert File(node["conf_path"]).contains(line)
+    def test_initial_members_line_has_correct_value(self, node, host, File):
+        mon_initial_members_line = host.check_output("grep 'mon initial members = ' /etc/ceph/{cluster}.conf".format(cluster=node['cluster_name']))
+        result = True
+        for host in node["vars"]["groups"]["mons"]:
+            pattern = re.compile(host)
+            if pattern.search(mon_initial_members_line) == None:
+                result = False
+                assert result
 
 
 class TestOSDs(object):

--- a/tests/functional/tests/test_install.py
+++ b/tests/functional/tests/test_install.py
@@ -1,5 +1,5 @@
 import pytest
-
+import re
 
 class TestInstall(object):
 
@@ -26,8 +26,10 @@ class TestCephConf(object):
         assert File(node["conf_path"]).contains("^mon host = .*$")
 
     def test_mon_host_line_has_correct_value(self, node, host):
-        mon_ips = []
+        mon_host_line = host.check_output("grep 'mon host = ' /etc/ceph/{cluster}.conf".format(cluster=node['cluster_name']))
+        result=True
         for x in range(0, node["num_mons"]):
-            mon_ips.append("{}.1{}".format(node["subnet"], x))
-        line = "mon host = {}".format(",".join(mon_ips))
-        assert host.file(node["conf_path"]).contains(line)
+            pattern=re.compile(("{}.1{}".format(node["subnet"], x)))
+            if pattern.search(mon_host_line) == None:
+                result=False
+            assert result


### PR DESCRIPTION
It might happen that the list of ips/hosts in following line (ceph.conf)
- `mon initial memebers = <hosts>`
- `mon host = <ips>`

are not ordered the same way depending on deployment.

This patch makes the tests looking for each ip or hostname in respective
lines.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>