### PR TITLE
tests: fix broken test when collocated daemons scenarios

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,8 +89,6 @@ def node(host, request):
         num_devices = len(ansible_vars.get("devices", []))
     if not num_devices:
         num_devices = len(ansible_vars.get("lvm_volumes", []))
-    num_osd_hosts = len(ansible_vars["groups"]["osds"])
-    total_osds = num_devices * num_osd_hosts
     cluster_name = ansible_vars.get("cluster", "ceph")
     conf_path = "/etc/ceph/{}.conf".format(cluster_name)
     if "osds" in group_names:
@@ -116,8 +114,6 @@ def node(host, request):
         osd_ids=osd_ids,
         num_mons=num_mons,
         num_devices=num_devices,
-        num_osd_hosts=num_osd_hosts,
-        total_osds=total_osds,
         cluster_name=cluster_name,
         conf_path=conf_path,
         cluster_address=cluster_address,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def node(host, request):
     if "nfss" in group_names and ceph_stable_release == "jewel":
         pytest.skip("nfs nodes can not be tested with ceph release jewel")
 
-    if "iscsigws" in group_names and ceph_stable_release == "jewel":
+    if group_names == ["iscsigws"] and ceph_stable_release == "jewel":
         pytest.skip("iscsigws nodes can not be tested with ceph release jewel")  # noqa E501
 
     if request.node.get_closest_marker("from_luminous") and ceph_release_num[ceph_stable_release] < ceph_release_num['luminous']:  # noqa E501

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def node(host, request):
     # because testinfra does not collect and provide ansible config passed in
     # from using --extra-vars
     ceph_stable_release = os.environ.get("CEPH_STABLE_RELEASE", "luminous")
-    node_type = ansible_vars["group_names"][0]
+    group_names = ansible_vars["group_names"]
     docker = ansible_vars.get("docker")
     osd_auto_discovery = ansible_vars.get("osd_auto_discovery")
     lvm_scenario = ansible_vars.get("osd_scenario") == 'lvm'
@@ -29,41 +29,50 @@ def node(host, request):
         'mimic': 13,
         'dev': 99
     }
-    if not request.node.get_marker(node_type) and not request.node.get_marker('all'):  # noqa E501
-        pytest.skip("Not a valid test for node type: %s" % node_type)
 
-    if request.node.get_marker("no_lvm_scenario") and lvm_scenario:
+    # capture the initial/default state
+    test_is_applicable = False
+    for marker in request.node.iter_markers():
+        if marker.name in group_names or marker.name == 'all':
+            test_is_applicable = True
+            break
+    # Check if any markers on the test method exist in the nodes group_names. If they do not, this test is not valid for the node being tested.
+    if not test_is_applicable:
+        reason = "%s: Not a valid test for node type: %s" % (request.function, group_names)
+        pytest.skip(reason)
+
+    if request.node.get_closest_marker("no_lvm_scenario") and lvm_scenario:
         pytest.skip("Not a valid test for lvm scenarios")
 
-    if not lvm_scenario and request.node.get_marker("lvm_scenario"):
+    if not lvm_scenario and request.node.get_closest_marker("lvm_scenario"):
         pytest.skip("Not a valid test for non-lvm scenarios")
 
-    if request.node.get_marker("no_docker") and docker:
+    if request.node.get_closest_marker("no_docker") and docker:
         pytest.skip(
             "Not a valid test for containerized deployments or atomic hosts")
 
-    if request.node.get_marker("docker") and not docker:
+    if request.node.get_closest_marker("docker") and not docker:
         pytest.skip(
             "Not a valid test for non-containerized deployments or atomic hosts")  # noqa E501
 
-    if node_type == "mgrs" and ceph_stable_release == "jewel":
+    if "mgrs" in group_names and ceph_stable_release == "jewel":
         pytest.skip("mgr nodes can not be tested with ceph release jewel")
 
-    if node_type == "nfss" and ceph_stable_release == "jewel":
+    if "nfss" in group_names and ceph_stable_release == "jewel":
         pytest.skip("nfs nodes can not be tested with ceph release jewel")
 
-    if node_type == "iscsigws" and ceph_stable_release == "jewel":
+    if "iscsigws" in group_names and ceph_stable_release == "jewel":
         pytest.skip("iscsigws nodes can not be tested with ceph release jewel")  # noqa E501
 
-    if request.node.get_marker("from_luminous") and ceph_release_num[ceph_stable_release] < ceph_release_num['luminous']:  # noqa E501
+    if request.node.get_closest_marker("from_luminous") and ceph_release_num[ceph_stable_release] < ceph_release_num['luminous']:  # noqa E501
         pytest.skip(
             "This test is only valid for releases starting from Luminous and above")  # noqa E501
 
-    if request.node.get_marker("before_luminous") and ceph_release_num[ceph_stable_release] >= ceph_release_num['luminous']:  # noqa E501
+    if request.node.get_closest_marker("before_luminous") and ceph_release_num[ceph_stable_release] >= ceph_release_num['luminous']:  # noqa E501
         pytest.skip("This test is only valid for release before Luminous")
 
     journal_collocation_test = ansible_vars.get("osd_scenario") == "collocated"
-    if request.node.get_marker("journal_collocation") and not journal_collocation_test:  # noqa E501
+    if request.node.get_closest_marker("journal_collocation") and not journal_collocation_test:  # noqa E501
         pytest.skip("Scenario is not using journal collocation")
 
     osd_ids = []
@@ -84,7 +93,7 @@ def node(host, request):
     total_osds = num_devices * num_osd_hosts
     cluster_name = ansible_vars.get("cluster", "ceph")
     conf_path = "/etc/ceph/{}.conf".format(cluster_name)
-    if node_type == "osds":
+    if "osds" in group_names:
         # I can assume eth2 because I know all the vagrant
         # boxes we test with use that interface. OSDs are the only
         # nodes that have this interface.

--- a/tests/functional/tests/mon/test_mons.py
+++ b/tests/functional/tests/mon/test_mons.py
@@ -40,22 +40,3 @@ class TestMons(object):
                 result = False
                 assert result
 
-
-class TestOSDs(object):
-
-    @pytest.mark.no_docker
-    def test_all_osds_are_up_and_in(self, node, host):
-        cmd = "sudo ceph --cluster={} --connect-timeout 5 -s".format(node["cluster_name"])
-        output = host.check_output(cmd)
-        phrase = "{num_osds} osds: {num_osds} up, {num_osds} in".format(num_osds=node["total_osds"])
-        assert phrase in output
-
-    @pytest.mark.docker
-    def test_all_docker_osds_are_up_and_in(self, node, host):
-        cmd = "sudo docker exec ceph-mon-{} ceph --cluster={} --connect-timeout 5 -s".format(
-            node["vars"]["inventory_hostname"],
-            node["cluster_name"]
-        )
-        output = host.check_output(cmd)
-        phrase = "{num_osds} osds: {num_osds} up, {num_osds} in".format(num_osds=node["total_osds"])
-        assert phrase in output

--- a/tests/functional/tests/osd/test_osds.py
+++ b/tests/functional/tests/osd/test_osds.py
@@ -1,4 +1,6 @@
 import pytest
+import json
+import os
 
 
 class TestOSDs(object):
@@ -45,3 +47,32 @@ class TestOSDs(object):
     @pytest.mark.lvm_scenario
     def test_ceph_volume_systemd_is_installed(self, node, host):
         host.exists('ceph-volume-systemd')
+
+    def _get_osd_id_from_host(self, node, osd_tree):
+        for n in osd_tree['nodes']:
+            if n['name'] == node['vars']['inventory_hostname'] and n['type'] == 'host':
+                children = n['children']
+        return children
+
+    def _get_nb_up_osds_from_ids(self, node, osd_tree):
+        nb_up = 0
+        ids = self._get_osd_id_from_host(node, osd_tree)
+        for n in osd_tree['nodes']:
+            if n['id'] in ids and n['status'] == 'up':
+                nb_up += 1
+        return nb_up
+
+    @pytest.mark.no_docker
+    def test_all_osds_are_up_and_in(self, node, host):
+        cmd = "sudo ceph --cluster={cluster} --connect-timeout 5 --keyring /var/lib/ceph/bootstrap-osd/{cluster}.keyring -n client.bootstrap-osd osd tree -f json".format(cluster=node["cluster_name"])
+        output = json.loads(host.check_output(cmd))
+        assert node["num_devices"] == self._get_nb_up_osds_from_ids(node, output)
+
+    @pytest.mark.docker
+    def test_all_docker_osds_are_up_and_in(self, node, host):
+        cmd = "sudo docker exec ceph-osd-{hostname}-sda ceph --cluster={cluster} --connect-timeout 5 --keyring /var/lib/ceph/bootstrap-osd/{cluster}.keyring -n client.bootstrap-osd osd tree -f json".format(
+            hostname=node["vars"]["inventory_hostname"],
+            cluster=node["cluster_name"]
+        )
+        output = json.loads(host.check_output(cmd))
+        assert node["num_devices"] == self._get_nb_up_osds_from_ids(node, output)

--- a/tests/functional/tests/rgw/test_rgw_tuning.py
+++ b/tests/functional/tests/rgw/test_rgw_tuning.py
@@ -42,7 +42,9 @@ class TestRGWs(object):
             cluster=cluster
         )
         output = host.check_output(cmd)
-        pools = node["vars"]["rgw_create_pools"]
+        pools = node["vars"].get("rgw_create_pools")
+        if pools == None:
+            pytest.skip('rgw_create_pools not defined, nothing to test')
         for pool_name, pg_num in pools.items():
             assert pool_name in output
             pg_num_str = "pg_num {pg_num}".format(pg_num=pg_num["pg_num"])

--- a/tests/requirements2.4.txt
+++ b/tests/requirements2.4.txt
@@ -2,4 +2,5 @@
 # testinfra < 1.7.1 does not work Ansible 2.4, see https://github.com/philpep/testinfra/issues/249
 testinfra==1.7.1
 pytest-xdist
+pytest==3.6.1
 notario>=0.0.13


### PR DESCRIPTION
At the moment, a lot of tests are skipped when daemons are collocated.
Our tests consider a node belong to only 1 group while it's possible for
certain scenario it can belong to multiple groups.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>