### PR TITLE
ceph-mon: Generate initial keyring

### DIFF
--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -2,7 +2,7 @@
 - name: generate monitor initial keyring
   local_action:
     module: shell
-      python -c "import os ; import struct ; import time; import base64 ; key = os.urandom(16) ; header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ; print base64.b64encode(header + key)" | tee {{ fetch_directory }}/monitor_keyring.conf
+      python -c "import os ; import struct ; import time; import base64 ; key = os.urandom(16) ; header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ; print(base64.b64encode(header + key).decode())" | tee {{ fetch_directory }}/monitor_keyring.conf
     creates: "{{ fetch_directory }}/monitor_keyring.conf"
   register: monitor_keyring
   become: false


### PR DESCRIPTION
Minor fix so that initial keyring can be generated using python3.

Signed-off-by: Ha Phan <thanhha.work@gmail.com>