### PR TITLE
Add keyring_permissions var  to set permissions for keyring files

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,10 @@
+rules:
+  default:
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - DCO
+          - "Testing: ceph-ansible PR Pipeline"
+      required_pull_request_reviews:
+        required_approving_review_count: 1

--- a/group_vars/ceph-fetch-keys.yml.sample
+++ b/group_vars/ceph-fetch-keys.yml.sample
@@ -10,4 +10,6 @@ dummy:
 
 #fetch_directory: fetch/
 #cluster: ceph
+# Permissions for client keyring files
+#keyring_permissions: '0600'
 

--- a/group_vars/clients.yml.sample
+++ b/group_vars/clients.yml.sample
@@ -38,6 +38,9 @@ dummy:
 #  - "{{ test }}"
 #  - "{{ test2 }}"
 
+# Permissions for client keyring files
+#keyring_permissions: '0600'
+
 # Generate a keyring using ceph-authtool CLI or python.
 # Eg:
 #  $ ceph-authtool --gen-print-key
@@ -46,8 +49,8 @@ dummy:
 #
 # To use a particular secret, you have to add 'key' to the dict below, so something like:
 # - { name: client.test, key: "AQAin8tUMICVFBAALRHNrV0Z4MXupRw4v9JQ6Q==" ...
-#
+
 #keys:
-#  - { name: client.test, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test" },  mode: "0600" }
-#  - { name: client.test2, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test2" },  mode: "0600" }
+#  - { name: client.test, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test" },  mode: "{{ keyring_permissions }}" }
+#  - { name: client.test2, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test2" },  mode: "{{ keyring_permissions }}" }
 

--- a/group_vars/iscsigws.yml.sample
+++ b/group_vars/iscsigws.yml.sample
@@ -64,6 +64,8 @@ dummy:
 # Whether or not to generate secure certificate to iSCSI gateway nodes
 #generate_crt: False
 
+# Permissions for client keyring files
+#keyring_permissions: '0600'
 
 ##################
 # RBD-TARGET-API #

--- a/group_vars/mdss.yml.sample
+++ b/group_vars/mdss.yml.sample
@@ -19,6 +19,9 @@ dummy:
 # will copy the admin key to the /etc/ceph/ directory
 #copy_admin_key: false
 
+# Permissions for client keyring files
+#keyring_permissions: '0600'
+
 ##########
 # DOCKER #
 ##########

--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -16,6 +16,9 @@ dummy:
 # will copy the admin key to the /etc/ceph/ directory
 #copy_admin_key: false
 
+# Permissions for client keyring files
+#keyring_permissions: '0600'
+
 
 ###########
 # MODULES #

--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -36,6 +36,8 @@ dummy:
 # Enable debugging for Calamari
 #calamari_debug: false
 
+# Permissions for client keyring files
+#keyring_permissions: '0600'
 
 ###############
 # CRUSH RULES #

--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -31,6 +31,9 @@ dummy:
 # can be set by 'ceph_nfs_service_suffix'
 # ceph_nfs_service_suffix: ansible_hostname
 
+# Permissions for client keyring files
+#keyring_permissions: '0600'
+
 #######################
 # Access type options #
 #######################

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -27,6 +27,9 @@ dummy:
 # will copy the admin key to the /etc/ceph/ directory
 #copy_admin_key: false
 
+# Permissions for client keyring files
+#keyring_permissions: '0600'
+
 
 ##############
 # CEPH OPTIONS

--- a/group_vars/rbdmirrors.yml.sample
+++ b/group_vars/rbdmirrors.yml.sample
@@ -23,6 +23,8 @@ dummy:
 # NOTE: deprecated generic local user id for pre-Luminous releases
 #ceph_rbd_mirror_local_user: "admin"
 
+# Permissions for client keyring files
+#keyring_permissions: '0600'
 
 #################
 # CONFIGURATION #

--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -50,6 +50,8 @@ dummy:
 #  foo:
 #    pg_num: 4
 
+# Permissions for client keyring files
+#keyring_permissions: '0600'
 
 ##########
 # DOCKER #

--- a/roles/ceph-client/defaults/main.yml
+++ b/roles/ceph-client/defaults/main.yml
@@ -30,6 +30,9 @@ pools:
   - "{{ test }}"
   - "{{ test2 }}"
 
+# Permissions for client keyring files
+keyring_permissions: '0600'
+
 # Generate a keyring using ceph-authtool CLI or python.
 # Eg:
 #  $ ceph-authtool --gen-print-key
@@ -38,7 +41,7 @@ pools:
 #
 # To use a particular secret, you have to add 'key' to the dict below, so something like:
 # - { name: client.test, key: "AQAin8tUMICVFBAALRHNrV0Z4MXupRw4v9JQ6Q==" ...
-#
+
 keys:
-  - { name: client.test, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test" },  mode: "0600" }
-  - { name: client.test2, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test2" },  mode: "0600" }
+  - { name: client.test, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test" },  mode: "{{ keyring_permissions }}" }
+  - { name: client.test2, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test2" },  mode: "{{ keyring_permissions }}" }

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -5,7 +5,7 @@
     dest: "/etc/ceph/"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   when:
     - cephx
     - copy_admin_key

--- a/roles/ceph-fetch-keys/defaults/main.yml
+++ b/roles/ceph-fetch-keys/defaults/main.yml
@@ -2,3 +2,5 @@
 
 fetch_directory: fetch/
 cluster: ceph
+# Permissions for client keyring files
+keyring_permissions: '0600'

--- a/roles/ceph-fetch-keys/tasks/main.yml
+++ b/roles/ceph-fetch-keys/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: set keys permissions
   file:
     path: "{{ item }}"
-    mode: 0600
+    mode: "{{ keyring_permissions }}"
     owner: root
     group: root
   with_items:

--- a/roles/ceph-iscsi-gw/defaults/main.yml
+++ b/roles/ceph-iscsi-gw/defaults/main.yml
@@ -56,6 +56,8 @@ client_connections: {}
 # Whether or not to generate secure certificate to iSCSI gateway nodes
 generate_crt: False
 
+# Permissions for client keyring files
+keyring_permissions: '0600'
 
 ##################
 # RBD-TARGET-API #

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -11,7 +11,7 @@
     dest: "/etc/ceph/{{ cluster }}.client.admin.keyring"
     owner: "root"
     group: "root"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   when:
     - cephx
 

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -11,6 +11,9 @@
 # will copy the admin key to the /etc/ceph/ directory
 copy_admin_key: false
 
+# Permissions for client keyring files
+keyring_permissions: '0600'
+
 ##########
 # DOCKER #
 ##########

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -16,7 +16,7 @@
     dest: "{{ item.name }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   with_items:
     - { name: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -8,6 +8,9 @@
 # will copy the admin key to the /etc/ceph/ directory
 copy_admin_key: false
 
+# Permissions for client keyring files
+keyring_permissions: '0600'
+
 
 ###########
 # MODULES #

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -13,7 +13,7 @@
     dest: "{{ item.dest }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   with_items:
     - { name: "/etc/ceph/{{ cluster }}.mgr.{{ ansible_hostname }}.keyring", dest: "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", dest: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
@@ -26,6 +26,6 @@
     path: /var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   when:
     - cephx

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -28,6 +28,8 @@ calamari: false
 # Enable debugging for Calamari
 calamari_debug: false
 
+# Permissions for client keyring files
+keyring_permissions: '0600'
 
 ###############
 # CRUSH RULES #

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -98,7 +98,7 @@
     path: "{{ item }}"
     owner: "ceph"
     group: "ceph"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   with_items:
     - "{{ ceph_keys.get('stdout_lines') | default([]) }}"
   when:

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -91,7 +91,7 @@
     state: file
     owner: 'ceph'
     group: 'ceph'
-    mode: '0600'
+    mode: "{{ keyring_permissions }}"
   when:
     - cephx
     - admin_secret != 'admin_secret'

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -23,6 +23,9 @@ ceph_nfs_enable_service: true
 # can be set by 'ceph_nfs_service_suffix'
 # ceph_nfs_service_suffix: ansible_hostname
 
+# Permissions for client keyring files
+keyring_permissions: '0600'
+
 #######################
 # Access type options #
 #######################

--- a/roles/ceph-nfs/tasks/common.yml
+++ b/roles/ceph-nfs/tasks/common.yml
@@ -5,7 +5,7 @@
     dest: "{{ item.name }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   with_items:
     - { name: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -19,6 +19,9 @@ dmcrypt_dedicated_journal: False # backward compatibility with stable-2.2, will 
 # will copy the admin key to the /etc/ceph/ directory
 copy_admin_key: false
 
+# Permissions for client keyring files
+keyring_permissions: '0600'
+
 
 ##############
 # CEPH OPTIONS

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -18,7 +18,7 @@
     dest: "{{ item.name }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   with_items:
     - { name: "/var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }

--- a/roles/ceph-rbd-mirror/defaults/main.yml
+++ b/roles/ceph-rbd-mirror/defaults/main.yml
@@ -15,6 +15,8 @@ copy_admin_key: false
 # NOTE: deprecated generic local user id for pre-Luminous releases
 ceph_rbd_mirror_local_user: "admin"
 
+# Permissions for client keyring files
+keyring_permissions: '0600'
 
 #################
 # CONFIGURATION #

--- a/roles/ceph-rbd-mirror/tasks/common.yml
+++ b/roles/ceph-rbd-mirror/tasks/common.yml
@@ -11,7 +11,7 @@
     dest: "/etc/ceph/"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   when:
     - cephx
     - copy_admin_key
@@ -22,7 +22,7 @@
     dest: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   when:
     - cephx
     - ceph_release_num[ceph_release] >= ceph_release_num.luminous

--- a/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
+++ b/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
@@ -22,7 +22,7 @@
     path: /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring
     owner: "ceph"
     group: "ceph"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   when:
     - cephx
     - ceph_release_num[ceph_release] >= ceph_release_num.luminous

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -42,6 +42,8 @@ rgw_pull_proto: "http"
 #  foo:
 #    pg_num: 4
 
+# Permissions for client keyring files
+keyring_permissions: '0600'
 
 ##########
 # DOCKER #

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -18,7 +18,7 @@
     dest: "{{ item.name }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ keyring_permissions }}"
   with_items:
     - { name: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }


### PR DESCRIPTION
Add keyring_permissions variable to control permissions for keyring
files in /etc/ceph. Default value is the same as it was (0600),
but this variable allows user to override it (f.e. set it to 0640).

Rationale: We are configuring a monitoring for Ceph. It runs under a separate user (telegraf), but this user is included into the ceph group. To have access to the admin keyring it need to have `/etc/ceph/client.admin.keyring` to be at least `rw-r-----` (0640). I added a variable into defaults with the same value as current value in the task, but allow to override it through variable in the inventory/group_vars/host_vars.