### PR TITLE
tests: factorize docker tests using docker_exec_cmd logic

### DIFF
--- a/tests/functional/tests/mds/test_mds.py
+++ b/tests/functional/tests/mds/test_mds.py
@@ -19,21 +19,16 @@ class TestMDSs(object):
         )
         assert host.service(service_name).is_enabled
 
-    @pytest.mark.no_docker
     def test_mds_is_up(self, node, host):
         hostname = node["vars"]["inventory_hostname"]
-        cmd = "sudo ceph --name client.bootstrap-mds --keyring /var/lib/ceph/bootstrap-mds/{cluster}.keyring --cluster={cluster} --connect-timeout 5 -f json -s".format(cluster=node['cluster_name'])
-        cluster_status = json.loads(host.check_output(cmd))
+        if node['docker']:
+            docker_exec_cmd = 'docker exec ceph-mds-{hostname}'.format(hostname=hostname)
+        else:
+            docker_exec_cmd = ''
 
-        assert (cluster_status['fsmap'].get('up', 0) + cluster_status['fsmap'].get('up:standby', 0)) == len(node["vars"]["groups"]["mdss"])
-
-    @pytest.mark.docker
-    def test_docker_mds_is_up(self, node, host):
-        hostname = node["vars"]["inventory_hostname"]
-        cmd = "sudo docker exec ceph-mds-{hostname} ceph --name client.bootstrap-mds --keyring /var/lib/ceph/bootstrap-mds/{cluster}.keyring --cluster={cluster} --connect-timeout 5 -f json -s".format(
-            hostname=node["vars"]["inventory_hostname"],
-            cluster=node["cluster_name"]
+        cmd = "sudo {docker_exec_cmd} ceph --name client.bootstrap-mds --keyring /var/lib/ceph/bootstrap-mds/{cluster}.keyring --cluster={cluster} --connect-timeout 5 -f json -s".format(
+            docker_exec_cmd=docker_exec_cmd,
+            cluster=node['cluster_name']
         )
         cluster_status = json.loads(host.check_output(cmd))
-
         assert (cluster_status['fsmap'].get('up', 0) + cluster_status['fsmap'].get('up:standby', 0)) == len(node["vars"]["groups"]["mdss"])

--- a/tests/functional/tests/rbd-mirror/test_rbd_mirror.py
+++ b/tests/functional/tests/rbd-mirror/test_rbd_mirror.py
@@ -58,25 +58,18 @@ class TestRbdMirrors(object):
         )
         assert host.service(service_name).is_enabled
 
-    @pytest.mark.no_docker
     @pytest.mark.from_luminous
     def test_rbd_mirror_is_up(self, node, host):
+        hostname=node["vars"]["inventory_hostname"]
+        cluster=node["cluster_name"]
+        if node['docker']:
+            docker_exec_cmd = 'docker exec ceph-rbd-mirror-{hostname}'.format(hostname=hostname)
+        else:
+            docker_exec_cmd = ''
         hostname = node["vars"]["inventory_hostname"]
         cluster = node['cluster_name']
-        cmd = "sudo ceph --name client.bootstrap-rbd --keyring /var/lib/ceph/bootstrap-rbd/{cluster}.keyring --cluster={cluster} --connect-timeout 5 -f json -s".format(
-            hostname=hostname,
-            cluster=cluster
-        )
-        output = host.check_output(cmd)
-        daemons = [i for i in json.loads(output)["servicemap"]["services"]["rbd-mirror"]["daemons"]]
-        assert hostname in daemons
-
-    @pytest.mark.docker
-    @pytest.mark.from_luminous
-    def test_docker_rbd_mirror_is_up(self, node, host):
-        hostname = node["vars"]["inventory_hostname"]
-        cluster = node['cluster_name']
-        cmd = "sudo docker exec ceph-rbd-mirror-{hostname} ceph --name client.bootstrap-rbd --keyring /var/lib/ceph/bootstrap-rbd/{cluster}.keyring --cluster={cluster} --connect-timeout 5 -f json -s".format(
+        cmd = "sudo {docker_exec_cmd} ceph --name client.bootstrap-rbd --keyring /var/lib/ceph/bootstrap-rbd/{cluster}.keyring --cluster={cluster} --connect-timeout 5 -f json -s".format(
+            docker_exec_cmd=docker_exec_cmd,
             hostname=hostname,
             cluster=cluster
         )

--- a/tests/functional/tests/rgw/test_rgw.py
+++ b/tests/functional/tests/rgw/test_rgw.py
@@ -22,12 +22,16 @@ class TestRGWs(object):
         )
         assert host.service(service_name).is_enabled
 
-    @pytest.mark.no_docker
     @pytest.mark.from_luminous
     def test_rgw_is_up(self, node, host):
-        hostname = node["vars"]["inventory_hostname"]
-        cluster = node['cluster_name']
-        cmd = "sudo ceph --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/{cluster}.keyring --cluster={cluster} --connect-timeout 5 -f json -s".format(
+        hostname=node["vars"]["inventory_hostname"]
+        cluster=node["cluster_name"]
+        if node['docker']:
+            docker_exec_cmd = 'docker exec ceph-rgw-{hostname}'.format(hostname=hostname)
+        else:
+            docker_exec_cmd = ''
+        cmd = "sudo {docker_exec_cmd} ceph --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/{cluster}.keyring --cluster={cluster} --connect-timeout 5 -f json -s".format(
+            docker_exec_cmd=docker_exec_cmd,
             hostname=hostname,
             cluster=cluster
         )
@@ -40,17 +44,3 @@ class TestRGWs(object):
         # rgw frontends ip_addr is configured on eth1
         ip_addr = host.interface("eth1").addresses[0]
         assert host.socket("tcp://{ip_addr}:{port}".format(ip_addr=ip_addr, port=8080)).is_listening
-
-
-    @pytest.mark.docker
-    @pytest.mark.from_luminous
-    def test_docker_rgw_is_up(self, node, host):
-        hostname = node["vars"]["inventory_hostname"]
-        cluster = node['cluster_name']
-        cmd = "sudo docker exec ceph-rgw-{hostname} ceph --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/{cluster}.keyring --cluster={cluster} --connect-timeout 5 -f json -s".format(
-            hostname=hostname,
-            cluster=cluster
-        )
-        output = host.check_output(cmd)
-        daemons = [i for i in json.loads(output)["servicemap"]["services"]["rgw"]["daemons"]]
-        assert hostname in daemons


### PR DESCRIPTION
avoid duplicating test unnecessarily just because of docker exec syntax.
Using the same logic than in the playbook with `docker_exec_cmd` allow us
to execute the same test on both containerized and non containerized environment.

The idea is to set a variable `docker_exec_cmd` with the
'docker exec <container-name>' string when containerized and
set it to '' when non containerized.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>