### PR TITLE
Add ceph_keyring_permissions var to set permissions for keyring files

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -296,6 +296,9 @@ dummy:
 
 #ceph_conf_key_directory: /etc/ceph
 
+# Permissions for keyring files in /etc/ceph
+#ceph_keyring_permissions: '0600'
+
 #cephx: true
 
 ## Client options

--- a/group_vars/clients.yml.sample
+++ b/group_vars/clients.yml.sample
@@ -46,8 +46,8 @@ dummy:
 #
 # To use a particular secret, you have to add 'key' to the dict below, so something like:
 # - { name: client.test, key: "AQAin8tUMICVFBAALRHNrV0Z4MXupRw4v9JQ6Q==" ...
-#
+
 #keys:
-#  - { name: client.test, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test" },  mode: "0600" }
-#  - { name: client.test2, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test2" },  mode: "0600" }
+#  - { name: client.test, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test" },  mode: "{{ ceph_keyring_permissions }}" }
+#  - { name: client.test2, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test2" },  mode: "{{ ceph_keyring_permissions }}" }
 

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -296,6 +296,9 @@ ceph_repository: rhcs
 
 #ceph_conf_key_directory: /etc/ceph
 
+# Permissions for keyring files in /etc/ceph
+#ceph_keyring_permissions: '0600'
+
 #cephx: true
 
 ## Client options

--- a/roles/ceph-client/defaults/main.yml
+++ b/roles/ceph-client/defaults/main.yml
@@ -38,7 +38,7 @@ pools:
 #
 # To use a particular secret, you have to add 'key' to the dict below, so something like:
 # - { name: client.test, key: "AQAin8tUMICVFBAALRHNrV0Z4MXupRw4v9JQ6Q==" ...
-#
+
 keys:
-  - { name: client.test, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test" },  mode: "0600" }
-  - { name: client.test2, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test2" },  mode: "0600" }
+  - { name: client.test, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test" },  mode: "{{ ceph_keyring_permissions }}" }
+  - { name: client.test2, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test2" },  mode: "{{ ceph_keyring_permissions }}" }

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -5,7 +5,7 @@
     dest: "/etc/ceph/"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   when:
     - cephx
     - copy_admin_key

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -288,6 +288,9 @@ generate_fsid: true
 
 ceph_conf_key_directory: /etc/ceph
 
+# Permissions for keyring files in /etc/ceph
+ceph_keyring_permissions: '0600'
+
 cephx: true
 
 ## Client options

--- a/roles/ceph-fetch-keys/tasks/main.yml
+++ b/roles/ceph-fetch-keys/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: set keys permissions
   file:
     path: "{{ item }}"
-    mode: 0600
+    mode: "{{ ceph_keyring_permissions }}"
     owner: root
     group: root
   with_items:

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -11,7 +11,7 @@
     dest: "/etc/ceph/{{ cluster }}.client.admin.keyring"
     owner: "root"
     group: "root"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   when:
     - cephx
 

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -16,7 +16,7 @@
     dest: "{{ item.name }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   with_items:
     - { name: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -13,7 +13,7 @@
     dest: "{{ item.dest }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   with_items:
     - { name: "/etc/ceph/{{ cluster }}.mgr.{{ ansible_hostname }}.keyring", dest: "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", dest: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
@@ -26,6 +26,6 @@
     path: /var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   when:
     - cephx

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -98,7 +98,7 @@
     path: "{{ item }}"
     owner: "ceph"
     group: "ceph"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   with_items:
     - "{{ ceph_keys.get('stdout_lines') | default([]) }}"
   when:

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -91,7 +91,7 @@
     state: file
     owner: 'ceph'
     group: 'ceph'
-    mode: '0600'
+    mode: "{{ ceph_keyring_permissions }}"
   when:
     - cephx
     - admin_secret != 'admin_secret'

--- a/roles/ceph-nfs/tasks/common.yml
+++ b/roles/ceph-nfs/tasks/common.yml
@@ -5,7 +5,7 @@
     dest: "{{ item.name }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   with_items:
     - { name: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -18,7 +18,7 @@
     dest: "{{ item.name }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   with_items:
     - { name: "/var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }

--- a/roles/ceph-rbd-mirror/tasks/common.yml
+++ b/roles/ceph-rbd-mirror/tasks/common.yml
@@ -11,7 +11,7 @@
     dest: "/etc/ceph/"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   when:
     - cephx
     - copy_admin_key
@@ -22,7 +22,7 @@
     dest: "/var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   when:
     - cephx
     - ceph_release_num[ceph_release] >= ceph_release_num.luminous

--- a/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
+++ b/roles/ceph-rbd-mirror/tasks/pre_requisite.yml
@@ -22,7 +22,7 @@
     path: /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring
     owner: "ceph"
     group: "ceph"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   when:
     - cephx
     - ceph_release_num[ceph_release] >= ceph_release_num.luminous

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -18,7 +18,7 @@
     dest: "{{ item.name }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0600"
+    mode: "{{ ceph_keyring_permissions }}"
   with_items:
     - { name: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }


### PR DESCRIPTION
Add `keyring_permissions` variable to control permissions for keyring
files in `/etc/ceph`. Default value is the same as it was (0600),
but this variable allows user to override it (f.e. set it to 0640).

Rationale: We are configuring a monitoring for Ceph. It runs under
a separate user (telegraf), but this user is included into the ceph
group. To have access to the admin keyring it need to have
/etc/ceph/client.admin.keyring to be at least rw-r----- (0640).
I added a variable into ceph-defaults with the same value as current
value in all related tasks.  This will allow to override it through variable
in the inventory/group_vars/host_vars.