### PR TITLE
mon: honour mon_docker_net_host option

### DIFF
--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -6,7 +6,7 @@ After=docker.service
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/docker rm ceph-mon-%i
 ExecStartPre=$(command -v mkdir) -p /etc/ceph /var/lib/ceph/mon
-ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i --net=host \
+ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i \
   --memory={{ ceph_mon_docker_memory_limit }} \
 {% if ceph_docker_version.split('.')[0] | version_compare('13', '>=') -%}
   --cpus={{ ceph_mon_docker_cpu_limit }} \


### PR DESCRIPTION
--net=host was hardcoded in the startup line so even though
mon_docker_net_host was set to False the net option would always be
activated.
mon_docker_net_host is set to True by default so this commit does not
change the behaviour.

Signed-off-by: Sébastien Han <seb@redhat.com>