### PR TITLE
Fix package state for upgrades on SuSE/RHEL

### DIFF
--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -16,4 +16,4 @@
 - name: install redhat ceph packages
   package:
     name: "{{ redhat_ceph_pkgs | unique }}"
-    state: present
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"

--- a/roles/ceph-common/tasks/installs/install_suse_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_suse_packages.yml
@@ -7,4 +7,4 @@
 - name: install suse ceph packages
   package:
     name: "{{ suse_ceph_pkgs | unique }}"
-    state: present
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"


### PR DESCRIPTION
During 226f80c22bf61a7e8f00f4cca5f35eda67280250 only Debian package
installs had the correct state set to ensure packages were upgraded when
the "upgrade_ceph_packages" var was set to true.

Signed-off-by: Andy McCrae <andy.mccrae@gmail.com>