### PR TITLE
ceph-client: do not kill the dummy container

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -106,13 +106,6 @@
     - inventory_hostname in groups.get(client_group_name) | first
     - item.1.rc != 0
 
-- name: kill a dummy container that created pool(s)/key(s)
-  command: docker rm -f ceph-create-keys
-  changed_when: false
-  when:
-    - containerized_deployment
-    - inventory_hostname == groups.get(client_group_name) | first
-
 - name: get client cephx keys
   copy:
     dest: "{{ item.source }}"


### PR DESCRIPTION
The container runs for 300 sec, then dies and removes itself thanks to
the '--rm' option, so there is no point of removing it. Also this is
causing failure under some circonstances.

Closing: https://bugzilla.redhat.com/show_bug.cgi?id=1568157
Signed-off-by: Sébastien Han <seb@redhat.com>