### PR TITLE
[skip ci] ci: remove DCO

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,6 @@ rules:
       required_status_checks:
         strict: true
         contexts:
-          - DCO
           - "Testing: ceph-ansible PR Pipeline"
       required_pull_request_reviews:
         required_approving_review_count: 1


### PR DESCRIPTION
We know a Signed-off-by check inside our pipeline so this bot is not
needed anymore.

Signed-off-by: Sébastien Han <seb@redhat.com>