### PR TITLE
ceph-common: fix rhcs condition

### DIFF
--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
@@ -6,7 +6,7 @@
   register: rhcs_mon_repo
   check_mode: no
   when:
-    - mon_group_name in group_names
+    - (mon_group_name in group_names or mgr_group_name in group_names)
 
 - name: enable red hat storage monitor repository
   command: subscription-manager repos --enable rhel-7-server-rhceph-{{ ceph_rhcs_version }}-mon-rpms


### PR DESCRIPTION
We forgot to add mgr_group_name when checking for the mon repo, thus the
conditional on the next task was failing.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1598185
Signed-off-by: Sébastien Han <seb@redhat.com>