### PR TITLE
common: remove hdparm

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -86,24 +86,20 @@ dummy:
 ############
 #debian_package_dependencies:
 #  - python-pycurl
-#  - hdparm
 
 #centos_package_dependencies:
 #  - python-pycurl
-#  - hdparm
 #  - epel-release
 #  - python-setuptools
 #  - libselinux-python
 
 #redhat_package_dependencies:
 #  - python-pycurl
-#  - hdparm
 #  - python-setuptools
 
 #suse_package_dependencies:
 #  - python-pycurl
 #  - python-xml
-#  - hdparm
 #  - python-setuptools
 
 # Whether or not to install the ceph-test package.

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -86,24 +86,20 @@ fetch_directory: ~/ceph-ansible-keys
 ############
 #debian_package_dependencies:
 #  - python-pycurl
-#  - hdparm
 
 #centos_package_dependencies:
 #  - python-pycurl
-#  - hdparm
 #  - epel-release
 #  - python-setuptools
 #  - libselinux-python
 
 #redhat_package_dependencies:
 #  - python-pycurl
-#  - hdparm
 #  - python-setuptools
 
 #suse_package_dependencies:
 #  - python-pycurl
 #  - python-xml
-#  - hdparm
 #  - python-setuptools
 
 # Whether or not to install the ceph-test package.

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -78,24 +78,20 @@ ceph_conf_local: false
 ############
 debian_package_dependencies:
   - python-pycurl
-  - hdparm
 
 centos_package_dependencies:
   - python-pycurl
-  - hdparm
   - epel-release
   - python-setuptools
   - libselinux-python
 
 redhat_package_dependencies:
   - python-pycurl
-  - hdparm
   - python-setuptools
 
 suse_package_dependencies:
   - python-pycurl
   - python-xml
-  - hdparm
   - python-setuptools
 
 # Whether or not to install the ceph-test package.

--- a/rundep.sample
+++ b/rundep.sample
@@ -15,7 +15,6 @@
 #fcgi
 #fuse-libs
 #glibc
-#hdparm
 #keyutils-libs
 #leveldb
 #libaio


### PR DESCRIPTION
As of Kraken, the journal code does not use the hdparm command anymore
so we can remove it from our package dependency list.

Fixes: https://github.com/ceph/ceph-ansible/issues/1402
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit f6910efa24389c264062963b2054c7cd29ffebb3)