### PR TITLE
tests: fix `_get_osd_id_from_host()` in TestOSDs()

### DIFF
--- a/tests/functional/tests/osd/test_osds.py
+++ b/tests/functional/tests/osd/test_osds.py
@@ -49,6 +49,7 @@ class TestOSDs(object):
         host.exists('ceph-volume-systemd')
 
     def _get_osd_id_from_host(self, node, osd_tree):
+        children = []
         for n in osd_tree['nodes']:
             if n['name'] == node['vars']['inventory_hostname'] and n['type'] == 'host':
                 children = n['children']


### PR DESCRIPTION
We must initialize `children` variable in `_get_osd_id_from_host()`,
otherwise, if for any reason the deployment has failed and result with
an osd host with no OSD registered, we won't enter in the condition,
therefore, `children` is never set and the function tries to return
something undefined.

Typical error:
```
E       UnboundLocalError: local variable 'children' referenced before assignment
```

Fixes: #2860

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>