### PR TITLE
common: switch from docker module to docker_container

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -51,7 +51,7 @@
     ignore_errors: true
 
   - name: remove ceph mds container
-    docker:
+    docker_container:
       image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       name: "ceph-mds-{{ ansible_hostname }}"
       state: absent
@@ -88,7 +88,7 @@
     ignore_errors: true
 
   - name: remove ceph mgr container
-    docker:
+    docker_container:
       image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       name: "ceph-mgr-{{ ansible_hostname }}"
       state: absent
@@ -135,7 +135,7 @@
     ignore_errors: true
 
   - name: remove ceph rgw container
-    docker:
+    docker_container:
       image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       name: "ceph-rgw-{{ ansible_hostname }}"
       state: absent
@@ -179,7 +179,7 @@
     ignore_errors: true
 
   - name: remove ceph rbd-mirror container
-    docker:
+    docker_container:
       image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       name: "ceph-rbd-mirror-{{ ansible_hostname }}"
       state: absent
@@ -218,7 +218,7 @@
     ignore_errors: true
 
   - name: remove ceph nfs container
-    docker:
+    docker_container:
       image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       name: "ceph-nfs-{{ ansible_hostname }}"
       state: absent
@@ -371,7 +371,7 @@
     delay: 10
 
   - name: remove ceph osd zap disk container
-    docker:
+    docker_container:
       image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       name: "ceph-osd-zap-{{ ansible_hostname }}-{{ item }}"
       state: absent
@@ -433,14 +433,14 @@
     ignore_errors: true
 
   - name: remove ceph mon container
-    docker:
+    docker_container:
       image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       name: "ceph-mon-{{ ansible_hostname }}"
       state: absent
     ignore_errors: true
 
   - name: remove restapi container
-    docker:
+    docker_container:
       image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       name: "ceph-restapi-{{ ansible_hostname }}"
       state: absent

--- a/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
+++ b/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
@@ -1,10 +1,10 @@
 ---
 - name: populate kv_store with default ceph.conf
-  docker:
+  docker_container:
     name: populate-kv-store
     image: "{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
     command: populate_kvstore
-    net: host
+    network: host
     env:
       KV_TYPE: "{{kv_type}}"
       KV_IP: "{{kv_endpoint}}"
@@ -16,11 +16,11 @@
     - mon_containerized_default_ceph_conf_with_kv
 
 - name: populate kv_store with custom ceph.conf
-  docker:
+  docker_container:
     name: populate-kv-store
     image: "{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
     command: populate_kvstore
-    net: host
+    network: host
     env:
       KV_TYPE: "{{kv_type}}"
       KV_IP: "{{kv_endpoint}}"
@@ -34,7 +34,7 @@
     - not mon_containerized_default_ceph_conf_with_kv
 
 - name: delete populate-kv-store docker
-  docker:
+  docker_container:
     name: populate-kv-store
     state: absent
     image: "{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -63,7 +63,8 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i \
   -e CEPH_DAEMON=MON \
   {{ ceph_mon_docker_extra_env }} \
   {{ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
-ExecStopPost=-/usr/bin/docker stop ceph-mon-%i
+ExecStop=-/usr/bin/docker stop ceph-mon-%i
+ExecStopPost=-/bin/rm -f /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-restapi/tasks/docker/start_docker_restapi.yml
+++ b/roles/ceph-restapi/tasks/docker/start_docker_restapi.yml
@@ -1,9 +1,9 @@
 ---
 - name: run the ceph rest api docker image
-  docker:
+  docker_container:
     image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
     name: "ceph-restapi-{{ ansible_hostname }}"
-    net: host
+    network: host
     expose: "{{ ceph_restapi_port }}"
     state: running
     env: "RESTAPI_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_restapi_docker_interface]['ipv4']['address'] }},CEPH_DAEMON=RESTAPI,{{ ceph_restapi_docker_extra_env }}"


### PR DESCRIPTION
As of ansible 2.4, `docker` module has been removed (was deprecated
since ansible 2.1).
We must switch to `docker_container` instead.

See: https://docs.ansible.com/ansible/latest/modules/docker_module.html#docker-module

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>