### PR TITLE
mgr: fix condition to add modules to ceph-mgr

### DIFF
--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -51,5 +51,5 @@
   with_items: "{{ ceph_mgr_modules }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
-    - item in _ceph_mgr_modules.disabled_modules
+    - item in _disabled_ceph_mgr_modules
     - ceph_release_num[ceph_release] >= ceph_release_num['luminous']


### PR DESCRIPTION
Follow up on #2784

We must check in the generated fact `_disabled_ceph_mgr_modules` to
enable disabled mgr module.
Otherwise, this task will be skipped because it's not comparing the
right list.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1600155

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>