### PR TITLE
tests: add latest-bis-jewel for jewel tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -153,6 +153,7 @@ setenv=
   jewel: CEPH_DOCKER_IMAGE_TAG = latest-jewel
   jewel: UPDATE_CEPH_STABLE_RELEASE = luminous
   jewel: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-luminous
+  jewel: CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-jewel
   luminous: CEPH_STABLE_RELEASE = luminous
   luminous: CEPH_DOCKER_IMAGE_TAG = latest-luminous
   luminous: CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-luminous


### PR DESCRIPTION
since no latest-bis-jewel exists, it's using latest-bis which points to
ceph mimic. In our testing, using it for idempotency/handlers tests
means upgrading from jewel to mimic which is not what we want do.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>