### PR TITLE
tests: support update scenarios in test_rbd_mirror_is_up()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ def node(host, request):
     # because testinfra does not collect and provide ansible config passed in
     # from using --extra-vars
     ceph_stable_release = os.environ.get("CEPH_STABLE_RELEASE", "luminous")
+    rolling_update = os.environ.get("ROLLING_UPDATE", "False")
     group_names = ansible_vars["group_names"]
     docker = ansible_vars.get("docker")
     osd_auto_discovery = ansible_vars.get("osd_auto_discovery")
@@ -121,6 +122,7 @@ def node(host, request):
         osds=osds,
         ceph_stable_release=ceph_stable_release,
         ceph_release_num=ceph_release_num,
+        rolling_update=rolling_update,
     )
     return data
 

--- a/tests/functional/tests/rbd-mirror/test_rbd_mirror.py
+++ b/tests/functional/tests/rbd-mirror/test_rbd_mirror.py
@@ -64,6 +64,7 @@ class TestRbdMirrors(object):
         ceph_stable_release=node['ceph_stable_release']
         hostname=node["vars"]["inventory_hostname"]
         cluster=node["cluster_name"]
+        rolling_update=node["rolling_update"]
         daemons = []
         if node['docker']:
             docker_exec_cmd = 'docker exec ceph-rbd-mirror-{hostname}'.format(hostname=hostname)
@@ -79,7 +80,7 @@ class TestRbdMirrors(object):
         output = host.check_output(cmd)
         status = json.loads(output)
         daemon_ids = [i for i in status["servicemap"]["services"]["rbd-mirror"]["daemons"].keys() if i != "summary"]
-        if ceph_release_num[ceph_stable_release] > ceph_release_num['luminous']:
+        if ceph_release_num[ceph_stable_release] > ceph_release_num['luminous'] or (ceph_release_num[ceph_stable_release] == ceph_release_num['luminous'] and rolling_update=='True'):
             for daemon_id in daemon_ids:
                 daemons.append(status["servicemap"]["services"]["rbd-mirror"]["daemons"][daemon_id]["metadata"]["hostname"])
             result = hostname in daemons

--- a/tox.ini
+++ b/tox.ini
@@ -166,6 +166,8 @@ setenv=
   mimic: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest
   lvm_osds: CEPH_STABLE_RELEASE = luminous
   bluestore_lvm_osds: CEPH_STABLE_RELEASE = luminous
+  update_cluster: ROLLING_UPDATE = True
+  update_docker_cluster: ROLLING_UPDATE = True
 deps= -r{toxinidir}/tests/requirements.txt
 changedir=
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw xenial cluster using non-collocated OSD scenario


### PR DESCRIPTION
`test_rbd_mirror_is_up()` is failing on update scenarios because it
assumes the `ceph_stable_release` is still set to the value of the
original ceph release, it means it won't enter in the right part of the
condition and fails.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>