### PR TITLE
validate: only run osd test on osd node

### DIFF
--- a/roles/ceph-validate/tasks/check_devices.yml
+++ b/roles/ceph-validate/tasks/check_devices.yml
@@ -10,7 +10,7 @@
   fail:
     msg: "{{ item }} is not a block special file!"
   when:
-    - item.rc != 0
+    - item.failed
   with_items: "{{ devices_parted.results }}"
 
 - name: validate dedicated_device is/are actually device(s)
@@ -18,20 +18,21 @@
     device: "{{ item }}"
     unit: MiB
   register: dedicated_device_parted
-  with_items: "{{ dedicated_device }}"
+  with_items: "{{ dedicated_devices }}"
   when:
     - osd_scenario == 'non-collocated'
 
 - name: fail if one of the dedicated_device is not a device
   fail:
     msg: "{{ item }} is not a block special file!"
-  when:
-    - item.rc != 0
   with_items: "{{ dedicated_device_parted.results }}"
+  when:
+    - osd_scenario == 'non-collocated'
+    - item.failed
 
 - name: fail if dedicated_device is not the size length as devices
   fail:
     msg: "dedicated_device lengtth must be identical to devices's length"
   when:
     - osd_scenario == 'non-collocated'
-    - dedicated_device|length != devices|length
+    - dedicated_devices|length != devices|length

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -55,3 +55,7 @@
 
 - name: include check_devices.yml
   include: check_devices.yml
+  when:
+    - osd_group_name in group_names
+    - not osd_auto_discovery | default(False)
+    - osd_scenario != "lvm"


### PR DESCRIPTION
Do not run device validation on every hosts, only on OSD nodes.

Signed-off-by: Sébastien Han <seb@redhat.com>