### PR TITLE
ceph-validate: the lvm osd scenario does not need to check devices

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -55,3 +55,4 @@
 
 - name: include check_devices.yml
   include: check_devices.yml
+  when: osd_scenario != "lvm"


### PR DESCRIPTION
This fixes a bug introduced by cf01e596b that was causing ceph-volume CI test to fail.