### PR TITLE
tests: stop hardcoding ansible version (stable-3.1)

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,5 @@ testinfra==1.7.1
 pytest-xdist
 pytest==3.6.1
 notario>=0.0.13
+ansible~=2.4,<2.5
+netaddr

--- a/tests/requirements2.2.txt
+++ b/tests/requirements2.2.txt
@@ -1,3 +1,0 @@
-# These are Python requirements needed to run the functional tests
-testinfra==1.6.0
-pytest-xdist

--- a/tests/requirements2.5.txt
+++ b/tests/requirements2.5.txt
@@ -1,1 +1,0 @@
-requirements2.4.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = {dev,jewel,luminous,rhcs}-{ansible2.2,ansible2.3,ansible2.4,ansible2.5}-{xenial_cluster,centos7_cluster,docker_cluster,update_cluster,cluster,update_docker_cluster,switch_to_containers,purge_filestore_osds_container,purge_filestore_osds_non_container,purge_cluster_non_container,purge_cluster_container,ooo_collocation}
-  {dev,luminous,rhcs}-{ansible2.3,ansible2.4,ansible2.5}-{filestore_osds_non_container,filestore_osds_container,bluestore_osds_container,bluestore_osds_non_container,bluestore_lvm_osds,lvm_osds,purge_lvm_osds,shrink_mon,shrink_osd,shrink_mon_container,shrink_osd_container,docker_cluster_collocation,purge_bluestore_osds_non_container,purge_bluestore_osds_container}
+envlist = {dev,jewel,luminous,rhcs}-{xenial_cluster,centos7_cluster,docker_cluster,update_cluster,cluster,update_docker_cluster,switch_to_containers,purge_filestore_osds_container,purge_filestore_osds_non_container,purge_cluster_non_container,purge_cluster_container,ooo_collocation}
+  {dev,luminous,rhcs}-{filestore_osds_non_container,filestore_osds_container,bluestore_osds_container,bluestore_osds_non_container,bluestore_lvm_osds,lvm_osds,purge_lvm_osds,shrink_mon,shrink_osd,shrink_mon_container,shrink_osd_container,docker_cluster_collocation,purge_bluestore_osds_non_container,purge_bluestore_osds_container}
 
 skipsdist = True
 
@@ -161,16 +161,7 @@ setenv=
   luminous: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest
   lvm_osds: CEPH_STABLE_RELEASE = luminous
   bluestore_lvm_osds: CEPH_STABLE_RELEASE = luminous
-deps=
-  ansible2.2: ansible==2.2.3
-  ansible2.2: -r{toxinidir}/tests/requirements2.2.txt
-  ansible2.3: ansible==2.3.1
-  ansible2.3: -r{toxinidir}/tests/requirements2.2.txt
-  ansible2.4: ansible==2.4.2
-  ansible2.4: -r{toxinidir}/tests/requirements2.4.txt
-  ansible2.5: ansible==2.5.0
-  ansible2.5: -r{toxinidir}/tests/requirements2.5.txt
-  ooo_collocation: netaddr
+deps= -r{toxinidir}/tests/requirements.txt
 changedir=
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw xenial cluster using non-collocated OSD scenario
   xenial_cluster: {toxinidir}/tests/functional/ubuntu/16.04/cluster


### PR DESCRIPTION
In addition to ceph/ceph-build#1082

Let's set the ansible version in each ceph-ansible branch's respective
requirements.txt.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>