### PR TITLE
tests: test master against ansible 2.6

### DIFF
--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -67,10 +67,10 @@
 
 - name: fail on unsupported ansible version
   fail:
-    msg: "Ansible version must be between 2.4.x and 2.5.x!"
+    msg: "Ansible version must be between 2.5.x and 2.6.x!"
   when:
     - ansible_version.major|int == 2
-    - (ansible_version.minor|int < 4 or ansible_version.minor|int > 5)
+    - (ansible_version.minor|int < 5 or ansible_version.minor|int > 6)
 
 - name: fail if systemd is not present
   fail:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,5 +3,5 @@ testinfra
 pytest-xdist
 pytest==3.6.1
 notario>=0.0.13
-ansible~=2.5,<2.6
+ansible~=2.6,<2.7
 netaddr


### PR DESCRIPTION
Ansible 2.4 is currently end-of-life.
Ansible 2.5 will go end-of-life after Ansible 2.7 is released.

Fixes: #2901

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>