### PR TITLE
tests: add support of 'ooo-collocation' scenario when testing against…

### DIFF
--- a/tests/functional/dev_setup.yml
+++ b/tests/functional/dev_setup.yml
@@ -6,23 +6,28 @@
     - vagrant_setup
   tasks:
 
+
+    - name: set_fact group_vars_path
+      set_fact:
+        group_vars_path: "{{ change_dir + '/hosts' if 'ooo-collocation' in change_dir.split('/') else change_dir + '/group_vars/all' }}"
+
     - name: change ceph_repository to 'dev'
       replace:
         regexp: "ceph_repository:.*"
         replace: "ceph_repository: dev"
-        dest: "{{ change_dir }}/group_vars/all"
+        dest: "{{ group_vars_path }}"
       when: change_dir is defined
 
     - name: change nfs-ganesha repository to 'dev'
       replace:
         regexp: "nfs_ganesha_stable:.*"
         replace: "nfs_ganesha_stable: false"
-        dest: "{{ change_dir }}/group_vars/all"
+        dest: "{{ group_vars_path }}"
       replace:
         regexp: "nfs_ganesha_dev:.*"
         replace: "nfs_ganesha_dev: true"
-        dest: "{{ change_dir }}/group_vars/all"
+        dest: "{{ group_vars_path }}"
       when: change_dir is defined
 
-    - name: print contents of {{ change_dir }}/group_vars/all
-      command: "cat {{ change_dir }}/group_vars/all"
+    - name: print contents of {{ group_vars_path }}
+      command: "cat {{ group_vars_path }}"


### PR DESCRIPTION
… ceph dev

The group_vars/all file is not available on 'ooo-collocation' scenario,
it's making the `dev_setup.yml` failing because this path is hardcoded.

The idea here is to check if the pattern 'ooo-collocation' is present in
`change_dir` variable so we can set this path properly according to the
scenario being run.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>