### PR TITLE
ceph-mds: add and document erasure coded cephfs pools

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -362,8 +362,8 @@ dummy:
 #cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
 #cephfs_pools:
-#  - { name: "{{ cephfs_data }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
-#  - { name: "{{ cephfs_metadata }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
+#  - { name: "{{ cephfs_data }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}", type: "" } # 'type: "erasure"' for erasure coded pool, or leave blank for replicated pool, which is default
+#  - { name: "{{ cephfs_metadata }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}", type: "" }
 
 ## OSD options
 #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -362,8 +362,8 @@ ceph_repository: rhcs
 #cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
 #cephfs_pools:
-#  - { name: "{{ cephfs_data }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
-#  - { name: "{{ cephfs_metadata }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
+#  - { name: "{{ cephfs_data }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}", type: "" } # 'type: "erasure"' for erasure coded pool, or leave blank for replicated pool, which is default
+#  - { name: "{{ cephfs_metadata }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}", type: "" }
 
 ## OSD options
 #

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -354,8 +354,8 @@ cephfs_data: cephfs_data # name of the data pool for a given filesystem
 cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
 cephfs_pools:
-  - { name: "{{ cephfs_data }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
-  - { name: "{{ cephfs_metadata }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}" }
+  - { name: "{{ cephfs_data }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}", type: "" } # 'type: "erasure"' for erasure coded pool, or leave blank for replicated pool, which is default
+  - { name: "{{ cephfs_metadata }}", pgs: "{{ hostvars[groups[mon_group_name][0]]['osd_pool_default_pg_num'] }}", type: "" }
 
 ## OSD options
 #

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -1,6 +1,6 @@
 ---
 - name: create filesystem pools
-  command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pgs }}"
+  command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pgs }} {{ item.type | default('') }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   with_items:


### PR DESCRIPTION
I wanted to have erasure coded pools for cephfs.

<http://docs.ceph.com/docs/master/rados/operations/pools/#create-a-pool> look under {replicated|erasure}

Signed-off-by: William Dang [william.dang@buildit.ws](mailto:william.dang@buildit.ws)
