### PR TITLE
ceph-mds: add and document erasure coded cephfs pools

### DIFF
--- a/library/ceph_pools.py
+++ b/library/ceph_pools.py
@@ -1,0 +1,224 @@
+#!/usr/bin/python
+# Copyright 2018, Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ceph_pool
+
+author: Guillaume Abrioux <gabrioux@redhat.com>
+
+short_description: Manage Ceph pool(s)
+
+version_added: "2.4"
+
+description:
+    - Manage Ceph pools creation, deletion.
+    It can also list and get information about pools.
+options:
+    cluster:
+        description:
+            - The ceph cluster name.
+        required: false
+        default: ceph
+'''
+
+RETURN = '''#  '''
+
+from ansible.module_utils.basic import AnsibleModule
+import datetime
+import os
+import struct
+import time
+import base64
+
+
+def fatal(message, module):
+    '''
+    Report a fatal error and exit
+    '''
+
+    if module:
+        module.fail_json(msg=message, rc=1)
+    else:
+        raise(Exception(message))
+
+def generate_ceph_cmd(cluster, args, containerized=None):
+    '''
+    Generate 'ceph' command line to execute
+    '''
+
+    cmd = []
+
+    base_cmd = [
+        'ceph',
+        '--cluster',
+        cluster,
+        'auth',
+    ]
+
+    cmd.extend(base_cmd + args)
+
+    if containerized:
+        cmd = containerized.split() + cmd
+
+    return cmd
+
+def exec_commands(module, cmd_list):
+    '''
+    Execute command(s)
+    '''
+
+    for cmd in cmd_list:
+        rc, out, err = module.run_command(cmd)
+        if rc != 0:
+            return rc, cmd, out, err
+
+    return rc, cmd, out, err
+
+def run_module():
+    module_args = dict(
+        cluster=dict(type='str', required=False, default='ceph'),
+        name=dict(type='str', required=False),
+        state=dict(type='str', required=True),
+        containerized=dict(type='str', required=False, default=None),
+        caps=dict(type='dict', required=False, default=None),
+        secret=dict(type='str', required=False, default=None),
+        import_key=dict(type='bool', required=False, default=True),
+        auid=dict(type='str', required=False, default=None),
+        dest=dict(type='str', required=False, default='/etc/ceph/'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    # Gather module parameters in variables
+    state = module.params['state']
+    name = module.params.get('name')
+    cluster = module.params.get('cluster')
+    containerized = module.params.get('containerized')
+    caps = module.params.get('caps')
+    secret = module.params.get('secret')
+    import_key = module.params.get('import_key')
+    auid = module.params.get('auid')
+    dest = module.params.get('dest')
+
+    result = dict(
+        changed=False,
+        stdout='',
+        stderr='',
+        rc='',
+        start='',
+        end='',
+        delta='',
+    )
+
+    if module.check_mode:
+        return result
+
+    startd = datetime.datetime.now()
+
+    # Test if the key exists, if it does we skip its creation
+    # We only want to run this check when a key needs to be added
+    # There is no guarantee that any cluster is running and we don't need one
+    if import_key:
+        rc, cmd, out, err = exec_commands(
+            module, info_key(cluster, name, containerized))
+
+    if state == "present":
+        if not caps:
+            fatal("Capabilities must be provided when state is 'present'", module)
+
+        # We allow 'present' to override any existing key ONLY if a secret is provided, if not we skip the creation
+        if import_key:
+            if rc == 0 and not secret:
+                result["stdout"] = "skipped, since {0} already exists, if you want to update a key use 'state: update'".format(
+                    name)
+                result['rc'] = rc
+                module.exit_json(**result)
+
+        rc, cmd, out, err = exec_commands(module, create_key(
+            module, result, cluster, name, secret, caps, import_key, auid, dest, containerized))
+
+    elif state == "update":
+        if not caps:
+            fatal("Capabilities must be provided when state is 'update'", module)
+
+        if rc != 0:
+            result["stdout"] = "skipped, since {0} does not exist".format(name)
+            result['rc'] = 0
+            module.exit_json(**result)
+
+        rc, cmd, out, err = exec_commands(
+            module, update_key(cluster, name, caps, containerized))
+
+    elif state == "absent":
+        rc, cmd, out, err = exec_commands(
+            module, delete_key(cluster, name, containerized))
+
+    elif state == "info":
+        if rc != 0:
+            result["stdout"] = "skipped, since {0} does not exist".format(name)
+            result['rc'] = 0
+            module.exit_json(**result)
+
+        rc, cmd, out, err = exec_commands(
+            module, info_key(cluster, name, containerized))
+
+    elif state == "list":
+        rc, cmd, out, err = exec_commands(
+            module, list_keys(cluster, containerized))
+
+    else:
+        module.fail_json(
+            msg='State must either be "present" or "absent" or "update" or "list" or "info".', changed=False, rc=1)
+
+    endd = datetime.datetime.now()
+    delta = endd - startd
+
+    result = dict(
+        cmd=cmd,
+        start=str(startd),
+        end=str(endd),
+        delta=str(delta),
+        rc=rc,
+        stdout=out.rstrip(b"\r\n"),
+        stderr=err.rstrip(b"\r\n"),
+        changed=True,
+    )
+
+    if rc != 0:
+        module.fail_json(msg='non-zero return code', **result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ def node(host, request):
     # because testinfra does not collect and provide ansible config passed in
     # from using --extra-vars
     ceph_stable_release = os.environ.get("CEPH_STABLE_RELEASE", "luminous")
+    rolling_update = os.environ.get("ROLLING_UPDATE", "False")
     group_names = ansible_vars["group_names"]
     docker = ansible_vars.get("docker")
     osd_auto_discovery = ansible_vars.get("osd_auto_discovery")
@@ -121,6 +122,7 @@ def node(host, request):
         osds=osds,
         ceph_stable_release=ceph_stable_release,
         ceph_release_num=ceph_release_num,
+        rolling_update=rolling_update,
     )
     return data
 

--- a/tests/functional/centos/7/docker/hosts
+++ b/tests/functional/centos/7/docker/hosts
@@ -1,29 +1,8 @@
 [mons]
 mon0
-mon1
-mon2
 
 [mgrs]
-mgr0
+mon0
 
 [osds]
 osd0 osd_crush_location="{ 'root': 'HDD', 'rack': 'mon-rackkkk', 'pod': 'monpod', 'host': 'osd0' }"
-
-[mdss]
-mds0
-
-[rgws]
-rgw0
-
-[nfss]
-nfs0
-
-[clients]
-client0
-client1
-
-[rbdmirrors]
-rbd-mirror0
-
-[iscsigws]
-iscsi-gw0

--- a/tests/functional/centos/7/docker/vagrant_variables.yml
+++ b/tests/functional/centos/7/docker/vagrant_variables.yml
@@ -4,15 +4,15 @@
 docker: True
 
 # DEFINE THE NUMBER OF VMS TO RUN
-mon_vms: 3
+mon_vms: 1
 osd_vms: 1
-mds_vms: 1
-rgw_vms: 1
-nfs_vms: 1
-rbd_mirror_vms: 1
-client_vms: 2
-iscsi_gw_vms: 1
-mgr_vms: 1
+mds_vms: 0
+rgw_vms: 0
+nfs_vms: 0
+rbd_mirror_vms: 0
+client_vms: 0
+iscsi_gw_vms: 0
+mgr_vms: 0
 
 # Deploy RESTAPI on each of the Monitors
 restapi: true

--- a/tests/functional/dev_setup.yml
+++ b/tests/functional/dev_setup.yml
@@ -6,23 +6,28 @@
     - vagrant_setup
   tasks:
 
+
+    - name: set_fact group_vars_path
+      set_fact:
+        group_vars_path: "{{ change_dir + '/hosts' if 'ooo-collocation' in change_dir.split('/') else change_dir + '/group_vars/all' }}"
+
     - name: change ceph_repository to 'dev'
       replace:
         regexp: "ceph_repository:.*"
         replace: "ceph_repository: dev"
-        dest: "{{ change_dir }}/group_vars/all"
+        dest: "{{ group_vars_path }}"
       when: change_dir is defined
 
     - name: change nfs-ganesha repository to 'dev'
       replace:
         regexp: "nfs_ganesha_stable:.*"
         replace: "nfs_ganesha_stable: false"
-        dest: "{{ change_dir }}/group_vars/all"
+        dest: "{{ group_vars_path }}"
       replace:
         regexp: "nfs_ganesha_dev:.*"
         replace: "nfs_ganesha_dev: true"
-        dest: "{{ change_dir }}/group_vars/all"
+        dest: "{{ group_vars_path }}"
       when: change_dir is defined
 
-    - name: print contents of {{ change_dir }}/group_vars/all
-      command: "cat {{ change_dir }}/group_vars/all"
+    - name: print contents of {{ group_vars_path }}
+      command: "cat {{ group_vars_path }}"

--- a/tests/functional/tests/rbd-mirror/test_rbd_mirror.py
+++ b/tests/functional/tests/rbd-mirror/test_rbd_mirror.py
@@ -64,6 +64,7 @@ class TestRbdMirrors(object):
         ceph_stable_release=node['ceph_stable_release']
         hostname=node["vars"]["inventory_hostname"]
         cluster=node["cluster_name"]
+        rolling_update=node["rolling_update"]
         daemons = []
         if node['docker']:
             docker_exec_cmd = 'docker exec ceph-rbd-mirror-{hostname}'.format(hostname=hostname)
@@ -79,7 +80,7 @@ class TestRbdMirrors(object):
         output = host.check_output(cmd)
         status = json.loads(output)
         daemon_ids = [i for i in status["servicemap"]["services"]["rbd-mirror"]["daemons"].keys() if i != "summary"]
-        if ceph_release_num[ceph_stable_release] > ceph_release_num['luminous']:
+        if ceph_release_num[ceph_stable_release] > ceph_release_num['luminous'] or (ceph_release_num[ceph_stable_release] == ceph_release_num['luminous'] and rolling_update=='True'):
             for daemon_id in daemon_ids:
                 daemons.append(status["servicemap"]["services"]["rbd-mirror"]["daemons"][daemon_id]["metadata"]["hostname"])
             result = hostname in daemons

--- a/tox.ini
+++ b/tox.ini
@@ -166,6 +166,8 @@ setenv=
   mimic: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest
   lvm_osds: CEPH_STABLE_RELEASE = luminous
   bluestore_lvm_osds: CEPH_STABLE_RELEASE = luminous
+  update_cluster: ROLLING_UPDATE = True
+  update_docker_cluster: ROLLING_UPDATE = True
 deps= -r{toxinidir}/tests/requirements.txt
 changedir=
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw xenial cluster using non-collocated OSD scenario


### PR DESCRIPTION
I wanted to have erasure coded pools for cephfs.

<http://docs.ceph.com/docs/master/rados/operations/pools/#create-a-pool> look under {replicated|erasure}
Fixes: #2889

Signed-off-by: William Dang [william.dang@buildit.ws](mailto:william.dang@buildit.ws)
