### PR TITLE
Run creation of empty rados index object to first monitor

### DIFF
--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -13,6 +13,8 @@
   when:
     - ceph_nfs_rados_backend
     - rados_index_exists.rc != 0
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
 
 - name: create /etc/ganesha
   file:


### PR DESCRIPTION
When distributing ceph-nfs role, creation of rados index object
fails as it assumes availability of client.admin locally.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1607970