### PR TITLE
rgw: add more config option for civetweb frontend

### DIFF
--- a/roles/ceph-rgw/tasks/docker/container_env_facts.yml
+++ b/roles/ceph-rgw/tasks/docker/container_env_facts.yml
@@ -1,12 +1,16 @@
 ---
+- name: set_fact docker_env_args '-e RGW_FRONTENDS={{ radosgw_civetweb_options }}'
+  set_fact:
+    docker_env_args: -e RGW_FRONTENDS={{ radosgw_civetweb_options }}
+
 - name: set_fact docker_env_args '-e RGW_ZONEGROUP={{ rgw_zonegroup }}'
   set_fact:
-    docker_env_args: -e RGW_ZONEGROUP={{ rgw_zonegroup }}
+    docker_env_args: "{{ docker_env_args }} -e RGW_ZONEGROUP={{ rgw_zonegroup }}"
   when:
     - rgw_zonegroup != ""
 
 - name: set_fact docker_env_args '-e RGW_ZONE={{ rgw_zone }}'
   set_fact:
-    docker_env_args: "{{ docker_env_args | default ('') }} -e RGW_ZONE={{ rgw_zone }}"
+    docker_env_args: "{{ docker_env_args }} -e RGW_ZONE={{ rgw_zone }}"
   when:
     - rgw_zone != ""


### PR DESCRIPTION
In containerized deployments we now inherite from the
radosgw_civetweb_options options when bootstrapping the container.

Depends on https://github.com/ceph/ceph-container/pull/1126

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1582411
Signed-off-by: Sébastien Han <seb@redhat.com>