### PR TITLE
site.yml.sample: fix install python2

### DIFF
--- a/site.yml.sample
+++ b/site.yml.sample
@@ -37,19 +37,19 @@
       raw: sudo apt-get -y install python-simplejson
       ignore_errors: yes
       when:
-        - systempython2.stat.exists is undefined or systempython2.stat.exists == false
+        - systempython2.stat is undefined or systempython2.stat.exists == false
 
     - name: install python2 for fedora
       raw: sudo dnf -y install python creates=/usr/bin/python
       ignore_errors: yes
       when:
-        - systempython2.stat.exists is undefined or systempython2.stat.exists == false
+        - systempython2.stat is undefined or systempython2.stat.exists == false
 
     - name: install python2 for opensuse
       raw: sudo zypper -n install python-base creates=/usr/bin/python2.7
       ignore_errors: yes
       when:
-        - systempython2.stat.exists is undefined or systempython2.stat.exists == false
+        - systempython2.stat is undefined or systempython2.stat.exists == false
 
     - name: gather facts
       setup:


### PR DESCRIPTION
Check `systempython2.stat` before `systempython2.stat.exists`.

Without this change, in the case that python2 is not installed, the `stat`
task fails without defining `systempython2.stat`. It leads that the next
installation tasks fail because of undefined `systempython2.stat`.

An example error output (edited for readability):

```
TASK [check for python2] ***********************************************
Wednesday 25 July 2018  14:52:47 +0900 (0:00:00.182)       0:00:00.182 *
fatal: [ceph-osd1.vlan221.vtj]: FAILED! => {
"changed": false, "module_stderr": "/bin/sh: 1: /usr/bin/python: not
found\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 127}
...ignoring

TASK [install python2 for debian based systems] ************************
Wednesday 25 July 2018  14:51:00 +0900 (0:00:01.742)       0:00:01.926 *
fatal: [ceph-mon2]: FAILED! => {
"msg": "The conditional check 'systempython2.stat.exists is undefined or
systempython2.stat.exists == false' failed. The error was: error while
evaluating conditional (systempython2.stat.exists is undefined or
systempython2.stat.exists == false): 'dict object' has no attribute 'stat'
\n\n The error appears to have been in
'/Users/arata/git/ceph-ansible/site.yml.sample': line 36, column 7, but
may\n be elsewhere in the file depending on the exact syntax problem.\n\n
The offending line appears to be:\n\n\n
    - name: install python2 for debian based systems\n
      ^ here\n
"}
...ignoring
```

Fixes: #2930
Signed-off-by: Arata Notsu <arata776@gmail.com>