### PR TITLE
igw: fix image removal during purge

### DIFF
--- a/library/igw_purge.py
+++ b/library/igw_purge.py
@@ -55,11 +55,11 @@ def delete_group(module, image_list, cfg):
     pending_list = list(image_list)
 
     for rbd_path in image_list:
-        if delete_rbd(module, rbd_path):
-            disk_key = rbd_path.replace('/', '.', 1)
-            cfg.del_item('disks', disk_key)
-            pending_list.remove(rbd_path)
-            cfg.changed = True
+        delete_rbd(module, rbd_path)
+        disk_key = rbd_path.replace('/', '.', 1)
+        cfg.del_item('disks', disk_key)
+        pending_list.remove(rbd_path)
+        cfg.changed = True
 
     if cfg.changed:
         cfg.commit()
@@ -74,8 +74,9 @@ def delete_rbd(module, rbd_path):
                                                         rbd_path)
     rc, rm_out, err = module.run_command(rm_cmd, use_unsafe_shell=True)
     logger.debug("delete RC = {}, {}".format(rc, rm_out, err))
-
-    return True if rc == 0 else False
+    if rc != 0:
+        logger.error("Could not fully cleanup image {}. Manually run the rbd "
+                     "command line tool to remove.".format(rbd_path))
 
 
 def is_cleanup_host(config):

--- a/library/igw_purge.py
+++ b/library/igw_purge.py
@@ -70,7 +70,8 @@ def delete_group(module, image_list, cfg):
 def delete_rbd(module, rbd_path):
 
     logger.debug("issuing delete for {}".format(rbd_path))
-    rm_cmd = 'rbd --no-progress rm {}'.format(rbd_path)
+    rm_cmd = 'rbd --no-progress --conf {} rm {}'.format(settings.config.cephconf,
+                                                        rbd_path)
     rc, rm_out, err = module.run_command(rm_cmd, use_unsafe_shell=True)
     logger.debug("delete RC = {}, {}".format(rc, rm_out, err))
 

--- a/roles/ceph-iscsi-gw/library/igw_purge.py
+++ b/roles/ceph-iscsi-gw/library/igw_purge.py
@@ -55,11 +55,11 @@ def delete_group(module, image_list, cfg):
     pending_list = list(image_list)
 
     for rbd_path in image_list:
-        if delete_rbd(module, rbd_path):
-            disk_key = rbd_path.replace('/', '.', 1)
-            cfg.del_item('disks', disk_key)
-            pending_list.remove(rbd_path)
-            cfg.changed = True
+        delete_rbd(module, rbd_path)
+        disk_key = rbd_path.replace('/', '.', 1)
+        cfg.del_item('disks', disk_key)
+        pending_list.remove(rbd_path)
+        cfg.changed = True
 
     if cfg.changed:
         cfg.commit()
@@ -74,8 +74,9 @@ def delete_rbd(module, rbd_path):
                                                         rbd_path)
     rc, rm_out, err = module.run_command(rm_cmd, use_unsafe_shell=True)
     logger.debug("delete RC = {}, {}".format(rc, rm_out, err))
-
-    return True if rc == 0 else False
+    if rc != 0:
+        logger.error("Could not fully cleanup image {}. Manually run the rbd "
+                     "command line tool to remove.".format(rbd_path))
 
 
 def is_cleanup_host(config):

--- a/roles/ceph-iscsi-gw/library/igw_purge.py
+++ b/roles/ceph-iscsi-gw/library/igw_purge.py
@@ -70,7 +70,8 @@ def delete_group(module, image_list, cfg):
 def delete_rbd(module, rbd_path):
 
     logger.debug("issuing delete for {}".format(rbd_path))
-    rm_cmd = 'rbd --no-progress rm {}'.format(rbd_path)
+    rm_cmd = 'rbd --no-progress --conf {} rm {}'.format(settings.config.cephconf,
+                                                        rbd_path)
     rc, rm_out, err = module.run_command(rm_cmd, use_unsafe_shell=True)
     logger.debug("delete RC = {}, {}".format(rc, rm_out, err))
 


### PR DESCRIPTION
We were not passing in the ceph conf info into the rbd image removal
command, so if the clustername was not the default igw purge would fail
due to the rbd rm command failing.

This just fixes the bug by passing in the ceph conf info which has the
clustername to use.

This fixes Red Hat bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1601949

Signed-off-by: Mike Christie <mchristi@redhat.com>