### PR TITLE
restapi: disable it when ceph version > luminous

### DIFF
--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -288,7 +288,11 @@
     - role: ceph-docker-common
     - role: ceph-config
       tags: ['ceph_update_config']
+      when:
+        - ceph_release_num[ceph_release] <= ceph_release_num.luminous
     - role: ceph-restapi
+      when:
+        - ceph_release_num[ceph_release] <= ceph_release_num.luminous
   post_tasks:
     - name: set ceph rest api install 'Complete'
       run_once: true

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -290,7 +290,11 @@
     - role: ceph-common
     - role: ceph-config
       tags: ['ceph_update_config']
+      when:
+        - ceph_release_num[ceph_release] <= ceph_release_num.luminous
     - role: ceph-restapi
+      when:
+        - ceph_release_num[ceph_release] <= ceph_release_num.luminous
   post_tasks:
     - name: set ceph rest api install 'Complete'
       run_once: true


### PR DESCRIPTION
ceph-rest-api binary has been removed in mimic so we cannot deploy it
anymore. We just keep the role and the compability for existing users.

Signed-off-by: Sébastien Han <seb@redhat.com>