### PR TITLE
[skip ci] config: enforce socket name

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -17,6 +17,12 @@ fsid = {{ fsid }}
 {% if common_single_host_mode is defined and common_single_host_mode %}
 osd crush chooseleaf type = 0
 {% endif %}
+{% if ceph_version not in ['jewel', 'kraken', 'luminous'] and containerized_deployment %}
+# let's force the admin socket the way it was so we can properly check for existing instances
+# also the line $cluster-$name.$pid.$cctid.asok is only needed when running multiple instances
+# of the same daemon, thing ceph-ansible cannot do at the time of writing
+admin socket = "$run_dir/$cluster-$name.asok"
+{% endif %}
 {# NOTE (leseb): the blank lines in-between are needed otherwise we won't get any line break #}
 
 {% set nb_mon = groups.get(mon_group_name, []) | length | int %}


### PR DESCRIPTION
This was introduced by
https://github.com/ceph/ceph/commit/59ee2e8d3b14511e8d07ef8325ac8ca96e051784
and made our socket checks impossible to run. The PID could be found,
but the cctid cannot.
This happens during upgrade to mimic and on cluster running on mimic.

So let's force the admin socket the way it was so we can properly check
for existing instances also the line $cluster-$name.$pid.$cctid.asok
is only needed when running multiple instances of the same daemon,
thing ceph-ansible cannot do at the time of writing

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1610220
Signed-off-by: Sébastien Han <seb@redhat.com>