### PR TITLE
defaults: backward compatibility with fqdn deployments

### DIFF
--- a/roles/ceph-defaults/templates/restart_mds_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_mds_daemon.sh.j2
@@ -3,10 +3,13 @@
 RETRIES="{{ handler_health_mds_check_retries }}"
 DELAY="{{ handler_health_mds_check_delay }}"
 MDS_NAME="{{ mds_name }}"
-SOCKET=/var/run/ceph/{{ cluster }}-mds.${MDS_NAME}.asok
 {% if containerized_deployment %}
 DOCKER_EXEC="docker exec ceph-mds-{{ ansible_hostname }}"
 {% endif %}
+
+# Backward compatibility
+$DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-mds.{{ ansible_fqdn }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-mds.{{ ansible_fqdn }}.asok
+$DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-mds.{{ ansible_hostname }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-mds.{{ ansible_hostname }}.asok
 
 # First, restart the daemon
 systemctl restart ceph-mds@${MDS_NAME}

--- a/roles/ceph-defaults/templates/restart_mgr_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_mgr_daemon.sh.j2
@@ -3,10 +3,13 @@
 RETRIES="{{ handler_health_mgr_check_retries }}"
 DELAY="{{ handler_health_mgr_check_delay }}"
 MGR_NAME="{{ ansible_hostname }}"
-SOCKET=/var/run/ceph/{{ cluster }}-mgr.${MGR_NAME}.asok
 {% if containerized_deployment %}
 DOCKER_EXEC="docker exec ceph-mgr-{{ ansible_hostname }}"
 {% endif %}
+
+# Backward compatibility
+$DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-mgr.{{ ansible_fqdn }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-mgr.{{ ansible_fqdn }}.asok
+$DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-mgr.{{ ansible_hostname }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-mgr.{{ ansible_hostname }}.asok
 
 systemctl reset-failed ceph-mgr@${MGR_NAME}
 # First, restart the daemon

--- a/roles/ceph-defaults/templates/restart_mon_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_mon_daemon.sh.j2
@@ -3,16 +3,17 @@
 RETRIES="{{ handler_health_mon_check_retries }}"
 DELAY="{{ handler_health_mon_check_delay }}"
 MONITOR_NAME="{{ monitor_name }}"
-SOCKET=/var/run/ceph/{{ cluster }}-mon.${MONITOR_NAME}.asok
 {% if containerized_deployment %}
 DOCKER_EXEC="docker exec ceph-mon-{{ ansible_hostname }}"
 {% endif %}
 
+# Backward compatibility
+$DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-mon.{{ ansible_fqdn }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-mon.{{ ansible_fqdn }}.asok
+$DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-mon.{{ ansible_hostname }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-mon.{{ ansible_hostname }}.asok
 
 check_quorum() {
 while [ $RETRIES -ne 0 ]; do
-  MEMBERS=$($DOCKER_EXEC ceph --cluster {{ cluster }} -s --format json | sed -r 's/.*"quorum_names":(\[[^]]+\]).*/\1/')
-  test "${MEMBERS/$MONITOR_NAME}" != "$MEMBERS" && exit 0
+  $DOCKER_EXEC ceph --cluster {{ cluster }} -s --format json | python -c 'import sys, json; exit(0) if "{{ monitor_name }}" in json.load(sys.stdin)["quorum_names"] else exit(1)' && exit 0
   sleep $DELAY
   let RETRIES=RETRIES-1
 done
@@ -27,7 +28,7 @@ exit 1
 }
 
 # First, restart the daemon
-systemctl restart ceph-mon@${MONITOR_NAME}
+systemctl restart ceph-mon@{{ ansible_hostname }}
 
 COUNT=10
 # Wait and ensure the socket exists after restarting the daemon

--- a/roles/ceph-defaults/templates/restart_rbd_mirror_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_rbd_mirror_daemon.sh.j2
@@ -3,13 +3,15 @@
 RETRIES="{{ handler_health_rbd_mirror_check_retries }}"
 DELAY="{{ handler_health_rbd_mirror_check_delay }}"
 RBD_MIRROR_NAME="{{ ansible_hostname }}"
+{% if containerized_deployment %}
+DOCKER_EXEC="docker exec ceph-rbd-mirror-{{ ansible_hostname }}"
+{% endif %}
 {% if ceph_release_num[ceph_release] < ceph_release_num['luminous'] %}
 SOCKET=/var/run/ceph/{{ cluster }}-client.admin.asok
 {% else %}
-SOCKET=/var/run/ceph/{{ cluster }}-client.rbd-mirror.${RBD_MIRROR_NAME}.asok
-{% endif %}
-{% if containerized_deployment %}
-DOCKER_EXEC="docker exec ceph-rbd-mirror-{{ ansible_hostname }}"
+# Backward compatibility
+$DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-client.rbd-mirror.{{ ansible_fqdn }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-client.rbd-mirror.{{ ansible_fqdn }}.asok
+$DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-client.rbd-mirror.{{ ansible_hostname }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-client.rbd-mirror.{{ ansible_hostname }}.asok
 {% endif %}
 
 # First, restart the daemon

--- a/roles/ceph-defaults/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_rgw_daemon.sh.j2
@@ -4,10 +4,12 @@ RETRIES="{{ handler_health_rgw_check_retries }}"
 DELAY="{{ handler_health_rgw_check_delay }}"
 RGW_NAME="{{ ansible_hostname }}"
 RGW_PORT="{{ radosgw_civetweb_port }}"
-SOCKET=/var/run/ceph/{{ cluster }}-client.rgw.${RGW_NAME}.asok
 {% if containerized_deployment %}
 DOCKER_EXEC="docker exec ceph-rgw-{{ ansible_hostname }}"
 {% endif %}
+# Backward compatibility
+$DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-client.rgw.{{ ansible_fqdn }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-client.rgw.{{ ansible_fqdn }}.asok
+$DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-client.rgw.{{ ansible_hostname }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-client.rgw.{{ ansible_hostname }}.asok
 {% if hostvars[inventory_hostname]['radosgw_address_block'] is defined and hostvars[inventory_hostname]['radosgw_address_block'] != 'subnet' %}
     {% if ip_version == 'ipv4' %}
 RGW_IP={{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }} \


### PR DESCRIPTION
This commit ensures we are backward compatible with fqdn deployments.
Since ceph-container enforces deployment to be done with shortname, we
must keep backward compatibility with clusters already deployed with
fqdn configuration

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>