### PR TITLE
corporate security does not like 0755 mode on directories

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -72,7 +72,7 @@
       state: directory
       owner: "ceph"
       group: "ceph"
-      mode: "0755"
+      mode: "{{ ceph_directories_mode | default('0755') }}"
 
   - name: "generate ceph configuration file: {{ cluster }}.conf"
     action: config_template
@@ -98,7 +98,7 @@
     file:
       path: "{{ fetch_directory }}/{{ fsid }}/etc/ceph"
       state: directory
-      mode: "0755"
+      mode: "{{ ceph_directories_mode | default('0755') }}"
     delegate_to: localhost
     when: ceph_conf_local | bool
 

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0755"
+    mode: "{{ ceph_directories_mode | default('0755') }}"
   with_items:
     - /var/lib/ceph/bootstrap-mds/
     - /var/lib/ceph/mds/{{ cluster }}-{{ mds_name }}

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0755"
+    mode: "{{ ceph_directories_mode | default('0755') }}"
 
 - name: fetch ceph mgr keyring
   ceph_key:

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -56,7 +56,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "u=rwX,g=rX,o=rX"
+    mode: "{{ ceph_directories_mode | default('0755') }}"
     recurse: true
 
 - name: create custom admin keyring

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -31,7 +31,7 @@
     state: directory
     owner: "ceph"
     group: "ceph"
-    mode: "0755"
+    mode: "{{ ceph_directories_mode | default('0755') }}"
   with_items:
     - { name: "/var/lib/ceph/bootstrap-rgw", create: "{{ nfs_obj_gw }}" }
     - { name: "/var/lib/ceph/radosgw", create: "{{ nfs_obj_gw }}" }

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0755"
+    mode: "{{ ceph_directories_mode | default('0755') }}"
   when: cephx | bool
   with_items:
     - /var/lib/ceph/bootstrap-osd/

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0755"
+    mode: "{{ ceph_directories_mode | default('0755') }}"
   with_items: "{{ rbd_client_admin_socket_path }}"
 
 - name: create rados gateway instance directories
@@ -14,7 +14,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0755"
+    mode: "{{ ceph_directories_mode | default('0755') }}"
   with_items: "{{ rgw_instances }}"
   when: rgw_instances is defined
 


### PR DESCRIPTION
This PR adds parametrization of directory mode when creating some basic directories for ceph.

This includes 2 most important from corporate security standpoint:

- /etc/ceph
- /var/lib/ceph

In next steps this can be further improved (by eg. moving `ceph_directories_mode` to group_vars or some role defaults).

This is solution for problem described in
https://github.com/ceph/ceph-ansible/issues/2920