### PR TITLE
osd: Fixed bug in regular expression in restart_osd_daemon.sh

### DIFF
--- a/roles/ceph-defaults/templates/restart_osd_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_osd_daemon.sh.j2
@@ -60,8 +60,8 @@ get_docker_osd_id() {
 }
 
 # For containerized deployments, the unit file looks like: ceph-osd@sda.service
-# For non-containerized deployments, the unit file looks like: ceph-osd@0.service
-for unit in $(systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-osd@([0-9]{1,2}|[a-z]+).service"); do
+# For non-containerized deployments, the unit file looks like: ceph-osd@NNN.service where NNN is OSD ID
+for unit in $(systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-osd@([0-9]{1,}|[a-z]+).service"); do
   # First, restart daemon(s)
   systemctl restart "${unit}"
   # We need to wait because it may take some time for the socket to actually exists
@@ -74,7 +74,7 @@ for unit in $(systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-
   osd_id=$whoami
   docker_exec="docker exec $container_id"
   {% else %}
-  osd_id=$(echo ${unit#ceph-osd@} | grep -oE '[0-9]{1,2}')
+  osd_id=$(echo ${unit#ceph-osd@} | grep -oE '[0-9]{1,}')
   {% endif %}
   SOCKET=/var/run/ceph/{{ cluster }}-osd.${osd_id}.asok
   while [ $COUNT -ne 0 ]; do


### PR DESCRIPTION
OSDs can have numbers >99 which means regular expression in `restart_osd_daemon.sh` should catch OSD number of any non-zero length.

This solves https://github.com/ceph/ceph-ansible/issues/2964
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1612853