### PR TITLE
iscsigw: install ceph-iscsi-cli package

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -5,6 +5,7 @@
       - ceph-iscsi-config
       - tcmu-runner
       - python-rtslib
+      - ceph-iscsi-cli
   when:
     - ansible_os_family == 'RedHat'
     - ceph_origin == 'repository'
@@ -48,6 +49,7 @@
     - ceph-iscsi-config
     - targetcli
     - python-rtslib
+    - ceph-iscsi-cli
   when:
     - ansible_os_family == 'RedHat'
 


### PR DESCRIPTION
Install ceph-iscsi-cli in order to provide the `gwcli` command tool.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1602785

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>