### PR TITLE
igw: enable and start rbd-target-api

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -72,3 +72,9 @@
     name: rbd-target-gw
     enabled: yes
     state: started
+
+- name: enable the rbd-target-api service and make sure it is running
+  service:
+    name: rbd-target-api
+    enabled: yes
+    state: started


### PR DESCRIPTION
The commit:

commit 1164cdc002cccb9dc1c6f10fb6b4370eafda3c4b
Author: Guillaume Abrioux <gabrioux@redhat.com>
Date:   Thu Aug 2 11:58:47 2018 +0200

    iscsigw: install ceph-iscsi-cli package

installs the cli package but does not start and enable the
rbd-target-api daemon needed for gwcli to communicate with the igw
nodes. This patch just enables and starts it for the non-container
setup. The container setup is already doing this.

This fixes bz https://bugzilla.redhat.com/show_bug.cgi?id=1613963.