### PR TITLE
[skip ci] common: upgrade/install ceph-test deb first

### DIFF
--- a/roles/ceph-common/tasks/installs/install_debian_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_packages.yml
@@ -6,12 +6,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
 
-- name: install ceph-common for debian
-  apt:
-    name: ceph-common
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
-
 - name: install ceph-test for debian
   apt:
     name: ceph-test
@@ -19,6 +13,12 @@
     default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
   when:
     - ceph_test
+
+- name: install ceph-common for debian
+  apt:
+    name: ceph-common
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
 
 - name: install rados gateway for debian
   apt:

--- a/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
@@ -1,4 +1,11 @@
 ---
+- name: install ceph-test for debian
+  apt:
+    name: ceph-test
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  when:
+    - ceph_test
+
 - name: install red hat storage ceph-common for debian
   apt:
     pkg: ceph-common
@@ -17,13 +24,6 @@
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   when:
     - osd_group_name in group_names
-
-- name: install ceph-test for debian
-  apt:
-    name: ceph-test
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  when:
-    - ceph_test
 
 - name: install red hat storage radosgw for debian
   apt:


### PR DESCRIPTION
When we deploy a Jewel cluster on Ubuntu with `ceph_test: True`, we're unable to upgrade that cluster to Luminous.

`apt-get install ceph-common` fails to upgrade to luminous if a jewel `ceph-test` package is installed:

```
  Some packages could not be installed. This may mean that you have
  requested an impossible situation or if you are using the unstable
  distribution that some required packages have not yet been created
  or been moved out of Incoming.
  The following information may help to resolve the situation:

  The following packages have unmet dependencies:
   ceph-base : Breaks: ceph-test (< 12.2.2-14) but 10.2.11-1xenial is to be installed
   ceph-mon : Breaks: ceph-test (< 12.2.2-14) but 10.2.11-1xenial is to be installed
```

In ceph-ansible master, we resolve this whole class of problem by installing all the packages in one operation (see b338fafd90bbe489726b92d703bf4bc29d1caf6d).

For the stable-3.1 branch, take a less-invasive approach, and upgrade ceph-test prior to any other package. This matches the approach I took for RPMs in 3752cc6f38dbf476845e975e6448225c0e103ad6, before we had the better solution in b338fafd90bbe489726b92d703bf4bc29d1caf6d.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1610997