### PR TITLE
rolling_update: fix upgrade when using fqdn

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -105,11 +105,21 @@
         - containerized_deployment
         - mon_host_count | int == 1
 
-    - name: stop ceph mon
+    - name: stop ceph mon - shortname
       systemd:
         name: ceph-mon@{{ ansible_hostname }}
         state: stopped
         enabled: yes
+      ignore_errors: True
+      when:
+        - not containerized_deployment
+
+    - name: stop ceph mon - fqdn
+      systemd:
+        name: ceph-mon@{{ ansible_fqdn }}
+        state: stopped
+        enabled: yes
+      ignore_errors: True
       when:
         - not containerized_deployment
 
@@ -124,7 +134,7 @@
   post_tasks:
     - name: start ceph mon
       systemd:
-        name: ceph-mon@{{ ansible_hostname }}
+        name: ceph-mon@{{ monitor_name }}
         state: started
         enabled: yes
       when:
@@ -132,7 +142,7 @@
 
     - name: restart containerized ceph mon
       systemd:
-        name: ceph-mon@{{ ansible_hostname }}
+        name: ceph-mon@{{ monitor_name }}
         state: restarted
         enabled: yes
         daemon_reload: yes


### PR DESCRIPTION
CLusters that were deployed using 'mon_use_fqdn' have a different unit
name, so during the upgrade this must be used otherwise the upgrade will
fail, looking for a unit that does not exist.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1597516
Signed-off-by: Sébastien Han <seb@redhat.com>