### PR TITLE
osd: generate device list for osd_auto_discovery on rolling_update

### DIFF
--- a/roles/ceph-osd/tasks/build_devices.yml
+++ b/roles/ceph-osd/tasks/build_devices.yml
@@ -12,6 +12,18 @@
     - item.value.holders|count == 0
     - "'dm-' not in item.key"
 
+- name: set_fact devices generate device list when osd_auto_discovery - rolling_update
+  set_fact:
+    devices: "{{ devices | default([]) + [ item.key | regex_replace('^', '/dev/') ] }}"
+  with_dict: "{{ ansible_devices }}"
+  when:
+    - osd_auto_discovery
+    - rolling_update
+    - ansible_devices is defined
+    - "'dm-' not in item.key"
+    - item.value.removable == "0"
+    - item.value.sectors != "0"
+
 - name: resolve dedicated device link(s)
   command: readlink -f {{ item }}
   changed_when: false


### PR DESCRIPTION
rolling_update relies on the list of devices when performing the restart
of the OSDs. The task that is builind the devices list out of the
ansible_devices dict only runs when there are no partitions on the
drives. However during an upgrade the OSD are already configured, they
have been prepared and have partitions so this task won't run and thus
the devices list will be empty, skipping the restart during
rolling_update. We now run the same task under different requirements
when rolling_update is true and build a list when:

* osd_auto_discovery is true
* rolling_update is true
* ansible_devices exists
* no dm/lv are part of the discovery
* the device is not removable
* the device has more than 1 sector

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1613626
Signed-off-by: Sébastien Han <seb@redhat.com>