### PR TITLE
lvm: fix condition when selecting which scenario to run

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -54,7 +54,7 @@
   include: scenarios/lvm.yml
   when:
     - osd_scenario == 'lvm'
-    - lvm_volumes is defined
+    - lvm_volumes|length > 0
     - not containerized_deployment
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
@@ -63,7 +63,7 @@
   include: scenarios/lvm-batch.yml
   when:
     - osd_scenario == 'lvm'
-    - devices is defined
+    - devices|length > 0
     - not containerized_deployment
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False


### PR DESCRIPTION
devices and lvm_volumes will always be defined, so we need to instead
check it's length before deciding to run the scenario.

This fixes the failure here:
https://2.jenkins.ceph.com/job/ceph-ansible-prs-luminous-bluestore_lvm_osds/86/consoleFull#1667273050b5dd38fa-a56e-4233-a5ca-584604e56e3a

Signed-off-by: Andrew Schoen <aschoen@redhat.com>