### PR TITLE
mon: fix calamari initialisation

### DIFF
--- a/roles/ceph-mon/tasks/calamari.yml
+++ b/roles/ceph-mon/tasks/calamari.yml
@@ -1,8 +1,17 @@
 ---
+- name: test if calamari-server is installed
+  command: rpm -q --qf "%{VERSION}\n" calamari-server
+  args:
+    warn: no
+  ignore_errors: true
+  check_mode: no
+  changed_when: false
+  register: calamari_server_rpm_state
+
 - name: install calamari server
   package:
     name: calamari-server
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+    state: "{{ 'latest' if (calamari_server_rpm_state.stdout.split('.')[0] is version(ceph_rhcs_version, '<') and not calamari_server_rpm_state.failed) else (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
   tags:
     - package-install
 


### PR DESCRIPTION
If calamari is already installed and ceph has been upgraded to a higher
version the initialisation will fail later. So if we detect the
calamari-server is too old compare to ceph_rhcs_version we try to update
it.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1601755
Signed-off-by: Sébastien Han <seb@redhat.com>