### PR TITLE
roles: ceph-defaults: Set ceph_uid on SUSE distributions

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -190,12 +190,12 @@
     - not containerized_deployment
     - ansible_os_family == 'Debian'
 
-- name: set_fact ceph_uid for red hat based system - non container
+- name: set_fact ceph_uid for red hat or suse based system - non container
   set_fact:
     ceph_uid: 167
   when:
     - not containerized_deployment
-    - ansible_os_family == 'RedHat'
+    - ansible_os_family in ['RedHat', 'Suse']
 
 - name: set_fact ceph_uid for debian based system - container
   set_fact:


### PR DESCRIPTION
The ceph_uid is also '167' on SUSE systems so extend the existing task.

Signed-off-by: Markos Chandras <mchandras@suse.de>