### PR TITLE
roles: ceph-defaults: Handle missing 'ceph' binary failures

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -221,6 +221,14 @@
 - block:
     - name: get current cluster status (if already running)
       command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} -s -f json"
+      changed_when: false
+      failed_when: false
+      check_mode: no
+      run_once: true
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      when:
+        - not rolling_update
+        - groups.get(mon_group_name, []) | length > 0
       register: ceph_current_status
 
     - name: set_fact ceph_current_status (convert to json)

--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -238,6 +238,7 @@
     - name: set_fact rgw_hostname
       set_fact:
         rgw_hostname: "{% for key in ceph_current_status['servicemap']['services']['rgw']['daemons'].keys() %}{% if key == ansible_fqdn %}{{ key }}{% endif %}{% endfor %}"
+      when: ceph_current_status['servicemap']['services']['rgw'] is defined
   when:
     - ceph_current_fsid.get('rc', 1) == 0
     - inventory_hostname in groups.get(rgw_group_name, [])


### PR DESCRIPTION
Since commit f422efb1d6b56ce56a7d39a21736a471e4ed357 ("config: ensure
rgw section has the correct name") we observe the following failures in
new Ceph deployment with OpenStack-Ansible

fatal: [aio1_ceph-rgw_container-fc588f0a]: FAILED! => {"changed": false,
"cmd": "ceph --cluster ceph -s -f json", "msg": "[Errno 2] No such file
or directory"

The problem is because of the following two problems:

- The commit added the following conditional: 'ansible_hostname !=
ansible_fqdn' which for a properly configured system it evaluates to
'True' since ansible_hostname is not supposed to return an FQDN.

- The task executes 'ceph' but at this point no package installation has
happened. Packages are normally installed in the 'ceph-common' role
which runs after the 'ceph-defaults' one.

As such, we can handle failures in the first task so the subsequent
ones will not fail.

Signed-off-by: Markos Chandras <mchandras@suse.de>