### PR TITLE
[skip ci] take-over-existing-cluster: do not call var_files

### DIFF
--- a/infrastructure-playbooks/take-over-existing-cluster.yml
+++ b/infrastructure-playbooks/take-over-existing-cluster.yml
@@ -1,6 +1,6 @@
 ---
 # NOTE (leseb):
-# The playbook aims to takeover a cluster that was not configured with 
+# The playbook aims to takeover a cluster that was not configured with
 # ceph-ansible.
 #
 # The procedure is as follows:
@@ -13,9 +13,6 @@
 
 - hosts: mons
   become: True
-  vars_files:
-    - roles/ceph-defaults/defaults/main.yml
-    - group_vars/all.yml
   roles:
     - ceph-defaults
     - ceph-fetch-keys


### PR DESCRIPTION
We were using var_files long ago when default variables were not in
ceph-defaults, now the role exists this is not need. Moreover having
these two var files added:

- roles/ceph-defaults/defaults/main.yml
- group_vars/all.yml

Will create collision and override necessary variables.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1555305
Signed-off-by: Sébastien Han <seb@redhat.com>