### PR TITLE
iscsi group name preserve backward compatibility

### DIFF
--- a/infrastructure-playbooks/purge-iscsi-gateways.yml
+++ b/infrastructure-playbooks/purge-iscsi-gateways.yml
@@ -20,7 +20,9 @@
         igw_purge_type: "{{ purge_config }}"
 
 - name: Removing the gateway configuration
-  hosts: iscsigws
+  hosts:
+    - iscsigws
+    - iscsi-gws # for backward compatibility only!
   become: yes
   vars:
     - igw_purge_type: "{{hostvars['localhost']['igw_purge_type']}}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -697,6 +697,7 @@
 
   hosts:
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
+    - iscsi-gws # for backward compatibility only!
 
   serial: 1
   become: True

--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -12,6 +12,7 @@
   - rbdmirrors
   - clients
   - iscsigws
+  - iscsi-gws # for backward compatibility only!
   - mgrs
 
   gather_facts: false
@@ -331,7 +332,9 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: iscsigws
+- hosts:
+    - iscsigws
+    - iscsi-gws # for backward compatibility only!
   gather_facts: false
   become: True
   pre_tasks:

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -13,6 +13,7 @@
   - clients
   - mgrs
   - iscsigws
+  - iscsi-gws # for backward compatibility only!
 
   gather_facts: false
   any_errors_fatal: true
@@ -358,7 +359,9 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: iscsigws
+- hosts:
+    - iscsigws
+    - iscsi-gws # for backward compatibility only!
   gather_facts: false
   become: True
   pre_tasks:


### PR DESCRIPTION
Recently we renamed the group_name for iscsi iscsigws where previously
it was named iscsi-gws. Existing deployments with a host file section
with iscsi-gws must continue to work.

This commit adds the old group name as a backoward compatility, no error
from Ansible should be expected, if the hostgroup is not found nothing
is played.

Close: https://bugzilla.redhat.com/show_bug.cgi?id=1619167
Signed-off-by: Sébastien Han <seb@redhat.com>