### PR TITLE
rolling_upgrade: set sortbitwise properly

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -415,7 +415,7 @@
       delegate_to: "{{ groups[mon_group_name][0] }}"
       when:
         - (ceph_versions.get('stdout', '{}')|from_json).get('osd', {}) | length == 1
-        - ceph_versions_osd | string | search("ceph version 12")
+        - ceph_versions_osd | string | search("ceph version 10")
         - not jewel_minor_update
 
     - name: get num_pgs - non container


### PR DESCRIPTION
Running 'osd set sortbitwise' when we detect a version 12 of Ceph is
wrong. When OSD are getting updated, even though the package is updated
they won't send their updated version (12) and will stick with 10 if the
command is not applied. So we have to check if OSD are sending a version
10 and then run the command to unlock the OSDs.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1600943
Signed-off-by: Sébastien Han <seb@redhat.com>