### PR TITLE
ci: stop using different images on the same run

### DIFF
--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -57,7 +57,6 @@
     - role: ceph-docker-common
       tags: [with_pkg, fetch_container_image]
       when:
-        - containerized_deployment | bool
         - not (is_atomic | bool)
         - (not (inventory_hostname in groups.get('clients', [])) or (inventory_hostname == groups.get('clients', [''])|first))
 

--- a/tests/functional/centos/7/docker-collocation/vagrant_variables.yml
+++ b/tests/functional/centos/7/docker-collocation/vagrant_variables.yml
@@ -46,7 +46,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-client_vagrant_box: centos/7
+# client_vagrant_box: centos/7
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/centos/7/ooo-collocation/vagrant_variables.yml
+++ b/tests/functional/centos/7/ooo-collocation/vagrant_variables.yml
@@ -46,7 +46,7 @@ disks: "[ '/dev/sda', '/dev/sdb', '/dev/sdc' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-client_vagrant_box: centos/7
+# client_vagrant_box: centos/7
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant


### PR DESCRIPTION
There is no point of using hosts running on atomic AND centos hosts. So
let's run containerized scenarios on Atomic only.

Signed-off-by: Sébastien Han <seb@redhat.com>