### PR TITLE
sites: fix conditonnal

### DIFF
--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -346,7 +346,7 @@
             start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
   roles:
     - { role: ceph-defaults, tags: ['ceph_update_config'] }
-    - { role: ceph-docker-common, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
+    - { role: ceph-docker-common }
     - { role: ceph-config, tags: ['ceph_update_config'], when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
     - { role: ceph-iscsi-gw, when: "ceph_release_num[ceph_release] >= ceph_release_num.luminous" }
   post_tasks:

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -376,8 +376,6 @@
     - role: ceph-defaults
       tags: ['ceph_update_config']
     - role: ceph-common
-      when:
-        - ceph_release_num[ceph_release] >= ceph_release_num.luminous
     - role: ceph-config
       tags: ['ceph_update_config']
       when:


### PR DESCRIPTION
Same problem again... ceph_release_num[ceph_release] is only set in
ceph-docker-common/common roles so putting the condition on that role
will never work. Removing the condition.

The downside of this is we will be installing packages and then skip the
role on the node.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1622210
Signed-off-by: Sébastien Han <seb@redhat.com>