### PR TITLE
purge: only purge /var/lib/ceph content

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -534,9 +534,7 @@
     listen: "remove data"
 
   - name: remove data
-    file:
-     path: /var/lib/ceph
-     state: absent
+    command: rm -rf /var/lib/ceph/*
     listen: "remove data"
 
   tasks:

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -651,8 +651,10 @@
       state: absent
     with_items:
       - /etc/ceph
-      - /var/lib/ceph
       - /var/log/ceph
+
+  - name: remove data
+    command: rm -rf /var/lib/ceph/*
 
 
 - name: purge fetch directory


### PR DESCRIPTION
Sometime /var/lib/ceph is mounted on a device so we won't be able to
remove it (device busy) so let's remove its content only.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1615872
Signed-off-by: Sébastien Han <seb@redhat.com>