### PR TITLE
roles: ceph-rgw: Enable the ceph-radosgw target

### DIFF
--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -20,3 +20,9 @@
     name: ceph-radosgw@rgw.{{ ansible_hostname }}
     state: started
     enabled: yes
+
+- name: enable the ceph-radosgw.target service
+  systemd:
+    name: ceph-radosgw.target
+    enabled: yes
+    masked: no


### PR DESCRIPTION
If the ceph-radosgw target is not enabled, then enabling the
ceph-radosgw@ service has no effect since nothing will pull
it on the next reboot. As such, we need to ensure that the
target is enabled.

Signed-off-by: Markos Chandras <mchandras@suse.de>