### PR TITLE
Use a tempfile to store restart scripts

### DIFF
--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -9,6 +9,23 @@
       register: result
       until: result is succeeded
 
+    - name: make tempdir for scripts
+      tempfile:
+        state: directory
+        prefix: ceph_ansible
+      listen:
+        - "restart ceph mons"
+        - "restart ceph osds"
+        - "restart ceph mdss"
+        - "restart ceph rgws"
+        - "restart ceph nfss"
+        - "restart ceph rbdmirrors"
+        - "restart ceph mgrs"
+        - "restart ceph tcmu-runner"
+        - "restart ceph rbd-target-api-gw"
+      register: tmpdirpath
+      when: tmpdirpath is not defined or tmpdirpath.path is not defined or tmpdirpath.state=="absent"
+
     - name: mons handler
       include_tasks: handler_mons.yml
       when: mon_group_name in group_names
@@ -53,3 +70,20 @@
       include_tasks: handler_rbd_target_api_gw.yml
       when: iscsi_gw_group_name in group_names
       listen: "restart ceph rbd-target-api-gw"
+
+    - name: remove tempdir for scripts
+      file:
+        path: "{{ tmpdirpath.path }}"
+        state: absent
+      listen:
+        - "restart ceph mons"
+        - "restart ceph osds"
+        - "restart ceph mdss"
+        - "restart ceph rgws"
+        - "restart ceph nfss"
+        - "restart ceph rbdmirrors"
+        - "restart ceph mgrs"
+        - "restart ceph tcmu-runner"
+        - "restart ceph rbd-target-api-gw"
+      register: tmpdirpath
+      when: tmpdirpath is defined

--- a/roles/ceph-handler/tasks/handler_mdss.yml
+++ b/roles/ceph-handler/tasks/handler_mdss.yml
@@ -6,13 +6,13 @@
 - name: copy mds restart script
   template:
     src: restart_mds_daemon.sh.j2
-    dest: /tmp/restart_mds_daemon.sh
+    dest: "{{ tmpdirpath.path }}/restart_mds_daemon.sh"
     owner: root
     group: root
     mode: 0750
 
 - name: restart ceph mds daemon(s)
-  command: /usr/bin/env bash /tmp/restart_mds_daemon.sh
+  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_mds_daemon.sh
   when:
     - handler_mds_status | bool
     - hostvars[item]['_mds_handler_called'] | default(False) | bool

--- a/roles/ceph-handler/tasks/handler_mgrs.yml
+++ b/roles/ceph-handler/tasks/handler_mgrs.yml
@@ -6,13 +6,13 @@
 - name: copy mgr restart script
   template:
     src: restart_mgr_daemon.sh.j2
-    dest: /tmp/restart_mgr_daemon.sh
+    dest: "{{ tmpdirpath.path }}/restart_mgr_daemon.sh"
     owner: root
     group: root
     mode: 0750
 
 - name: restart ceph mgr daemon(s)
-  command: /usr/bin/env bash /tmp/restart_mgr_daemon.sh
+  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_mgr_daemon.sh
   when:
     - handler_mgr_status | bool
     - hostvars[item]['_mgr_handler_called'] | default(False) | bool

--- a/roles/ceph-handler/tasks/handler_mons.yml
+++ b/roles/ceph-handler/tasks/handler_mons.yml
@@ -9,13 +9,13 @@
 - name: copy mon restart script
   template:
     src: restart_mon_daemon.sh.j2
-    dest: /tmp/restart_mon_daemon.sh
+    dest: "{{ tmpdirpath.path }}/restart_mon_daemon.sh"
     owner: root
     group: root
     mode: 0750
 
 - name: restart ceph mon daemon(s)
-  command: /usr/bin/env bash /tmp/restart_mon_daemon.sh
+  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_mon_daemon.sh
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - handler_mon_status | bool

--- a/roles/ceph-handler/tasks/handler_nfss.yml
+++ b/roles/ceph-handler/tasks/handler_nfss.yml
@@ -6,13 +6,13 @@
 - name: copy nfs restart script
   template:
     src: restart_nfs_daemon.sh.j2
-    dest: /tmp/restart_nfs_daemon.sh
+    dest: "{{ tmpdirpath.path }}/restart_nfs_daemon.sh"
     owner: root
     group: root
     mode: 0750
 
 - name: restart ceph nfs daemon(s)
-  command: /usr/bin/env bash /tmp/restart_nfs_daemon.sh
+  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_nfs_daemon.sh
   when:
     - handler_nfs_status | bool
     - hostvars[item]['_nfs_handler_called'] | default(False) | bool

--- a/roles/ceph-handler/tasks/handler_osds.yml
+++ b/roles/ceph-handler/tasks/handler_osds.yml
@@ -12,13 +12,13 @@
 - name: copy osd restart script
   template:
     src: restart_osd_daemon.sh.j2
-    dest: /tmp/restart_osd_daemon.sh
+    dest: "{{ tmpdirpath.path }}/restart_osd_daemon.sh"
     owner: root
     group: root
     mode: 0750
 
 - name: restart ceph osds daemon(s)
-  command: /usr/bin/env bash /tmp/restart_osd_daemon.sh
+  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_osd_daemon.sh
   when:
     - handler_osd_status | bool
     - handler_health_osd_check | bool

--- a/roles/ceph-handler/tasks/handler_rbd_target_api_gw.yml
+++ b/roles/ceph-handler/tasks/handler_rbd_target_api_gw.yml
@@ -6,13 +6,13 @@
 - name: copy rbd-target-api restart script
   template:
     src: restart_rbd_target_api.sh.j2
-    dest: /tmp/restart_rbd_target_api.sh
+    dest: "{{ tmpdirpath.path }}/restart_rbd_target_api.sh"
     owner: root
     group: root
     mode: 0750
 
 - name: restart rbd-target-api
-  command: /usr/bin/env bash /tmp/restart_rbd_target_api.sh
+  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_rbd_target_api.sh
   when:
     - ceph_rbd_target_api_stat.get('rc') == 0
     - hostvars[item]['_rbd_target_api_handler_called'] | default(False) | bool
@@ -32,13 +32,13 @@
 - name: copy rbd-target-gw restart script
   template:
     src: restart_rbd_target_gw.sh.j2
-    dest: /tmp/restart_rbd_target_gw.sh
+    dest: "{{ tmpdirpath.path }}/restart_rbd_target_gw.sh"
     owner: root
     group: root
     mode: 0750
 
 - name: restart rbd-target-gw
-  command: /usr/bin/env bash /tmp/restart_rbd_target_gw.sh
+  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_rbd_target_gw.sh
   when:
     - ceph_rbd_target_gw_stat.get('rc') == 0
     - hostvars[item]['_rbd_target_gw_handler_called'] | default(False) | bool

--- a/roles/ceph-handler/tasks/handler_rbdmirrors.yml
+++ b/roles/ceph-handler/tasks/handler_rbdmirrors.yml
@@ -6,13 +6,13 @@
 - name: copy rbd mirror restart script
   template:
     src: restart_rbd_mirror_daemon.sh.j2
-    dest: /tmp/restart_rbd_mirror_daemon.sh
+    dest: "{{ tmpdirpath.path }}/restart_rbd_mirror_daemon.sh"
     owner: root
     group: root
     mode: 0750
 
 - name: restart ceph rbd mirror daemon(s)
-  command: /usr/bin/env bash /tmp/restart_rbd_mirror_daemon.sh
+  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_rbd_mirror_daemon.sh
   when:
     - handler_rbd_mirror_status | bool
     - hostvars[item]['_rbdmirror_handler_called'] | default(False) | bool

--- a/roles/ceph-handler/tasks/handler_rgws.yml
+++ b/roles/ceph-handler/tasks/handler_rgws.yml
@@ -6,13 +6,13 @@
 - name: copy rgw restart script
   template:
     src: restart_rgw_daemon.sh.j2
-    dest: /tmp/restart_rgw_daemon.sh
+    dest: "{{ tmpdirpath.path }}/restart_rgw_daemon.sh"
     owner: root
     group: root
     mode: 0750
 
 - name: restart ceph rgw daemon(s)
-  command: /usr/bin/env bash /tmp/restart_rgw_daemon.sh
+  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_rgw_daemon.sh
   when:
     - handler_rgw_status | bool
     - hostvars[item]['_rgw_handler_called'] | default(False) | bool

--- a/roles/ceph-handler/tasks/handler_tcmu_runner.yml
+++ b/roles/ceph-handler/tasks/handler_tcmu_runner.yml
@@ -6,13 +6,13 @@
 - name: copy tcmu-runner restart script
   template:
     src: restart_tcmu_runner.sh.j2
-    dest: /tmp/restart_tcmu_runner.sh
+    dest: "{{ tmpdirpath.path }}/restart_tcmu_runner.sh"
     owner: root
     group: root
     mode: 0750
 
 - name: restart tcmu-runner
-  command: /usr/bin/env bash /tmp/restart_tcmu_runner.sh
+  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_tcmu_runner.sh
   when:
     - ceph_tcmu_runner_stat.get('rc') == 0
     - hostvars[item]['_tcmu_runner_handler_called'] | default(False) | bool


### PR DESCRIPTION
Make a tempfile directory and copy the restart scripts there (and then
execute them from there), rather than using insecure known filenames
in /tmp/

This is a partial fix for ceph/ceph-ansible#2937

Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>