### PR TITLE
tests: allow to define a custom number of OSDs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,9 @@ def node(host, request):
         num_devices = len(ansible_vars.get("devices", []))
     if not num_devices:
         num_devices = len(ansible_vars.get("lvm_volumes", []))
+    # If number of devices doesn't map to number of OSDs, allow tests to define
+    # that custom number, defaulting it to ``num_devices``
+    num_osds = ansible_vars.get('num_osds', num_devices)
     cluster_name = ansible_vars.get("cluster", "ceph")
     conf_path = "/etc/ceph/{}.conf".format(cluster_name)
     if "osds" in group_names:
@@ -116,6 +119,7 @@ def node(host, request):
         osd_ids=osd_ids,
         num_mons=num_mons,
         num_devices=num_devices,
+        num_osds=num_osds,
         cluster_name=cluster_name,
         conf_path=conf_path,
         cluster_address=cluster_address,

--- a/tests/functional/tests/osd/test_osds.py
+++ b/tests/functional/tests/osd/test_osds.py
@@ -11,12 +11,12 @@ class TestOSDs(object):
 
     def test_osds_listen_on_public_network(self, node, host):
         # TODO: figure out way to paramaterize this test
-        nb_port = (node["num_devices"] * 2)
+        nb_port = (node["num_osds"] * 2)
         assert host.check_output("netstat -lntp | grep ceph-osd | grep %s | wc -l" % (node["address"])) == str(nb_port)
 
     def test_osds_listen_on_cluster_network(self, node, host):
         # TODO: figure out way to paramaterize this test
-        nb_port = (node["num_devices"] * 2)
+        nb_port = (node["num_osds"] * 2)
         assert host.check_output("netstat -lntp | grep ceph-osd | grep %s | wc -l" % (node["cluster_address"])) == str(nb_port)
 
     def test_osd_services_are_running(self, node, host):
@@ -67,7 +67,7 @@ class TestOSDs(object):
     def test_all_osds_are_up_and_in(self, node, host):
         cmd = "sudo ceph --cluster={cluster} --connect-timeout 5 --keyring /var/lib/ceph/bootstrap-osd/{cluster}.keyring -n client.bootstrap-osd osd tree -f json".format(cluster=node["cluster_name"])
         output = json.loads(host.check_output(cmd))
-        assert node["num_devices"] == self._get_nb_up_osds_from_ids(node, output)
+        assert node["num_osds"] == self._get_nb_up_osds_from_ids(node, output)
 
     @pytest.mark.docker
     def test_all_docker_osds_are_up_and_in(self, node, host):
@@ -76,4 +76,4 @@ class TestOSDs(object):
             cluster=node["cluster_name"]
         )
         output = json.loads(host.check_output(cmd))
-        assert node["num_devices"] == self._get_nb_up_osds_from_ids(node, output)
+        assert node["num_osds"] == self._get_nb_up_osds_from_ids(node, output)


### PR DESCRIPTION
In ceph-volume, we can have more (or less) OSDs running that the number of devices. To be able to test that, we need to be able to define a custom number of expected OSDs to be running.

For example, in `ceph-volume lvm batch` if it received an input of a slow and fast device (two devices in total): `/dev/sda /dev/nvme0n1` the total OSDs will be 1, not 2. 

The changes should not affect current tests, while still allowing modification for newer tests.