### PR TITLE
ceph-nfs: run rados cmds in container

### DIFF
--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -1,15 +1,23 @@
 ---
+- name: set_fact docker_exec_cmd_nfs
+  set_fact:
+    docker_exec_cmd_nfs: "docker exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
+  when:
+    - containerized_deployment
+
 - name: check if rados index object exists
-  shell: "rados -p {{ cephfs_data }} --cluster {{ cluster }} ls|grep {{ ceph_nfs_rados_export_index }}"
+  shell: "{{ docker_exec_cmd_nfs | default('') }} rados -p {{ cephfs_data }} --cluster {{ cluster }} ls|grep {{ ceph_nfs_rados_export_index }}"
   changed_when: false
   failed_when: false
   register: rados_index_exists
   check_mode: no
   when:
     - ceph_nfs_rados_backend
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
 
 - name: create an empty rados index object
-  shell: "echo | rados -p {{ cephfs_data }} --cluster {{ cluster }} put {{ ceph_nfs_rados_export_index }} -"
+  shell: "{{ docker_exec_cmd_nfs | default('') }} rados -p {{ cephfs_data }} --cluster {{ cluster }} put {{ ceph_nfs_rados_export_index }} /dev/null"
   when:
     - ceph_nfs_rados_backend
     - rados_index_exists.rc != 0


### PR DESCRIPTION
When ceph-nfs is deployed containerized and ceph-common is not
installed on the host the start_nfs task fails because the rados
command is missing on the host.

Run rados commands from a ceph container instead so that
they will succeed.

Signed-off-by: Tom Barron <tpb@dyncloud.net>