### PR TITLE
ceph-mon: remove unnessary command

### DIFF
--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -5,7 +5,7 @@ After=docker.service
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/docker rm ceph-mon-%i
-ExecStartPre=$(command -v mkdir) -p /etc/ceph /var/lib/ceph/mon
+ExecStartPre=/usr/bin/mkdir -p /etc/ceph /var/lib/ceph/mon
 ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i \
   --memory={{ ceph_mon_docker_memory_limit }} \
 {% if ceph_docker_version.split('.')[0] | version_compare('13', '>=') -%}


### PR DESCRIPTION
It appears it's not necessary to find the path of mkdir since it's the same most of the time (as far as I can tell).

Closes: https://github.com/ceph/ceph-ansible/issues/3064
Signed-off-by: Sébastien Han <seb@redhat.com>