### PR TITLE
Add support for different NTP daemons

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -105,9 +105,14 @@ dummy:
 # Whether or not to install the ceph-test package.
 #ceph_test: false
 
-# Enable the ntp service by default to avoid clock skew on
-# ceph nodes
+# Enable the ntp service by default to avoid clock skew on ceph nodes
+# Disable if an appropriate NTP client is already installed and configured
 #ntp_service_enabled: true
+
+# Set type of NTP client daemon to use, valid entries are chronyd, ntpd or timesyncd
+# Note that this selection is currently ignored on containerized deployments
+#ntp_daemon_type: timesyncd
+
 
 # Set uid/gid to default '64045' for bootstrap directories.
 # '64045' is used for debian based distros. It must be set to 167 in case of rhel based distros.

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -105,9 +105,14 @@ fetch_directory: ~/ceph-ansible-keys
 # Whether or not to install the ceph-test package.
 #ceph_test: false
 
-# Enable the ntp service by default to avoid clock skew on
-# ceph nodes
+# Enable the ntp service by default to avoid clock skew on ceph nodes
+# Disable if an appropriate NTP client is already installed and configured
 #ntp_service_enabled: true
+
+# Set type of NTP client daemon to use, valid entries are chronyd, ntpd or timesyncd
+# Note that this selection is currently ignored on containerized deployments
+#ntp_daemon_type: timesyncd
+
 
 # Set uid/gid to default '64045' for bootstrap directories.
 # '64045' is used for debian based distros. It must be set to 167 in case of rhel based distros.

--- a/roles/ceph-common/tasks/misc/ntp_debian.yml
+++ b/roles/ceph-common/tasks/misc/ntp_debian.yml
@@ -1,11 +1,29 @@
 ---
-- name: install ntp on debian
-  package:
-    name: ntp
-    state: present
+- name: setup ntpd
+  block:
+    - command: timedatectl set-ntp no
+    - package:
+        name: ntp
+        state: present
+    - service:
+        name: ntp
+        enabled: yes
+        state: started
+  when: ntp_daemon_type == "ntpd"
 
-- name: start the ntp service
-  service:
-    name: ntp
-    enabled: yes
-    state: started
+- name: setup chrony
+  block:
+    - command: timedatectl set-ntp no
+    - package:
+        name: chrony
+        state: present
+    - service:
+        name: chronyd
+        enabled: yes
+        state: started
+  when: ntp_daemon_type == "chronyd"
+
+- name: setup timesyncd
+  block:
+    - command: timedatectl set-ntp on
+  when: ntp_daemon_type == "timesyncd"

--- a/roles/ceph-common/tasks/misc/ntp_rpm.yml
+++ b/roles/ceph-common/tasks/misc/ntp_rpm.yml
@@ -1,11 +1,29 @@
 ---
-- name: install ntp
-  package:
-    name: ntp
-    state: present
+- name: setup ntpd
+  block:
+    - command: timedatectl set-ntp no
+    - package:
+        name: ntp
+        state: present
+    - service:
+        name: ntpd
+        enabled: yes
+        state: started
+  when: ntp_daemon_type == "ntpd"
 
-- name: start the ntp service
-  service:
-    name: ntpd
-    enabled: yes
-    state: started
+- name: setup chrony
+  block:
+    - command: timedatectl set-ntp no
+    - package:
+        name: chrony
+        state: present
+    - service:
+        name: chronyd
+        enabled: yes
+        state: started
+  when: ntp_daemon_type == "chronyd"
+
+- name: setup timesyncd
+  block:
+    - command: timedatectl set-ntp on
+  when: ntp_daemon_type == "timesyncd"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -97,9 +97,14 @@ suse_package_dependencies:
 # Whether or not to install the ceph-test package.
 ceph_test: false
 
-# Enable the ntp service by default to avoid clock skew on
-# ceph nodes
+# Enable the ntp service by default to avoid clock skew on ceph nodes
+# Disable if an appropriate NTP client is already installed and configured
 ntp_service_enabled: true
+
+# Set type of NTP client daemon to use, valid entries are chronyd, ntpd or timesyncd
+# Note that this selection is currently ignored on containerized deployments
+ntp_daemon_type: timesyncd
+
 
 # Set uid/gid to default '64045' for bootstrap directories.
 # '64045' is used for debian based distros. It must be set to 167 in case of rhel based distros.

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -28,6 +28,13 @@
     - ceph_rhcs_cdn_debian_repo == 'https://customername:customerpasswd@rhcs.download.redhat.com'
     - ceph_repository not in ['rhcs', 'dev', 'obs']
 
+- name: validate ntp daemon type
+  fail:
+    msg: "ntp_daemon_type must be one of chronyd, ntpd, or timesyncd"
+  when:
+    - ntp_service_enabled
+    - ntp_daemon_type not in ['chronyd', 'ntpd', 'timesyncd']
+
 - name: make sure journal_size configured
   debug:
     msg: "WARNING: journal_size is configured to {{ journal_size }}, which is less than 5GB. This is not recommended and can lead to severe issues."


### PR DESCRIPTION
Allow user to choose between timesyncd, chronyd and ntpd
Installation will default to timesyncd since it is distributed as
part of the systemd installation for most distros.

Fixes issue #3086 on Github

Signed off by: Benjamin Cherian <benjamin_cherian@amat.com>