### PR TITLE
mon: fix `ExecStartPre` option in systemd unit file

### DIFF
--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -5,7 +5,7 @@ After=docker.service
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/docker rm ceph-mon-%i
-ExecStartPre=$(command -v mkdir) -p /etc/ceph /var/lib/ceph/mon
+ExecStartPre=/bin/sh -c '"$(command -v mkdir)" -p /etc/ceph /var/lib/ceph/mon'
 ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i \
   --memory={{ ceph_mon_docker_memory_limit }} \
 {% if ceph_docker_version.split('.')[0] | version_compare('13', '>=') -%}


### PR DESCRIPTION
This command line is not supported.
According to official documentation:

```
Note that shell command lines are not directly supported.
If shell command lines are to be used,
they need to be passed explicitly to a shell implementation of some kind.
```

We must run this using /bin/sh instead.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>