### PR TITLE
tests: do not upgrade ceph release for switch_to_containers scenario

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -137,10 +137,10 @@ commands=
       ireallymeanit=yes \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
-      ceph_docker_image={env:UPDATE_CEPH_DOCKER_IMAGE:ceph/daemon} \
-      ceph_docker_image_tag={env:UPDATE_CEPH_DOCKER_IMAGE_TAG:latest} \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest} \
+      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
+      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
 
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-switch-to-containers {toxinidir}/tests/functional/tests


### PR DESCRIPTION
Using `UPDATE_*` environment variables here will make an upgrade of the ceph release when running switch_to_containers scenario which is not correct.

Eg:
If ceph luminous was first deployed, then we should switch to ceph luminous containers, not to mimic.