### PR TITLE
nfs: ignore error on semanage command for ganesha_t

### DIFF
--- a/roles/ceph-nfs/tasks/ganesha_selinux_fix.yml
+++ b/roles/ceph-nfs/tasks/ganesha_selinux_fix.yml
@@ -23,6 +23,7 @@
 - name: run semanage permissive -a ganesha_t
   command: semanage permissive -a ganesha_t
   changed_when: false
+  failed_when: false
   when:
     - selinuxstatus.stdout != 'Disabled'
     - ganesha_t_permissive.rc != 0


### PR DESCRIPTION
As of rhel 7.6, it has been decided it doesn't make sense to confine
`ganesha_t` anymore. It means this domain won't exist anymore.

Let's add a `failed_when: false` in order to make the deployment not
failing when trying to run this command.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1626070

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>