### PR TITLE
igw: stop daemons on purge all calls

### DIFF
--- a/infrastructure-playbooks/purge-iscsi-gateways.yml
+++ b/infrastructure-playbooks/purge-iscsi-gateways.yml
@@ -36,4 +36,9 @@
       when: igw_purge_type == 'all'
 
     - name: restart rbd-target-gw daemons
+      service: name=rbd-target-gw state=stopped
+      when: igw_purge_type == 'all'
+
+    - name: restart rbd-target-gw daemons
       service: name=rbd-target-gw state=restarted
+      when: igw_purge_type == 'lio'


### PR DESCRIPTION
When purging the entire igw config (lio and rbd) stop the api and gw
daemons. Note that the api and gw daemons are bound so you only need
to stop the gw one explicitly.

Fixes Red Hat BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1621255

Signed-off-by: Mike Christie <mchristi@redhat.com>