### PR TITLE
shrink-osd: fix purge osd on containerized deployment

### DIFF
--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -131,10 +131,12 @@
         - containerized_deployment
 
     - name: resolve parent device
-      command: lsblk --nodeps -no pkname "{{ item.stdout }}"
+      command: lsblk --nodeps -no pkname "{{ item.0.stdout }}"
       register: resolved_parent_device
-      with_items:
+      delegate_to: "{{ item.1 }}"
+      with_together:
         - "{{ osd_to_kill_disks.results }}"
+        - "{{ osd_hosts }}"
       when:
         - containerized_deployment
 
@@ -142,13 +144,15 @@
       shell: |
         docker run --rm \
         --privileged=true \
-        --name ceph-osd-zap-{{ ansible_hostname }}-{{ item.stdout }} \
+        --name ceph-osd-zap-{{ ansible_hostname }}-{{ item.0.stdout }} \
         -v /dev/:/dev/ \
-        -e OSD_DEVICE=/dev/{{ item.stdout }} \
+        -e OSD_DEVICE=/dev/{{ item.0.stdout }} \
         {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
         zap_device
-      with_items:
+      delegate_to: "{{ item.1 }}"
+      with_together:
         - "{{ resolved_parent_device.results }}"
+        - "{{ osd_hosts }}"
       when:
         - containerized_deployment
 

--- a/tests/functional/centos/7/shrink_osd/hosts
+++ b/tests/functional/centos/7/shrink_osd/hosts
@@ -1,5 +1,5 @@
 [mons]
-ceph-mon0 monitor_address=192.168.1.10
+ceph-mon0 monitor_address=192.168.71.10
 
 [mgrs]
 ceph-mon0


### PR DESCRIPTION
ce1dd8d introduced the purge osd on containers but it was incorrect.

`resolve parent device` and `zap ceph osd disks` tasks must be delegated to
their respective OSD nodes.
Indeed, they were run on the ansible node, it means it was trying to
resolve parent devices from this node where it should be done on OSD
nodes.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1612095

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>