### PR TITLE
tests: pin sphinx version to 1.7.9

### DIFF
--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -5,6 +5,6 @@ skipsdist = True
 [testenv:docs]
 basepython=python
 changedir=source
-deps=sphinx
+deps=sphinx==1.7.9
 commands=
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html


### PR DESCRIPTION
using sphinx 1.8.0 breaks our doc test CI job.

Typical error:

```
Exception occurred:
  File
  "/home/jenkins-build/build/workspace/ceph-ansible-docs-pull-requests/docs/.tox/docs/lib/python2.7/site-packages/sphinx/highlighting.py",  line 26, in <module>
      from sphinx.ext import doctest
      SyntaxError: unqualified exec is not allowed in function 'run' it contains a nested function with free variables (doctest.py, line 97)
```

See: https://github.com/sphinx-doc/sphinx/issues/5417

Pinning to 1.7.9 to fix our CI.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>