### PR TITLE
tests: fix monitor_address for shrink_osd scenario

### DIFF
--- a/tests/functional/centos/7/shrink_osd/hosts
+++ b/tests/functional/centos/7/shrink_osd/hosts
@@ -1,5 +1,5 @@
 [mons]
-ceph-mon0 monitor_address=192.168.1.10
+ceph-mon0 monitor_address=192.168.71.10
 
 [mgrs]
 ceph-mon0


### PR DESCRIPTION
b89cc1746 introduced a typo. This commit fixes it

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 3382c5226c8e6e974dee7be39392652a203bb280)