### PR TITLE
ceph-config: default devices and lvm_volumes when setting num_osds

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -14,28 +14,28 @@
       set_fact:
         num_osds: "{{ devices | length | int }}"
       when:
-        - devices | length > 0
+        - devices | default([]) | length > 0
         - (osd_scenario == 'collocated' or osd_scenario == 'non-collocated')
 
     - name: count number of osds for lvm scenario
       set_fact:
         num_osds: "{{ lvm_volumes | length | int }}"
       when:
-        - lvm_volumes | length > 0
+        - lvm_volumes | default([]) | length > 0
         - osd_scenario == 'lvm'
 
     - name: get number of osds for lvm-batch scenario
       command: "ceph-volume lvm batch --report --format=json --osds-per-device osds_per_device {{ devices | join(' ') }}"
       register: lvm_batch_devices
       when:
-        - devices | length > 0
+        - devices | default([]) | length > 0
         - osd_scenario == 'lvm'
 
     - name: set_fact num_osds
       set_fact:
         num_osds: "{{ (lvm_batch_devices.stdout | from_json).osds | length | int }}"
       when:
-        - devices | length > 0
+        - devices | default([]) | length > 0
         - osd_scenario == 'lvm'
     when:
       - inventory_hostname in groups.get(osd_group_name, [])


### PR DESCRIPTION
This avoids errors when the osd scenario choosen does not require
setting devices or lvm_volumes. The default values for these are not
set because they exist in the ceph-osd role, not ceph-defaults.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>