### PR TITLE
restart_osd_daemon.sh.j2 - consider scrubbing pgs as OK

### DIFF
--- a/roles/ceph-defaults/templates/restart_osd_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_osd_daemon.sh.j2
@@ -10,7 +10,7 @@ check_pgs() {
     return 0
   fi
   while [ $RETRIES -ne 0 ]; do
-    test "[""$($docker_exec ceph $CEPH_CLI -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["pgmap"]["num_pgs"])')""]" = "$($docker_exec ceph $CEPH_CLI -s -f json | python -c 'import sys, json; print [ i["count"] for i in json.load(sys.stdin)["pgmap"]["pgs_by_state"] if i["state_name"] == "active+clean"]')"
+    test "$($docker_exec ceph $CEPH_CLI -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["pgmap"]["num_pgs"])')" -eq "$($docker_exec ceph $CEPH_CLI -s -f json | python -c 'import sys, json; print sum ( [ i["count"] for i in json.load(sys.stdin)["pgmap"]["pgs_by_state"] if "active+clean" in i["state_name"]])')"
     RET=$?
     test $RET -eq 0 && return 0
     sleep $DELAY

--- a/roles/ceph-defaults/templates/restart_osd_daemon.sh.j2
+++ b/roles/ceph-defaults/templates/restart_osd_daemon.sh.j2
@@ -61,7 +61,7 @@ get_docker_osd_id() {
 
 # For containerized deployments, the unit file looks like: ceph-osd@sda.service
 # For non-containerized deployments, the unit file looks like: ceph-osd@NNN.service where NNN is OSD ID
-for unit in $(systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-osd@([0-9]{1,}|[a-z]+).service"); do
+for unit in $(systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-osd@([0-9]+|[a-z]+).service"); do
   # First, restart daemon(s)
   systemctl restart "${unit}"
   # We need to wait because it may take some time for the socket to actually exists
@@ -74,7 +74,7 @@ for unit in $(systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-
   osd_id=$whoami
   docker_exec="docker exec $container_id"
   {% else %}
-  osd_id=$(echo ${unit#ceph-osd@} | grep -oE '[0-9]{1,}')
+  osd_id=$(echo ${unit#ceph-osd@} | grep -oE '[0-9]+')
   {% endif %}
   SOCKET=/var/run/ceph/{{ cluster }}-osd.${osd_id}.asok
   while [ $COUNT -ne 0 ]; do


### PR DESCRIPTION
After restarting each OSD, restart_osd_daemon.sh checks that the
cluster is in a good state before moving on to the next one. One of
the checks it does is that the number of pgs in the state
"active+clean" is equal to the total number of pgs in the cluster.

On large clusters (e.g. we have 173,696 pgs), it is likely that at
least one pg will be scrubbing and/or deep-scrubbing at any one
time. These pgs are in state "active+clean+scrubbing" or
"active+clean+scrubbing+deep", so the script was erroneously not
including them in the "good" count.

Fix this by summing the total of pgs in these 3 good states, and
comparing that to the num_pgs in pgmap; do this as an integer
comparison.

(could this be backported to at least stable-3.0 please?)

Closes: #2008
Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>