### PR TITLE
vagrantfile: fix references to OpenStack settings

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -162,11 +162,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       os.keypair_name = settings['os_keypair_name']
       os.security_groups = ['default']
 
-      if settings['os.networks'] then
+      if settings['os_networks'] then
         os.networks = settings['os_networks']
       end
 
-      if settings['os.floating_ip_pool'] then
+      if settings['os_floating_ip_pool'] then
         os.floating_ip_pool = settings['os_floating_ip_pool']
       end
 


### PR DESCRIPTION
In case of an OpenStack "box", the Vagrantfile intend to check the
existence of os_networks and os_floating_ip_pool settings in
vagrant_variables.yml and pass them to the provider if they are set.
Due to two typos in the Vagrantfile this is not working as it checks the
wrong variable names.
This commit fixes the typos so these settings can be used.

Signed-off-by: Norbert Illés <illesnorbi@gmail.com>