### PR TITLE
tests: test master against ansible 2.7

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -16,10 +16,10 @@ Obsoletes:      ceph-iscsi-ansible <= 1.5
 
 BuildArch:      noarch
 
-BuildRequires: ansible >= 2.4.2.0
+BuildRequires: ansible >= 2.7
 BuildRequires: python2-devel
 
-Requires: ansible >= 2.4.2.0
+Requires: ansible >= 2.7
 Requires: python-netaddr
 Requires: python-notario >=  0.0.13
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -75,7 +75,7 @@ The ``master`` branch should be considered experimental and used with caution.
 
 - ``stable-3.1`` Support for Ceph version ``luminous`` and ``mimic``. This branch supports Ansible version ``2.4``.
 
-- ``master`` Support for Ceph versions ``luminous``, and ``mimic``. This branch supports Ansible version ``2.6``.
+- ``master`` Support for Ceph versions ``luminous``, and ``mimic``. This branch supports Ansible version ``2.6`` and ``2.7``.
 
 Configuration and Usage
 =======================

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # These are Python requirements needed to run ceph-ansible master
 notario>=0.0.13
-ansible~=2.6,<2.7
+ansible~=2.7,<2.8
 netaddr

--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -67,10 +67,10 @@
 
 - name: fail on unsupported ansible version
   fail:
-    msg: "Ansible version must be between 2.5.x and 2.6.x!"
+    msg: "Ansible version must be between 2.6.x and 2.7.x!"
   when:
     - ansible_version.major|int == 2
-    - (ansible_version.minor|int < 5 or ansible_version.minor|int > 6)
+    - (ansible_version.minor|int < 6 or ansible_version.minor|int > 7)
 
 - name: fail if systemd is not present
   fail:

--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -67,10 +67,10 @@
 
 - name: fail on unsupported ansible version
   fail:
-    msg: "Ansible version must be between 2.6.x and 2.7.x!"
+    msg: "Ansible version must be 2.7!"
   when:
-    - ansible_version.major|int == 2
-    - (ansible_version.minor|int < 6 or ansible_version.minor|int > 7)
+    - ansible_version.major|int != 2
+    - ansible_version.minor|int != 7
 
 - name: fail if systemd is not present
   fail:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,5 +3,5 @@ testinfra
 pytest-xdist
 pytest==3.6.1
 notario>=0.0.13
-ansible~=2.6,<2.7
+ansible~=2.7,<2.8
 netaddr


### PR DESCRIPTION
Let's test ceph-ansible master against ansible 2.7 to catch early any
potential issue with this ansible version.

Closes: #3148

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>