### PR TITLE
docs: supported validation by the ceph-validate role

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -152,6 +152,26 @@ An example of a validation failure might look like:
         "changed": false
         }
 
+Supported Validation
+^^^^^^^^^^^^^^^^^^^^
+
+The ``ceph-validate`` role currently supports validation of the proper config for the following
+osd scenarios:
+
+- ``collocated``
+- ``non-collocated``
+- ``lvm``
+
+The following install options are also validated by the ``ceph-validate`` role:
+
+- ``ceph_origin`` set to ``distro``
+- ``ceph_origin`` set to ``repository``
+- ``ceph_origin`` set to ``local``
+- ``ceph_repository`` set to ``rhcs``
+- ``ceph_repository`` set to ``dev``
+- ``ceph_repository`` set to ``community``
+
+
 Installation methods
 --------------------
 


### PR DESCRIPTION
List the osd_scenarios and install options that are validated by the
ceph-validate role in the documentation.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>