### PR TITLE
tests: add an RGW node on osd0 for ooo-collocation

### DIFF
--- a/tests/functional/centos/7/ooo-collocation/hosts
+++ b/tests/functional/centos/7/ooo-collocation/hosts
@@ -85,3 +85,4 @@ rbdmirrors:
 rgws:
   hosts:
     mon0: {}
+    osd0: {}


### PR DESCRIPTION
get more coverage by adding an RGW daemon collocated on osd0.
We've missed a bug in the past which could have been caught earlier in
the CI.
Let's add this additional daemon in order to have a better coverage.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>