### PR TITLE
Fix version check in ceph.conf template

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -17,7 +17,7 @@ fsid = {{ fsid }}
 {% if common_single_host_mode is defined and common_single_host_mode %}
 osd crush chooseleaf type = 0
 {% endif %}
-{% if ceph_version not in ['jewel', 'kraken', 'luminous'] and containerized_deployment %}
+{% if ceph_release not in ['jewel', 'kraken', 'luminous'] and containerized_deployment %}
 # let's force the admin socket the way it was so we can properly check for existing instances
 # also the line $cluster-$name.$pid.$cctid.asok is only needed when running multiple instances
 # of the same daemon, thing ceph-ansible cannot do at the time of writing


### PR DESCRIPTION
We need to look for ceph_release when comparing with release names,
not ceph_version.