### PR TITLE
purge: actually remove of /var/lib/ceph/*

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -222,7 +222,7 @@
       timeout: 500
 
   - name: remove data
-    command: rm -rf /var/lib/ceph/*
+    shell: rm -rf /var/lib/ceph/*
 
   tasks:
 
@@ -534,7 +534,7 @@
     listen: "remove data"
 
   - name: remove data
-    command: rm -rf /var/lib/ceph/*
+    shell: rm -rf /var/lib/ceph/*
     listen: "remove data"
 
   tasks:

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -654,7 +654,7 @@
       - /var/log/ceph
 
   - name: remove data
-    command: rm -rf /var/lib/ceph/*
+    shell: rm -rf /var/lib/ceph/*
 
 
 - name: purge fetch directory


### PR DESCRIPTION
38dc20e74b89c1833d45f677f405fe758fd10c04 introduced a bug in the purge
playbooks because using `*` in `command` module doesn't work.

`/var/lib/ceph/*` files are not purged, it means there is a leftover.

When trying to redeploy a cluster, it failed because monitor daemon was
detecting existing keyring, therefore, it assumed a cluster already
existed.

Typical error (from container output):

```
Sep 26 13:18:16 mon0 docker[31316]: 2018-09-26 13:18:16  /entrypoint.sh: Existing mon, trying to rejoin cluster...
Sep 26 13:18:16 mon0 docker[31316]: 2018-09-26 13:18:16.9323937f15b0d74700 -1 auth: unable to find a keyring on /etc/ceph/test.client.admin.keyring,/etc/ceph/test.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,:(2) No such file or directory
Sep 26 13:18:23 mon0 docker[31316]: 2018-09-26 13:18:23  /entrypoint.sh:
SUCCESS
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1633563

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>