### PR TITLE
purge-cluster: recursively remove ceph-related files, symlinks and directories under /etc/systemd/system.

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -633,6 +633,8 @@
     find:
       paths: "/etc/systemd/system"
       pattern: "ceph*"
+      recurse: true
+      file_type: any
     register: systemd_files
 
   - name: remove ceph systemd unit files


### PR DESCRIPTION
fix: https://github.com/ceph/ceph-ansible/issues/3166

Signed-off-by: wumingqiao <wumingqiao@beyondcent.com>