### PR TITLE
switch: support migration when cluster is scrubbing

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -111,6 +111,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - ceph-docker-common
     - ceph-mon
 
@@ -168,6 +169,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - ceph-docker-common
     - ceph-mgr
 
@@ -282,6 +284,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - ceph-docker-common
     - ceph-osd
 
@@ -343,6 +346,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - ceph-docker-common
     - ceph-mds
 
@@ -385,6 +389,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - ceph-docker-common
     - ceph-rgw
 
@@ -427,6 +432,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - ceph-docker-common
     - ceph-rbd-mirror
 
@@ -473,5 +479,6 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - ceph-docker-common
     - ceph-nfs

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -295,9 +295,9 @@
       command: "docker exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph --cluster {{ cluster }} -s --format json"
       register: ceph_health_post
       until: >
-        ((ceph_health_post.stdout | from_json).pgmap.pgs_by_state | length) == 1
+        (((ceph_health_post.stdout | from_json).pgmap.pgs_by_state | length) > 0)
         and
-        (ceph_health_post.stdout | from_json).pgmap.pgs_by_state.0.state_name == "active+clean"
+        (((ceph_health_post.stdout | from_json).pgmap.pgs_by_state | selectattr('state_name', 'search', '^active\\+clean') | map(attribute='count') | list | sum) == (ceph_pgs.stdout | from_json).pgmap.num_pgs)
       delegate_to: "{{ groups[mon_group_name][0] }}"
       retries: "{{ health_osd_check_retries }}"
       delay: "{{ health_osd_check_delay }}"

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -109,6 +109,13 @@
       failed_when: false
       when: ldb_files.rc == 0
 
+    - name: copy mon initial keyring in /etc/ceph to satisfy fetch config task in ceph-docker-common
+      command: cp /var/lib/ceph/mon/{{ cluster }}-{{ ansible_hostname }}/keyring /etc/ceph/{{ cluster }}.mon.keyring
+      args:
+        creates: /etc/ceph/{{ cluster }}.mon.keyring
+      changed_when: false
+      failed_when: false
+
   roles:
     - ceph-defaults
     - ceph-handler


### PR DESCRIPTION
Similar to c13a3c3 we must allow scrubbing when running this playbook.

In cluster with a large number of PGs, it can be expected some of them
scrubbing, it's a normal operation.
Preventing from scrubbing operation force to set noscrub flag.

This commit allows to switch from non containerized to containerized
environment even while PGs are scrubbing.

Closes: #3182

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>