### PR TITLE
ceph-volume: makes the lvm scenario idempotent when using the simple configuration

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -364,6 +364,7 @@ dummy:
 #non_hci_safety_factor: 0.7
 #osd_memory_target: 4000000000
 #journal_size: 5120 # OSD journal size in MB
+#block_db_size: -1 # block db size in bytes for the ceph-volume lvm batch. -1 means use the default of 'as big as possible'.
 #public_network: 0.0.0.0/0
 #cluster_network: "{{ public_network | regex_replace(' ', '') }}"
 #osd_mkfs_type: xfs

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -364,6 +364,7 @@ ceph_rhcs_version: 3
 #non_hci_safety_factor: 0.7
 #osd_memory_target: 4000000000
 #journal_size: 5120 # OSD journal size in MB
+#block_db_size: -1 # block db size in bytes for the ceph-volume lvm batch. -1 means use the default of 'as big as possible'.
 #public_network: 0.0.0.0/0
 #cluster_network: "{{ public_network | regex_replace(' ', '') }}"
 #osd_mkfs_type: xfs

--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -2,6 +2,7 @@
 import datetime
 import json
 
+
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',
     'status': ['preview'],
@@ -207,7 +208,7 @@ def batch(module):
     if objectstore == "filestore":
         cmd.extend(["--journal-size", journal_size])
 
-    if objectstore == "bluestore" and block_db_size != -1:
+    if objectstore == "bluestore" and block_db_size != "-1":
         cmd.extend(["--block-db-size", block_db_size])
 
     if report:
@@ -442,8 +443,8 @@ def run_module():
         dmcrypt=dict(type='bool', required=False, default=False),
         batch_devices=dict(type='list', required=False, default=[]),
         osds_per_device=dict(type='int', required=False, default=1),
-        journal_size=dict(type='int', required=False, default=5120),
-        block_db_size=dict(type='int', required=False, default=-1),
+        journal_size=dict(type='str', required=False, default="5120"),
+        block_db_size=dict(type='str', required=False, default="-1"),
         report=dict(type='bool', required=False, default=False),
     )
 

--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -108,6 +108,13 @@ options:
             - Only applicable if action is 'batch'.
         required: false
         default: -1
+    report:
+        description:
+            - If provided the --report flag will be passed to 'ceph-volume lvm batch'.
+            - No OSDs will be created.
+            - Results will be returned in json format.
+            - Only applicable if action is 'batch'.
+        required: false
 
 
 author:
@@ -173,6 +180,7 @@ def batch(module):
     osds_per_device = module.params['osds_per_device']
     journal_size = module.params['journal_size']
     block_db_size = module.params['block_db_size']
+    report = module.params['report']
 
     if not batch_devices:
         module.fail_json(msg='batch_devices must be provided if action is "batch"', changed=False, rc=1)
@@ -201,6 +209,12 @@ def batch(module):
 
     if objectstore == "bluestore" and block_db_size != -1:
         cmd.extend(["--block-db-size", block_db_size])
+
+    if report:
+        cmd.extend([
+            "--report",
+            "--format=json",
+        ])
 
     cmd.extend(batch_devices)
 
@@ -430,6 +444,7 @@ def run_module():
         osds_per_device=dict(type='int', required=False, default=1),
         journal_size=dict(type='int', required=False, default=5120),
         block_db_size=dict(type='int', required=False, default=-1),
+        report=dict(type='bool', required=False, default=False),
     )
 
     module = AnsibleModule(

--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -285,7 +285,18 @@ def batch(module):
     report_cmd.extend(report_flags)
 
     rc, out, err = module.run_command(report_cmd, encoding=None)
-    report_result = json.loads(out)
+    try:
+        report_result = json.loads(out)
+    except ValueError:
+        result = dict(
+            cmd=report_cmd,
+            stdout=out.rstrip(b"\r\n"),
+            stderr=err.rstrip(b"\r\n"),
+            rc=rc,
+            changed=True,
+        )
+        module.fail_json(msg='non-zero return code', **result)
+
     if not report:
         rc, out, err = module.run_command(cmd, encoding=None)
     else:

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -38,6 +38,7 @@
         report: true
         action: "batch"
       register: lvm_batch_report
+      failed_when: false
       environment:
         CEPH_VOLUME_DEBUG: 1
       when:
@@ -50,6 +51,26 @@
       when:
         - devices | default([]) | length > 0
         - osd_scenario == 'lvm'
+        - (lvm_batch_report.stdout | from_json).changed
+
+    - name: run 'ceph-volume lvm list' to see how many osds have already been created
+      ceph_volume:
+        action: "list"
+      register: lvm_list
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+      when:
+        - devices | default([]) | length > 0
+        - osd_scenario == 'lvm'
+        - not (lvm_batch_report.stdout | from_json).changed
+
+    - name: set_fact num_osds from the output of 'ceph-volume lvm list'
+      set_fact:
+        num_osds: "{{ lvm_list.stdout | from_json | length | int }}"
+      when:
+        - devices | default([]) | length > 0
+        - osd_scenario == 'lvm'
+        - not (lvm_batch_report.stdout | from_json).changed
 
     when:
       - inventory_hostname in groups.get(osd_group_name, [])

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -38,7 +38,6 @@
         report: true
         action: "batch"
       register: lvm_batch_report
-      failed_when: false
       environment:
         CEPH_VOLUME_DEBUG: 1
       when:

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -27,16 +27,30 @@
         - lvm_volumes | default([]) | length > 0
         - osd_scenario == 'lvm'
 
-    # This is a best guess. Ideally we'd like to use `ceph-volume lvm batch --report` to get
-    # a more accurate number but the ceph.conf needs to be in place before that is possible.
-    # There is a tracker to add functionality to ceph-volume which would allow doing this
-    # without the need for a ceph.conf: http://tracker.ceph.com/issues/36088
-    - name: count number of osds for lvm batch scenario
-      set_fact:
-        num_osds: "{{ devices | length | int * osds_per_device | default(1) }}"
+    - name: run 'ceph-volume lvm batch --report' to see how many osds are to be created
+      ceph_volume:
+        cluster: "{{ cluster }}"
+        objectstore: "{{ osd_objectstore }}"
+        batch_devices: "{{ devices }}"
+        osds_per_device: "{{ osds_per_device | default(1) | int }}"
+        journal_size: "{{ journal_size }}"
+        block_db_size: "{{ block_db_size }}"
+        report: true
+        action: "batch"
+      register: lvm_batch_report
+      environment:
+        CEPH_VOLUME_DEBUG: 1
       when:
         - devices | default([]) | length > 0
         - osd_scenario == 'lvm'
+
+    - name: set_fact num_osds from the output of 'ceph-volume lvm batch --report'
+      set_fact:
+        num_osds: "{{ (lvm_batch_report.stdout | from_json).osds | length | int }}"
+      when:
+        - devices | default([]) | length > 0
+        - osd_scenario == 'lvm'
+
     when:
       - inventory_hostname in groups.get(osd_group_name, [])
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -356,6 +356,7 @@ hci_safety_factor: 0.2
 non_hci_safety_factor: 0.7
 osd_memory_target: 4000000000
 journal_size: 5120 # OSD journal size in MB
+block_db_size: -1 # block db size in bytes for the ceph-volume lvm batch. -1 means use the default of 'as big as possible'.
 public_network: 0.0.0.0/0
 cluster_network: "{{ public_network | regex_replace(' ', '') }}"
 osd_mkfs_type: xfs

--- a/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
@@ -8,6 +8,8 @@
     dmcrypt: "{{ dmcrypt|default(omit) }}"
     crush_device_class: "{{ crush_device_class|default(omit) }}"
     osds_per_device: "{{ osds_per_device }}"
+    journal_size: "{{ journal_size }}"
+    block_db_size: "{{ block_db_size }}"
     action: "batch"
   environment:
     CEPH_VOLUME_DEBUG: 1

--- a/tests/functional/centos/7/lvm-batch/group_vars/all
+++ b/tests/functional/centos/7/lvm-batch/group_vars/all
@@ -7,7 +7,6 @@ public_network: "192.168.39.0/24"
 cluster_network: "192.168.40.0/24"
 monitor_interface: eth1
 radosgw_interface: eth1
-journal_size: 100
 osd_objectstore: "bluestore"
 crush_device_class: test
 osd_scenario: lvm


### PR DESCRIPTION
This depends on https://github.com/ceph/ceph/pull/24404

As well as making the ``ceph_volume`` module idempotent when the ``action`` is ``batch``, this adds support for ``journal_size`` and ``block_db_size`` which allows us to get an accurate number of OSDs that will be created in ``ceph-config`` before a config file is written. The new ``ceph-volume`` flags ``--journal-size`` and ``--block-db-size`` was added in https://github.com/ceph/ceph/pull/24201 and is still unreleased.