### PR TITLE
ceph: remove custom cluster name support

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -33,17 +33,6 @@ dummy:
 # Directory to fetch cluster fsid, keys etc...
 #fetch_directory: fetch/
 
-# The 'cluster' variable determines the name of the cluster.
-# Changing the default value to something else means that you will
-# need to change all the command line calls as well, for example if
-# your cluster name is 'foo':
-# "ceph health" will become "ceph --cluster foo health"
-#
-# An easier way to handle this is to use the environment variable CEPH_ARGS
-# So run: "export CEPH_ARGS="--cluster foo"
-# With that you will be able to run "ceph health" normally
-#cluster: ceph
-
 # Inventory host group variables
 #mon_group_name: mons
 #osd_group_name: osds
@@ -621,4 +610,5 @@ dummy:
 ###############
 
 #use_fqdn_yes_i_am_sure: false
-
+#use_custom_cluster_name_yes_i_am_sure: false
+#cluster: ceph

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -33,17 +33,6 @@ dummy:
 # Directory to fetch cluster fsid, keys etc...
 fetch_directory: ~/ceph-ansible-keys
 
-# The 'cluster' variable determines the name of the cluster.
-# Changing the default value to something else means that you will
-# need to change all the command line calls as well, for example if
-# your cluster name is 'foo':
-# "ceph health" will become "ceph --cluster foo health"
-#
-# An easier way to handle this is to use the environment variable CEPH_ARGS
-# So run: "export CEPH_ARGS="--cluster foo"
-# With that you will be able to run "ceph health" normally
-#cluster: ceph
-
 # Inventory host group variables
 #mon_group_name: mons
 #osd_group_name: osds
@@ -621,4 +610,5 @@ ceph_rhcs_version: 3
 ###############
 
 #use_fqdn_yes_i_am_sure: false
-
+#use_custom_cluster_name_yes_i_am_sure: false
+#cluster: ceph

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -25,17 +25,6 @@ ceph_release_num:
 # Directory to fetch cluster fsid, keys etc...
 fetch_directory: fetch/
 
-# The 'cluster' variable determines the name of the cluster.
-# Changing the default value to something else means that you will
-# need to change all the command line calls as well, for example if
-# your cluster name is 'foo':
-# "ceph health" will become "ceph --cluster foo health"
-#
-# An easier way to handle this is to use the environment variable CEPH_ARGS
-# So run: "export CEPH_ARGS="--cluster foo"
-# With that you will be able to run "ceph health" normally
-cluster: ceph
-
 # Inventory host group variables
 mon_group_name: mons
 osd_group_name: osds
@@ -613,3 +602,5 @@ openstack_keys:
 ###############
 
 use_fqdn_yes_i_am_sure: false
+use_custom_cluster_name_yes_i_am_sure: false
+cluster: ceph

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -10,6 +10,13 @@
     - mon_use_fqdn or mds_use_fqdn
     - not use_fqdn_yes_i_am_sure
 
+- name: fail if cluster name is different than 'ceph'
+  fail:
+    msg: "Custom cluster name configuration is not supported anymore. Use 'use_custom_cluster_name_yes_i_am_sure: true' if you really want to use it (you should be already running a cluster with a custom name). See release notes for more details"
+  when:
+    - cluster != 'ceph'
+    - not use_custom_cluster_name_yes_i_am_sure
+
 - name: fail if local scenario is enabled on debian
   fail:
     msg: "'local' installation scenario not supported on Debian systems"

--- a/tests/functional/centos/7/bs-lvm-osds/group_vars/all
+++ b/tests/functional/centos/7/bs-lvm-osds/group_vars/all
@@ -2,7 +2,6 @@
 
 ceph_origin: repository
 ceph_repository: community
-cluster: test
 public_network: "192.168.39.0/24"
 cluster_network: "192.168.40.0/24"
 monitor_interface: eth1

--- a/tests/functional/centos/7/bs-osds-container/group_vars/all.yml
+++ b/tests/functional/centos/7/bs-osds-container/group_vars/all.yml
@@ -2,7 +2,6 @@
 
 docker: true
 containerized_deployment: true
-cluster: test
 monitor_interface: eth1
 public_network: "192.168.35.0/24"
 cluster_network: "192.168.36.0/24"

--- a/tests/functional/centos/7/bs-osds-non-container/group_vars/all.yml
+++ b/tests/functional/centos/7/bs-osds-non-container/group_vars/all.yml
@@ -2,7 +2,6 @@
 
 ceph_origin: repository
 ceph_repository: community
-cluster: test
 monitor_interface: eth1
 public_network: "192.168.45.0/24"
 cluster_network: "192.168.46.0/24"

--- a/tests/functional/centos/7/cluster/group_vars/all
+++ b/tests/functional/centos/7/cluster/group_vars/all
@@ -1,7 +1,6 @@
 ---
 ceph_origin: repository
 ceph_repository: community
-cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 radosgw_interface: eth1

--- a/tests/functional/centos/7/docker-collocation/group_vars/all
+++ b/tests/functional/centos/7/docker-collocation/group_vars/all
@@ -4,7 +4,6 @@
 docker: True
 
 containerized_deployment: True
-cluster: test
 monitor_interface: eth1
 radosgw_interface: eth1
 ceph_mon_docker_subnet: "{{ public_network }}"

--- a/tests/functional/centos/7/docker/group_vars/all
+++ b/tests/functional/centos/7/docker/group_vars/all
@@ -4,7 +4,6 @@
 docker: True
 
 containerized_deployment: True
-cluster: test
 monitor_interface: eth1
 radosgw_interface: eth1
 ceph_mon_docker_subnet: "{{ public_network }}"

--- a/tests/functional/centos/7/fs-osds-container/group_vars/all.yml
+++ b/tests/functional/centos/7/fs-osds-container/group_vars/all.yml
@@ -2,7 +2,6 @@
 
 docker: true
 containerized_deployment: true
-cluster: test
 monitor_interface: eth1
 public_network: "192.168.55.0/24"
 cluster_network: "192.168.56.0/24"

--- a/tests/functional/centos/7/fs-osds-non-container/group_vars/all.yml
+++ b/tests/functional/centos/7/fs-osds-non-container/group_vars/all.yml
@@ -2,7 +2,6 @@
 
 ceph_origin: repository
 ceph_repository: community
-cluster: test
 monitor_interface: eth1
 public_network: "192.168.65.0/24"
 cluster_network: "192.168.66.0/24"

--- a/tests/functional/centos/7/lvm-batch/group_vars/all
+++ b/tests/functional/centos/7/lvm-batch/group_vars/all
@@ -2,7 +2,6 @@
 
 ceph_origin: repository
 ceph_repository: community
-cluster: ceph
 public_network: "192.168.39.0/24"
 cluster_network: "192.168.40.0/24"
 monitor_interface: eth1
@@ -13,7 +12,7 @@ crush_device_class: test
 osd_scenario: lvm
 copy_admin_key: true
 devices:
-  - /dev/sdb 
+  - /dev/sdb
   - /dev/sdc
 os_tuning_params:
   - { name: fs.file-max, value: 26234859 }

--- a/tests/functional/centos/7/lvm-osds/group_vars/all
+++ b/tests/functional/centos/7/lvm-osds/group_vars/all
@@ -2,7 +2,6 @@
 
 ceph_origin: repository
 ceph_repository: community
-cluster: ceph
 public_network: "192.168.39.0/24"
 cluster_network: "192.168.40.0/24"
 monitor_interface: eth1

--- a/tests/functional/centos/7/ooo-collocation/hosts
+++ b/tests/functional/centos/7/ooo-collocation/hosts
@@ -8,7 +8,6 @@ all:
         rgw_keystone_admin_user: swift, rgw_keystone_api_version: 3, rgw_keystone_implicit_tenants: 'true',
         rgw_keystone_url: 'http://192.168.95.10:5000', rgw_s3_auth_use_keystone: 'true', rgw_keystone_revocation_interval: 0}
     ceph_mgr_docker_extra_env: '-e MGR_DASHBOARD=0'
-    cluster: mycluster
     ceph_docker_image: ceph/daemon
     ceph_docker_image_tag: v3.0.3-stable-3.0-luminous-centos-7-x86_64
     ceph_docker_registry: docker.io

--- a/tests/functional/centos/7/shrink_osd/group_vars/all
+++ b/tests/functional/centos/7/shrink_osd/group_vars/all
@@ -1,7 +1,6 @@
 ---
 ceph_origin: repository
 ceph_repository: community
-cluster: test
 public_network: "192.168.71.0/24"
 cluster_network: "192.168.72.0/24"
 journal_size: 100

--- a/tests/functional/centos/7/shrink_osd_container/group_vars/all
+++ b/tests/functional/centos/7/shrink_osd_container/group_vars/all
@@ -4,7 +4,6 @@
 docker: True
 
 containerized_deployment: True
-cluster: test
 monitor_interface: eth1
 radosgw_interface: eth1
 ceph_mon_docker_subnet: "{{ public_network }}"


### PR DESCRIPTION
The dev team decided not to support custom cluster names in the future.
So now, if your cluster variable is different than 'ceph' the playbook
will fail. For existing cluster with custom name you need to set
'use_custom_cluster_name_yes_i_am_sure' to True. This means you know
what you're doing.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1635924
Signed-off-by: Sébastien Han <seb@redhat.com>