### PR TITLE
rolling_update: add ceph-handler role

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -117,6 +117,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-config
@@ -289,6 +290,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-config
@@ -353,6 +355,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-config
@@ -506,6 +509,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-config
@@ -552,6 +556,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-config
@@ -606,6 +611,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-config
@@ -656,6 +662,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-config
@@ -711,6 +718,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-config
@@ -741,6 +749,7 @@
 
   roles:
     - ceph-defaults
+    - ceph-handler
     - { role: ceph-common, when: not containerized_deployment }
     - { role: ceph-docker-common, when: containerized_deployment }
     - ceph-config


### PR DESCRIPTION
since the introduction of ceph-handler, it has to be added in
rolling_update playbook as well

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>