### PR TITLE
[skip ci] rhcs: add helpers for the containerized deployment

### DIFF
--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -518,9 +518,9 @@ ceph_rhcs_version: 3
 ##########
 #docker_exec_cmd:
 #docker: false
-#ceph_docker_image: "ceph/daemon"
-#ceph_docker_image_tag: latest
-#ceph_docker_registry: docker.io
+ceph_docker_image: "rhceph-3-rhel7"
+ceph_docker_image_tag: "latest"
+ceph_docker_registry: "registry.access.redhat.com/rhceph/"
 #ceph_docker_enable_centos_extra_repo: false
 #ceph_docker_on_openstack: false
 #containerized_deployment: False

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -2,4 +2,7 @@ ceph_repository: rhcs
 ceph_origin: repository
 fetch_directory: ~/ceph-ansible-keys
 ceph_rhcs_version: 3
+ceph_docker_image: "rhceph-3-rhel7"
+ceph_docker_image_tag: "latest"
+ceph_docker_registry: "registry.access.redhat.com/rhceph/"
 # END OF FILE, DO NOT TOUCH ME!


### PR DESCRIPTION
We give more assistance to consultants deplying by setting the registry
and the image name.

Signed-off-by: Sébastien Han <seb@redhat.com>