### PR TITLE
config: remove complex jinja logic in ceph.conf.j2

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -11,9 +11,6 @@ auth supported = none
 {% if ip_version == 'ipv6'  %}
 ms bind ipv6 = true
 {% endif %}
-{% if not containerized_deployment_with_kv and not containerized_deployment %}
-fsid = {{ fsid }}
-{% endif %}
 {% if common_single_host_mode is defined and common_single_host_mode %}
 osd crush chooseleaf type = 0
 {% endif %}
@@ -41,81 +38,18 @@ mon initial members = {% for host in groups[mon_group_name] %}
     {% endfor %}
 {% endif %}
 
-{% if not containerized_deployment and not containerized_deployment_with_kv -%}
-mon host = {% if nb_mon > 0 %}
-  {% for host in groups[mon_group_name] -%}
-    {% if hostvars[host]['monitor_address_block'] is defined and hostvars[host]['monitor_address_block'] != 'subnet' %}
-      {% if ip_version == 'ipv4' -%}
-        {{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(hostvars[host]['monitor_address_block']) | first }}
-      {%- elif ip_version == 'ipv6' -%}
-        [{{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(hostvars[host]['monitor_address_block']) | first }}]
-      {%- endif %}
-    {% elif hostvars[host]['monitor_address'] is defined and hostvars[host]['monitor_address'] != '0.0.0.0' -%}
-      {% if ip_version == 'ipv4' -%}
-        {{ hostvars[host]['monitor_address'] }}
-      {%- elif ip_version == 'ipv6' -%}
-        [{{ hostvars[host]['monitor_address'] }}]
-      {%- endif %}
-    {%- elif hostvars[host]['monitor_interface'] is defined -%}
-      {% set interface = 'ansible_' + (hostvars[host]['monitor_interface'] | replace('-', '_')) %}
-      {% if ip_version == 'ipv4' -%}
-        {{ hostvars[host][interface][ip_version]['address'] }}
-      {%- elif ip_version == 'ipv6' -%}
-        [{{ hostvars[host][interface][ip_version][0]['address'] }}]
-      {%- endif %}
-    {%- else -%}
-      {% set interface = 'ansible_' + (monitor_interface | replace('-', '_')) %}
-      {% if ip_version == 'ipv4' -%}
-        {{ hostvars[host][interface][ip_version]['address'] }}
-      {%- elif ip_version == 'ipv6' -%}
-        [{{ hostvars[host][interface][ip_version][0]['address'] }}]
-      {%- endif %}
-    {%- endif %}
-   {% if not loop.last -%},{%- endif %}
-  {%- endfor %}
-  {% elif nb_mon == 0 and inventory_hostname in groups.get(client_group_name, []) %}
-  {{ external_cluster_mon_ips }}
-  {% endif %}
-{%- endif %}
-
-{% if containerized_deployment %}
 fsid = {{ fsid }}
+{% if containerized_deployment %}
 log file = /dev/null
 mon cluster log file = /dev/null
+{% endif %}
 mon host = {% if nb_mon > 0 %}
-{% for host in groups[mon_group_name] -%}
-    {% if hostvars[host]['monitor_address_block'] is defined and hostvars[host]['monitor_address_block'] != 'subnet' %}
-      {% if ip_version == 'ipv4' -%}
-        {{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(hostvars[host]['monitor_address_block']) | first }}
-      {%- elif ip_version == 'ipv6' -%}
-        [{{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(hostvars[host]['monitor_address_block']) | first }}]
-      {%- endif %}
-    {% elif hostvars[host]['monitor_address'] is defined and hostvars[host]['monitor_address'] != '0.0.0.0' -%}
-      {% if ip_version == 'ipv4' -%}
-        {{ hostvars[host]['monitor_address'] }}
-      {%- elif ip_version == 'ipv6' -%}
-        [{{ hostvars[host]['monitor_address'] }}]
-      {%- endif %}
-    {%- elif hostvars[host]['monitor_interface'] is defined -%}
-      {% set interface = 'ansible_' + (hostvars[host]['monitor_interface'] | replace('-', '_')) %}
-      {% if ip_version == 'ipv4' -%}
-        {{ hostvars[host][interface][ip_version]['address'] }}
-      {%- elif ip_version == 'ipv6' -%}
-        [{{ hostvars[host][interface][ip_version][0]['address'] }}]
-      {%- endif %}
-    {%- else -%}
-      {% set interface = 'ansible_' + (monitor_interface | replace('-', '_')) %}
-      {% if ip_version == 'ipv4' -%}
-        {{ hostvars[host][interface][ip_version]['address'] }}
-      {%- elif ip_version == 'ipv6' -%}
-        [{{ hostvars[host][interface][ip_version][0]['address'] }}]
-      {%- endif %}
-    {%- endif %}
-    {% if not loop.last -%},{%- endif %}
-  {%- endfor %}
-  {% elif nb_mon == 0 and inventory_hostname in groups.get(client_group_name, []) %}
-  {{ external_cluster_mon_ips }}
-  {% endif %}
+{% for host in _monitor_addresses -%}
+{{ host.addr }}
+{%- if not loop.last -%},{%- endif %}
+{%- endfor %}
+{% elif nb_mon == 0 and inventory_hostname in groups.get(client_group_name, []) %}
+{{ external_cluster_mon_ips }}
 {% endif %}
 
 {% if public_network is defined %}
@@ -152,7 +86,7 @@ filestore xattr use omap = true
 {% endif %}
 {% endif %}
 {% if osd_objectstore == 'bluestore' %}
-{% set _num_osds = num_osds | default(0) | int %}
+{% set _num_osds = num_osds | default(0) | int %}
 [osd]
 {% if is_hci and _num_osds > 0 %}
 {% if ansible_memtotal_mb * hci_safety_factor / _num_osds > osd_memory_target %} # hci_safety_factor is the safety factor for HCI deployments
@@ -175,45 +109,7 @@ osd memory target = {{ _osd_memory_target | default(osd_memory_target) }}
 host = {{ _rgw_hostname }}
 keyring = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ _rgw_hostname }}/keyring
 log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[host]['ansible_hostname'] }}.log
-{% if hostvars[host]['radosgw_address_block'] is defined and hostvars[host]['radosgw_address_block'] != 'subnet' %}
-    {% if ip_version == 'ipv4' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}={{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% elif ip_version == 'ipv6' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}=[{{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}]:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% endif %}
-{% elif radosgw_address_block is defined and radosgw_address_block != 'subnet' -%}
-    {% if ip_version == 'ipv4' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}={{ radosgw_address_block | ipaddr(radosgw_address_block) | first }}:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% elif ip_version == 'ipv6' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}=[{{ radosgw_address_block | ipaddr(radosgw_address_block) | first }}]:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% endif %}
-{% elif hostvars[host]['radosgw_address'] is defined and hostvars[host]['radosgw_address'] != 'address' -%}
-    {% if ip_version == 'ipv4' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}={{ hostvars[host]['radosgw_address'] }}:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% elif ip_version == 'ipv6' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}=[{{ hostvars[host]['radosgw_address'] }}]:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% endif %}
-{% elif radosgw_address is defined and radosgw_address != 'address' -%}
-    {% if ip_version == 'ipv4' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}={{ radosgw_address }}:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% elif ip_version == 'ipv6' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}=[{{ radosgw_address }}]:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% endif %}
-{% elif hostvars[host]['radosgw_interface'] is defined -%}
-    {% set interface='ansible_' + (hostvars[host]['radosgw_interface'] | replace('-', '_')) %}
-    {% if ip_version == 'ipv4' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}={{ hostvars[host][interface][ip_version]['address'] }}:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% elif ip_version == 'ipv6' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}=[{{ hostvars[host][interface][ip_version][0]['address'] }}]:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% endif %}
-{% else %}
-    {% set interface='ansible_' + (radosgw_interface | replace('-', '_')) %}
-    {% if ip_version == 'ipv4' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}={{ hostvars[host][interface][ip_version]['address'] }}:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% elif ip_version == 'ipv6' %}
-rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}=[{{ hostvars[host][interface][ip_version][0]['address'] }}]:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
-    {% endif %}
-{% endif %}
+rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}={{ hostvars[host]['_radosgw_address'] }}:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}
 {% endfor %}
 {% endif %}
 

--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -239,3 +239,9 @@
     - ceph_current_status['servicemap'] is defined
     - ceph_current_status['servicemap']['services'] is defined
     - ceph_current_status['servicemap']['services']['rgw'] is defined
+
+- name: import_tasks set_monitor_address.yml
+  import_tasks: set_monitor_address.yml
+
+- name: import_tasks set_radosgw_address.yml
+  import_tasks: set_radosgw_address.yml

--- a/roles/ceph-defaults/tasks/set_monitor_address.yml
+++ b/roles/ceph-defaults/tasks/set_monitor_address.yml
@@ -1,0 +1,44 @@
+---
+- name: set_fact _monitor_address to monitor_address_block
+  set_fact:
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_all_' + ip_version + '_addresses'] | ipaddr(hostvars[item]['monitor_address_block']) | first | ipwrap }] }}"
+  with_items:
+    - "{{ groups.get(mon_group_name, []) }}"
+  when:
+    - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') |  map(attribute='name') | list"
+    - hostvars[item]['monitor_address_block'] is defined
+    - hostvars[item]['monitor_address_block'] != 'subnet'
+
+- name: set_fact _monitor_address to monitor_address
+  set_fact:
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['monitor_address'] | ipwrap}] }}"
+  with_items:
+    - "{{ groups.get(mon_group_name, []) }}"
+  when:
+    - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
+    - hostvars[item]['monitor_address'] is defined
+    - hostvars[item]['monitor_address'] != '0.0.0.0'
+
+- name: set_fact _monitor_address to monitor_interface - ipv4
+  set_fact:
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_' + (hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version]['address'] | ipwrap }]  }}"
+  with_items:
+    - "{{ groups.get(mon_group_name, []) }}"
+  when:
+    - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
+    - ip_version == 'ipv4'
+    - hostvars[item]['monitor_address_block'] | default('subnet')  == 'subnet'
+    - hostvars[item]['monitor_address'] | default('0.0.0.0') == '0.0.0.0'
+    - hostvars[item]['monitor_interface'] | default('interface') != 'interface'
+
+- name: set_fact _monitor_address to monitor_interface - ipv6
+  set_fact:
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_' + (hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version][0]['address'] | ipwrap }] }}"
+  with_items:
+    - "{{ groups.get(mon_group_name, []) }}"
+  when:
+    - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
+    - ip_version == 'ipv6'
+    - hostvars[item]['monitor_address_block'] | default('subnet')  == 'subnet'
+    - hostvars[item]['monitor_address'] | default('0.0.0.0') == '0.0.0.0'
+    - hostvars[item]['monitor_interface'] | default('interface') != 'interface'

--- a/roles/ceph-defaults/tasks/set_monitor_address.yml
+++ b/roles/ceph-defaults/tasks/set_monitor_address.yml
@@ -42,3 +42,9 @@
     - hostvars[item]['monitor_address_block'] | default('subnet')  == 'subnet'
     - hostvars[item]['monitor_address'] | default('0.0.0.0') == '0.0.0.0'
     - hostvars[item]['monitor_interface'] | default('interface') != 'interface'
+
+- name: set_fact _current_monitor_address
+  set_fact:
+    _current_monitor_address: "{{ item.addr }}"
+  with_items: "{{ _monitor_addresses }}"
+  when: inventory_hostname == item.name

--- a/roles/ceph-defaults/tasks/set_radosgw_address.yml
+++ b/roles/ceph-defaults/tasks/set_radosgw_address.yml
@@ -1,0 +1,35 @@
+---
+- name: set_fact _radosgw_address to radosgw_address_block
+  set_fact:
+    _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first | ipwrap }}"
+  when:
+    - radosgw_address_block is defined
+    - radosgw_address_block != 'subnet'
+
+- name: set_fact _radosgw_address to radosgw_address
+  set_fact:
+    _radosgw_address: "{{ radosgw_address | ipwrap }}"
+  when:
+    - radosgw_address is defined
+    - radosgw_address != 'address'
+
+- block:
+  - name: set_fact _interface
+    set_fact:
+      _interface: "{{ 'ansible_' + (radosgw_interface | replace('-', '_')) }}"
+
+  - name: set_fact _radosgw_address to radosgw_interface - ipv4
+    set_fact:
+      _radosgw_address: "{{ hostvars[inventory_hostname][_interface][ip_version]['address'] }}"
+    when:
+      - ip_version == 'ipv4'
+
+  - name: set_fact _radosgw_address to radosgw_interface - ipv6
+    set_fact:
+      _radosgw_address: "{{ hostvars[inventory_hostname][_interface][ip_version][0]['address'] }}"
+    when:
+      - ip_version == 'ipv6'
+  when:
+    - radosgw_address_block == 'subnet'
+    - radosgw_address == 'address'
+    - radosgw_interface != 'interface'

--- a/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
@@ -10,45 +10,7 @@ DOCKER_EXEC="docker exec ceph-rgw-{{ ansible_hostname }}"
 # Backward compatibility
 $DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-client.rgw.{{ ansible_fqdn }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-client.rgw.{{ ansible_fqdn }}.asok
 $DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-client.rgw.{{ ansible_hostname }}.asok && SOCKET=/var/run/ceph/{{ cluster }}-client.rgw.{{ ansible_hostname }}.asok
-{% if hostvars[inventory_hostname]['radosgw_address_block'] is defined and hostvars[inventory_hostname]['radosgw_address_block'] != 'subnet' %}
-    {% if ip_version == 'ipv4' %}
-RGW_IP={{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }} \
-    {% elif ip_version == 'ipv6' %}
-RGW_IP=[{{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}] \
-    {% endif %}
-{% elif radosgw_address_block is defined and radosgw_address_block != 'subnet' -%}
-    {% if ip_version == 'ipv4' %}
-RGW_IP={{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }} \
-    {% elif ip_version == 'ipv6' %}
-RGW_IP=[{{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}] \
-    {% endif %}
-{% elif hostvars[inventory_hostname]['radosgw_address'] is defined and hostvars[inventory_hostname]['radosgw_address'] != 'address' -%}
-    {% if ip_version == 'ipv4' %}
-RGW_IP={{ hostvars[inventory_hostname]['radosgw_address'] }} \
-    {% elif ip_version == 'ipv6' %}
-RGW_IP=[{{ hostvars[inventory_hostname]['radosgw_address'] }}] \
-    {% endif %}
-{% elif radosgw_address is defined and radosgw_address != 'address' -%}
-    {% if ip_version == 'ipv4' %}
-RGW_IP={{ radosgw_address }} \
-    {% elif ip_version == 'ipv6' %}
-RGW_IP=[{{ radosgw_address }}] \
-    {% endif %}
-{% elif hostvars[inventory_hostname]['radosgw_interface'] is defined -%}
-    {% set interface = 'ansible_' + (hostvars[inventory_hostname]['radosgw_interface'] | replace('-', '_')) %}
-    {% if ip_version == 'ipv4' %}
-RGW_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
-    {% elif ip_version == 'ipv6' %}
-RGW_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
-    {% endif %}
-{% else %}
-    {% set interface = 'ansible_' + (radosgw_interface | replace('-', '_')) %}
-    {% if ip_version == 'ipv4' %}
-RGW_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
-    {% elif ip_version == 'ipv6' %}
-RGW_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
-    {% endif %}
-{% endif %}
+RGW_IP={{ hostvars[inventory_hostname]['_radosgw_address'] }}
 
 check_for_curl_or_wget() {
   if $DOCKER_EXEC command -v wget &>/dev/null; then

--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -16,65 +16,12 @@
   delay: 15
   until: monitor_socket.rc == 0
 
-- name: ipv4 - force peer addition as potential bootstrap peer for cluster bringup - monitor_interface
-  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[groups[mon_group_name][0]]['ansible_' + monitor_interface].ipv4.address }}"
+- name: force peer addition as potential bootstrap peer for cluster bringup
+  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ _current_monitor_address }}"
   changed_when: false
   failed_when: false
   when:
     - not containerized_deployment_with_kv
-    - ip_version == 'ipv4'
-    - hostvars[groups[mon_group_name][0]]['monitor_interface'] is defined
-    - hostvars[groups[mon_group_name][0]]['monitor_interface'] != 'interface'
-
-- name: ipv4 - force peer addition as potential bootstrap peer for cluster bringup - monitor_address
-  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[groups[mon_group_name][0]]['monitor_address'] }}"
-  changed_when: false
-  failed_when: false
-  when:
-    - not containerized_deployment_with_kv
-    - ip_version == 'ipv4'
-    - hostvars[groups[mon_group_name][0]]['monitor_address'] is defined
-    - hostvars[groups[mon_group_name][0]]['monitor_address'] != '0.0.0.0'
-
-- name: ipv4 - force peer addition as potential bootstrap peer for cluster bringup - monitor_address_block
-  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[groups[mon_group_name][0]]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}"
-  changed_when: false
-  failed_when: false
-  when:
-    - not containerized_deployment_with_kv
-    - ip_version == 'ipv4'
-    - hostvars[groups[mon_group_name][0]]['monitor_address_block'] is defined
-    - hostvars[groups[mon_group_name][0]]['monitor_address_block'] != 'subnet'
-
-- name: ipv6 - force peer addition as potential bootstrap peer for cluster bringup - monitor_interface
-  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['ansible_' + monitor_interface].ipv6[0].address }}]"
-  changed_when: false
-  failed_when: false
-  when:
-    - not containerized_deployment_with_kv
-    - ip_version == 'ipv6'
-    - hostvars[groups[mon_group_name][0]]['monitor_interface'] is defined
-    - hostvars[groups[mon_group_name][0]]['monitor_interface'] != 'interface'
-
-- name: ipv6 - force peer addition as potential bootstrap peer for cluster bringup - monitor_address
-  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['monitor_address'] }}]"
-  changed_when: false
-  failed_when: false
-  when:
-    - not containerized_deployment_with_kv
-    - ip_version == 'ipv6'
-    - hostvars[groups[mon_group_name][0]]['monitor_address'] is defined
-    - hostvars[groups[mon_group_name][0]]['monitor_address'] != '0.0.0.0'
-
-- name: ipv6 - force peer addition as potential bootstrap peer for cluster bringup - monitor_address_block
-  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}]"
-  changed_when: false
-  failed_when: false
-  when:
-    - not containerized_deployment_with_kv
-    - ip_version == 'ipv6'
-    - hostvars[groups[mon_group_name][0]]['monitor_address_block'] is defined
-    - hostvars[groups[mon_group_name][0]]['monitor_address_block'] != 'subnet'
 
 - name: include fetch_configs.yml
   include_tasks: fetch_configs.yml

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -30,33 +30,11 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i \
   --net=host \
 {% endif -%}
   -e IP_VERSION={{ ip_version[-1:] }} \
-{% if monitor_address_block != 'subnet' %}
-    {% if ip_version == 'ipv4' -%}
-  -e MON_IP={{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }} \
-    {% elif ip_version == 'ipv6' -%}
-  -e MON_IP=[{{ hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(monitor_address_block) | first }}] \
-    {% endif -%}
-{% elif hostvars[inventory_hostname]['monitor_address'] is defined and hostvars[inventory_hostname]['monitor_address'] != '0.0.0.0' %}
-    {% if ip_version == 'ipv4' -%}
-  -e MON_IP={{ hostvars[inventory_hostname]['monitor_address'] }} \
-    {% elif ip_version == 'ipv6' -%}
-  -e MON_IP=[{{ hostvars[inventory_hostname]['monitor_address'] }}] \
-    {% endif -%}
-{% elif hostvars[inventory_hostname]['monitor_interface'] is defined %}
-    {% set interface = 'ansible_' + (hostvars[inventory_hostname]['monitor_interface'] | replace('-', '_')) %}
-    {% if ip_version == 'ipv4' -%}
-  -e MON_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
-    {% elif ip_version == 'ipv6' -%}
-  -e MON_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
-    {% endif -%}
-{% else %}
-    {% set interface = 'ansible_' + (monitor_interface | replace('-', '_')) %}
-    {% if ip_version == 'ipv4' -%}
-  -e MON_IP={{ hostvars[inventory_hostname][interface][ip_version]['address'] }} \
-    {% elif ip_version == 'ipv6' -%}
-  -e MON_IP=[{{ hostvars[inventory_hostname][interface][ip_version][0]['address'] }}] \
-    {% endif -%}
-{%- endif %}
+{% for host in _monitor_addresses %}
+{% if host.name == inventory_hostname %}
+-e MON_IP={{ host.addr }} \
+{% endif %}
+{% endfor %}
   -e CLUSTER={{ cluster }} \
   -e FSID={{ fsid }} \
   -e CEPH_PUBLIC_NETWORK={{ public_network | regex_replace(' ', '') }} \

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -30,11 +30,7 @@ ExecStart=/usr/bin/docker run --rm --name ceph-mon-%i \
   --net=host \
 {% endif -%}
   -e IP_VERSION={{ ip_version[-1:] }} \
-{% for host in _monitor_addresses %}
-{% if host.name == inventory_hostname %}
--e MON_IP={{ host.addr }} \
-{% endif %}
-{% endfor %}
+  -e MON_IP={{ _current_monitor_address }} \
   -e CLUSTER={{ cluster }} \
   -e FSID={{ fsid }} \
   -e CEPH_PUBLIC_NETWORK={{ public_network | regex_replace(' ', '') }} \


### PR DESCRIPTION
using consecutive set_fact in the playbook instead of complex jinja syntax
makes ceph.conf.j2 more readable.
By the way, jinja can be painful to debug at some point.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>