### PR TITLE
Add ability to use a different client container

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -516,6 +516,10 @@ dummy:
 #ceph_docker_image: "ceph/daemon"
 #ceph_docker_image_tag: latest
 #ceph_docker_registry: docker.io
+## Client only docker image - defaults to {{ ceph_docker_image }}
+#ceph_client_docker_image: "{{ ceph_docker_image }}"
+#ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
+#ceph_client_docker_registry: "{{ ceph_docker_registry }}"
 #ceph_docker_enable_centos_extra_repo: false
 #ceph_docker_on_openstack: false
 #containerized_deployment: False

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -516,6 +516,10 @@ ceph_rhcs_version: 3
 ceph_docker_image: "rhceph-3-rhel7"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.access.redhat.com/rhceph/"
+## Client only docker image - defaults to {{ ceph_docker_image }}
+#ceph_client_docker_image: "{{ ceph_docker_image }}"
+#ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
+#ceph_client_docker_registry: "{{ ceph_docker_registry }}"
 #ceph_docker_enable_centos_extra_repo: false
 #ceph_docker_on_openstack: false
 #containerized_deployment: False

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -33,7 +33,7 @@
     -v {{ ceph_conf_key_directory }}:{{ ceph_conf_key_directory }}:z \
     --name ceph-create-keys \
     --entrypoint=sleep \
-    {{ ceph_docker_registry}}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
+    {{ ceph_client_docker_registry}}/{{ ceph_client_docker_image }}:{{ ceph_client_docker_image_tag }} \
     300
   changed_when: false
   when:

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -508,6 +508,10 @@ docker: false
 ceph_docker_image: "ceph/daemon"
 ceph_docker_image_tag: latest
 ceph_docker_registry: docker.io
+## Client only docker image - defaults to {{ ceph_docker_image }}
+ceph_client_docker_image: "{{ ceph_docker_image }}"
+ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
+ceph_client_docker_registry: "{{ ceph_docker_registry }}"
 ceph_docker_enable_centos_extra_repo: false
 ceph_docker_on_openstack: false
 containerized_deployment: False

--- a/roles/ceph-docker-common/tasks/main.yml
+++ b/roles/ceph-docker-common/tasks/main.yml
@@ -82,7 +82,7 @@
     - fetch_container_image
 
 - name: get ceph version
-  command: docker run --rm --entrypoint /usr/bin/ceph {{ ceph_docker_registry}}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} --version
+  command: docker run --rm --entrypoint /usr/bin/ceph {{ ceph_client_docker_registry}}/{{ ceph_client_docker_image }}:{{ ceph_client_docker_image_tag }} --version
   changed_when: false
   check_mode: no
   register: ceph_version


### PR DESCRIPTION
Currently a throw-away container is built to run ceph client
commands to setup users, pools & auth keys. This utilises
the same base ceph container which has all the ceph services
inside it.

This PR allows the use of a separate container if the deployer
wishes - but defaults to use the same full ceph container.

This can be used for different architectures or distributions,
which may support the the Ceph client, but not Ceph server,
and allows the deployer to build and specify a separate client
container if need be.

Signed-off-by: Andy McCrae <andy.mccrae@gmail.com>