### PR TITLE
site: use ceph-default to show cluster state

### DIFF
--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -374,14 +374,14 @@
   become: True
   tasks:
     - name: get ceph status from the first monitor
-      command: docker exec ceph-mon-{{ hostvars[groups['mons'][0]]['ansible_hostname'] }} ceph --cluster {{ cluster }} -s
+      command: docker exec ceph-mon-{{ hostvars[groups['mons'][0]]['ansible_hostname'] }} ceph --cluster {{ cluster | default ('ceph') }} -s
       register: ceph_status
       changed_when: false
       delegate_to: "{{ groups['mons'][0] }}"
       run_once: true
       ignore_errors: true # we skip the error if mon_group_name is different than 'mons'
 
-    - name: "show ceph status for cluster {{ cluster }}"
+    - name: "show ceph status for cluster {{ cluster | default ('ceph') }}"
       debug:
         msg: "{{ ceph_status.stdout_lines }}"
       delegate_to: "{{ groups['mons'][0] }}"

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -408,14 +408,14 @@
   become: True
   tasks:
     - name: get ceph status from the first monitor
-      command: ceph --cluster {{ cluster }} -s
+      command: ceph --cluster {{ cluster | default ('ceph') }} -s
       register: ceph_status
       changed_when: false
       delegate_to: "{{ groups['mons'][0] }}"
       run_once: true
       ignore_errors: true # we skip the error if mon_group_name is different than 'mons'
 
-    - name: "show ceph status for cluster {{ cluster }}"
+    - name: "show ceph status for cluster {{ cluster | default ('ceph') }}"
       debug:
         msg: "{{ ceph_status.stdout_lines }}"
       delegate_to: "{{ groups['mons'][0] }}"


### PR DESCRIPTION
We need to play cpeh-defaults before showing that task so if the clsuter
name is 'ceph' then we get the default value from 'cluster' based on the
content of cpeh-defaults.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1636962
Signed-off-by: Sébastien Han <seb@redhat.com>