### PR TITLE
docs: correct mandatory config options

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -222,7 +222,9 @@ selection or other aspects of your cluster.
 - ``public_network``
 - ``osd_scenario``
 - ``monitor_interface`` or ``monitor_address``
-- ``radosgw_interface`` or ``radosgw_address``
+
+
+When deploying RGW instance(s) you are required to set the ``radosgw_interface`` or ``radosgw_address`` config option.
 
 ``ceph.conf`` Configuration File
 ---------------------------------


### PR DESCRIPTION
'radosgw_interface' or 'radosgw_address' config option does
not need to be set for all ceph-ansible deployments.

Closes: https://github.com/ceph/ceph-ansible/issues/3143

Signed-off-by: Ramana Raja <rraja@redhat.com>