### PR TITLE
ceph-validate: remove versions checks for bluestore and lvm scenario

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -43,27 +43,6 @@
     - osd_objectstore == 'filestore'
     - osd_group_name in group_names
 
-- name: check if osd_scenario lvm is supported by the selected ceph version
-  fail:
-    msg: "osd_scenario lvm is not supported by the selected Ceph version, use Luminous or newer."
-  when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
-    - ceph_repository not in ['rhcs', 'dev']
-    - not containerized_deployment
-    - osd_scenario == "lvm"
-    - ceph_release_num[ceph_release] < ceph_release_num.luminous
-
-- name: check if bluestore is supported by the selected ceph version
-  fail:
-    msg: "bluestore is not supported by the selected Ceph version, use Luminous or above."
-  when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
-    - ceph_repository not in ['rhcs', 'dev']
-    - osd_objectstore == 'bluestore'
-    - ceph_release_num[ceph_release] < ceph_release_num.luminous
-
 - name: include check_system.yml
   include_tasks: check_system.yml
 


### PR DESCRIPTION
These checks will never pass unless ceph_stable_release is passed and
ceph-defaults is run before ceph-validate. Additionally, we don't want
to support deploying jewel upstream at ceph-ansible master.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1637537

Signed-off-by: Andrew Schoen <aschoen@redhat.com>