### PR TITLE
common: update firewall rules, add cluster_network for osds

### DIFF
--- a/roles/ceph-common/tasks/misc/configure_firewall_rpm.yml
+++ b/roles/ceph-common/tasks/misc/configure_firewall_rpm.yml
@@ -22,6 +22,7 @@
   firewalld:
     service: ceph-mon
     zone: "{{ ceph_mon_firewall_zone }}"
+    source: "{{ public_network }}"
     permanent: true
     immediate: false # if true then fails in case firewalld is stopped
     state: enabled
@@ -37,6 +38,7 @@
   firewalld:
     service: ceph
     zone: "{{ ceph_mgr_firewall_zone }}"
+    source: "{{ public_network }}"
     permanent: true
     immediate: false # if true then fails in case firewalld is stopped
     state: enabled
@@ -53,9 +55,13 @@
   firewalld:
     service: ceph
     zone: "{{ ceph_osd_firewall_zone }}"
+    source: "{{ item }}"
     permanent: true
     immediate: false # if true then fails in case firewalld is stopped
     state: enabled
+  with_items:
+    - "{{ public_network }}"
+    - "{{ cluster_network }}"
   notify: restart firewalld
   when:
     - osd_group_name is defined
@@ -68,6 +74,7 @@
   firewalld:
     port: "{{ radosgw_frontend_port }}/tcp"
     zone: "{{ ceph_rgw_firewall_zone }}"
+    source: "{{ public_network }}"
     permanent: true
     immediate: false # if true then fails in case firewalld is stopped
     state: enabled
@@ -83,6 +90,7 @@
   firewalld:
     service: ceph
     zone: "{{ ceph_mds_firewall_zone }}"
+    source: "{{ public_network }}"
     permanent: true
     immediate: false # if true then fails in case firewalld is stopped
     state: enabled
@@ -98,6 +106,7 @@
   firewalld:
     service: nfs
     zone: "{{ ceph_nfs_firewall_zone }}"
+    source: "{{ public_network }}"
     permanent: true
     immediate: false # if true then fails in case firewalld is stopped
     state: enabled
@@ -113,6 +122,7 @@
   firewalld:
     port: "111/tcp"
     zone: "{{ ceph_nfs_firewall_zone }}"
+    source: "{{ public_network }}"
     permanent: true
     immediate: false # if true then fails in case firewalld is stopped
     state: enabled
@@ -128,6 +138,7 @@
   firewalld:
     port: "{{ restapi_port }}/tcp"
     zone: "{{ ceph_restapi_firewall_zone }}"
+    source: "{{ public_network }}"
     permanent: true
     immediate: false # if true then fails in case firewalld is stopped
     state: enabled
@@ -143,6 +154,7 @@
   firewalld:
     service: ceph
     zone: "{{ ceph_rbdmirror_firewall_zone }}"
+    source: "{{ public_network }}"
     permanent: true
     immediate: false # if true then fails in case firewalld is stopped
     state: enabled
@@ -158,6 +170,7 @@
   firewalld:
     port: "5001/tcp"
     zone: "{{ ceph_iscsi_firewall_zone }}"
+    source: "{{ public_network }}"
     permanent: true
     immediate: false # if true then fails in case firewalld is stopped
     state: enabled


### PR DESCRIPTION
At the moment, all daemons accept connections from `0.0.0.0`.
We should at least restrict to `public_network` and add
`cluster_network` for OSDs.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1541840

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>