### PR TITLE
tests: install lvm2 before setting up ceph-volume/LVM tests

### DIFF
--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -5,6 +5,12 @@
   become: yes
   tasks:
 
+    # Some images may not have lvm2 installed
+    - name: install lvm2
+      package:
+        name: lvm2
+        state: present
+
     - name: create physical volume
       command: pvcreate /dev/sdb
       failed_when: false


### PR DESCRIPTION
This fixes broken ceph-volume tests caused because lvm2 is no longer pre-installed in its images.

    [vagrant@osd0 ~]$ which lvs
    /usr/bin/which: no lvs in (/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/vagrant/.local/bin:/home/vagrant/bin)
    [vagrant@osd0 ~]$ sudo su
    [root@osd0 vagrant]# which lvs
    /usr/bin/which: no lvs in (/sbin:/bin:/usr/sbin:/usr/bin)
    [root@osd0 vagrant]# lvm
    bash: lvm: command not found
    [root@osd0 vagrant]# yum provides lvs
    Loaded plugins: fastestmirror
    Determining fastest mirrors
     * base: mirror.vcu.edu
     * extras: www.gtlib.gatech.edu
     * updates: mirror.siena.edu
    base                                                                                                                                                       | 3.6 kB  00:00:00
    extras                                                                                                                                                     | 3.4 kB  00:00:00
    updates                                                                                                                                                    | 3.4 kB  00:00:00
    (1/4): base/7/x86_64/group_gz                                                                                                                              | 166 kB  00:00:00
    (2/4): extras/7/x86_64/primary_db                                                                                                                          | 204 kB  00:00:00
    (3/4): base/7/x86_64/primary_db                                                                                                                            | 5.9 MB  00:00:00
    (4/4): updates/7/x86_64/primary_db                                                                                                                         | 6.0 MB  00:00:01
    base/7/x86_64/filelists_db                                                                                                                                 | 6.9 MB  00:00:00
    extras/7/x86_64/filelists_db                                                                                                                               | 603 kB  00:00:00
    updates/7/x86_64/filelists_db                                                                                                                              | 3.2 MB  00:00:00
    7:lvm2-2.02.177-4.el7.x86_64 : Userland logical volume management tools
    Repo        : base
    Matched from:
    Filename    : /usr/sbin/lvs
    
    
    [root@osd0 vagrant]# yum install lvm2
    Loaded plugins: fastestmirror
    Loading mirror speeds from cached hostfile
     * base: mirror.vcu.edu
     * extras: www.gtlib.gatech.edu
     * updates: mirror.siena.edu
    Resolving Dependencies
    ...

Tests are failing with:

     TASK [create physical volume] **************************************************
     task path: /tmp/tox.NUa8QhzceL/centos7-bluestore-create/tmp/ceph-ansible/tests/functional/lvm_setup.yml:8
     ok: [osd0] => {
         "changed": false, 
         "cmd": "pvcreate /dev/sdb", 
         "failed_when_result": false, 
         "rc": 2
     }
     
     MSG:
     
     [Errno 2] No such file or directory
