### PR TITLE
tests: ensure lvm2 package is installed

### DIFF
--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -1,9 +1,13 @@
 ---
 
 - hosts: osds
-  gather_facts: false
   become: yes
   tasks:
+
+    - name: ensure lvm2 package is installed
+      package:
+        name: lvm2
+        state: present
 
     - name: create physical volume
       command: pvcreate /dev/sdb


### PR DESCRIPTION
Looks like the new CentOS/7 vagrant image doesnt have the `lvm2` package
installed.

```
-bash: pvs: command not found
```

```
fatal: [osd0]: FAILED! => {
      "changed": false
}

MSG:

Failed to find required executable pvs in paths: /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>