### PR TITLE
tests: fix lvm2 setup issue

### DIFF
--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -1,7 +1,7 @@
 ---
 
 - hosts: osds
-  gather_facts: false
+  gather_facts: true
   become: yes
   tasks:
 


### PR DESCRIPTION
not gathering fact causes `package` module to fail because it needs to
detect which OS we are running on to select the right package manager.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>