### PR TITLE
ceph-defaults: do not set UID 167 if image tag contains "latest"

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -216,7 +216,7 @@
     ceph_uid: 167
   when:
     - containerized_deployment
-    - ceph_docker_image_tag | string is search("latest") or ceph_docker_image_tag | string is search("centos") or ceph_docker_image_tag | string is search("fedora")
+    - ceph_docker_image_tag | string is search("centos") or ceph_docker_image_tag | string is search("fedora")
 
 - name: set_fact ceph_uid for red hat
   set_fact:


### PR DESCRIPTION
For an Ubuntu image with "latest" in the tag, the previously set
UID 64045 will be overwritten with the UID 167. This should not be the case.