### PR TITLE
[skip ci] ceph-defaults: set ceph_stable_openstack_release_uca to queens

### DIFF
--- a/docs/source/installation/methods.rst
+++ b/docs/source/installation/methods.rst
@@ -41,7 +41,7 @@ UCA repository
 
 If ``ceph_repository`` is set to ``uca``, packages you will be by default installed from http://ubuntu-cloud.archive.canonical.com/ubuntu, this can be changed by tweaking ``ceph_stable_repo_uca``.
 You can also decide which OpenStack version the Ceph packages should come from by tweaking ``ceph_stable_openstack_release_uca``.
-For example, ``ceph_stable_openstack_release_uca: liberty``.
+For example, ``ceph_stable_openstack_release_uca: queens``.
 
 Dev repository
 ~~~~~~~~~~~~~~

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -213,7 +213,7 @@ dummy:
 #
 #
 #ceph_stable_repo_uca: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
-#ceph_stable_openstack_release_uca: liberty
+#ceph_stable_openstack_release_uca: queens
 #ceph_stable_release_uca: "{{ansible_lsb.codename}}-updates/{{ceph_stable_openstack_release_uca}}"
 
 # REPOSITORY: openSUSE OBS

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -213,7 +213,7 @@ ceph_rhcs_version: 3
 #
 #
 #ceph_stable_repo_uca: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
-#ceph_stable_openstack_release_uca: liberty
+#ceph_stable_openstack_release_uca: queens
 #ceph_stable_release_uca: "{{ansible_lsb.codename}}-updates/{{ceph_stable_openstack_release_uca}}"
 
 # REPOSITORY: openSUSE OBS

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -205,7 +205,7 @@ ceph_rhcs_cdn_debian_repo_version: "/3-release/" # for GA, later for updates use
 #
 #
 #ceph_stable_repo_uca: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
-#ceph_stable_openstack_release_uca: liberty
+#ceph_stable_openstack_release_uca: queens
 #ceph_stable_release_uca: "{{ansible_lsb.codename}}-updates/{{ceph_stable_openstack_release_uca}}"
 
 # REPOSITORY: openSUSE OBS


### PR DESCRIPTION
Liberty is no longer available in the UCA. The last available release there
is currently Queens.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>