### PR TITLE
backport: allow rolling updates during PG scrubbing

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -185,8 +185,6 @@
       with_items:
         - noout
         - norebalance
-        - noscrub
-        - nodeep-scrub
       delegate_to: "{{ mon_host }}"
       when: not containerized_deployment
 
@@ -196,8 +194,6 @@
       with_items:
         - noout
         - norebalance
-        - noscrub
-        - nodeep-scrub
       delegate_to: "{{ mon_host }}"
       when: containerized_deployment
 
@@ -360,9 +356,7 @@
       command: "{{ docker_exec_cmd_update_osd|default('') }} ceph --cluster {{ cluster }} -s --format json"
       register: ceph_health_post
       until: >
-        ((ceph_health_post.stdout | from_json).pgmap.pgs_by_state | length) == 1
-        and
-        (ceph_health_post.stdout | from_json).pgmap.pgs_by_state.0.state_name == "active+clean"
+        ((ceph_health_post.stdout | from_json).pgmap.pgs_by_state | selectattr('state_name', 'search', '^active\\+clean') | map(attribute='count') | list | sum) == (ceph_pgs.stdout | from_json).pgmap.num_pgs
       delegate_to: "{{ groups[mon_group_name][0] }}"
       retries: "{{ health_osd_check_retries }}"
       delay: "{{ health_osd_check_delay }}"
@@ -394,8 +388,6 @@
       with_items:
         - noout
         - norebalance
-        - noscrub
-        - nodeep-scrub
       delegate_to: "{{ groups[mon_group_name][0] }}"
 
     - name: get osd versions

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -184,6 +184,7 @@
       command: ceph --cluster {{ cluster }} osd set {{ item }}
       with_items:
         - noout
+        - norebalance
         - noscrub
         - nodeep-scrub
       delegate_to: "{{ mon_host }}"
@@ -194,6 +195,7 @@
         docker exec ceph-mon-{{ hostvars[mon_host]['ansible_hostname'] }} ceph --cluster {{ cluster }} osd set {{ item }}
       with_items:
         - noout
+        - norebalance
         - noscrub
         - nodeep-scrub
       delegate_to: "{{ mon_host }}"
@@ -391,6 +393,7 @@
       command: "{{ docker_exec_cmd_update_osd|default('') }} ceph osd unset {{ item }} --cluster {{ cluster }}"
       with_items:
         - noout
+        - norebalance
         - noscrub
         - nodeep-scrub
       delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
Cherry picking two commits from master to allow rolling updates during PG scrubbing.
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1616066