### PR TITLE
docker-ce is used in aarch64 instead of docker engine

### DIFF
--- a/roles/ceph-docker-common/tasks/pre_requisites/debian_prerequisites.yml
+++ b/roles/ceph-docker-common/tasks/pre_requisites/debian_prerequisites.yml
@@ -48,7 +48,7 @@
 
 - name: install docker on debian
   package:
-    name: docker-engine
+    name: "{{ 'docker-ce' if ansible_architecture == 'aarch64' else 'docker-engine' }}"
     state: present
     update_cache: yes
 


### PR DESCRIPTION
Signed-off-by: Nan Li <herbert.nan@linaro.org>