### PR TITLE
test: fix docker test for lvm

### DIFF
--- a/tests/functional/tests/osd/test_osds.py
+++ b/tests/functional/tests/osd/test_osds.py
@@ -71,8 +71,15 @@ class TestOSDs(object):
 
     @pytest.mark.docker
     def test_all_docker_osds_are_up_and_in(self, node, host):
-        cmd = "sudo docker exec ceph-osd-0 ceph --cluster={cluster} --connect-timeout 5 --keyring /var/lib/ceph/bootstrap-osd/{cluster}.keyring -n client.bootstrap-osd osd tree -f json".format(
-            hostname=node["vars"]["inventory_hostname"],
+        osd_scenario = node["vars"].get('osd_scenario', False)
+        if osd_scenario in ['lvm', 'lvm-batch']:
+            osd_id = "0"
+        else:
+            hostname = node["vars"]["inventory_hostname"]
+            osd_id = os.path.join(hostname+"-sda")
+
+        cmd = "sudo docker exec ceph-osd-{osd_id} ceph --cluster={cluster} --connect-timeout 5 --keyring /var/lib/ceph/bootstrap-osd/{cluster}.keyring -n client.bootstrap-osd osd tree -f json".format(
+            osd_id=osd_id,
             cluster=node["cluster_name"]
         )
         output = json.loads(host.check_output(cmd))


### PR DESCRIPTION
The CI is still running ceph-disk tests upstream. So until
https://github.com/ceph/ceph-ansible/pull/3187 is merged nothing will
pass anymore.

Signed-off-by: Sébastien Han <seb@redhat.com>