### PR TITLE
handler: fix osd containers handler

### DIFF
--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -105,8 +105,8 @@
     - osd_group_name in group_names
     - containerized_deployment
     - not rolling_update
-    - ceph_osd_container_stat.get('rc') == 0
     - inventory_hostname == groups.get(osd_group_name) | last
+    - ceph_osd_container_stat.get('rc') == 0
     - ceph_osd_container_stat.get('stdout_lines', [])|length != 0
     - handler_health_osd_check
     - hostvars[item]['_osd_handler_called'] | default(False)


### PR DESCRIPTION
`ceph_osd_container_stat` might not be set on other osd node.
We must ensure we are on the last node before trying to evaluate
`ceph_osd_container_stat`.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>