### PR TITLE
Manual backport of #3171 in stable-3.1

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -190,7 +190,7 @@
   pre_tasks:
     - name: collect running osds and ceph-disk unit(s)
       shell: |
-        systemctl list-units | grep "loaded active" | grep -Eo 'ceph-osd@[0-9]{1,2}.service|ceph-disk@dev-[a-z]{3,4}[0-9]{1}.service'
+        systemctl list-units | grep "loaded active" | grep -Eo 'ceph-osd@[0-9]+.service|ceph-disk@dev-[a-z]{3,4}[0-9]{1}.service'
       register: running_osds
       changed_when: false
       failed_when: false

--- a/roles/ceph-defaults/handlers/main.yml
+++ b/roles/ceph-defaults/handlers/main.yml
@@ -105,8 +105,8 @@
     - osd_group_name in group_names
     - containerized_deployment
     - not (rolling_update | default(False))
-    - hostvars[item]['ceph_osd_container_stat'].get('rc') == 0
     - inventory_hostname == groups.get(osd_group_name) | last
+    - hostvars[item]['ceph_osd_container_stat'].get('rc') == 0
     - hostvars[item]['ceph_osd_container_stat'].get('stdout_lines', [])|length != 0
     - handler_health_osd_check
     - hostvars[item]['_osd_handler_called'] | default(False)


### PR DESCRIPTION
The current regex had a limitation of 99 OSDs, now this limit has been
removed and regardless the number of OSDs they will all be collected.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1630430