### PR TITLE
ceph-volume: fix TypeError exception when setting osds-per-device > 1

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -294,7 +294,7 @@ def batch(module, container_image):
         cmd.append('--dmcrypt')
 
     if osds_per_device > 1:
-        cmd.extend(['--osds-per-device', osds_per_device])
+        cmd.extend(['--osds-per-device', str(osds_per_device)])
 
     if objectstore == 'filestore':
         cmd.extend(['--journal-size', journal_size])


### PR DESCRIPTION
osds-per-device needs to be passed to run_command as a string.
Otherwise, expandvars method will try to iterate over an integer.

Signed-off-by: Maciej Naruszewicz <maciej.naruszewicz@intel.com>