### PR TITLE
[skip ci] [DNM]: Create snapshot-aware tox environments

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 # These are Python requirements needed to run the functional tests
+tox==3.5.0
 testinfra
 pytest-xdist
 pytest==3.6.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {dev,luminous,mimic,rhcs}-{xenial_cluster,centos7_cluster,cluster,docker_cluster,update_cluster,update_docker_cluster,switch_to_containers,ooo_collocation,bluestore_lvm_osds,bluestore_lvm_osds_container,lvm_osds,purge_lvm_osds,shrink_mon,shrink_osd,shrink_mon_container,shrink_osd_container,docker_cluster_collocation,lvm_batch,lvm_osds_container,lvm_batch_container,infra_lv_create,add_osds,add_osds_container,rgw_multisite,rgw_multisite_container}
+envlist = {dev,luminous,mimic,rhcs}-{xenial_cluster,centos7_cluster,cluster,docker_cluster,update_cluster,update_docker_cluster,switch_to_containers,ooo_collocation,bluestore_lvm_osds,bluestore_lvm_osds_container,lvm_osds,purge_lvm_osds,shrink_mon,shrink_osd,shrink_mon_container,shrink_osd_container,docker_cluster_collocation,lvm_batch,lvm_osds_container,lvm_batch_container,infra_lv_create,add_osds,add_osds_container,rgw_multisite,rgw_multisite_container}{-mksnap,-snap,-snap-fast}
   infra_lv_create
 
 skipsdist = True
@@ -179,6 +179,37 @@ commands=
   ansible-playbook -vv --ssh-extra-args='-F {changedir}/secondary/vagrant_ssh_config' -i {changedir}/secondary/hosts {toxinidir}/tests/functional/rgw_multisite.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest}"
   bash -c "cd {changedir}/secondary && vagrant destroy --force"
 
+# moved into separate section because the quoted extra-vars does not parse
+# correctly with the environment factor prefix
+[deployment-playbook]
+commands=
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
+      delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
+      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:mimic} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
+      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
+      copy_admin_key={env:COPY_ADMIN_KEY:False} \
+  "
+
+[deployment-playbook-idempotent]
+commands=
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} \
+      --extra-vars "\
+      delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
+      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:mimic} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-master} # not ideal but what can we do? \
+      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
+      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
+      copy_admin_key={env:COPY_ADMIN_KEY:False} " \
+      --extra-vars @ceph-override.json
+
 [testenv]
 whitelist_externals =
     vagrant
@@ -274,89 +305,70 @@ changedir=
   rgw_multisite_container: {toxinidir}/tests/functional/centos/7/rgw-multisite-container
 
 commands=
-  rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
-  dev: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
+  !snap-rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
+  !snap-dev: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
 
-  vagrant up --no-provision {posargs:--provider=virtualbox}
-  bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
+  !snap: vagrant up --no-provision {posargs:--provider=virtualbox}
+  !snap: bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   # configure lvm
-  centos7_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  docker_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  docker_cluster_collocation: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  lvm_osds: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  lvm_osds_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  bluestore_lvm_osds: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  bluestore_lvm_osds_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  shrink_osd: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  shrink_osd_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  purge_lvm_osds: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  update_docker_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  update_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  purge_cluster_non_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  purge_cluster_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
-  switch_to_containers: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-centos7_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-docker_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-docker_cluster_collocation: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-lvm_osds: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-lvm_osds_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-bluestore_lvm_osds: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-bluestore_lvm_osds_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-shrink_osd: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-shrink_osd_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-purge_lvm_osds: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-update_docker_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-update_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-purge_cluster_non_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-purge_cluster_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  !snap-switch_to_containers: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
 
-  rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
+  !snap-rhcs: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
 
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/setup.yml
+  !snap: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/setup.yml
+  !snap: {[deployment-playbook]commands}
 
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
-      delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:mimic} \
-      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
-      copy_admin_key={env:COPY_ADMIN_KEY:False} \
-  "
+  mksnap: bash {toxinidir}/contrib/snapshot_vms.sh -s cluster_ceph
+  snap: bash {toxinidir}/contrib/snapshot_vms.sh -r cluster_ceph
 
   # wait 30sec for services to be ready
-  sleep 30
+  !mksnap: sleep 30
   # test cluster state using ceph-ansible tests
-  testinfra -n 8 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
+  !mksnap-!fast: testinfra -n 8 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
 
   # reboot all vms
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/reboot.yml
+  !mksnap-!fast: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/reboot.yml
 
   # wait 30sec for services to be ready
-  sleep 30
+  !mksnap-!fast: sleep 30
   # retest to ensure cluster came back up correctly after rebooting
-  testinfra -n 8 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
+  !mksnap-!fast: testinfra -n 8 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests
 
   # handlers/idempotency test
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} \
-      --extra-vars "\
-      delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:mimic} \
-      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-master} # not ideal but what can we do? \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
-      copy_admin_key={env:COPY_ADMIN_KEY:False} " \
-      --extra-vars @ceph-override.json
+  !mksnap-!fast: {[deployment-playbook-idempotent]commands}
 
-  purge_cluster_non_container: {[purge]commands}
-  purge_cluster_container: {[purge]commands}
-  purge_filestore_osds_non_container: {[purge]commands}
-  purge_bluestore_osds_non_container: {[purge]commands}
-  purge_filestore_osds_container: {[purge]commands}
-  purge_bluestore_osds_container: {[purge]commands}
-  purge_lvm_osds: {[purge-lvm]commands}
-  switch_to_containers: {[switch-to-containers]commands}
-  update_cluster: {[update]commands}
-  update_docker_cluster: {[update]commands}
-  shrink_mon: {[shrink-mon]commands}
-  shrink_mon_container: {[shrink-mon]commands}
-  shrink_osd: {[shrink-osd]commands}
-  shrink_osd_container: {[shrink-osd]commands}
-  add_osds: {[add-osds]commands}
-  add_osds_container: {[add-osds]commands}
-  rgw_multisite: {[rgw-multisite]commands}
-  rgw_multisite_container: {[rgw-multisite]commands}
+  !mksnap-purge_cluster_non_container: {[purge]commands}
+  !mksnap-purge_cluster_container: {[purge]commands}
+  !mksnap-purge_filestore_osds_non_container: {[purge]commands}
+  !mksnap-purge_bluestore_osds_non_container: {[purge]commands}
+  !mksnap-purge_filestore_osds_container: {[purge]commands}
+  !mksnap-purge_bluestore_osds_container: {[purge]commands}
+  !mksnap-purge_lvm_osds: {[purge-lvm]commands}
+  !mksnap-switch_to_containers: {[switch-to-containers]commands}
+  !mksnap-update_cluster: {[update]commands}
+  !mksnap-update_docker_cluster: {[update]commands}
+  !mksnap-shrink_mon: {[shrink-mon]commands}
+  !mksnap-shrink_mon_container: {[shrink-mon]commands}
+  !mksnap-shrink_osd: {[shrink-osd]commands}
+  !mksnap-shrink_osd_container: {[shrink-osd]commands}
+  !mksnap-add_osds: {[add-osds]commands}
+  !mksnap-add_osds_container: {[add-osds]commands}
+  !mksnap-rgw_multisite: {[rgw-multisite]commands}
+  !mksnap-rgw_multisite_container: {[rgw-multisite]commands}
 
-  vagrant destroy --force
+  !mksnap-!snap: vagrant destroy --force


### PR DESCRIPTION
This is an attempt at speeding up testing for developers by integrating vm snapshotting into the tox test suites. This patch adds the ability to create and snapshot an initial deployment, and then optionally run tests against these snapshots without reproducing the initial deployment.

Usage:

* All previous tox environments should behave identically to before this patch
* Three new factors are added for each of the previous test environments
* {environment}-mksnap: builds the snapshot of the initial deployment
* {environment}-snap: uses the previously built snapshot and runs infra etc..
* {environment}-snap-fast: uses snapshot, but skips all the infra tests

Todo:

* add support for, or disable, for non-libvirt providers
* I haven't figured out how the `cluster_ceph` `shrink_osd` names get injected into the vagrant environment that creates the virtual machine names, so this is currently hard coded for the `cluster` environment. but ideally we also want to expand this name so snapshots for all possible environments can be persisted.