### PR TITLE
ceph-infra: reload firewall after rules are added

### DIFF
--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -27,7 +27,7 @@
     zone: "{{ ceph_mon_firewall_zone }}"
     source: "{{ public_network }}"
     permanent: true
-    immediate: false # if true then fails in case firewalld is stopped
+    immediate: true
     state: enabled
   notify: restart firewalld
   when:
@@ -43,7 +43,7 @@
     zone: "{{ ceph_mgr_firewall_zone }}"
     source: "{{ public_network }}"
     permanent: true
-    immediate: false # if true then fails in case firewalld is stopped
+    immediate: true
     state: enabled
   notify: restart firewalld
   when:
@@ -59,7 +59,7 @@
     zone: "{{ ceph_osd_firewall_zone }}"
     source: "{{ item }}"
     permanent: true
-    immediate: false # if true then fails in case firewalld is stopped
+    immediate: true
     state: enabled
   with_items:
     - "{{ public_network }}"
@@ -78,7 +78,7 @@
     zone: "{{ ceph_rgw_firewall_zone }}"
     source: "{{ public_network }}"
     permanent: true
-    immediate: false # if true then fails in case firewalld is stopped
+    immediate: true
     state: enabled
   notify: restart firewalld
   when:
@@ -94,7 +94,7 @@
     zone: "{{ ceph_mds_firewall_zone }}"
     source: "{{ public_network }}"
     permanent: true
-    immediate: false # if true then fails in case firewalld is stopped
+    immediate: true
     state: enabled
   notify: restart firewalld
   when:
@@ -110,7 +110,7 @@
     zone: "{{ ceph_nfs_firewall_zone }}"
     source: "{{ public_network }}"
     permanent: true
-    immediate: false # if true then fails in case firewalld is stopped
+    immediate: true
     state: enabled
   notify: restart firewalld
   when:
@@ -126,7 +126,7 @@
     zone: "{{ ceph_nfs_firewall_zone }}"
     source: "{{ public_network }}"
     permanent: true
-    immediate: false # if true then fails in case firewalld is stopped
+    immediate: true
     state: enabled
   notify: restart firewalld
   when:
@@ -142,7 +142,7 @@
     zone: "{{ ceph_restapi_firewall_zone }}"
     source: "{{ public_network }}"
     permanent: true
-    immediate: false # if true then fails in case firewalld is stopped
+    immediate: true
     state: enabled
   notify: restart firewalld
   when:
@@ -158,7 +158,7 @@
     zone: "{{ ceph_rbdmirror_firewall_zone }}"
     source: "{{ public_network }}"
     permanent: true
-    immediate: false # if true then fails in case firewalld is stopped
+    immediate: true
     state: enabled
   notify: restart firewalld
   when:
@@ -174,7 +174,7 @@
     zone: "{{ ceph_iscsi_firewall_zone }}"
     source: "{{ public_network }}"
     permanent: true
-    immediate: false # if true then fails in case firewalld is stopped
+    immediate: true
     state: enabled
   notify: restart firewalld
   when:


### PR DESCRIPTION
we ensure that firewalld is installed and running before adding any
rule. This has no sense anymore not to reload firewalld once the rule
are added.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>