### PR TITLE
[skip ci] ceph_mgr : systemd reload

### DIFF
--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -32,6 +32,12 @@
     - ceph_mgr_systemd_overrides is defined
     - ansible_service_mgr == 'systemd'
 
+- name: ceph-mgr systemd reload
+  systemd: daemon_reload=yes
+  changed_when: false
+  when:
+- ansible_service_mgr == 'systemd'
+
 - name: start and add that the mgr service to the init sequence
   service:
     name: "ceph-mgr@{{ ansible_hostname }}"


### PR DESCRIPTION
Force systemd to reload configuration before trying to start ceph-mgr service, as it doesn't start without it in a node with ceph-mon and ceph-mgr only.