### PR TITLE
roles: do not limit docker_memory_limit for various daemons

### DIFF
--- a/group_vars/iscsigws.yml.sample
+++ b/group_vars/iscsigws.yml.sample
@@ -88,14 +88,14 @@ dummy:
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
 
 # TCMU_RUNNER resource limitation
-#ceph_tcmu_runner_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+#ceph_tcmu_runner_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_tcmu_runner_docker_cpu_limit: 1
 
 # RBD_TARGET_GW resource limitation
-#ceph_rbd_target_gw_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+#ceph_rbd_target_gw_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_rbd_target_gw_docker_cpu_limit: 1
 
 # RBD_TARGET_API resource limitation
-#ceph_rbd_target_api_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+#ceph_rbd_target_api_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_rbd_target_api_docker_cpu_limit: 1
 

--- a/group_vars/iscsigws.yml.sample
+++ b/group_vars/iscsigws.yml.sample
@@ -88,14 +88,14 @@ dummy:
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
 
 # TCMU_RUNNER resource limitation
-#ceph_tcmu_runner_docker_memory_limit: 1g
+#ceph_tcmu_runner_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 #ceph_tcmu_runner_docker_cpu_limit: 1
 
 # RBD_TARGET_GW resource limitation
-#ceph_rbd_target_gw_docker_memory_limit: 1g
+#ceph_rbd_target_gw_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 #ceph_rbd_target_gw_docker_cpu_limit: 1
 
 # RBD_TARGET_API resource limitation
-#ceph_rbd_target_api_docker_memory_limit: 1g
+#ceph_rbd_target_api_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 #ceph_rbd_target_api_docker_cpu_limit: 1
 

--- a/group_vars/mdss.yml.sample
+++ b/group_vars/mdss.yml.sample
@@ -27,7 +27,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
-#ceph_mds_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+#ceph_mds_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_mds_docker_cpu_limit: 1
 
 # we currently for MDS_NAME to hostname because of a bug in ceph-docker

--- a/group_vars/mdss.yml.sample
+++ b/group_vars/mdss.yml.sample
@@ -27,7 +27,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
-#ceph_mds_docker_memory_limit: 4g
+#ceph_mds_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 #ceph_mds_docker_cpu_limit: 1
 
 # we currently for MDS_NAME to hostname because of a bug in ceph-docker

--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -32,7 +32,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mgr_docker_extra_env' variable.
-#ceph_mgr_docker_memory_limit: 1g
+#ceph_mgr_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 #ceph_mgr_docker_cpu_limit: 1
 
 #ceph_mgr_docker_extra_env:

--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -32,7 +32,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mgr_docker_extra_env' variable.
-#ceph_mgr_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+#ceph_mgr_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_mgr_docker_cpu_limit: 1
 
 #ceph_mgr_docker_extra_env:

--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -78,7 +78,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mon_docker_extra_env' variable.
-#ceph_mon_docker_memory_limit: 3g
+#ceph_mon_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 #ceph_mon_docker_cpu_limit: 1
 
 # Use this variable to add extra env configuration to run your mon container.

--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -78,7 +78,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mon_docker_extra_env' variable.
-#ceph_mon_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+#ceph_mon_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_mon_docker_cpu_limit: 1
 
 # Use this variable to add extra env configuration to run your mon container.

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -233,7 +233,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
-#ceph_osd_docker_memory_limit: 5g
+#ceph_osd_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 #ceph_osd_docker_cpu_limit: 1
 
 # The next two variables are undefined, and thus, unused by default.

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -233,7 +233,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
-#ceph_osd_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+#ceph_osd_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_osd_docker_cpu_limit: 1
 
 # The next two variables are undefined, and thus, unused by default.

--- a/group_vars/rbdmirrors.yml.sample
+++ b/group_vars/rbdmirrors.yml.sample
@@ -51,7 +51,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_rbd_mirror_docker_extra_env' variable.
-#ceph_rbd_mirror_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+#ceph_rbd_mirror_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_rbd_mirror_docker_cpu_limit: 1
 
 #ceph_rbd_mirror_docker_extra_env:

--- a/group_vars/rbdmirrors.yml.sample
+++ b/group_vars/rbdmirrors.yml.sample
@@ -51,7 +51,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_rbd_mirror_docker_extra_env' variable.
-#ceph_rbd_mirror_docker_memory_limit: 1g
+#ceph_rbd_mirror_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 #ceph_rbd_mirror_docker_cpu_limit: 1
 
 #ceph_rbd_mirror_docker_extra_env:

--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -62,7 +62,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_rgw_docker_extra_env' variable.
-#ceph_rgw_docker_memory_limit: 1g
+#ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 #ceph_rgw_docker_cpu_limit: 1
 
 #ceph_rgw_docker_extra_env:

--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -62,7 +62,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_rgw_docker_extra_env' variable.
-#ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+#ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_rgw_docker_cpu_limit: 1
 
 #ceph_rgw_docker_extra_env:

--- a/roles/ceph-iscsi-gw/defaults/main.yml
+++ b/roles/ceph-iscsi-gw/defaults/main.yml
@@ -80,13 +80,13 @@ trusted_ip_list: 192.168.122.1
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
 
 # TCMU_RUNNER resource limitation
-ceph_tcmu_runner_docker_memory_limit: 1g
+ceph_tcmu_runner_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 ceph_tcmu_runner_docker_cpu_limit: 1
 
 # RBD_TARGET_GW resource limitation
-ceph_rbd_target_gw_docker_memory_limit: 1g
+ceph_rbd_target_gw_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 ceph_rbd_target_gw_docker_cpu_limit: 1
 
 # RBD_TARGET_API resource limitation
-ceph_rbd_target_api_docker_memory_limit: 1g
+ceph_rbd_target_api_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 ceph_rbd_target_api_docker_cpu_limit: 1

--- a/roles/ceph-iscsi-gw/defaults/main.yml
+++ b/roles/ceph-iscsi-gw/defaults/main.yml
@@ -80,13 +80,13 @@ trusted_ip_list: 192.168.122.1
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
 
 # TCMU_RUNNER resource limitation
-ceph_tcmu_runner_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+ceph_tcmu_runner_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_tcmu_runner_docker_cpu_limit: 1
 
 # RBD_TARGET_GW resource limitation
-ceph_rbd_target_gw_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+ceph_rbd_target_gw_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_rbd_target_gw_docker_cpu_limit: 1
 
 # RBD_TARGET_API resource limitation
-ceph_rbd_target_api_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+ceph_rbd_target_api_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_rbd_target_api_docker_cpu_limit: 1

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -19,7 +19,7 @@ copy_admin_key: false
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
-ceph_mds_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+ceph_mds_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_mds_docker_cpu_limit: 1
 
 # we currently for MDS_NAME to hostname because of a bug in ceph-docker

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -19,7 +19,7 @@ copy_admin_key: false
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
-ceph_mds_docker_memory_limit: 4g
+ceph_mds_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 ceph_mds_docker_cpu_limit: 1
 
 # we currently for MDS_NAME to hostname because of a bug in ceph-docker

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -24,7 +24,7 @@ ceph_mgr_modules: [status]
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mgr_docker_extra_env' variable.
-ceph_mgr_docker_memory_limit: 1g
+ceph_mgr_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 ceph_mgr_docker_cpu_limit: 1
 
 ceph_mgr_docker_extra_env:

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -24,7 +24,7 @@ ceph_mgr_modules: [status]
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mgr_docker_extra_env' variable.
-ceph_mgr_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+ceph_mgr_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_mgr_docker_cpu_limit: 1
 
 ceph_mgr_docker_extra_env:

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -70,7 +70,7 @@ create_crush_tree: false
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mon_docker_extra_env' variable.
-ceph_mon_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+ceph_mon_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_mon_docker_cpu_limit: 1
 
 # Use this variable to add extra env configuration to run your mon container.

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -70,7 +70,7 @@ create_crush_tree: false
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mon_docker_extra_env' variable.
-ceph_mon_docker_memory_limit: 3g
+ceph_mon_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 ceph_mon_docker_cpu_limit: 1
 
 # Use this variable to add extra env configuration to run your mon container.

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -225,7 +225,7 @@ ceph_config_keys: [] # DON'T TOUCH ME
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
-ceph_osd_docker_memory_limit: 5g
+ceph_osd_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 ceph_osd_docker_cpu_limit: 1
 
 # The next two variables are undefined, and thus, unused by default.

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -225,7 +225,7 @@ ceph_config_keys: [] # DON'T TOUCH ME
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
-ceph_osd_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+ceph_osd_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_osd_docker_cpu_limit: 1
 
 # The next two variables are undefined, and thus, unused by default.

--- a/roles/ceph-rbd-mirror/defaults/main.yml
+++ b/roles/ceph-rbd-mirror/defaults/main.yml
@@ -43,7 +43,7 @@ ceph_rbd_mirror_remote_user: ""
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_rbd_mirror_docker_extra_env' variable.
-ceph_rbd_mirror_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+ceph_rbd_mirror_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_rbd_mirror_docker_cpu_limit: 1
 
 ceph_rbd_mirror_docker_extra_env:

--- a/roles/ceph-rbd-mirror/defaults/main.yml
+++ b/roles/ceph-rbd-mirror/defaults/main.yml
@@ -43,7 +43,7 @@ ceph_rbd_mirror_remote_user: ""
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_rbd_mirror_docker_extra_env' variable.
-ceph_rbd_mirror_docker_memory_limit: 1g
+ceph_rbd_mirror_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 ceph_rbd_mirror_docker_cpu_limit: 1
 
 ceph_rbd_mirror_docker_extra_env:

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -54,7 +54,7 @@ rgw_pull_proto: "http"
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_rgw_docker_extra_env' variable.
-ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}"
+ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_rgw_docker_cpu_limit: 1
 
 ceph_rgw_docker_extra_env:

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -54,7 +54,7 @@ rgw_pull_proto: "http"
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_rgw_docker_extra_env' variable.
-ceph_rgw_docker_memory_limit: 1g
+ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}"
 ceph_rgw_docker_cpu_limit: 1
 
 ceph_rgw_docker_extra_env:


### PR DESCRIPTION
Since we do not have enough data to put valid upper bounds for the memory
usage of these daemons, do not put artificial limits by default. This will
help us avoid failures like OOM kills due to low default values.

Whenever required, these limits can be manually enforced by the user.

More details in
https://bugzilla.redhat.com/show_bug.cgi?id=1638148

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1638148
Signed-off-by: Neha Ojha <nojha@redhat.com>