### PR TITLE
ceph_volume: add container support for batch

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -288,6 +288,9 @@ def batch(module, container_image):
     cmd.extend(['--%s' % objectstore])
     cmd.append('--yes')
 
+    if container_image:
+        cmd.append('--prepare')
+
     if crush_device_class:
         cmd.extend(['--crush-device-class', crush_device_class])
 
@@ -556,10 +559,6 @@ def run_module():
 
     elif action == 'batch':
         # Batch prepare AND activate OSDs
-        if container_image:
-            fatal(
-                'Batch operation is currently not supported on containerized deployment (https://tracker.ceph.com/issues/36363)', module)  # noqa E501
-
         report = module.params.get('report', None)
 
         # Add --report flag for the idempotency test

--- a/library/test_ceph_volume.py
+++ b/library/test_ceph_volume.py
@@ -243,6 +243,7 @@ class TestCephVolumeModule(object):
                                  'batch',
                                  '--filestore',
                                  '--yes',
+                                 '--prepare',
                                  '--journal-size',
                                  '100',
                                  '/dev/sda',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def node(host, request):
     rolling_update = os.environ.get("ROLLING_UPDATE", "False")
     group_names = ansible_vars["group_names"]
     docker = ansible_vars.get("docker")
+    fsid = ansible_vars.get("fsid")
     osd_auto_discovery = ansible_vars.get("osd_auto_discovery")
     osd_scenario = ansible_vars.get("osd_scenario")
     lvm_scenario = osd_scenario in ['lvm', 'lvm-batch']
@@ -92,7 +93,7 @@ def node(host, request):
         if cmd.rc == 0:
             osd_ids = cmd.stdout.rstrip("\n").split("\n")
             osds = osd_ids
-            if docker:
+            if docker and fsid == "6e008d48-1661-11e8-8546-008c3214218a":
                 osds = []
                 for device in ansible_vars.get("devices", []):
                     real_dev = host.run("sudo readlink -f %s" % device)


### PR DESCRIPTION
https://tracker.ceph.com/issues/36363 has been resolved and the patch
has been backported to luminous and mimic so let's enable the container
support.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1541415
Signed-off-by: Sébastien Han <seb@redhat.com>