### PR TITLE
rgw: move multisite default variables in ceph-defaults

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -466,6 +466,33 @@ dummy:
 # Set this to true to enable Object access via NFS. Requires an RGW role.
 #nfs_obj_gw: true
 
+
+#############
+# MULTISITE #
+#############
+
+#rgw_multisite: false
+
+# The following Multi-site related variables should be set by the user.
+# rgw_zone is set to "default" to enable compression for clusters configured without rgw multi-site
+# If multisite is configured rgw_zone should not be set to "default". See README-MULTISITE.md for an example.
+#rgw_zone: default
+
+#rgw_zonemaster: true
+#rgw_zonesecondary: false
+#rgw_multisite_endpoint_addr: "{{ ansible_fqdn }}"
+#rgw_zonegroup: solarsystem # should be set by the user
+#rgw_zone_user: zone.user
+#rgw_realm: milkyway # should be set by the user
+#system_access_key: 6kWkikvapSnHyE22P7nO # should be re-created by the user
+#system_secret_key: MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt # should be re-created by the user
+
+# Multi-site remote pull URL variables
+#rgw_pull_port: "{{ radosgw_civetweb_port }}"
+#rgw_pull_proto: "http"
+#rgw_pullhost: localhost # rgw_pullhost only needs to be declared if there is a zone secondary. It should be the same as rgw_multisite_endpoint_addr for the master cluster
+
+
 ###################
 # CONFIG OVERRIDE #
 ###################

--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -49,31 +49,6 @@ dummy:
 #    size: ""
 
 
-#############
-# MULTISITE #
-#############
-
-#rgw_multisite: false
-
-# The following Multi-site related variables should be set by the user.
-# rgw_zone is set to "default" to enable compression for clusters configured without rgw multi-site
-# If multisite is configured rgw_zone should not be set to "default". See README-MULTISITE.md for an example.
-#rgw_zone: default
-
-#rgw_zonemaster: true
-#rgw_zonesecondary: false
-#rgw_multisite_endpoint_addr: "{{ ansible_fqdn }}"
-#rgw_zonegroup: solarsystem # should be set by the user
-#rgw_zone_user: zone.user
-#rgw_realm: milkyway # should be set by the user
-#system_access_key: 6kWkikvapSnHyE22P7nO # should be re-created by the user
-#system_secret_key: MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt # should be re-created by the user
-
-# Multi-site remote pull URL variables
-#rgw_pull_port: "{{ radosgw_civetweb_port }}"
-#rgw_pull_proto: "http"
-#rgw_pullhost: localhost # rgw_pullhost only needs to be declared if there is a zone secondary. It should be the same as rgw_multisite_endpoint_addr for the master cluster
-
 ##########
 # DOCKER #
 ##########

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -466,6 +466,33 @@ ceph_rhcs_version: 3
 # Set this to true to enable Object access via NFS. Requires an RGW role.
 #nfs_obj_gw: true
 
+
+#############
+# MULTISITE #
+#############
+
+#rgw_multisite: false
+
+# The following Multi-site related variables should be set by the user.
+# rgw_zone is set to "default" to enable compression for clusters configured without rgw multi-site
+# If multisite is configured rgw_zone should not be set to "default". See README-MULTISITE.md for an example.
+#rgw_zone: default
+
+#rgw_zonemaster: true
+#rgw_zonesecondary: false
+#rgw_multisite_endpoint_addr: "{{ ansible_fqdn }}"
+#rgw_zonegroup: solarsystem # should be set by the user
+#rgw_zone_user: zone.user
+#rgw_realm: milkyway # should be set by the user
+#system_access_key: 6kWkikvapSnHyE22P7nO # should be re-created by the user
+#system_secret_key: MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt # should be re-created by the user
+
+# Multi-site remote pull URL variables
+#rgw_pull_port: "{{ radosgw_civetweb_port }}"
+#rgw_pull_proto: "http"
+#rgw_pullhost: localhost # rgw_pullhost only needs to be declared if there is a zone secondary. It should be the same as rgw_multisite_endpoint_addr for the master cluster
+
+
 ###################
 # CONFIG OVERRIDE #
 ###################

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -458,6 +458,33 @@ nfs_file_gw: false
 # Set this to true to enable Object access via NFS. Requires an RGW role.
 nfs_obj_gw: true
 
+
+#############
+# MULTISITE #
+#############
+
+rgw_multisite: false
+
+# The following Multi-site related variables should be set by the user.
+# rgw_zone is set to "default" to enable compression for clusters configured without rgw multi-site
+# If multisite is configured rgw_zone should not be set to "default". See README-MULTISITE.md for an example.
+rgw_zone: default
+
+rgw_zonemaster: true
+rgw_zonesecondary: false
+rgw_multisite_endpoint_addr: "{{ ansible_fqdn }}"
+#rgw_zonegroup: solarsystem # should be set by the user
+#rgw_zone_user: zone.user
+#rgw_realm: milkyway # should be set by the user
+#system_access_key: 6kWkikvapSnHyE22P7nO # should be re-created by the user
+#system_secret_key: MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt # should be re-created by the user
+
+# Multi-site remote pull URL variables
+rgw_pull_port: "{{ radosgw_civetweb_port }}"
+rgw_pull_proto: "http"
+#rgw_pullhost: localhost # rgw_pullhost only needs to be declared if there is a zone secondary. It should be the same as rgw_multisite_endpoint_addr for the master cluster
+
+
 ###################
 # CONFIG OVERRIDE #
 ###################

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -41,31 +41,6 @@ copy_admin_key: false
 #    size: ""
 
 
-#############
-# MULTISITE #
-#############
-
-rgw_multisite: false
-
-# The following Multi-site related variables should be set by the user.
-# rgw_zone is set to "default" to enable compression for clusters configured without rgw multi-site
-# If multisite is configured rgw_zone should not be set to "default". See README-MULTISITE.md for an example.
-rgw_zone: default
-
-rgw_zonemaster: true
-rgw_zonesecondary: false
-rgw_multisite_endpoint_addr: "{{ ansible_fqdn }}"
-#rgw_zonegroup: solarsystem # should be set by the user
-#rgw_zone_user: zone.user
-#rgw_realm: milkyway # should be set by the user
-#system_access_key: 6kWkikvapSnHyE22P7nO # should be re-created by the user
-#system_secret_key: MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt # should be re-created by the user
-
-# Multi-site remote pull URL variables
-rgw_pull_port: "{{ radosgw_civetweb_port }}"
-rgw_pull_proto: "http"
-#rgw_pullhost: localhost # rgw_pullhost only needs to be declared if there is a zone secondary. It should be the same as rgw_multisite_endpoint_addr for the master cluster
-
 ##########
 # DOCKER #
 ##########

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -71,7 +71,7 @@
 
 - name: include check_rgw_multisite.yml
   include_tasks: check_rgw_multisite.yml
-  when: 
+  when:
     - inventory_hostname in groups.get(rgw_group_name, [])
     - rgw_multisite
 


### PR DESCRIPTION
Move all rgw multisite variables in ceph-defaults so ceph-validate can
go through them.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>