### PR TITLE
Fix for invalid "changed" property on lvm batch.

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -589,7 +589,6 @@ def run_module():
 
         if not report:
             # if not asking for a report, let's just run the batch command
-            changed = report_result['changed']
             if changed:
                 # Batch prepare the OSD
                 rc, cmd, out, err = exec_command(

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -50,7 +50,7 @@
       when:
         - devices | default([]) | length > 0
         - osd_scenario == 'lvm'
-        - (lvm_batch_report.stdout | from_json).changed
+        - lvm_batch_report.changed
 
     - name: run 'ceph-volume lvm list' to see how many osds have already been created
       ceph_volume:
@@ -61,7 +61,7 @@
       when:
         - devices | default([]) | length > 0
         - osd_scenario == 'lvm'
-        - not (lvm_batch_report.stdout | from_json).changed
+        - not lvm_batch_report.changed
 
     - name: set_fact num_osds from the output of 'ceph-volume lvm list'
       set_fact:
@@ -69,7 +69,7 @@
       when:
         - devices | default([]) | length > 0
         - osd_scenario == 'lvm'
-        - not (lvm_batch_report.stdout | from_json).changed
+        - not lvm_batch_report.changed
 
     when:
       - inventory_hostname in groups.get(osd_group_name, [])


### PR DESCRIPTION
It seems like lvm batch bluestore deployment checks incorrectly for the .changed property on ceph command output.

This fix seems to work as intended, but testing/comments required.