### PR TITLE
remove task named "include ntp debian setup tasks"

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -11,16 +11,10 @@
   tags:
     - package-install
 
-- name: debian based systems tasks
-  block:
-    - name: include installs/install_on_debian.yml
-      include_tasks: installs/install_on_debian.yml
-      tags:
-        - package-install
-    - name: include ntp debian setup tasks
-      include_tasks: "misc/ntp_debian.yml"
-      when:
-        - ntp_service_enabled
+- name: include installs/install_on_debian.yml
+  include_tasks: installs/install_on_debian.yml
+  tags:
+    - package-install
   when:
     - ansible_os_family == 'Debian'
 


### PR DESCRIPTION
The task was included by mistake while resolving a merge confict for
commit 8edbda96df6896d51703fcc250f562abb4011a2d. The task removed in
commit b3a71eeb08e9cdb2607ed60d724f387a0a24d3de.
    
Fixes: https://github.com/ceph/ceph-ansible/issues/3292
Signed-off-by: Rishabh Dave <ridave@redhat.com>