### PR TITLE
don't loop over a task using package management modules

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -550,49 +550,43 @@
 
   - name: purge ceph packages with yum
     yum:
-      name: "{{ item }}"
+      name: "{{ ceph_packages }}"
       state: absent
-    with_items: "{{ ceph_packages }}"
     when: ansible_pkg_mgr == 'yum'
 
   - name: purge ceph packages with dnf
     dnf:
-      name: "{{ item }}"
+      name: "{{ ceph_packages }}"
       state: absent
-    with_items: "{{ ceph_packages }}"
     when: ansible_pkg_mgr == 'dnf'
 
   - name: purge ceph packages with apt
     apt:
-      name: "{{ item }}"
+      name: "{{ ceph_packages }}"
       state: absent
       purge: true
-    with_items: "{{ ceph_packages }}"
     when: ansible_pkg_mgr == 'apt'
 
   - name: purge remaining ceph packages with yum
     yum:
-      name: "{{ item }}"
+      name: "{{ ceph_remaining_packages }}"
       state: absent
-    with_items: "{{ ceph_remaining_packages }}"
     when:
       - ansible_pkg_mgr == 'yum'
       - purge_all_packages == true
 
   - name: purge remaining ceph packages with dnf
     dnf:
-      name: "{{ item }}"
+      name: "{{ ceph_remaining_packages }}"
       state: absent
-    with_items: "{{ ceph_remaining_packages }}"
     when:
       - ansible_pkg_mgr == 'dnf'
       - purge_all_packages == true
 
   - name: purge remaining ceph packages with apt
     apt:
-      name: "{{ item }}"
+      name: "{{ ceph_remaining_packages }}"
       state: absent
-    with_items: "{{ ceph_remaining_packages }}"
     when:
       - ansible_pkg_mgr == 'apt'
       - purge_all_packages == true

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -507,25 +507,18 @@
 
       - name: remove pip and docker on debian
         apt:
-          name: "{{ item }}"
+          name: [python-pip, docker-engine]
           state: absent
           update_cache: yes
           autoremove: yes
-        with_items:
-          - python-pip
-          - docker-engine
     when: ansible_distribution == 'Debian'
 
   - name: remove pip and docker on ubuntu
     apt:
-      name: "{{ item }}"
+      name: [python-pip, docker, docker.io]
       state: absent
       update_cache: yes
       autoremove: yes
-    with_items:
-      - python-pip
-      - docker
-      - docker.io
     when: ansible_distribution == 'Ubuntu'
 
   - name: red hat based systems tasks
@@ -539,25 +532,19 @@
         block:
           - name: remove pip on redhat
             yum:
-              name: "{{ item }}"
+              name: python-pip
               state: absent
-            with_items:
-              - python-pip
 
           - name: remove docker-engine on redhat
             yum:
-              name: "{{ item }}"
+              name: docker-engine
               state: absent
-            with_items:
-              - docker-engine
 
           # for CentOS
           - name: remove docker on redhat
             yum:
-              name: "{{ item }}"
+              name: docker
               state: absent
-            with_items:
-              - docker
 
           - name: remove package dependencies on redhat
             command: yum -y autoremove
@@ -575,12 +562,8 @@
         block:
           - name: remove pip and docker on redhat
             dnf:
-              name: "{{ item }}"
+              name: [python-pip, docker-engine, docker]
               state: absent
-            with_items:
-              - python-pip
-              - docker-engine
-              - docker
 
           - name: remove package dependencies on redhat
             command: dnf -y autoremove


### PR DESCRIPTION
For tasks using (Ansible) modules for package management utilities,
pass the list of packages to be installed instead of repeating the task
for each package. Using the latter manner of installing a list of
packages leads to a deprecation warning by ansible-playbook command.

Fixes: https://github.com/ceph/ceph-ansible/issues/3293
Signed-off-by: Rishabh Dave <ridave@redhat.com>