### PR TITLE
ceph-common: update_cache whenever a new deb repo is added

### DIFF
--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -1,8 +1,0 @@
----
-- name: update apt cache if a repo was added
-  apt:
-    update_cache: yes
-  register: update_apt_cache
-  retries: 5
-  delay: 2
-  until: update_apt_cache | success

--- a/roles/ceph-common/tasks/installs/debian_community_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_community_repository.yml
@@ -8,5 +8,4 @@
   apt_repository:
     repo: "deb {{ ceph_stable_repo }} {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
     state: present
-    update_cache: no
-  notify: update apt cache if a repo was added
+    update_cache: yes

--- a/roles/ceph-common/tasks/installs/debian_dev_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_dev_repository.yml
@@ -9,5 +9,4 @@
   apt_repository:
     repo: "{{ ceph_dev_deb_repo.content }}"
     state: present
-    update_cache: no
-  notify: update apt cache if a repo was added
+    update_cache: yes

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install_debian.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install_debian.yml
@@ -8,10 +8,9 @@
   apt_repository:
     repo: "deb {{ ceph_rhcs_cdn_debian_repo }}{{ ceph_rhcs_cdn_debian_repo_version }}/{{ item.repo }} {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
     state: present
-    update_cache: no
+    update_cache: yes
   with_items:
     - { repo: "MON", configure: (mon_group_name in group_names or mgr_group_name in group_names) }
     - { repo: "OSD", configure: (osd_group_name in group_names) }
     - { repo: "Tools", configure: (rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names) }
   when: item.configure
-  notify: update apt cache if a repo was added

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install_debian.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install_debian.yml
@@ -52,9 +52,8 @@
   apt_repository:
     repo: "deb file://{{ ceph_rhcs_repository_path }}/{{ item }} {{ ansible_lsb.codename }} main"
     state: present
-    update_cache: no
+    update_cache: yes
   with_items:
     - MON
     - OSD
     - Tools
-  notify: update apt cache if a repo was added


### PR DESCRIPTION
The use of a handler meant that the cache would be updated at the very
end of the play, which doesn't work when adding a development repo and
trying to install right after it. This mostly reverts
53cdddf88699263763b36643565e5f846d9d13a8 without an actual `git revert`
because that caused other conflicts.

PR that caused the breakage: https://github.com/ceph/ceph-ansible/pull/3277