### PR TITLE
rbd-mirror: enable ceph-rbd-mirror.target

### DIFF
--- a/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
@@ -24,17 +24,12 @@
     enabled: no
   changed_when: false
 
-# This task is a workaround for rbd-mirror not starting after reboot
-# The upstream fix is: https://github.com/ceph/ceph/pull/17969
-# It's affecting, ceph version 12.2.0 (32ce2a3ae5239ee33d6150705cdb24d43bab910c) luminous (rc) and before
 - name: enable ceph-rbd-mirror.target
   systemd:
     name: "ceph-rbd-mirror.target"
     state: started
     enabled: yes
   changed_when: false
-  when:
-    - ceph_release_num[ceph_release] == ceph_release_num.luminous
 
 - name: start and add the rbd-mirror service instance
   service:

--- a/tox.ini
+++ b/tox.ini
@@ -240,6 +240,7 @@ setenv=
   add_osds_container: CEPH_STABLE_RELEASE = luminous
   rgw_multisite: CEPH_STABLE_RELEASE = luminous
   rgw_multisite_container: CEPH_STABLE_RELEASE = luminous
+  ooo_collocation: CEPH_DOCKER_IMAGE_TAG = v3.0.3-stable-3.0-luminous-centos-7-x86_64
 deps= -r{toxinidir}/tests/requirements.txt
 changedir=
   # tests a 1 mon, 1 osd, 1 mds and 1 rgw xenial cluster using non-collocated OSD scenario


### PR DESCRIPTION
Without this the daemon will never start after reboot.

Signed-off-by: Sébastien Han <seb@redhat.com>