### PR TITLE
igw: stop tcmu-runner on iscsi purge

### DIFF
--- a/infrastructure-playbooks/purge-iscsi-gateways.yml
+++ b/infrastructure-playbooks/purge-iscsi-gateways.yml
@@ -35,19 +35,16 @@
       igw_purge: mode="disks"
       when: igw_purge_type == 'all'
 
-    - name: stop and disable rbd-target-api daemon
+    - name: stop and disable daemons
       service:
-        name: rbd-target-api
+        name: "{{ item }}"
         state: stopped
         enabled: no
       when: igw_purge_type == 'all'
-
-    - name: stop and disable rbd-target-gw daemon
-      service:
-        name: rbd-target-gw
-        state: stopped
-        enabled: no
-      when: igw_purge_type == 'all'
+      with_items:
+        - rbd-target-api
+        - rbd-target-gw
+        - tcmu-runner
 
     - name: restart rbd-target-gw daemons
       service: name=rbd-target-gw state=restarted


### PR DESCRIPTION
When the iscsi purge playbook is run we stop the gw and api daemons but
not tcmu-runner which I forgot on the previous PR.

Fixes Red Hat BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1621255

Signed-off-by: Mike Christie <mchristi@redhat.com>