### PR TITLE
ceph-nfs: use mkdir instead of /usr/bin/mkdir

### DIFF
--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -6,7 +6,7 @@ After=docker.service
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/docker rm ceph-nfs-%i
-ExecStartPre=/usr/bin/mkdir -p /etc/ceph /etc/ganesha /var/lib/nfs/ganesha
+ExecStartPre=mkdir -p /etc/ceph /etc/ganesha /var/lib/nfs/ganesha
 ExecStart=/usr/bin/docker run --rm --net=host \
   {% if not containerized_deployment_with_kv -%}
   -v /var/lib/ceph:/var/lib/ceph:z \


### PR DESCRIPTION
On Ubuntu mkdir lives in /bin and not in /usr/bin