### PR TITLE
don't use private option for import_role

### DIFF
--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -44,11 +44,9 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     - import_role:
         name: ceph-validate
-        private: false
 
 - hosts: osds
   gather_facts: False
@@ -69,33 +67,26 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     - import_role:
         name: ceph-handler
-        private: false
 
     - import_role:
         name: ceph-infra
-        private: false
 
     - import_role:
         name: ceph-container-common
-        private: false
       when: containerized_deployment | bool
 
     - import_role:
         name: ceph-common
-        private: false
       when: not containerized_deployment | bool
 
     - import_role:
         name: ceph-config
-        private: false
 
     - import_role:
         name: ceph-osd
-        private: false
 
     # post-tasks for preceding import
     - name: unset noup flag

--- a/infrastructure-playbooks/rgw-standalone.yml
+++ b/infrastructure-playbooks/rgw-standalone.yml
@@ -8,17 +8,13 @@
   tasks:
   - import_role:
       name: ceph-defaults
-      private: false
   - import_role:
       name: ceph-fetch-keys
-      private: false
 
 - hosts: rgws
   become: True
   tasks:
   - import_role:
       name: ceph-defaults
-      private: false
   - import_role:
       name: ceph-rgw
-      private: false

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -124,27 +124,20 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
       when: not containerized_deployment
     - import_role:
         name: ceph-container-common
-        private: false
       when: containerized_deployment
     - import_role:
         name: ceph-config
-        private: false
     - import_role:
         name: ceph-mon
-        private: false
     - import_role:
         name: ceph-mgr
-        private: false
       when: groups.get(mgr_group_name, []) | length == 0
 
     - name: start ceph mon
@@ -261,7 +254,6 @@
   tasks:
     - import_role:
         name: ceph-defaults
-        private: false
 
     - name: non container - get current fsid
       command: "ceph --cluster {{ cluster }} fsid"
@@ -342,24 +334,18 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
       when: not containerized_deployment
     - import_role:
         name: ceph-container-common
-        private: false
       when: containerized_deployment
     - import_role:
         name: ceph-config
-        private: false
     - import_role:
         name: ceph-mgr
-        private: false
 
     - name: start ceph mgr
       systemd:
@@ -413,24 +399,18 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
       when: not containerized_deployment
     - import_role:
         name: ceph-container-common
-        private: false
       when: containerized_deployment
     - import_role:
         name: ceph-config
-        private: false
     - import_role:
         name: ceph-osd
-        private: false
 
     - name: get osd numbers
       shell: "if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi"
@@ -511,7 +491,6 @@
   tasks:
     - import_role:
         name: ceph-defaults
-        private: false
 
     - name: set_fact docker_exec_cmd_osd
       set_fact:
@@ -563,24 +542,18 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
       when: not containerized_deployment
     - import_role:
         name: ceph-container-common
-        private: false
       when: containerized_deployment
     - import_role:
         name: ceph-config
-        private: false
     - import_role:
         name: ceph-mds
-        private: false
 
     - name: start ceph mds
       systemd:
@@ -618,24 +591,18 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
       when: not containerized_deployment
     - import_role:
         name: ceph-container-common
-        private: false
       when: containerized_deployment
     - import_role:
         name: ceph-config
-        private: false
     - import_role:
         name: ceph-rgw
-        private: false
 
     - name: start ceph rgw
       systemd:
@@ -681,24 +648,18 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
       when: not containerized_deployment
     - import_role:
         name: ceph-container-common
-        private: false
       when: containerized_deployment
     - import_role:
         name: ceph-config
-        private: false
     - import_role:
         name: ceph-rbd-mirror
-        private: false
 
     - name: start ceph rbd mirror
       systemd:
@@ -740,24 +701,18 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
       when: not containerized_deployment
     - import_role:
         name: ceph-container-common
-        private: false
       when: containerized_deployment
     - import_role:
         name: ceph-config
-        private: false
     - import_role:
         name: ceph-nfs
-        private: false
 
     - name: start nfs gateway
       systemd:
@@ -802,24 +757,18 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
       when: not containerized_deployment
     - import_role:
         name: ceph-container-common
-        private: false
       when: containerized_deployment
     - import_role:
         name: ceph-config
-        private: false
     - import_role:
         name: ceph-iscsi-gw
-        private: false
 
     - name: start rbd-target-gw
       systemd:
@@ -840,24 +789,18 @@
   tasks:
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
       when: not containerized_deployment
     - import_role:
         name: ceph-container-common
-        private: false
       when: containerized_deployment
     - import_role:
         name: ceph-config
-        private: false
     - import_role:
         name: ceph-client
-        private: false
 
 
 - name: show ceph status
@@ -867,7 +810,6 @@
   tasks:
     - import_role:
         name: ceph-defaults
-        private: false
 
     - name: set_fact docker_exec_cmd_status
       set_fact:

--- a/infrastructure-playbooks/shrink-mon.yml
+++ b/infrastructure-playbooks/shrink-mon.yml
@@ -69,7 +69,6 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     # post_tasks for preceding import
     - name: pick a monitor different than the one we want to remove

--- a/infrastructure-playbooks/shrink-osd-ceph-disk.yml
+++ b/infrastructure-playbooks/shrink-osd-ceph-disk.yml
@@ -54,7 +54,6 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     # post-task for preceding import
     - name: "set_fact docker_exec_cmd build {{ container_binary }} exec command (containerized)"

--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -58,7 +58,6 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     # post-task for preceding import
     - name: set_fact docker_exec_cmd build docker exec command (containerized)

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -114,16 +114,12 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-container-common
-        private: false
     - import_role:
         name: ceph-mon
-        private: false
 
     # post-tasks for preceding import -
   post_tasks:
@@ -180,19 +176,15 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     - import_role:
         name: ceph-handler
-        private: false
 
     - import_role:
         name: ceph-container-common
-        private: false
 
     - import_role:
         name: ceph-mgr
-        private: false
 
 
 - name: switching from non-containerized to containerized ceph osd
@@ -212,7 +204,6 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     # pre-tasks for following importing
     - name: collect running osds and ceph-disk unit(s)
@@ -301,19 +292,15 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     - import_role:
         name: ceph-handler
-        private: false
 
     - import_role:
         name: ceph-container-common
-        private: false
 
     - import_role:
         name: ceph-osd
-        private: false
 
     # post-task for preceding import -
     - name: get num_pgs
@@ -376,19 +363,15 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     - import_role:
         name: ceph-handler
-        private: false
 
     - import_role:
         name: ceph-container-common
-        private: false
 
     - import_role:
          name: ceph-mds
-         private: false
 
 
 - name: switching from non-containerized to containerized ceph rgw
@@ -430,19 +413,15 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     - import_role:
         name: ceph-handler
-        private: false
 
     - import_role:
         name: ceph-container-common
-        private: false
 
     - import_role:
         name: ceph-rgw
-        private: false
 
 
 - name: switching from non-containerized to containerized ceph rbd-mirror
@@ -483,19 +462,15 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     - import_role:
         name: ceph-handler
-        private: false
 
     - import_role:
         name: ceph-container-common
-        private: false
 
     - import_role:
         name: ceph-rbd-mirror
-        private: false
 
 
 - name: switching from non-containerized to containerized ceph nfs
@@ -541,16 +516,12 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     - import_role:
         name: ceph-handler
-        private: false
 
     - import_role:
         name: ceph-container-common
-        private: false
 
     - import_role:
         name: ceph-nfs
-        private: false

--- a/infrastructure-playbooks/take-over-existing-cluster.yml
+++ b/infrastructure-playbooks/take-over-existing-cluster.yml
@@ -16,10 +16,8 @@
   tasks:
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-fetch-keys
-        private: false
 
 - hosts:
   - mons
@@ -36,7 +34,6 @@
   tasks:
     - import_role:
         name: ceph-defaults
-        private: false
 
     # post-tasks for preceding import -
     - name: get the name of the existing ceph cluster

--- a/infrastructure-playbooks/untested-by-ci/replace-osd.yml
+++ b/infrastructure-playbooks/untested-by-ci/replace-osd.yml
@@ -57,7 +57,6 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
 
     # post-tasks for preceding import -
     - name: set_fact docker_exec_cmd build docker exec command (containerized)

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -61,20 +61,15 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: [with_pkg, fetch_container_image]
     - import_role:
         name: ceph-validate
-        private: false
     - import_role:
         name: ceph-infra
-        private: false
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-container-common
-        private: false
       tags: [with_pkg, fetch_container_image]
       when:
         - not (is_atomic | bool)
@@ -110,24 +105,18 @@
   tasks:
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-container-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-mon
-        private: false
     - import_role:
         name: ceph-mgr
-        private: false
 
 - hosts: mons
   tasks:
@@ -154,21 +143,17 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-container-common
-        private: false
     - import_role:
         name: ceph-config
         private: fals
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-mgr
-        private: false
 
     # post-tasks for upcoming imports -
     - name: set ceph manager install 'Complete'
@@ -195,21 +180,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-container-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-osd
-        private: false
 
     # post-tasks for preceding imports -
     - name: set ceph osd install 'Complete'
@@ -236,21 +216,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-container-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-mds
-        private: false
 
     # post-tasks for preceding imports -
     - name: set ceph mds install 'Complete'
@@ -277,21 +252,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-container-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-rgw
-        private: false
 
     # post-tasks for preceding imports -
     - name: set ceph rgw install 'Complete'
@@ -318,21 +288,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-container-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-nfs
-        private: false
 
     # post-tasks for following imports -
     - name: set ceph nfs install 'Complete'
@@ -359,21 +324,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-container-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-rbd-mirror
-        private: false
 
     # post-tasks for preceding imports -
     - name: set ceph rbd mirror install 'Complete'
@@ -400,23 +360,18 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-container-common
-        private: false
       when:
         - inventory_hostname == groups.get('clients', ['']) | first
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-client
-        private: false
 
     # post-tasks for preceding imports -
     - name: set ceph client install 'Complete'
@@ -445,21 +400,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-container-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-iscsi-gw
-        private: false
 
     # post-tasks for preceding imports -
   post_tasks:

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -74,13 +74,10 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
     - import_role:
         name: ceph-validate
-        private: false
     - import_role:
         name: ceph-infra
-        private: false
 
 - hosts: mons
   gather_facts: false
@@ -98,24 +95,18 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-mon
-        private: false
     - import_role:
         name: ceph-mgr
-        private: false
 
     # post-tasks for preceding imports -
     - name: set ceph monitor install 'Complete'
@@ -142,21 +133,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-mgr
-        private: false
 
     # post-tasks for following imports -
     - name: set ceph manager install 'Complete'
@@ -183,21 +169,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-agent
-        private: false
 
     # post-tasks for following imports -
     - name: set ceph agent install 'Complete'
@@ -224,21 +205,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-osd
-        private: false
 
     # post-tasks for following imports -
     - name: set ceph osd install 'Complete'
@@ -265,21 +241,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-mds
-        private: false
 
     # post-tasks for following imports -
     - name: set ceph mds install 'Complete'
@@ -306,21 +277,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-rgw
-        private: false
 
     # post-tasks for following imports -
     - name: set ceph rgw install 'Complete'
@@ -347,21 +313,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-nfs
-        private: false
 
     # post-tasks for following imports -
     - name: set ceph nfs install 'Complete'
@@ -388,21 +349,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-rbd-mirror
-        private: false
 
     # post-tasks for following imports -
     - name: set ceph rbd mirror install 'Complete'
@@ -429,21 +385,16 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-client
-        private: false
 
     # post-tasks for following imports -
     - name: set ceph client install 'Complete'
@@ -472,23 +423,18 @@
 
     - import_role:
         name: ceph-defaults
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
-        private: false
     - import_role:
         name: ceph-common
-        private: false
       when:
         - ceph_release_num[ceph_release] >= ceph_release_num.luminous
     - import_role:
         name: ceph-config
-        private: false
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-iscsi-gw
-        private: false
 
     # post-tasks for following imports -
     - name: set ceph iscsi gw install 'Complete'

--- a/test.yml
+++ b/test.yml
@@ -4,19 +4,13 @@
   tasks:
   - import_role:
       name: ceph.ceph-common
-      private: false
   - import_role:
       name: ceph-mon
-      private: false
   - import_role:
       name: ceph-osd
-      private: false
   - import_role:
       name: ceph-mds
-      private: false
   - import_role:
       name: ceph-rgw
-      private: false
   - import_role:
       name: ceph-fetch-keys
-      private: false


### PR DESCRIPTION
Since variable sharing has been made default for roles, private option
has been deprecated; so stop using it.

Signed-off-by: Rishabh Dave <ridave@redhat.com>