### PR TITLE
[skip ci] switch: do not mask systemd unit

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -239,7 +239,6 @@
         name: "{{ item }}"
         state: stopped
         enabled: no
-        masked: yes
       with_items: "{{ running_osds.stdout_lines | default([])}}"
       when: running_osds != []
 

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -218,23 +218,7 @@
       changed_when: false
       failed_when: false
 
-    - name: collect osd devices
-      shell: |
-        blkid | awk '/ceph data/ { sub ("1:", "", $1); print $1 }'
-      register: collect_devices
-      changed_when: false
-      when:
-        - devices is not defined or (devices is defined and devices == [])
-
-    - name: set devices
-      set_fact:
-        devices: "{{ collect_devices.stdout_lines | list }}"
-      when:
-        - collect_devices is defined
-        - not collect_devices.get("skipped")
-        - collect_devices != []
-
-    - name: stop/disable non-containerized ceph osd(s), ceph-disk units (if any) and ceph-volume units (if any)
+    - name: stop/disable/mask non-containerized ceph osd(s) and ceph-disk units (if any)
       systemd:
         name: "{{ item }}"
         state: stopped
@@ -289,28 +273,27 @@
         - ldb_files.rc == 0
 
     - name: check if containerized osds are already running
-      shell: |
-        docker ps | grep -sq {{ item | regex_replace('/', '') }}
+      command: >
+        docker ps --filter='name=ceph-osd'
       changed_when: false
       failed_when: false
-      with_items: "{{ devices }}"
       register: osd_running
 
-    - name: resolve device(s) path(s)
-      command: readlink -f {{ item }}
+    - name: get osd directories
+      command: >
+        ls -1 /var/lib/ceph/osd
+      register: osd_dirs
       changed_when: false
-      with_items: "{{ devices }}"
-      register: devices_canonicalize
 
     - name: unmount all the osd directories
-      command: umount "{{ item.0.stdout }}"1
+      command: >
+        umount /var/lib/ceph/osd/{{ item }}
       changed_when: false
       failed_when: false
-      with_together:
-        - "{{ devices_canonicalize.results }}"
-        - "{{ osd_running.results }}"
+      with_items:
+        - "{{ osd_dirs.stdout_lines }}"
       when:
-        - item.1.get("rc", 0) != 0
+        - osd_running.rc != 0
 
     - import_role:
         name: ceph-defaults

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -213,7 +213,7 @@
     # pre-tasks for following importing
     - name: collect running osds and ceph-disk unit(s)
       shell: |
-        systemctl list-units | grep "loaded active" | grep -Eo 'ceph-osd@[0-9]+.service|ceph-disk@dev-[a-z]{3,4}[0-9]{1}.service'
+        systemctl list-units | grep "loaded active" | grep -Eo 'ceph-osd@[0-9]+.service|ceph-disk@dev-[a-z]{3,4}[0-9]{1}.service|ceph-volume|ceph\.target'
       register: running_osds
       changed_when: false
       failed_when: false
@@ -234,13 +234,23 @@
         - not collect_devices.get("skipped")
         - collect_devices != []
 
-    - name: stop/disable/mask non-containerized ceph osd(s) and ceph-disk units (if any)
+    - name: stop/disable non-containerized ceph osd(s), ceph-disk units (if any) and ceph-volume units (if any)
       systemd:
         name: "{{ item }}"
         state: stopped
         enabled: no
       with_items: "{{ running_osds.stdout_lines | default([])}}"
       when: running_osds != []
+
+    - name: remove old ceph-osd systemd units
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - /usr/lib/systemd/system/ceph-osd.target
+        - /usr/lib/systemd/system/ceph-osd@.service
+        - /usr/lib/systemd/system/ceph-volume@.service
+        - /etc/systemd/system/ceph.target.wants
 
     - set_fact:
         ceph_uid: 64045


### PR DESCRIPTION
If we mask it we won't be able to start the OSD container since now the
osd container use the osd ID as a name such as: ceph-osd@0

Fixes the error:  Failed to execute operation: Cannot send after transport endpoint shutdown

Signed-off-by: Sébastien Han <seb@redhat.com>