### PR TITLE
tox: add lvm setup to shrink mon

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -291,6 +291,8 @@ commands=
   bluestore_lvm_osds_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
   shrink_osd: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
   shrink_osd_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  shrink_mon: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  shrink_mon_container: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
   purge_lvm_osds: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
   update_docker_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
   update_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml


### PR DESCRIPTION
Fix shrink mon scenario by setting lvm so we can configure ceph-volume
lvm osds.

Signed-off-by: Sébastien Han <seb@redhat.com>