### PR TITLE
validate: allow stable-3.2 to run with ansible 2.4

### DIFF
--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -67,10 +67,10 @@
 
 - name: fail on unsupported ansible version
   fail:
-    msg: "Ansible version must be between 2.5.x and 2.6.x!"
+    msg: "Ansible version must be between 2.4.x and 2.6.x!"
   when:
     - ansible_version.major|int == 2
-    - (ansible_version.minor|int < 5 or ansible_version.minor|int > 6)
+    - (ansible_version.minor|int < 4 or ansible_version.minor|int > 6)
 
 - name: fail if systemd is not present
   fail:


### PR DESCRIPTION
Although this is not officially supported, this commit allows
`stable-3.2` to run against ansible 2.4.
This should ease the transition in RHOSP.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>