### PR TITLE
infra: don't restart firewalld if unit is masked

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -245,3 +245,6 @@
 
 - name: import_tasks set_radosgw_address.yml
   import_tasks: set_radosgw_address.yml
+
+- name: populate service facts
+  service_facts:

--- a/roles/ceph-infra/handlers/main.yml
+++ b/roles/ceph-infra/handlers/main.yml
@@ -4,3 +4,6 @@
     name: firewalld
     state: restarted
     enabled: yes
+  when:
+    - ansible_facts['services']['firewalld.service'] is defined
+    - ansible_facts['services']['firewalld.service']['state'] != 'masked'


### PR DESCRIPTION
if firewalld.service systemd unit is masked, the handler will fail when
trying to restart it.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1650281

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>