### PR TITLE
ceph_key: rbd-mirror keyring is missing pre nautilus

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -103,6 +103,12 @@
   when:
     - cephx
 
+- name: register rbd-mirror bootstrap key
+  set_fact:
+    bootstrap_rbd_mirror_keyring: "/var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring"
+  when:
+    - ceph_release_num[ceph_release] >= ceph_release_num.nautilus
+
 - name: copy keys to the ansible server
   fetch:
     src: "{{ item }}"
@@ -114,7 +120,7 @@
     - /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring
     - /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring
     - /var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring
-    - /var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring
+    - "{{ bootstrap_rbd_mirror_keyring | default([]) }}"
   when:
     - cephx
     - inventory_hostname == groups[mon_group_name] | last


### PR DESCRIPTION
We should not try and copy
/var/lib/ceph/bootstrap-rbd-mirror/ceph.keyring on releases before
nautilus.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>