### PR TITLE
validate plugin: handle missing exception fields without traceback

### DIFF
--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -96,10 +96,15 @@ class ActionModule(ActionBase):
                         notario.validate(host_vars, lvm_bluestore_scenario, defined_keys=True)
 
         except Invalid as error:
-            display.vvvv("Notario Failure: %s" % str(error))
-            msg = "[{}] Validation failed for variable: {}".format(host, error.path[0])
-            display.error(msg)
-            reason = "[{}] Reason: {}".format(host, error.reason)
+            display.vvv("Notario Failure: %s" % str(error))
+            msg = ""
+            if error.path:
+                msg = "[{}] Validation failed for variable: {}".format(host, error.path[0])
+                display.error(msg)
+                reason = "[{}] Reason: {}".format(host, error.reason)
+            else:
+                reason = "[{}] Reason: {}".format(host, str(error))
+            given = ""
             try:
                 if "schema is missing" not in error.message:
                     for i in range(0, len(error.path)):
@@ -108,7 +113,8 @@ class ActionModule(ActionBase):
                                     host, error.path[0])
                         else:
                             given = given + ": {}".format(error.path[i])
-                    display.error(given)
+                    if given:
+                        display.error(given)
                 else:
                     given = ""
                     reason = "[{}] Reason: {}".format(host, error.message)
@@ -116,8 +122,9 @@ class ActionModule(ActionBase):
                 given = ""
             display.error(reason)
             result['failed'] = mode == 'strict'
-            result['msg'] = "\n".join([msg, reason, given])
-            result['stderr_lines'] = msg.split('\n')
+            result['msg'] = "\n".join([s for s in (msg, reason, given) if len(s) > 0])
+            result['stderr_lines'] = result['msg'].split('\n')
+
 
         return result
 


### PR DESCRIPTION
"missing variable" errors introduced by #3058 would attempt to
be reported, but since the exception contained no "path" definition,
would cause a second exception in the Invalid exception handler.
Make the exception handler verify that any field it tries to use
exists, clean up its message formatting, and reduce the verbose
level to see the literal error from notario in case more goes
wrong in future.

Signed-off-by: Dan Mick <dan.mick@redhat.com>