### PR TITLE
client: fix a typo in create_users_keys.yml

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -124,7 +124,7 @@
         {{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }}
         osd pool set {{ item.name }} size {{ item.size | default('') }}
       with_items: "{{ pools | unique }}"
-      delegate_to: "{{ delegate_node }}"
+      delegate_to: "{{ delegated_node }}"
       changed_when: false
       when:
         - pools | length > 0


### PR DESCRIPTION
cd1e4ee024ef400ded25e8c99948648ead3a0892 introduced a typo.
This commit fixes it.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>