### PR TITLE
[skip ci] ceph.ceph-container-common remove symlink

### DIFF
--- a/roles/ceph.ceph-container-common
+++ b/roles/ceph.ceph-container-common
@@ -1,1 +1,0 @@
-ceph-container-common


### PR DESCRIPTION
This error was introduced in the recent refactor of ceph-docker-common
in https://github.com/ceph/ceph-ansible/pull/3251. However, the Ansible
galaxy linter is not happy about it and fails importing the role.
Removing this since it's not used anymore.

Signed-off-by: Sébastien Han <seb@redhat.com>