### PR TITLE
osd_memory_target: standardize unit and fix calculation

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -360,7 +360,7 @@ dummy:
 #is_hci: false
 #hci_safety_factor: 0.2
 #non_hci_safety_factor: 0.7
-#osd_memory_target: 4000000000
+#osd_memory_target: 4294967296
 #journal_size: 5120 # OSD journal size in MB
 #block_db_size: -1 # block db size in bytes for the ceph-volume lvm batch. -1 means use the default of 'as big as possible'.
 #public_network: 0.0.0.0/0

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -360,7 +360,7 @@ ceph_rhcs_version: 3
 #is_hci: false
 #hci_safety_factor: 0.2
 #non_hci_safety_factor: 0.7
-#osd_memory_target: 4000000000
+#osd_memory_target: 4294967296
 #journal_size: 5120 # OSD journal size in MB
 #block_db_size: -1 # block db size in bytes for the ceph-volume lvm batch. -1 means use the default of 'as big as possible'.
 #public_network: 0.0.0.0/0

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -89,12 +89,12 @@ filestore xattr use omap = true
 {% set _num_osds = num_osds | default(0) | int %}
 [osd]
 {% if is_hci and _num_osds > 0 %}
-{% if ansible_memtotal_mb * hci_safety_factor / _num_osds > osd_memory_target %} # hci_safety_factor is the safety factor for HCI deployments
-{% set _osd_memory_target = (ansible_memtotal_mb * hci_safety_factor / _num_osds) %}
+{% if ansible_memtotal_mb * 1048576 * hci_safety_factor / _num_osds > osd_memory_target %} # hci_safety_factor is the safety factor for HCI deployments
+{% set _osd_memory_target = (ansible_memtotal_mb * 1048576 * hci_safety_factor / _num_osds) %}
 {% endif %}
 {% elif _num_osds > 0 %}
-{% if ansible_memtotal_mb * non_hci_safety_factor / _num_osds > osd_memory_target %} # non_hci_safety_factor is the safety factor for dedicated nodes
-{% set _osd_memory_target = (ansible_memtotal_mb * non_hci_safety_factor / _num_osds) %}
+{% if ansible_memtotal_mb * 1048576 * non_hci_safety_factor / _num_osds > osd_memory_target %} # non_hci_safety_factor is the safety factor for dedicated nodes
+{% set _osd_memory_target = (ansible_memtotal_mb * 1048576 * non_hci_safety_factor / _num_osds) %}
 {% endif %}
 {% endif %}
 osd memory target = {{ _osd_memory_target | default(osd_memory_target) }}

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -352,7 +352,7 @@ cephfs_pools:
 is_hci: false
 hci_safety_factor: 0.2
 non_hci_safety_factor: 0.7
-osd_memory_target: 4000000000
+osd_memory_target: 4294967296
 journal_size: 5120 # OSD journal size in MB
 block_db_size: -1 # block db size in bytes for the ceph-volume lvm batch. -1 means use the default of 'as big as possible'.
 public_network: 0.0.0.0/0


### PR DESCRIPTION
* The default value of osd_memory_target used by ceph is 4294967296 bytes,
so use the same as ceph-ansible default.

* Convert ansible_memtotal_mb to bytes to calculate osd_memory_target

Fixes bug in https://github.com/ceph/ceph-ansible/pull/3113
Signed-off-by: Neha Ojha <nojha@redhat.com>