### PR TITLE
start_osds: Use list instead of keys

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -228,7 +228,7 @@
 - name: set_fact rgw_hostname
   set_fact:
     rgw_hostname: "{% set _value = ansible_hostname -%}
-    {% for key in ceph_current_status['servicemap']['services']['rgw']['daemons'].keys() -%}
+    {% for key in (ceph_current_status['servicemap']['services']['rgw']['daemons'] | list) -%}
     {% if key == ansible_fqdn -%}
     {% set _value = key -%}
     {% endif -%}

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -54,7 +54,7 @@
     state: started
     enabled: yes
     daemon_reload: yes
-  with_items: "{{ devices if osd_scenario != 'lvm' else (ceph_osd_ids.stdout | from_json).keys() }}"
+  with_items: "{{ devices if osd_scenario != 'lvm' else (ceph_osd_ids.stdout | from_json | list) }}"
 
 - name: ensure systemd service override directory exists
   file:


### PR DESCRIPTION
If you use python3 based ansible then keys() returns a dict_keys object,
not a list of keys. This breaks the installation on such a system. Using
the list filter provides a more robust solution that should work on both
python2 and python3 based ansible. You can find some more information
about the issue, here:

https://github.com/ansible/ansible/issues/19514

Signed-off-by: Boris Ranto <branto@redhat.com>