### PR TITLE
ceph-volume: be idempotent when the batch strategy changes

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -578,13 +578,22 @@ def run_module():
         try:
             report_result = json.loads(out)
         except ValueError:
+            strategy_change = "strategy changed" in out
+            if strategy_change:
+                out = json.dumps({"changed": False, "stdout": out.rstrip(b"\r\n")})
+                rc = 0
+                changed = False
+            else:
+                out = out.rstrip(b"\r\n")
             result = dict(
                 cmd=cmd,
-                stdout=out.rstrip(b"\r\n"),
+                stdout=out,
                 stderr=err.rstrip(b"\r\n"),
                 rc=rc,
                 changed=changed,
             )
+            if strategy_change:
+                module.exit_json(**result)
             module.fail_json(msg='non-zero return code', **result)
 
         if not report:


### PR DESCRIPTION
If you deploy with 2 HDDs and 1 SDD then each subsequent deploy both
HDD drives will be filtered out, because they're already used by ceph.
ceph-volume will report this as a 'strategy change' because the device
list went from a mixed type of HDD and SDD to a single type of only SDD.

This situation results in a non-zero exit code from ceph-volume. We want
to handle this situation gracefully and report that nothing will be changed.
A similar json structure to what would have been given by ceph-volume is
returned in the 'stdout' key.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1650306

Sample output:

```
TASK [ceph-config : run 'ceph-volume lvm batch --report' to see how many osds are to be created] **************************************************************************
task path: /Users/andrewschoen/dev/ceph/src/ceph-volume/ceph_volume/tests/functional/batch/.tox/centos7-bluestore-mixed_type/tmp/ceph-ansible/roles/ceph-config/tasks/main.yml:30
skipping: [mon0] => {
    "changed": false,
    "skip_reason": "Conditional result was False"
}
ok: [osd0] => {
    "changed": false,
    "cmd": [
        "ceph-volume",
        "--cluster",
        "test",
        "lvm",
        "batch",
        "--bluestore",
        "--yes",
        "/dev/sdb",
        "/dev/sdc",
        "/dev/nvme0n1",
        "--report",
        "--format=json"
    ],
    "rc": 0
}

STDOUT:

{"changed": false, "stdout": "--> Aborting because strategy changed from bluestore.MixedType to bluestore.SingleType after filtering"}
```