### PR TITLE
osd: expose udev into the container

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -181,6 +181,7 @@ def container_exec(binary, container_image):
 
     command_exec = ['docker', 'run', '--rm', '--privileged', '--net=host',
                     '-v', '/run/lock/lvm:/run/lock/lvm:z',
+                    '-v', '/var/run/udev/:/var/run/udev/:z',
                     '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',
                     '-v', '/run/lvm/lvmetad.socket:/run/lvm/lvmetad.socket',
                     '-v', '/var/lib/ceph/:/var/lib/ceph/:z',

--- a/library/test_ceph_volume.py
+++ b/library/test_ceph_volume.py
@@ -41,6 +41,7 @@ class TestCephVolumeModule(object):
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
         expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
+                                 '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
                                  '-v', '/run/lvm/lvmetad.socket:/run/lvm/lvmetad.socket',  # noqa E501
                                  '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
@@ -56,6 +57,7 @@ class TestCephVolumeModule(object):
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
         expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
+                                 '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
                                  '-v', '/run/lvm/lvmetad.socket:/run/lvm/lvmetad.socket',  # noqa E501
                                  '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
@@ -110,6 +112,7 @@ class TestCephVolumeModule(object):
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
         expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
+                                 '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
                                  '-v', '/run/lvm/lvmetad.socket:/run/lvm/lvmetad.socket',  # noqa E501
                                  '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
@@ -136,6 +139,7 @@ class TestCephVolumeModule(object):
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
         expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
+                                 '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
                                  '-v', '/run/lvm/lvmetad.socket:/run/lvm/lvmetad.socket',  # noqa E501
                                  '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
@@ -183,6 +187,7 @@ class TestCephVolumeModule(object):
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
         expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
+                                 '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
                                  '-v', '/run/lvm/lvmetad.socket:/run/lvm/lvmetad.socket',  # noqa E501
                                  '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
@@ -231,6 +236,7 @@ class TestCephVolumeModule(object):
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
         expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
+                                 '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
                                  '-v', '/run/lvm/lvmetad.socket:/run/lvm/lvmetad.socket',  # noqa E501
                                  '-v', '/var/lib/ceph/:/var/lib/ceph/:z',

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -26,7 +26,7 @@
 
 - name: set_fact docker_exec_start_osd
   set_fact:
-    docker_exec_start_osd: "{{ 'docker run --rm --privileged=true -v /run/lvm/lvmetad.socket:/run/lvm/lvmetad.socket -v /etc/ceph:/etc/ceph:z -v /dev:/dev --entrypoint=ceph-volume ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else 'ceph-volume' }}"
+    docker_exec_start_osd: "{{ 'docker run --rm --privileged=true -v /run/lvm/lvmetad.socket:/run/lvm/lvmetad.socket -v /var/run/udev/:/var/run/udev/:z -v /etc/ceph:/etc/ceph:z -v /dev:/dev --entrypoint=ceph-volume ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else 'ceph-volume' }}"
 
 - name: collect osd ids
   shell: >


### PR DESCRIPTION
In order to be able to retrieve udev information, we must expose its
socket. As per, https://github.com/ceph/ceph/pull/25201 ceph-volume will
start consuming udev output.

Signed-off-by: Sébastien Han <seb@redhat.com>