### PR TITLE
validate: change default value for `radosgw_address`

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -402,7 +402,7 @@ dummy:
 # Eg. If you want to specify for each radosgw node which address the radosgw will bind to you can set it in your **inventory host file** by using 'radosgw_address' variable.
 # Preference will go to radosgw_address if both radosgw_address and radosgw_interface are defined.
 #radosgw_interface: interface
-#radosgw_address: address
+#radosgw_address: 0.0.0.0
 #radosgw_address_block: subnet
 #radosgw_keystone_ssl: false # activate this when using keystone PKI keys
 # Rados Gateway options

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -402,7 +402,7 @@ ceph_rhcs_version: 3
 # Eg. If you want to specify for each radosgw node which address the radosgw will bind to you can set it in your **inventory host file** by using 'radosgw_address' variable.
 # Preference will go to radosgw_address if both radosgw_address and radosgw_interface are defined.
 #radosgw_interface: interface
-#radosgw_address: address
+#radosgw_address: 0.0.0.0
 #radosgw_address_block: subnet
 #radosgw_keystone_ssl: false # activate this when using keystone PKI keys
 # Rados Gateway options

--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -187,7 +187,7 @@ def validate_rados_options(value):
     Either radosgw_interface, radosgw_address or radosgw_address_block must
     be defined.
     """
-    radosgw_address_given = notario_store["radosgw_address"] != "address"
+    radosgw_address_given = notario_store["radosgw_address"] != "0.0.0.0"
     radosgw_address_block_given = notario_store["radosgw_address_block"] != "subnet"
     radosgw_interface_given = notario_store["radosgw_interface"] != "interface"
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -394,7 +394,7 @@ radosgw_frontend_options: "{{ radosgw_civetweb_options if radosgw_frontend_type 
 # Eg. If you want to specify for each radosgw node which address the radosgw will bind to you can set it in your **inventory host file** by using 'radosgw_address' variable.
 # Preference will go to radosgw_address if both radosgw_address and radosgw_interface are defined.
 radosgw_interface: interface
-radosgw_address: address
+radosgw_address: 0.0.0.0
 radosgw_address_block: subnet
 radosgw_keystone_ssl: false # activate this when using keystone PKI keys
 # Rados Gateway options

--- a/roles/ceph-defaults/tasks/set_radosgw_address.yml
+++ b/roles/ceph-defaults/tasks/set_radosgw_address.yml
@@ -11,7 +11,7 @@
     _radosgw_address: "{{ radosgw_address | ipwrap }}"
   when:
     - radosgw_address is defined
-    - radosgw_address != 'address'
+    - radosgw_address != '0.0.0.0'
 
 - block:
   - name: set_fact _interface
@@ -31,5 +31,5 @@
       - ip_version == 'ipv6'
   when:
     - radosgw_address_block == 'subnet'
-    - radosgw_address == 'address'
+    - radosgw_address == '0.0.0.0'
     - radosgw_interface != 'interface'


### PR DESCRIPTION
change default value of `radosgw_address` to keep consistency with
`monitor_address`.
Moreover, `ceph-validate` checks if the value is '0.0.0.0' to determine
if it has to run `check_eth_rgw.yml`.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1600227

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>