### PR TITLE
osd: re-introduce disk_list check

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -11,6 +11,14 @@
     when:
       - ceph_docker_on_openstack
 
+  - name: test if the container image has the disk_list function
+    command: docker run --rm --entrypoint=stat {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} disk_list.sh
+    changed_when: false
+    failed_when: false
+    register: disk_list
+    when:
+      - osd_scenario != 'lvm'
+
   - name: generate ceph osd docker run script
     become: true
     template:


### PR DESCRIPTION
This commit
https://github.com/ceph/ceph-ansible/commit/4cc1506303739f13bb7a6e1022646ef90e004c90#diff-51bbe3572e46e3b219ad726da44b64ebL13
accidentally removed this check.

This is a must have for ceph-disk based containerized OSDs.

Signed-off-by: Sébastien Han <seb@redhat.com>