### PR TITLE
revert: infra: do not start firewalld if unit is masked

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -269,6 +269,3 @@
   import_tasks: set_radosgw_address.yml
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])
-
-- name: populate service facts
-  service_facts:

--- a/roles/ceph-infra/handlers/main.yml
+++ b/roles/ceph-infra/handlers/main.yml
@@ -4,6 +4,3 @@
     name: firewalld
     state: restarted
     enabled: yes
-  when:
-    - ansible_facts['services']['firewalld.service'] is defined
-    - ansible_facts['services']['firewalld.service']['state'] != 'masked'

--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -12,179 +12,171 @@
   when:
     - not containerized_deployment
 
-- name: start firewalld
-  service:
-    name: firewalld
-    state: started
-    enabled: yes
-  when:
-    - firewalld_pkg_query.get('rc', 1) == 0
-      or is_atomic
+- block:
+  - name: start firewalld
+    service:
+      name: firewalld
+      state: started
+      enabled: yes
 
-- name: open monitor and manager ports
-  firewalld:
-    service: "{{ item.service }}"
-    zone: "{{ item.zone }}"
-    source: "{{ public_network }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  notify: restart firewalld
-  with_items:
-    - { 'service': 'ceph-mon', 'zone': "{{ ceph_mon_firewall_zone }}" }
-    - { 'service': 'ceph', 'zone': "{{ ceph_mgr_firewall_zone }}" }
-  when:
-    - mon_group_name is defined
-    - mon_group_name in group_names
-    - (firewalld_pkg_query.get('rc', 1) == 0 or is_atomic)
-  tags:
-    - firewall
+  - name: open monitor and manager ports
+    firewalld:
+      service: "{{ item.service }}"
+      zone: "{{ item.zone }}"
+      source: "{{ public_network }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    notify: restart firewalld
+    with_items:
+      - { 'service': 'ceph-mon', 'zone': "{{ ceph_mon_firewall_zone }}" }
+      - { 'service': 'ceph', 'zone': "{{ ceph_mgr_firewall_zone }}" }
+    when:
+      - mon_group_name is defined
+      - mon_group_name in group_names
+    tags:
+      - firewall
 
-- name: open manager ports
-  firewalld:
-    service: ceph
-    zone: "{{ ceph_mgr_firewall_zone }}"
-    source: "{{ public_network }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  notify: restart firewalld
-  when:
-    - mgr_group_name is defined
-    - mgr_group_name in group_names
-    - (firewalld_pkg_query.get('rc', 1) == 0 or is_atomic)
-  tags:
-    - firewall
+  - name: open manager ports
+    firewalld:
+      service: ceph
+      zone: "{{ ceph_mgr_firewall_zone }}"
+      source: "{{ public_network }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    notify: restart firewalld
+    when:
+      - mgr_group_name is defined
+      - mgr_group_name in group_names
+    tags:
+      - firewall
 
-- name: open osd ports
-  firewalld:
-    service: ceph
-    zone: "{{ ceph_osd_firewall_zone }}"
-    source: "{{ item }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  with_items:
-    - "{{ public_network }}"
-    - "{{ cluster_network }}"
-  notify: restart firewalld
-  when:
-    - osd_group_name is defined
-    - osd_group_name in group_names
-    - (firewalld_pkg_query.get('rc', 1) == 0 or is_atomic)
-  tags:
-    - firewall
+  - name: open osd ports
+    firewalld:
+      service: ceph
+      zone: "{{ ceph_osd_firewall_zone }}"
+      source: "{{ item }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    with_items:
+      - "{{ public_network }}"
+      - "{{ cluster_network }}"
+    notify: restart firewalld
+    when:
+      - osd_group_name is defined
+      - osd_group_name in group_names
+    tags:
+      - firewall
 
-- name: open rgw ports
-  firewalld:
-    port: "{{ radosgw_frontend_port }}/tcp"
-    zone: "{{ ceph_rgw_firewall_zone }}"
-    source: "{{ public_network }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  notify: restart firewalld
-  when:
-    - rgw_group_name is defined
-    - rgw_group_name in group_names
-    - (firewalld_pkg_query.get('rc', 1) == 0 or is_atomic)
-  tags:
-    - firewall
+  - name: open rgw ports
+    firewalld:
+      port: "{{ radosgw_frontend_port }}/tcp"
+      zone: "{{ ceph_rgw_firewall_zone }}"
+      source: "{{ public_network }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    notify: restart firewalld
+    when:
+      - rgw_group_name is defined
+      - rgw_group_name in group_names
+    tags:
+      - firewall
 
-- name: open mds ports
-  firewalld:
-    service: ceph
-    zone: "{{ ceph_mds_firewall_zone }}"
-    source: "{{ public_network }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  notify: restart firewalld
-  when:
-    - mds_group_name is defined
-    - mds_group_name in group_names
-    - (firewalld_pkg_query.get('rc', 1) == 0 or is_atomic)
-  tags:
-    - firewall
+  - name: open mds ports
+    firewalld:
+      service: ceph
+      zone: "{{ ceph_mds_firewall_zone }}"
+      source: "{{ public_network }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    notify: restart firewalld
+    when:
+      - mds_group_name is defined
+      - mds_group_name in group_names
+    tags:
+      - firewall
 
-- name: open nfs ports
-  firewalld:
-    service: nfs
-    zone: "{{ ceph_nfs_firewall_zone }}"
-    source: "{{ public_network }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  notify: restart firewalld
-  when:
-    - nfs_group_name is defined
-    - nfs_group_name in group_names
-    - (firewalld_pkg_query.get('rc', 1) == 0 or is_atomic)
-  tags:
-    - firewall
+  - name: open nfs ports
+    firewalld:
+      service: nfs
+      zone: "{{ ceph_nfs_firewall_zone }}"
+      source: "{{ public_network }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    notify: restart firewalld
+    when:
+      - nfs_group_name is defined
+      - nfs_group_name in group_names
+    tags:
+      - firewall
 
-- name: open nfs ports (portmapper)
-  firewalld:
-    port: "111/tcp"
-    zone: "{{ ceph_nfs_firewall_zone }}"
-    source: "{{ public_network }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  notify: restart firewalld
-  when:
-    - nfs_group_name is defined
-    - nfs_group_name in group_names
-    - (firewalld_pkg_query.get('rc', 1) == 0 or is_atomic)
-  tags:
-    - firewall
+  - name: open nfs ports (portmapper)
+    firewalld:
+      port: "111/tcp"
+      zone: "{{ ceph_nfs_firewall_zone }}"
+      source: "{{ public_network }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    notify: restart firewalld
+    when:
+      - nfs_group_name is defined
+      - nfs_group_name in group_names
+    tags:
+      - firewall
 
-- name: open rbdmirror ports
-  firewalld:
-    service: ceph
-    zone: "{{ ceph_rbdmirror_firewall_zone }}"
-    source: "{{ public_network }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  notify: restart firewalld
-  when:
-    - rbdmirror_group_name is defined
-    - rbdmirror_group_name in group_names
-    - (firewalld_pkg_query.get('rc', 1) == 0 or is_atomic)
-  tags:
-    - firewall
+  - name: open rbdmirror ports
+    firewalld:
+      service: ceph
+      zone: "{{ ceph_rbdmirror_firewall_zone }}"
+      source: "{{ public_network }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    notify: restart firewalld
+    when:
+      - rbdmirror_group_name is defined
+      - rbdmirror_group_name in group_names
+    tags:
+      - firewall
 
-- name: open iscsi target ports
-  firewalld:
-    port: "3260/tcp"
-    zone: "{{ ceph_iscsi_firewall_zone }}"
-    source: "{{ public_network }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  notify: restart firewalld
-  when:
-    - iscsi_gw_group_name is defined
-    - iscsi_gw_group_name in group_names
-    - (firewalld_pkg_query.get('rc', 1) == 0 or is_atomic)
-  tags:
-    - firewall
+  - name: open iscsi target ports
+    firewalld:
+      port: "3260/tcp"
+      zone: "{{ ceph_iscsi_firewall_zone }}"
+      source: "{{ public_network }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    notify: restart firewalld
+    when:
+      - iscsi_gw_group_name is defined
+      - iscsi_gw_group_name in group_names
+    tags:
+      - firewall
 
-- name: open iscsi api ports
-  firewalld:
-    port: "{{ api_port | default(5000) }}/tcp"
-    zone: "{{ ceph_iscsi_firewall_zone }}"
-    source: "{{ public_network }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  notify: restart firewalld
+  - name: open iscsi api ports
+    firewalld:
+      port: "{{ api_port | default(5000) }}/tcp"
+      zone: "{{ ceph_iscsi_firewall_zone }}"
+      source: "{{ public_network }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    notify: restart firewalld
+    when:
+      - iscsi_gw_group_name is defined
+      - iscsi_gw_group_name in group_names
+    tags:
+      - firewall
+
   when:
-    - iscsi_gw_group_name is defined
-    - iscsi_gw_group_name in group_names
-    - (firewalld_pkg_query.get('rc', 1) == 0 or is_atomic)
-  tags:
-    - firewall
+    - (firewalld_pkg_query.get('rc', 1) == 0
+      or is_atomic)
 
 - meta: flush_handlers


### PR DESCRIPTION
If firewalld unit is masked, setting `configure_firewall: false` is
enough

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>