### PR TITLE
[skip ci] osd: remove an incorrect information

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -7,10 +7,6 @@
 # file as a good configuration file when no variable in it.
 dummy:
 
-# You can override default vars defined in defaults/main.yml here,
-# but I would advice to use host or group vars instead
-
-
 ###########
 # GENERAL #
 ###########

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -1,8 +1,4 @@
 ---
-# You can override default vars defined in defaults/main.yml here,
-# but I would advice to use host or group vars instead
-
-
 ###########
 # GENERAL #
 ###########


### PR DESCRIPTION
This is false, `./defaults/main.yml` is not supposed to be modified
directly. groups_vars a/o host_vars should always be preferred.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>