### PR TITLE
rolling_update: do not fail on missing keys

### DIFF
--- a/roles/ceph-mon/tasks/docker/fetch_configs.yml
+++ b/roles/ceph-mon/tasks/docker/fetch_configs.yml
@@ -4,6 +4,7 @@
     src: "{{ item.0 }}"
     dest: "{{ fetch_directory }}/{{ fsid }}/{{ item.0 }}"
     flat: yes
+    fail_on_missing: "{{ 'no' if rolling_update else 'yes' }}"
   with_together:
     - "{{ ceph_config_keys }}"
     - "{{ statconfig.results }}"


### PR DESCRIPTION
We don't want to fail on key that are not present since they will get
created after the mons are updated. They will be created by the task
"create potentially missing keys (rbd and rbd-mirror)".

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1650572
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit ebc901c6af67300f7b7b8da1b2d0a74147798da5)