### PR TITLE
travis: remove sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 language: python
 python:
   - "3.6"


### PR DESCRIPTION
The sudo keyword will be fully deprecated.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>