### PR TITLE
tox: add missing ceph_docker_image_tag in shrink

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -120,6 +120,7 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/shrink-mon.yml --extra-vars "\
       ireallymeanit=yes \
       mon_to_kill={env:MON_TO_KILL:ceph-mon2} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
   "
 [shrink-osd]
 commands=
@@ -127,6 +128,7 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/shrink-osd.yml --extra-vars "\
       ireallymeanit=yes \
       osd_to_kill=0 \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
   "
 
 [switch-to-containers]


### PR DESCRIPTION
When calling shrink on containerized deployment, we were first doing the
setup with `latest-master` and then when calling the playbook we were
using the default value for `ceph_docker_image_tag` that comes from
ceph-defaults. Now we pass
`ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master}` so the
play will run the right container image.

Signed-off-by: Sébastien Han <seb@redhat.com>