### PR TITLE
mgr: little refact

### DIFF
--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -20,8 +20,9 @@ dummy:
 ###########
 # MODULES #
 ###########
-# Ceph mgr modules to enable, current modules available are: status,dashboard,localpool,restful,zabbix,prometheus,influx
-#ceph_mgr_modules: [status]
+# Ceph mgr modules to enable, to view the list of available mpdules see: http://docs.ceph.com/docs/CEPH_VERSION/mgr/
+# and replace CEPH_VERSION with your current Ceph version, e,g: 'mimic'
+#ceph_mgr_modules: []
 
 
 ##########

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -12,8 +12,9 @@ copy_admin_key: false
 ###########
 # MODULES #
 ###########
-# Ceph mgr modules to enable, current modules available are: status,dashboard,localpool,restful,zabbix,prometheus,influx
-ceph_mgr_modules: [status]
+# Ceph mgr modules to enable, to view the list of available mpdules see: http://docs.ceph.com/docs/CEPH_VERSION/mgr/
+# and replace CEPH_VERSION with your current Ceph version, e,g: 'mimic'
+ceph_mgr_modules: []
 
 
 ##########

--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -12,36 +12,9 @@
   include_tasks: pre_requisite.yml
   when: not containerized_deployment
 
-- name: inclide start_mgr.yml
+- name: include start_mgr.yml
   include_tasks: start_mgr.yml
 
-- name: get enabled modules from ceph-mgr
-  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} --format json mgr module ls"
-  changed_when: false
-  register: _ceph_mgr_modules
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-
-- name: set _ceph_mgr_modules fact (convert _ceph_mgr_modules.stdout to a dict)
-  set_fact:
-    _ceph_mgr_modules: "{{ _ceph_mgr_modules.get('stdout', '{}') | from_json }}"
-
-- name: set _disabled_ceph_mgr_modules fact
-  set_fact:
-    _disabled_ceph_mgr_modules: "{% if _ceph_mgr_modules.disabled_modules | length == 0 %}[]{% elif _ceph_mgr_modules.disabled_modules[0] | type_debug != 'dict' %}{{ _ceph_mgr_modules['disabled_modules'] }}{% else %}{{ _ceph_mgr_modules['disabled_modules'] | map(attribute='name') | list }}{% endif %}"
-
-- name: disable ceph mgr enabled modules
-  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module disable {{ item }}"
-  # When ceph release is jewel, ceph-mgr role is skipped. It means, the enabled_ceph_mgr_modules doesn't contain 'stdout' attribute.
-  # Therefore, we need to get a default value which can be used up by from_json filter.
-  with_items: "{{ _ceph_mgr_modules.get('enabled_modules', []) }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  when:
-    - item not in ceph_mgr_modules
-    - not _ceph_mgr_modules.get('skipped')
-
-- name: add modules to ceph-mgr
-  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module enable {{ item }}"
-  with_items: "{{ ceph_mgr_modules }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  when:
-    - (item in _disabled_ceph_mgr_modules or _disabled_ceph_mgr_modules == [])
+- name: include mgr_modules.yml
+  include_tasks: mgr_modules.yml
+  when: ceph_mgr_modules|length > 0

--- a/roles/ceph-mgr/tasks/mgr_modules.yml
+++ b/roles/ceph-mgr/tasks/mgr_modules.yml
@@ -1,0 +1,28 @@
+---
+- name: get enabled modules from ceph-mgr
+  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} --format json mgr module ls"
+  changed_when: false
+  register: _ceph_mgr_modules
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+
+- name: set _ceph_mgr_modules fact (convert _ceph_mgr_modules.stdout to a dict)
+  set_fact:
+    _ceph_mgr_modules: "{{ _ceph_mgr_modules.get('stdout', '{}') | from_json }}"
+
+- name: set _disabled_ceph_mgr_modules fact
+  set_fact:
+    _disabled_ceph_mgr_modules: "{% if _ceph_mgr_modules.disabled_modules | length == 0 %}[]{% elif _ceph_mgr_modules.disabled_modules[0] | type_debug != 'dict' %}{{ _ceph_mgr_modules['disabled_modules'] }}{% else %}{{ _ceph_mgr_modules['disabled_modules'] | map(attribute='name') | list }}{% endif %}"
+
+- name: disable ceph mgr enabled modules
+  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module disable {{ item }}"
+  with_items: "{{ _ceph_mgr_modules.get('enabled_modules', []) }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  when:
+    - item not in ceph_mgr_modules
+
+- name: add modules to ceph-mgr
+  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module enable {{ item }}"
+  with_items: "{{ ceph_mgr_modules }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  when:
+    - (item in _disabled_ceph_mgr_modules or _disabled_ceph_mgr_modules == [])


### PR DESCRIPTION
This commit removes the default module, so ceph-ansible does not enable
any manager module.
To enable a module you need to set a value to 'ceph_mgr_modules', you
can pass a list of modules like this:

ceph_mgr_modules:
  - status
  - dashboard

Signed-off-by: Sébastien Han <seb@redhat.com>