### PR TITLE
ceph-defaults: do not use podman only on atomic

### DIFF
--- a/roles/ceph-defaults/tasks/facts.yml
+++ b/roles/ceph-defaults/tasks/facts.yml
@@ -19,7 +19,7 @@
 
 - name: set_fact container_binary
   set_fact:
-    container_binary: "{{ 'podman' if is_atomic and is_podman and ansible_distribution == 'Fedora' else 'docker' }}"
+    container_binary: "{{ 'podman' if is_podman and ansible_distribution == 'Fedora' else 'docker' }}"
   when: containerized_deployment
 
 - name: set_fact monitor_name ansible_hostname


### PR DESCRIPTION
We want to test podman on f29 non-atomic, atomic is not a hard
requirement. However, if you want to get podman then you will have to
install it first before running the playbook.

Signed-off-by: Sébastien Han <seb@redhat.com>