### PR TITLE
[skip ci] mergify: trigger rdo ci on each PR

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -84,3 +84,11 @@ pull_request_rules:
     conditions:
       - label=backport-stable-3.2
     name: backport stable-3.2
+
+# this will trigger the RDO CI to test the ceph-ansible PR
+  - name: check rdo
+    conditions:
+      - head=master
+    actions:
+      comment:
+        message: "check-rdo"


### PR DESCRIPTION
mergify will now put a comment on a each PR with 'check-rdo' so this
will trigger the RDO CI to test the ceph-ansible PR.

Signed-off-by: Sébastien Han <seb@redhat.com>