### PR TITLE
purge-container: move facts gathering after ceph-defaults role import

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -308,18 +308,17 @@
   gather_facts: true
   become: true
 
-  pre_tasks:
-  - name: gather monitors facts
-    setup:
-    delegate_to: "{{ item }}"
-    delegate_facts: True
-    with_items: "{{ groups.get(mon_group_name, 'mons') }}"
-
   tasks:
 
   - import_role:
       name: ceph-defaults
       private: false
+
+  - name: gather monitors facts
+    setup:
+    delegate_to: "{{ item }}"
+    delegate_facts: True
+    with_items: "{{ groups.get(mon_group_name | default('mons')) }}"
 
   - import_role:
       name: ceph-facts


### PR DESCRIPTION
This task has to be called after the role `ceph-defaults` has been
played, otherwise, `mon_group_name` will never be known.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>