### PR TITLE
add support for rocksdb and wal on the same partition in non-collocated

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -123,8 +123,9 @@ dummy:
 # - The devices listed in 'devices' will get 2 partitions, one for 'block' and one for 'data'.
 # 'data' is only 100MB big and do not store any of your data, it's just a bunch of Ceph metadata.
 # 'block' will store all your actual data.
-# - The devices in 'dedicated_devices' will get 1 partition for RocksDB DB, called 'block.db'
-#  and one for RocksDB WAL, called 'block.wal'
+# - The devices in 'dedicated_devices' will get one partition for RocksDB DB, called 'block.db'
+#  and one for RocksDB WAL, called 'block.wal'. To use a single partition for RocksDB and WAL together
+#  set bluestore_wal_devices to [].
 #
 # By default dedicated_devices will represent block.db
 #
@@ -147,6 +148,8 @@ dummy:
 #
 # By default, if 'bluestore_wal_devices' is empty, it will get the content of 'dedicated_devices'.
 # If set, then you will have a dedicated partition on a specific device for block.wal.
+#
+# Set bluestore_wal_devices: [] to use the same partition for RocksDB and WAL.
 #
 # Example of what you will get:
 # [root@ceph-osd0 ~]# blkid /dev/sd*

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -115,8 +115,9 @@ valid_osd_scenarios:
 # - The devices listed in 'devices' will get 2 partitions, one for 'block' and one for 'data'.
 # 'data' is only 100MB big and do not store any of your data, it's just a bunch of Ceph metadata.
 # 'block' will store all your actual data.
-# - The devices in 'dedicated_devices' will get 1 partition for RocksDB DB, called 'block.db'
-#  and one for RocksDB WAL, called 'block.wal'
+# - The devices in 'dedicated_devices' will get one partition for RocksDB DB, called 'block.db'
+#  and one for RocksDB WAL, called 'block.wal'. To use a single partition for RocksDB and WAL together
+#  set bluestore_wal_devices to [].
 #
 # By default dedicated_devices will represent block.db
 #
@@ -139,6 +140,8 @@ dedicated_devices: []
 #
 # By default, if 'bluestore_wal_devices' is empty, it will get the content of 'dedicated_devices'.
 # If set, then you will have a dedicated partition on a specific device for block.wal.
+#
+# Set bluestore_wal_devices: [] to use the same partition for RocksDB and WAL.
 #
 # Example of what you will get:
 # [root@ceph-osd0 ~]# blkid /dev/sd*

--- a/roles/ceph-osd/tasks/scenarios/non-collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/non-collocated.yml
@@ -70,6 +70,18 @@
     - not containerized_deployment
     - item.0.partitions|length == 0
 
+- name: manually prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) with a dedicated device for db
+  command: "ceph-disk prepare {{ ceph_disk_cli_options }} --block.db {{ item.1 }} {{ item.2 }}"
+  with_together:
+    - "{{ parted_results.results | default([]) }}"
+    - "{{ dedicated_devices }}"
+    - "{{ devices | unique }}"
+  when:
+    - osd_objectstore == 'bluestore'
+    - not containerized_deployment
+    - item.0.partitions|length == 0
+    - bluestore_wal_devices|length == 0
+
 - name: manually prepare ceph "{{ osd_objectstore }}" non-containerized osd disk(s) with a dedicated device for db and wal
   command: "ceph-disk prepare {{ ceph_disk_cli_options }} --block.db {{ item.1 }} --block.wal {{ item.2 }} {{ item.3 }}"
   with_together:
@@ -81,3 +93,4 @@
     - osd_objectstore == 'bluestore'
     - not containerized_deployment
     - item.0.partitions|length == 0
+    - bluestore_wal_devices|length > 0


### PR DESCRIPTION
In non-collocated scenario two separate partitions are created for RocksDB and WAL when using the same device for both. If I understand the documentation at [BlueStore documentation](http://docs.ceph.com/docs/mimic/rados/configuration/bluestore-config-ref/) correctly, it isn't required to explicitly create a partition for WAL, since it will be located along the RocksDB anyway.

This pull request adds support for setting `bluestore_wal_devices: []`. In this case no WAL device is passed to `ceph-disk` creating a single partition for RocksDB only.