### PR TITLE
set any_errors_fatal to true for all host section

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -89,6 +89,7 @@
         - (not (inventory_hostname in groups.get('clients', [])) or (inventory_hostname == groups.get('clients', [''])|first))
 
 - hosts: mons
+  any_errors_fatal: true
   tasks:
     - name: set ceph monitor install 'In Progress'
       run_once: true
@@ -122,6 +123,7 @@
         name: ceph-mgr
 
 - hosts: mons
+  any_errors_fatal: true
   tasks:
     - name: set ceph monitor install 'Complete'
       run_once: true
@@ -134,6 +136,7 @@
 - hosts: mgrs
   become: True
   gather_facts: false
+  any_errors_fatal: true
   tasks:
     # pre-tasks for following imports -
     - name: set ceph manager install 'In Progress'
@@ -451,6 +454,7 @@
 - hosts: mons
   gather_facts: false
   become: True
+  any_errors_fatal: true
   tasks:
     - import_role:
         name: ceph-defaults

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -478,6 +478,7 @@
 - hosts: mons
   gather_facts: false
   become: True
+  any_errors_fatal: true
   tasks:
     - import_role:
         name: ceph-defaults


### PR DESCRIPTION
Add `any_errors_fatal: true` to all host sections in site.yml.sample and site-container.yml.sample` so that the playbook execution ceases spontaneously and instantaneously when errors occurs.