### PR TITLE
lint: Remote package tasks should have a retry

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_community_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_community_repository.yml
@@ -3,6 +3,8 @@
   apt_key:
     data: "{{ lookup('file', role_path+'/files/cephstable.asc') }}"
     state: present
+  register: result
+  until: result is succeeded
 
 - name: configure debian ceph stable community repository
   apt_repository:

--- a/roles/ceph-common/tasks/installs/install_on_clear.yml
+++ b/roles/ceph-common/tasks/installs/install_on_clear.yml
@@ -3,3 +3,5 @@
   swupd:
     name: storage-cluster
     state: present
+  register: result
+  until: result is succeeded

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -8,6 +8,8 @@
   apt:
     update_cache: yes
     cache_valid_time: 3600
+  register: result
+  until: result is succeeded
 
 - name: install dependencies
   apt:

--- a/roles/ceph-common/tasks/installs/install_on_suse.yml
+++ b/roles/ceph-common/tasks/installs/install_on_suse.yml
@@ -19,6 +19,8 @@
     state: present
     update_cache: yes
   with_items: "{{ suse_package_dependencies }}"
+  register: result
+  until: result is succeeded
 
 - name: include install_suse_packages.yml
   include_tasks: install_suse_packages.yml

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
@@ -6,6 +6,7 @@
   register: rhcs_mon_repo
   when:
     - (mon_group_name in group_names or mgr_group_name in group_names)
+  until: rhcs_mon_repo is succeeded
 
 - name: enable red hat storage monitor repository
   command: subscription-manager repos --enable rhel-7-server-rhceph-{{ ceph_rhcs_version }}-mon-rpms
@@ -22,6 +23,7 @@
   check_mode: no
   when:
     - osd_group_name in group_names
+  until: rhcs_osd_repo is succeeded
 
 - name: enable red hat storage osd repository
   command: subscription-manager repos --enable rhel-7-server-rhceph-{{ ceph_rhcs_version }}-osd-rpms
@@ -38,6 +40,7 @@
   check_mode: no
   when:
     - (rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names)
+  until: rhcs_tools_repo is succeeded
 
 - name: enable red hat storage tools repository
   command: subscription-manager repos --enable rhel-7-server-rhceph-{{ ceph_rhcs_version }}-tools-rpms

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install_debian.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install_debian.yml
@@ -3,6 +3,8 @@
   apt_key:
     data: "{{ lookup('file', role_path+'/files/cephstablerhcs.asc') }}"
     state: present
+  register: result
+  until: result is succeeded
 
 - name: enable red hat storage monitor repository for debian systems
   apt_repository:

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install.yml
@@ -47,6 +47,8 @@
   rpm_key:
     key: "{{ ceph_rhcs_repository_path }}/RPM-GPG-KEY-redhat-release"
     state: present
+  register: result
+  until: result is succeeded
 
 - name: add red hat storage repository for redhat systems
   template:

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install_debian.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install_debian.yml
@@ -47,6 +47,8 @@
   apt_key:
     file: "{{ ceph_rhcs_repository_path }}/MON/release.asc"
     state: present
+  register: result
+  until: result is succeeded
 
 - name: add red hat storage repository for debian systems
   apt_repository:

--- a/roles/ceph-common/tasks/installs/redhat_community_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_community_repository.yml
@@ -3,6 +3,8 @@
   rpm_key:
     key: "{{ ceph_stable_key }}"
     state: present
+  register: result
+  until: result is succeeded
 
 - name: configure red hat ceph stable community repository
   yum_repository:
@@ -12,3 +14,5 @@
     state: present
     gpgkey: "{{ ceph_stable_key }}"
     baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_stable_release }}/{{ ceph_stable_redhat_distro }}/$basearch"
+  register: result
+  until: result is succeeded

--- a/roles/ceph-container-common/tasks/pre_requisites/debian_prerequisites.yml
+++ b/roles/ceph-container-common/tasks/pre_requisites/debian_prerequisites.yml
@@ -11,6 +11,8 @@
   apt_key:
     url: https://apt.dockerproject.org/gpg
     state: present
+  register: result
+  until: result is succeeded
 
 - name: add docker and debian testing repository
   apt_repository:
@@ -64,3 +66,5 @@
   pip:
     name: six
     version: 1.9.0
+  register: result
+  until: result is succeeded

--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -4,6 +4,8 @@
     update-cache: yes
   when:
     - ansible_os_family == 'Debian'
+  register: result
+  until: result is succeeded
 
 # We only want to restart on hosts that have called the handler.
 # This var is set when he handler is called, and unset after the

--- a/roles/ceph-mds/tasks/non_containerized.yml
+++ b/roles/ceph-mds/tasks/non_containerized.yml
@@ -7,6 +7,8 @@
   when:
     - mds_group_name in group_names
     - ansible_os_family == 'Debian'
+  register: result
+  until: result is succeeded
 
 - name: install redhat ceph-mds package
   package:

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -22,6 +22,8 @@
     - ceph_repository != 'rhcs'
     - ansible_os_family == 'Suse'
     - item.install | bool
+  register: result
+  until: result is succeeded
 
 # NOTE (leseb): we use root:ceph for permissions since ganesha
 # does not have the right selinux context to read ceph directories.


### PR DESCRIPTION
Make linter happy and add more robustness to remote tasks by retrying 3
times (the default) before failing.

Signed-off-by: Sébastien Han <seb@redhat.com>