### PR TITLE
document missing support for non-containerized deployment

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -123,9 +123,9 @@ dummy:
 # - The devices listed in 'devices' will get 2 partitions, one for 'block' and one for 'data'.
 # 'data' is only 100MB big and do not store any of your data, it's just a bunch of Ceph metadata.
 # 'block' will store all your actual data.
-# - The devices in 'dedicated_devices' will get one partition for RocksDB DB, called 'block.db'
+# - The devices in 'dedicated_devices' will get 1 partition for RocksDB DB, called 'block.db'
 #  and one for RocksDB WAL, called 'block.wal'. To use a single partition for RocksDB and WAL together
-#  set bluestore_wal_devices to [].
+#  set bluestore_wal_devices to [] (supported only for non-containerized deployment).
 #
 # By default dedicated_devices will represent block.db
 #
@@ -149,7 +149,7 @@ dummy:
 # By default, if 'bluestore_wal_devices' is empty, it will get the content of 'dedicated_devices'.
 # If set, then you will have a dedicated partition on a specific device for block.wal.
 #
-# Set bluestore_wal_devices: [] to use the same partition for RocksDB and WAL.
+# Set bluestore_wal_devices: [] to use the same partition for RocksDB and WAL (supported only for non-containerized deployment).
 #
 # Example of what you will get:
 # [root@ceph-osd0 ~]# blkid /dev/sd*

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -115,9 +115,9 @@ valid_osd_scenarios:
 # - The devices listed in 'devices' will get 2 partitions, one for 'block' and one for 'data'.
 # 'data' is only 100MB big and do not store any of your data, it's just a bunch of Ceph metadata.
 # 'block' will store all your actual data.
-# - The devices in 'dedicated_devices' will get one partition for RocksDB DB, called 'block.db'
+# - The devices in 'dedicated_devices' will get 1 partition for RocksDB DB, called 'block.db'
 #  and one for RocksDB WAL, called 'block.wal'. To use a single partition for RocksDB and WAL together
-#  set bluestore_wal_devices to [].
+#  set bluestore_wal_devices to [] (supported only for non-containerized deployment).
 #
 # By default dedicated_devices will represent block.db
 #
@@ -141,7 +141,7 @@ dedicated_devices: []
 # By default, if 'bluestore_wal_devices' is empty, it will get the content of 'dedicated_devices'.
 # If set, then you will have a dedicated partition on a specific device for block.wal.
 #
-# Set bluestore_wal_devices: [] to use the same partition for RocksDB and WAL.
+# Set bluestore_wal_devices: [] to use the same partition for RocksDB and WAL (supported only for non-containerized deployment).
 #
 # Example of what you will get:
 # [root@ceph-osd0 ~]# blkid /dev/sd*


### PR DESCRIPTION
This is an update to my PR #3444. Because of the way the ceph-daemon container is implemented, I don't see an easy way to port this change to the containerized deployment. So I added a short notice to the documentation, that deploying RocksDB and WAL in a single partition isn't supported for containerized deployment.