### PR TITLE
add 'custom' as valid ceph_repository value

### DIFF
--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -164,7 +164,7 @@ def ceph_origin_choices(value):
 
 
 def ceph_repository_choices(value):
-    assert value in ['community', 'rhcs', 'dev'], "ceph_repository must be either 'community', 'rhcs' or 'dev'"
+    assert value in ['community', 'rhcs', 'dev', 'custom'], "ceph_repository must be either 'community', 'rhcs', 'dev', or 'custom'"
 
 
 def ceph_repository_type_choices(value):


### PR DESCRIPTION
Validation currently fails when `ceph_repository: custom` even though this is a valid choice according to:

https://github.com/ceph/ceph-ansible/blob/561746f75e3913b30e6ae3f14768ebc8a516bf66/group_vars/all.yml.sample#L245

Setting the following works as documented/advertised with this patch:
```
---
ceph_repository: custom
ceph_custom_repo: http://somehost.com/path/to/custom.repo
```