### PR TITLE
Vagrantfile: remove useless default values

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,11 +78,9 @@ ansible_provision = proc do |ansible|
   else
     ansible.extra_vars = ansible.extra_vars.merge({
       devices: settings['disks'],
-      osd_scenario: 'collocated',
       monitor_interface: ETH,
       radosgw_interface: ETH,
       os_tuning_params: settings['os_tuning_params'],
-      pool_default_size: '2',
     })
   end
 


### PR DESCRIPTION
Those default values are useless and might cause issues.

- `osd_scenario` should be mandatory anyway.
- `pool_default_size` is not used anymore (this has been refactored
recently.

Closes: #3468

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>