### PR TITLE
update: do not enforce `serial: 1` on client nodes

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -800,7 +800,7 @@
     upgrade_ceph_packages: True
   hosts:
     - "{{ client_group_name|default('clients') }}"
-  serial: 1
+  serial: "{{ client_update_batch | default(ansible_forks) }}"
   become: True
   tasks:
     - import_role:


### PR DESCRIPTION
There is no need to enforce `serial: 1` on client nodes.
Let's make it parameterizable by introducing a new *extra* variable
`client_update_batch`, if not filled this will default to `{{
ansible_forks }}`.

NOTE: this is only usable as an extra variable passed with
`-e client_update_batch=<num>`

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1650184

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>