### PR TITLE
tests: install nfs-ganesha v2.7

### DIFF
--- a/tests/functional/centos/7/cluster/group_vars/all
+++ b/tests/functional/centos/7/cluster/group_vars/all
@@ -9,7 +9,7 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 nfs_ganesha_stable: true
 nfs_ganesha_dev: false
-nfs_ganesha_stable_branch: V2.5-stable
+nfs_ganesha_stable_branch: V2.7-stable
 nfs_ganesha_flavor: "ceph_master"
 openstack_config: True
 openstack_glance_pool:

--- a/tests/functional/ubuntu/16.04/cluster/group_vars/all
+++ b/tests/functional/ubuntu/16.04/cluster/group_vars/all
@@ -24,7 +24,7 @@ debian_ceph_packages:
   - ceph-common
   - ceph-fuse
 nfs_ganesha_stable: true
-nfs_ganesha_stable_branch: V2.5-stable
+nfs_ganesha_stable_branch: V2.7-stable
 nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 nfs_ganesha_dev: false
 nfs_ganesha_flavor: "ceph_master"


### PR DESCRIPTION
... by default for xenial and centos7 scenarios. nfs-ganesha 2.5
and nfs-ganesha v2.6 have hit end of life. And nfs-ganesha v2.7
is compatible with luminous and mimic versions of Ceph that
this branch (stable-3.2) of ceph-ansible supports.

Fixes: #3178

Signed-off-by: Ramana Raja <rraja@redhat.com>