### PR TITLE
testinfra/osds double the amount of ports OSDs listen to

### DIFF
--- a/tests/functional/tests/osd/test_osds.py
+++ b/tests/functional/tests/osd/test_osds.py
@@ -11,13 +11,13 @@ class TestOSDs(object):
 
     def test_osds_listen_on_public_network(self, node, host):
         # TODO: figure out way to paramaterize this test
-        nb_port = (node["num_osds"] * 2)
+        nb_port = (node["num_osds"] * 4)
         assert host.check_output(
             "netstat -lntp | grep ceph-osd | grep %s | wc -l" % (node["address"])) == str(nb_port)  # noqa E501
 
     def test_osds_listen_on_cluster_network(self, node, host):
         # TODO: figure out way to paramaterize this test
-        nb_port = (node["num_osds"] * 2)
+        nb_port = (node["num_osds"] * 4)
         assert host.check_output("netstat -lntp | grep ceph-osd | grep %s | wc -l" %  # noqa E501
                                  (node["cluster_address"])) == str(nb_port)
 


### PR DESCRIPTION
Since msgr2 changes got merged, the OSDs in master (to be nautilus) will
double the amount of ports they listen to.

Failures look like:

    [gw3] darwin -- Python 2.7.14 /Users/alfredo/python/ceph/src/ceph-volume/ceph_volume/tests/functional/batch/.tox/centos7-bluestore-mixed_type/bin/python2.7
    
    self = <tests.osd.test_osds.TestOSDs object at 0x10e6fe810>
    node = {'address': '192.168.3.100', 'ceph_release_num': {'dev': 99, 'jewel': 10, 'kraken': 11, 'luminous': 12, ...}, 'ceph_stable_release': 'luminous', 'cluster_address': '192.168.4.200', ...}
    host = <testinfra.host.Host object at 0x10de20a10>
    
        def test_osds_listen_on_cluster_network(self, node, host):
            # TODO: figure out way to paramaterize this test
            nb_port = (node["num_osds"] * 2)
    >       assert host.check_output("netstat -lntp | grep ceph-osd | grep %s | wc -l" %  # noqa E501
                                     (node["cluster_address"])) == str(nb_port)
    E       AssertionError: assert '8' == '4'
    E         - 8
    E         + 4


For two OSDs, this is now the output (double what it was before):

    [root@osd0 vagrant]# netstat -lntp | grep ceph-osd
    tcp        0      0 192.168.4.200:6800      0.0.0.0:*               LISTEN      11823/ceph-osd
    tcp        0      0 192.168.3.100:6800      0.0.0.0:*               LISTEN      11823/ceph-osd
    tcp        0      0 192.168.4.200:6801      0.0.0.0:*               LISTEN      11823/ceph-osd
    tcp        0      0 192.168.3.100:6801      0.0.0.0:*               LISTEN      11823/ceph-osd
    tcp        0      0 192.168.4.200:6802      0.0.0.0:*               LISTEN      11823/ceph-osd
    tcp        0      0 192.168.3.100:6802      0.0.0.0:*               LISTEN      11823/ceph-osd
    tcp        0      0 192.168.4.200:6803      0.0.0.0:*               LISTEN      11823/ceph-osd
    tcp        0      0 192.168.3.100:6803      0.0.0.0:*               LISTEN      11823/ceph-osd
    tcp        0      0 192.168.4.200:6804      0.0.0.0:*               LISTEN      12291/ceph-osd
    tcp        0      0 192.168.3.100:6804      0.0.0.0:*               LISTEN      12291/ceph-osd
    tcp        0      0 192.168.4.200:6805      0.0.0.0:*               LISTEN      12291/ceph-osd
    tcp        0      0 192.168.3.100:6805      0.0.0.0:*               LISTEN      12291/ceph-osd
    tcp        0      0 192.168.4.200:6806      0.0.0.0:*               LISTEN      12291/ceph-osd
    tcp        0      0 192.168.3.100:6806      0.0.0.0:*               LISTEN      12291/ceph-osd
    tcp        0      0 192.168.4.200:6807      0.0.0.0:*               LISTEN      12291/ceph-osd
    tcp        0      0 192.168.3.100:6807      0.0.0.0:*               LISTEN      12291/ceph-osd
