### PR TITLE
mon: force peer addition

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -1,4 +1,18 @@
 ---
+- name: wait for the monitor socket to exist
+  stat:
+    path: "/var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok"
+  register: socket
+  until: socket.stat.exists
+
+- name: add bootstrap peers for monitors to form quorum
+  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[item.1]['_current_monitor_address'] }}:{{ item.0 }}"
+  with_nested:
+    - 3300
+    - "{{ groups[mon_group_name] }}"
+  changed_when: false
+  failed_when: false
+
 - name: waiting for the monitor(s) to form the quorum...
   command: >
     {{ docker_exec_cmd }}


### PR DESCRIPTION
Somewhat something changed with the introduction of msg2 and we have to
add each node as a peer so the monitors can form a quorum. This might be
due to our CI environment, although adding this is completly harmless
and solves monitors not being able to form quorum.

It seems that the initial monitor map wasn't containing the right
information about the peers (addresses like 0.0.0.0/0r1, for each rank.

Signed-off-by: Sébastien Han <seb@redhat.com>