### PR TITLE
ceph-infra: Remove test of is_atomic

### DIFF
--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -176,7 +176,6 @@
       - firewall
 
   when:
-    - (firewalld_pkg_query.get('rc', 1) == 0
-      or is_atomic)
+    - firewalld_pkg_query.get('rc', 1) == 0
 
 - meta: flush_handlers


### PR DESCRIPTION
When configure_firewall runs is_atomic is undefined.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>