### PR TITLE
ceph-infra: allow defining NTP servers

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -105,6 +105,13 @@ dummy:
 # Note that this selection is currently ignored on containerized deployments
 #ntp_daemon_type: timesyncd
 
+# Mention NTP server you would like to use
+#ntp_servers:
+# - server1
+# - server2
+
+# Remove default ntp servers
+#ntp_remove_default_servers: true
 
 # Set uid/gid to default '64045' for bootstrap directories.
 # '64045' is used for debian based distros. It must be set to 167 in case of rhel based distros.

--- a/roles/ceph-infra/tasks/setup_ntp.yml
+++ b/roles/ceph-infra/tasks/setup_ntp.yml
@@ -10,7 +10,24 @@
         ntp_service_name: ntpd
       when: ansible_os_family in ['RedHat', 'Suse']
 
-- name: setup ntp daemon
+- name: install ntp packages
+  block:
+    - name: install ntpd
+      when: ntp_daemon_type == "ntpd"
+      package:
+        name: ntp
+        state: present
+      register: result
+      until: result is succeeded
+    - name: install chronyd
+      when: ntp_daemon_type == "chronyd"
+      package:
+        name: chrony
+        state: present
+      register: result
+      until: result is succeeded
+
+- name: start and enable timesyncd
   block:
     - name: install and enable timesyncd
       command: timedatectl set-ntp on
@@ -23,38 +40,22 @@
       command: timedatectl set-ntp no
       when: ntp_daemon_type != "timesyncd"
 
-    - name: setup ntpd
-      when: ntp_daemon_type == "ntpd"
-      block:
-        - name: install ntp
-          package:
-            name: ntp
-            state: present
-          register: result
-          until: result is succeeded
-        - name: enable and start ntp
-          service:
-            name: "{{ ntp_service_name }}"
-            enabled: yes
-            state: started
-          notify:
-            - disable chronyd
-            - disable timesyncd
+    - name: enable and start ntp
+      when: ntp_daemon_type == 'ntpd'
+      service:
+        name: "{{ ntp_service_name }}"
+        enabled: yes
+        state: started
+      notify:
+        - disable chronyd
+        - disable timesyncd
 
-    - name: setup chronyd
-      when: ntp_daemon_type == "chronyd"
-      block:
-        - name: install chrony
-          package:
-            name: chrony
-            state: present
-          register: result
-          until: result is succeeded
-        - name: enable and start chronyd
-          service:
-            name: chronyd
-            enabled: yes
-            state: started
-          notify:
-            - disable chronyd
-            - disable timesyncd
+    - name: enable and start chronyd
+      when: ntp_daemon_type == 'chronyd'
+      service:
+        name: chronyd
+        enabled: yes
+        state: started
+      notify:
+        - disable chronyd
+        - disable timesyncd

--- a/roles/ceph-infra/tasks/setup_ntp.yml
+++ b/roles/ceph-infra/tasks/setup_ntp.yml
@@ -27,7 +27,45 @@
       register: result
       until: result is succeeded
 
-- name: start and enable timesyncd
+- name: add/remove ntp servers
+  block:
+    - name: remove default ntp servers
+      when:
+        - ntp_remove_default_servers is defined
+        - ntp_remove_default_servers == true
+      block:
+        - name: remove default ntp servers from ntp.conf
+          when: ntp_daemon_type == 'ntpd'
+          lineinfile:
+            regexp: 'pool\.ntp\.org'
+            state: absent
+            path: /etc/ntp.conf
+        - name: remove default ntp servers from chrony.conf
+          when: ntp_daemon_type == 'chronyd'
+          lineinfile:
+            regexp: 'pool\.ntp\.org'
+            state: absent
+            path: /etc/chrony.conf
+
+    - name: add ntp servers if provided
+      when: ntp_servers is defined
+      block:
+        - name: add ntp servers for ntp.conf
+          when: ntp_daemon_type == 'ntpd'
+          lineinfile:
+            path: /etc/ntp.conf
+            line: 'server {{ item }}'
+            insertafter: BOF
+          loop: '{{ ntp_servers }}'
+        - name: add ntp servers to chrony.conf
+          when: ntp_daemon_type == 'chronyd'
+          lineinfile:
+            path: /etc/chrony.conf
+            line: 'server {{ item }}'
+            insertafter: BOF
+          loop: '{{ ntp_servers }}'
+
+- name: start and enable ntp daemons
   block:
     - name: install and enable timesyncd
       command: timedatectl set-ntp on


### PR DESCRIPTION
Variable `ntp_servers` allows defining a list of NTP servers that will
be added to the configuration file of the NTP daemon chosen using 
`ntp_daemon_type` and `ntp_remove_default_servers` allows getting rid
of all NTP servers currently mentioned in configuration file.

Fixes: https://github.com/ceph/ceph-ansible/issues/3485