### PR TITLE
tox.ini: setup LVs in OSD hosts for '*-cluster' scenarios

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -306,6 +306,7 @@ commands=
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   # configure lvm
+  cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
   centos7_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
   docker_cluster: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml
   docker_cluster_collocation: ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/lvm_setup.yml


### PR DESCRIPTION
forward ports https://github.com/ceph/ceph-ansible/pull/3400 from 3.2 to master.

fixes: #3501 