### PR TITLE
refact the 'raw' installation of python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ ceph-ansible.spec
 *.pytest_cache
 !.travis.yml
 !.mergify.yml
+!raw_install_python.yml

--- a/raw_install_python.yml
+++ b/raw_install_python.yml
@@ -1,0 +1,24 @@
+---
+- name: check for python
+  stat:
+    path: /usr/bin/python
+  ignore_errors: yes
+  register: systempython
+
+- name: install python for debian based systems
+  raw: apt-get -y install python-simplejson
+  ignore_errors: yes
+  when:
+    - systempython.stat is undefined or not systempython.stat.exists
+
+- name: install python for fedora
+  raw: dnf -y install python3; ln -sf /usr/bin/python3 /usr/bin/python creates=/usr/bin/python
+  ignore_errors: yes
+  when:
+    - systempython.stat is undefined or not systempython.stat.exists
+
+- name: install python for opensuse
+  raw: zypper -n install python-base creates=/usr/bin/python2.7
+  ignore_errors: yes
+  when:
+    - systempython.stat is undefined or not systempython.stat.exists

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -21,6 +21,9 @@
   vars:
     delegate_facts_host: True
 
+  pre_tasks:
+    - import_tasks: raw_install_python.yml
+
   tasks:
     # pre-tasks for following import -
     - name: gather facts

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -27,29 +27,8 @@
   pre_tasks:
     # If we can't get python2 installed before any module is used we will fail
     # so just try what we can to get it installed
-    - name: check for python2
-      stat:
-        path: /usr/bin/python
-      ignore_errors: yes
-      register: systempython2
 
-    - name: install python2 for debian based systems
-      raw: sudo apt-get -y install python-simplejson
-      ignore_errors: yes
-      when:
-        - systempython2.stat is undefined or not systempython2.stat.exists
-
-    - name: install python2 for fedora
-      raw: sudo dnf -y install python creates=/usr/bin/python
-      ignore_errors: yes
-      when:
-        - systempython2.stat is undefined or not systempython2.stat.exists
-
-    - name: install python2 for opensuse
-      raw: sudo zypper -n install python-base creates=/usr/bin/python2.7
-      ignore_errors: yes
-      when:
-        - systempython2.stat is undefined or not systempython2.stat.exists
+    - import_tasks: raw_install_python.yml
 
     - name: gather facts
       setup:

--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -1,4 +1,9 @@
 ---
+- hosts: all
+  gather_facts: false
+  become: yes
+  tasks:
+    - import_tasks: ../../raw_install_python.yml
 
 - hosts: osds
   gather_facts: false

--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -1,5 +1,4 @@
 ---
-
 - hosts: all
   gather_facts: true
   become: yes


### PR DESCRIPTION
to avoid duplicating code in `site.yml.sample`, `site-docker.yml.sample`
and `setup.yml`, let's isolate this part of the code and simply include
it each time we need it.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>