### PR TITLE
Preserve rolling_update backward compatibility with ansible < 2.5

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -800,7 +800,7 @@
     upgrade_ceph_packages: True
   hosts:
     - "{{ client_group_name|default('clients') }}"
-  serial: "{{ client_update_batch | default(ansible_forks) }}"
+  serial: "{{ client_update_batch | default(20) }}"
   become: True
   tasks:
     - import_role:


### PR DESCRIPTION
Signed-off-by: Giulio Fidente <gfidente@redhat.com>