### PR TITLE
rolling_update: enforce default value for client_update_batch

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -800,7 +800,7 @@
     upgrade_ceph_packages: True
   hosts:
     - "{{ client_group_name|default('clients') }}"
-  serial: "{{ client_update_batch | default(ansible_forks) }}"
+  serial: "{{ client_update_batch | default((groups[client_group_name | default('clients')] | length * client_update_batch_percentage | default(0.2) | float) | int) }}"
   become: True
   tasks:
     - import_role:


### PR DESCRIPTION
`ansible_forks` isn't something always set by ansible.

This commit allows to either pass `client_update_batch` as an extra variable
that will be the *number* of node per batch or
`client_update_batch_percentage` as an extra variable as well that will
be the percentage of the total number of client node in a decimal
representation (eg: `0.5` for `50%`).

If none of them are passed, the default value is 0.2 (20%).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1650184

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>