### PR TITLE
override ceph_release with ceph_stable_release

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -44,6 +44,14 @@
   tags:
     - always
 
+- name: set_fact ceph_release - override ceph_release with ceph_stable_release
+  set_fact:
+    ceph_release: "{{ ceph_stable_release }}"
+  when:
+    - ceph_origin == 'repository'
+  tags:
+    - always
+
 - name: include facts_mon_fsid.yml
   include_tasks: facts_mon_fsid.yml
   run_once: true


### PR DESCRIPTION
when `ceph_origin` is set to `'repository'` and `ceph_repository` to
`'community'` we need to ensure `ceph_release` reflect `ceph_stable_release`.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>