### PR TITLE
Don't add loop devices with osd_auto_discovery

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -185,6 +185,7 @@
     - item.value.partitions|count == 0
     - item.value.holders|count == 0
     - "'dm-' not in item.key"
+    - "'loop' not in item.key"
 
 - name: set_fact ceph_uid for debian based system - non container
   set_fact:


### PR DESCRIPTION
Discovered this as a problem when deploying openstack-ansible,
during container creation, /var/lib/machines.raw gets mounted,
which leads to a loop0 device with sectors != "0"

Signed-off-by: Erik Berg <openstack@slipsprogrammor.no>