### PR TITLE
Fix ceph.conf generation

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -19,9 +19,9 @@ osd crush chooseleaf type = 0
 {% set nb_mon = groups.get(mon_group_name, []) | length | int %}
 {% set nb_client = groups.get(client_group_name, []) | length | int %}
 {% set nb_osd = groups.get(osd_group_name, []) | length | int %}
-{% if inventory_hostname in groups.get(client_group_name, []) and not inventory_hostname == groups.get(client_group_name, []) | first %}}
-{% set ceph_release = hostvars[groups[client_group_name][0]]['ceph_release'] %}}
-{% endif %}}
+{% if inventory_hostname in groups.get(client_group_name, []) and not inventory_hostname == groups.get(client_group_name, []) | first %}
+{% set ceph_release = hostvars[groups[client_group_name][0]]['ceph_release'] %}
+{% endif %}
 
 {% if nb_mon > 0 and inventory_hostname in groups.get(mon_group_name, []) %}
 mon initial members = {% for host in groups[mon_group_name] %}


### PR DESCRIPTION
877979c78 in #3486 broke ceph.conf generation entirely. Remove the stray
curly brace.

Signed-off-by: Zack Cerza <zack@redhat.com>