### PR TITLE
tests: fix rgw testinfra failure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ def node(host, request):
     fsid = ansible_vars.get("fsid")
     osd_auto_discovery = ansible_vars.get("osd_auto_discovery")
     osd_scenario = ansible_vars.get("osd_scenario")
+    radosgw_num_instances = ansible_vars.get("radosgw_num_instances", 1)
     lvm_scenario = osd_scenario in ['lvm', 'lvm-batch']
     ceph_release_num = {
         'jewel': 10,
@@ -117,6 +118,7 @@ def node(host, request):
         ceph_stable_release=ceph_stable_release,
         ceph_release_num=ceph_release_num,
         rolling_update=rolling_update,
+        radosgw_num_instances=radosgw_num_instances,
     )
     return data
 

--- a/tests/functional/tests/rgw/test_rgw.py
+++ b/tests/functional/tests/rgw/test_rgw.py
@@ -12,7 +12,7 @@ class TestRGWs(object):
         assert result
 
     def test_rgw_service_is_running(self, node, host):
-        for i in range(int(node["vars"]["radosgw_num_instances"])):
+        for i in range(int(node["radosgw_num_instances"])):
             service_name = "ceph-radosgw@rgw.{hostname}.rgw{seq}".format(
                 hostname=node["vars"]["inventory_hostname"],
                 seq=i
@@ -20,7 +20,7 @@ class TestRGWs(object):
             assert host.service(service_name).is_running
 
     def test_rgw_service_is_enabled(self, node, host):
-        for i in range(int(node["vars"]["radosgw_num_instances"])):
+        for i in range(int(node["radosgw_num_instances"])):
             service_name = "ceph-radosgw@rgw.{hostname}.rgw{seq}".format(
                 hostname=node["vars"]["inventory_hostname"],
                 seq=i
@@ -46,7 +46,7 @@ class TestRGWs(object):
         output = host.check_output(cmd)
         daemons = [i for i in json.loads(
             output)["servicemap"]["services"]["rgw"]["daemons"]]
-        for i in range(int(node["vars"]["radosgw_num_instances"])):
+        for i in range(int(node["radosgw_num_instances"])):
             instance_name = "{hostname}.rgw{seq}".format(
                 hostname=hostname,
                 seq=i
@@ -57,7 +57,7 @@ class TestRGWs(object):
     def test_rgw_http_endpoint(self, node, host):
         # rgw frontends ip_addr is configured on eth1
         ip_addr = host.interface("eth1").addresses[0]
-        for i in range(int(node["vars"]["radosgw_num_instances"])):
+        for i in range(int(node["radosgw_num_instances"])):
             assert host.socket(
                 "tcp://{ip_addr}:{port}".format(ip_addr=ip_addr,
                                                 port=(8080+i))


### PR DESCRIPTION
fix the wrong path used in various rgw testinfra tests.
set `1` as default value for `radosgw_num_instances`: if
`ansible_vars.get(radosgw_num_instances)` returns `None`, we can assume
there's only 1 instance since it's the default value in ceph-defaults.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>