### PR TITLE
Install nfs-ganesha stable v2.7

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -159,7 +159,7 @@ dummy:
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-#nfs_ganesha_stable_branch: V2.6-stable
+#nfs_ganesha_stable_branch: V2.7-stable
 #nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 
 

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -159,7 +159,7 @@ ceph_repository: rhcs
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-#nfs_ganesha_stable_branch: V2.6-stable
+#nfs_ganesha_stable_branch: V2.7-stable
 #nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -151,7 +151,7 @@ ceph_stable_release: dummy
 ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-nfs_ganesha_stable_branch: V2.6-stable
+nfs_ganesha_stable_branch: V2.7-stable
 nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 
 

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -29,5 +29,5 @@ iscsi-gw0 ceph_repository="dev"
 [all:vars]
 nfs_ganesha_stable=True
 nfs_ganesha_dev=False
-nfs_ganesha_stable_branch="V2.5-stable"
+nfs_ganesha_stable_branch="V2.7-stable"
 nfs_ganesha_flavor="ceph_master"

--- a/tests/functional/all_daemons/hosts-ubuntu
+++ b/tests/functional/all_daemons/hosts-ubuntu
@@ -29,7 +29,7 @@ iscsi-gw0 ceph_repository="dev"
 [all:vars]
 debian_ceph_packages=['ceph', 'ceph-common', 'ceph-fuse']
 nfs_ganesha_stable=True
-nfs_ganesha_stable_branch="V2.5-stable"
+nfs_ganesha_stable_branch="V2.7-stable"
 nfs_ganesha_stable_deb_repo="{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 nfs_ganesha_dev=False
 nfs_ganesha_flavor="ceph_master"

--- a/tests/functional/shrink_mon/hosts-ubuntu
+++ b/tests/functional/shrink_mon/hosts-ubuntu
@@ -29,7 +29,7 @@ iscsi-gw0 ceph_repository="dev"
 [all:vars]
 debian_ceph_packages=['ceph', 'ceph-common', 'ceph-fuse']
 nfs_ganesha_stable=True
-nfs_ganesha_stable_branch="V2.5-stable"
+nfs_ganesha_stable_branch="V2.7-stable"
 nfs_ganesha_stable_deb_repo="{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 nfs_ganesha_dev=False
 nfs_ganesha_flavor="ceph_master"


### PR DESCRIPTION
nfs-ganesha v2.5 and 2.6 have hit EOL. Install nfs-ganesha v2.7
stable that is currently being maintained.

Signed-off-by: Ramana Raja <rraja@redhat.com>