### PR TITLE
use shortname in keyring path

### DIFF
--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -643,7 +643,7 @@ def run_module():
             module, list_keys(cluster, user, user_key, container_image))
 
     elif state == "fetch_initial_keys":
-        hostname = socket.gethostname()
+        hostname = socket.gethostname().split('.', 1)[0]
         user = "mon."
         user_key = os.path.join(
             "/var/lib/ceph/mon/" + cluster + "-" + hostname + "/keyring")


### PR DESCRIPTION
socket.gethostname may return a FQDN. Problem found in Linode.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>