### PR TITLE
delegate key creation to first mon

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -48,6 +48,7 @@
     with_items:
       - "{{ groups.get(mgr_group_name, []) }}" # this honors the condition where mgrs run on separate machines
       - "{{ groups.get(mon_group_name, []) }}" # this honors the new rule where mgrs are always collocated with mons
+    delegate_to: "{{ groups[mon_group_name][0] }}"
 
   - name: copy ceph mgr key(s) to the ansible server
     fetch:
@@ -55,13 +56,12 @@
       dest: "{{ fetch_directory }}/{{ fsid }}/{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
       flat: yes
     with_items:
-      - "{{ groups.get(mgr_group_name, []) }}"
-    when:
-      - groups.get(mgr_group_name, []) | length > 0
+      - "{{ groups.get(mgr_group_name, []) }}" # this honors the condition where mgrs run on separate machines
+      - "{{ groups.get(mon_group_name, []) }}" # this honors the new rule where mgrs are always collocated with mons
+    delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
     - cephx
     - not rolling_update
-    - inventory_hostname == groups[mon_group_name]|last # only on the last to avoid key creation collision
 
 - name: copy keys to the ansible server
   fetch:


### PR DESCRIPTION
Otherwise keys get scattered over the mons.

Also, create all keys on the first mon and copy those to the other mons to be
consistent.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>