### PR TITLE
set `any_errors_fatal` true for left out host sections

### DIFF
--- a/site.yml.sample
+++ b/site.yml.sample
@@ -82,6 +82,7 @@
 - hosts: mons
   gather_facts: false
   become: True
+  any_errors_fatal: true
   pre_tasks:
     - name: set ceph monitor install 'In Progress'
       run_once: true
@@ -112,6 +113,7 @@
 - hosts: mgrs
   gather_facts: false
   become: True
+  any_errors_fatal: true
   pre_tasks:
     - name: set ceph manager install 'In Progress'
       run_once: true
@@ -142,6 +144,7 @@
 - hosts: agents
   gather_facts: false
   become: True
+  any_errors_fatal: true
   pre_tasks:
     - name: set ceph agent install 'In Progress'
       run_once: true
@@ -172,6 +175,7 @@
 - hosts: osds
   gather_facts: false
   become: True
+  any_errors_fatal: true
   pre_tasks:
     - name: set ceph osd install 'In Progress'
       run_once: true
@@ -202,6 +206,7 @@
 - hosts: mdss
   gather_facts: false
   become: True
+  any_errors_fatal: true
   pre_tasks:
     - name: set ceph mds install 'In Progress'
       run_once: true
@@ -232,6 +237,7 @@
 - hosts: rgws
   gather_facts: false
   become: True
+  any_errors_fatal: true
   pre_tasks:
     - name: set ceph rgw install 'In Progress'
       run_once: true
@@ -262,6 +268,7 @@
 - hosts: nfss
   gather_facts: false
   become: True
+  any_errors_fatal: true
   pre_tasks:
     - name: set ceph nfs install 'In Progress'
       run_once: true
@@ -292,6 +299,7 @@
 - hosts: restapis
   gather_facts: false
   become: True
+  any_errors_fatal: true
   pre_tasks:
     - name: set ceph rest api install 'In Progress'
       run_once: true
@@ -324,6 +332,7 @@
 - hosts: rbdmirrors
   gather_facts: false
   become: True
+  any_errors_fatal: true
   pre_tasks:
     - name: set ceph rbd mirror install 'In Progress'
       run_once: true
@@ -354,6 +363,7 @@
 - hosts: clients
   gather_facts: false
   become: True
+  any_errors_fatal: true
   pre_tasks:
     - name: set ceph client install 'In Progress'
       run_once: true
@@ -386,6 +396,7 @@
     - iscsi-gws # for backward compatibility only!
   gather_facts: false
   become: True
+  any_errors_fatal: true
   pre_tasks:
     - name: set ceph iscsi gateway install 'In Progress'
       run_once: true


### PR DESCRIPTION
Many hosts sections in site.yml.sample were left out during the
backport commit 6e2cd0930fa17f5d50c73496eff71074301f55bd.