### PR TITLE
tests: do not play dev_setup on containerized deployment

### DIFF
--- a/tests/functional/dev_setup.yml
+++ b/tests/functional/dev_setup.yml
@@ -7,27 +7,29 @@
   tasks:
 
 
-    - name: set_fact group_vars_path
-      set_fact:
-        group_vars_path: "{{ change_dir + '/hosts' if 'ooo-collocation' in change_dir.split('/') else change_dir + '/group_vars/all' }}"
+    - block:
+      - name: set_fact group_vars_path
+        set_fact:
+          group_vars_path: "{{ change_dir + '/hosts' if 'ooo-collocation' in change_dir.split('/') else change_dir + '/group_vars/all' }}"
 
-    - name: change ceph_repository to 'dev'
-      replace:
-        regexp: "ceph_repository:.*"
-        replace: "ceph_repository: dev"
-        dest: "{{ group_vars_path }}"
-      when: change_dir is defined
+      - name: change ceph_repository to 'dev'
+        replace:
+          regexp: "ceph_repository:.*"
+          replace: "ceph_repository: dev"
+          dest: "{{ group_vars_path }}"
+        when: change_dir is defined
 
-    - name: change nfs-ganesha repository to 'dev'
-      replace:
-        regexp: "nfs_ganesha_stable=.*"
-        replace: "nfs_ganesha_stable=False"
-        dest: "{{ group_vars_path }}"
-      replace:
-        regexp: "nfs_ganesha_dev:.*"
-        replace: "nfs_ganesha_dev=True"
-        dest: "{{ group_vars_path }}"
-      when: change_dir is defined
+      - name: change nfs-ganesha repository to 'dev'
+        replace:
+          regexp: "nfs_ganesha_stable=.*"
+          replace: "nfs_ganesha_stable=False"
+          dest: "{{ group_vars_path }}"
+        replace:
+          regexp: "nfs_ganesha_dev:.*"
+          replace: "nfs_ganesha_dev=True"
+          dest: "{{ group_vars_path }}"
+        when: change_dir is defined
 
-    - name: print contents of {{ group_vars_path }}
-      command: "cat {{ group_vars_path }}"
+      - name: print contents of {{ group_vars_path }}
+        command: "cat {{ group_vars_path }}"
+      when: dev_setup

--- a/tox.ini
+++ b/tox.ini
@@ -215,6 +215,7 @@ setenv=
   ANSIBLE_KEEP_REMOTE_FILES = 1
   # only available for ansible >= 2.5
   ANSIBLE_STDOUT_CALLBACK = yaml
+  non_container: DEV_SETUP = True
   centos: CEPH_ANSIBLE_VAGRANT_BOX = centos/7
   fedora: CEPH_ANSIBLE_VAGRANT_BOX = fedora/29-atomic-host
   # Set the vagrant box image to use
@@ -271,7 +272,7 @@ changedir=
 
 commands=
   rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
-  !container,update: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
+  !update: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
 
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}


### PR DESCRIPTION
using `!` mark in tox.ini doesn't work on comma separated list.
The idea here is to skip all containerized scenario in dev_setup.yml and
use the `!` for the update scenario.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>