### PR TITLE
[skip ci] tests/stable-3.2: run lvm_setup.yml only when osd_scenario is lvm

### DIFF
--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -5,68 +5,70 @@
   become: yes
   tasks:
 
-    - name: check if it is atomic host
-      stat:
-        path: /run/ostree-booted
-      register: stat_ostree
-      tags:
-        - always
+    - block:
+      - name: check if it is atomic host
+        stat:
+          path: /run/ostree-booted
+        register: stat_ostree
+        tags:
+          - always
 
-    - name: set_fact is_atomic
-      set_fact:
-        is_atomic: '{{ stat_ostree.stat.exists }}'
-      tags:
-        - always
+      - name: set_fact is_atomic
+        set_fact:
+          is_atomic: '{{ stat_ostree.stat.exists }}'
+        tags:
+          - always
 
-    # Some images may not have lvm2 installed
-    - name: install lvm2
-      package:
-        name: lvm2
-        state: present
-      when:
-        - not is_atomic
+      # Some images may not have lvm2 installed
+      - name: install lvm2
+        package:
+          name: lvm2
+          state: present
+        when:
+          - not is_atomic
 
-    - name: create physical volume
-      command: pvcreate /dev/sdb
-      failed_when: false
+      - name: create physical volume
+        command: pvcreate /dev/sdb
+        failed_when: false
 
-    - name: create volume group
-      command: vgcreate test_group /dev/sdb
-      failed_when: false
+      - name: create volume group
+        command: vgcreate test_group /dev/sdb
+        failed_when: false
 
-    - name: create logical volume 1
-      command: lvcreate --yes -l 50%FREE -n data-lv1 test_group
-      failed_when: false
+      - name: create logical volume 1
+        command: lvcreate --yes -l 50%FREE -n data-lv1 test_group
+        failed_when: false
 
-    - name: create logical volume 2
-      command: lvcreate --yes -l 50%FREE -n data-lv2 test_group
-      failed_when: false
+      - name: create logical volume 2
+        command: lvcreate --yes -l 50%FREE -n data-lv2 test_group
+        failed_when: false
 
-    - name: partition /dev/sdc for journals
-      parted:
-        device: /dev/sdc
-        number: 1
-        part_start: 0%
-        part_end: 50%
-        unit: '%'
-        label: gpt
-        state: present
+      - name: partition /dev/sdc for journals
+        parted:
+          device: /dev/sdc
+          number: 1
+          part_start: 0%
+          part_end: 50%
+          unit: '%'
+          label: gpt
+          state: present
 
-    - name: partition /dev/sdc for journals
-      parted:
-        device: /dev/sdc
-        number: 2
-        part_start: 50%
-        part_end: 100%
-        unit: '%'
-        state: present
-        label: gpt
+      - name: partition /dev/sdc for journals
+        parted:
+          device: /dev/sdc
+          number: 2
+          part_start: 50%
+          part_end: 100%
+          unit: '%'
+          state: present
+          label: gpt
 
-    - name: create journals vg from /dev/sdc2
-      lvg:
-        vg: journals
-        pvs: /dev/sdc2
+      - name: create journals vg from /dev/sdc2
+        lvg:
+          vg: journals
+          pvs: /dev/sdc2
 
-    - name: create journal1 lv
-      command: lvcreate --yes -l 100%FREE -n journal1 journals
-      failed_when: false
+      - name: create journal1 lv
+        command: lvcreate --yes -l 100%FREE -n journal1 journals
+        failed_when: false
+      when: osd_scenario == 'lvm'


### PR DESCRIPTION
especially for ooo_collocation scenario which is still using ceph-disk
testing.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>