### PR TITLE
Enable creation of EC and replicated rules during deployment

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -37,21 +37,59 @@ dummy:
 ###############
 #crush_rule_config: false
 
+# Definition for EC profile (arguments to ceph osd erasure-code-profile set)
+#ec42_profile:
+#  name: ec_42
+#  plugin: jerasure
+#  ec_config:
+#    k: 4
+#    m: 2
+#    crush-device-class: "hdd"
+
+# Definition for replicated rule (arguments to ceph osd crush rule create-replicated)
+#osd_rep_rule:
+#  name: osd_replicated
+#  root: default
+#  type: host
+#  class: hdd
+#  default: false
+
+# Definition for erasure-coded rule (arguments to ceph osd crush rule create-erasure) 
+#ec42_rule:
+#  name: ec42
+#  ec_profile: ec_42
+#  default: false
+
+# Definition for simple rule (arguments to ceph osd crush rule create-simple)
 #crush_rule_hdd:
 #  name: HDD
 #  root: HDD
 #  type: host
 #  default: false
 
+# Definition for simple rule (arguments to ceph osd crush rule create-simple)
 #crush_rule_ssd:
 #  name: SSD
 #  root: SSD
 #  type: host
 #  default: false
 
+# Rules with arguments for create-simple
 #crush_rules:
 #  - "{{ crush_rule_hdd }}"
 #  - "{{ crush_rule_ssd }}"
+
+# Rules with arguments for create-replicated
+#crush_rep_rules:
+#  - "{{ osd_rep_rule }}"
+
+# EC Profiles to create
+#ec_profiles:
+#  - "{{ ec42_profile }}"
+
+# Rules with arguments for create-erasure-coded
+#crush_ec_rules:
+#  - "{{ ec42_rule }}"
 
 # Caution: this will create crush roots and racks according to hostvars {{ osd_crush_location }}
 # and will move hosts into them which might lead to significant data movement in the cluster!

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -405,6 +405,7 @@ ceph_rhcs_version: 3
 #radosgw_address: 0.0.0.0
 #radosgw_address_block: subnet
 #radosgw_keystone_ssl: false # activate this when using keystone PKI keys
+#radosgw_num_instances: 1
 # Rados Gateway options
 #email_address: foo@bar.com
 

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -29,21 +29,59 @@ secure_cluster_flags:
 ###############
 crush_rule_config: false
 
+# Definition for EC profile (arguments to ceph osd erasure-code-profile set)
+ec42_profile:
+  name: ec_42
+  plugin: jerasure
+  ec_config:
+    k: 4
+    m: 2
+    crush-device-class: "hdd"
+
+# Definition for replicated rule (arguments to ceph osd crush rule create-replicated)
+osd_rep_rule:
+  name: osd_replicated
+  root: default
+  type: host
+  class: hdd
+  default: false
+
+# Definition for erasure-coded rule (arguments to ceph osd crush rule create-erasure) 
+ec42_rule:
+  name: ec42
+  ec_profile: ec_42
+  default: false
+
+# Definition for simple rule (arguments to ceph osd crush rule create-simple)
 crush_rule_hdd:
   name: HDD
   root: HDD
   type: host
   default: false
 
+# Definition for simple rule (arguments to ceph osd crush rule create-simple)
 crush_rule_ssd:
   name: SSD
   root: SSD
   type: host
   default: false
 
+# Rules with arguments for create-simple
 crush_rules:
   - "{{ crush_rule_hdd }}"
   - "{{ crush_rule_ssd }}"
+
+# Rules with arguments for create-replicated
+crush_rep_rules:
+  - "{{ osd_rep_rule }}"
+
+# EC Profiles to create
+ec_profiles:
+  - "{{ ec42_profile }}"
+
+# Rules with arguments for create-erasure-coded
+crush_ec_rules:
+  - "{{ ec42_rule }}"
 
 # Caution: this will create crush roots and racks according to hostvars {{ osd_crush_location }}
 # and will move hosts into them which might lead to significant data movement in the cluster!

--- a/roles/ceph-mon/tasks/crush_rules.yml
+++ b/roles/ceph-mon/tasks/crush_rules.yml
@@ -11,7 +11,28 @@
     - create_crush_tree
     - hostvars[item]['osd_crush_location'] is defined
 
-- name: create configured crush rules
+- name: create crush ec profiles
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd erasure-code-profile set {{ item.name }} plugin={{ item.plugin }} {{ item.ec_config | to_json | regex_replace('\\:\\ ','=') | regex_replace('[\\[\\]{}\\\"]') | regex_replace('\\,\\ ',' ') }}"
+  with_items: "{{ ec_profiles | unique }}"
+  changed_when: false
+  when:
+    - inventory_hostname == groups.get(mon_group_name) | last
+
+- name: create configured crush ec rules
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-erasure {{ item.name }} {{ item.ec_profile }}"
+  with_items: "{{ crush_ec_rules | unique }}"
+  changed_when: false
+  when:
+    - inventory_hostname == groups.get(mon_group_name) | last
+
+- name: create configured crush replicated rules
+  command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-replicated {{ item.name }} {{ item.root }} {{ item.type }} {{ item.class }}"
+  with_items: "{{ crush_rep_rules | unique }}"
+  changed_when: false
+  when:
+    - inventory_hostname == groups.get(mon_group_name) | last
+
+- name: create configured crush simple rules
   command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-simple {{ item.name }} {{ item.root }} {{ item.type }}"
   with_items: "{{ crush_rules | unique }}"
   changed_when: false
@@ -22,7 +43,7 @@
   command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd -f json crush rule dump {{ item.name }}"
   register: info_ceph_default_crush_rule
   changed_when: false
-  with_items: "{{ crush_rules }}"
+  loop: "{{ [crush_rules, crush_rep_rules, crush_ec_rules]|flatten(levels=1) }}"
   when:
     - inventory_hostname == groups.get(mon_group_name) | last
     - item.default


### PR DESCRIPTION
Allows users to create EC profiles and replicated rules with specific device types.
Solves issue #3556  