### PR TITLE
don't install NTPd on Atomic

### DIFF
--- a/roles/ceph-infra/tasks/setup_ntp.yml
+++ b/roles/ceph-infra/tasks/setup_ntp.yml
@@ -10,51 +10,62 @@
         ntp_service_name: ntpd
       when: ansible_os_family in ['RedHat', 'Suse']
 
-- name: setup ntp daemon
+# Installation of NTP daemons needs to be a separate task since installations
+# can't happen on Atomic
+- name: install the ntp daemon
+  when: not is_atomic
   block:
-    - name: install and enable timesyncd
+    - name: install ntpd
+      package:
+        name: ntp
+        state: present
+      register: result
+      until: result is succeeded
+      when:
+        - ntp_daemon_type == "ntpd"
+
+    - name: install chrony
+      package:
+        name: chrony
+        state: present
+      register: result
+      until: result is succeeded
+      when:
+        - ntp_daemon_type == "chronyd"
+
+- name: enable the ntp daemon and disable the rest
+  block:
+    - name: enable timesyncing on timesyncd
       command: timedatectl set-ntp on
-      when: ntp_daemon_type == "timesyncd"
       notify:
         - disable ntpd
         - disable chronyd
+      when:
+        - ntp_daemon_type == "timesyncd"
 
     - name: disable time sync using timesyncd if we are not using it
       command: timedatectl set-ntp no
-      when: ntp_daemon_type != "timesyncd"
+      when:
+        - ntp_daemon_type != "timesyncd"
 
-    - name: setup ntpd
-      when: ntp_daemon_type == "ntpd"
-      block:
-        - name: install ntp
-          package:
-            name: ntp
-            state: present
-          register: result
-          until: result is succeeded
-        - name: enable and start ntp
-          service:
-            name: "{{ ntp_service_name }}"
-            enabled: yes
-            state: started
-          notify:
-            - disable chronyd
-            - disable timesyncd
+    - name: enable ntpd
+      service:
+        name: "{{ ntp_service_name }}"
+        enabled: yes
+        state: started
+      notify:
+        - disable chronyd
+        - disable timesyncd
+      when:
+        - ntp_daemon_type == "ntpd"
 
-    - name: setup chronyd
-      when: ntp_daemon_type == "chronyd"
-      block:
-        - name: install chrony
-          package:
-            name: chrony
-            state: present
-          register: result
-          until: result is succeeded
-        - name: enable and start chronyd
-          service:
-            name: chronyd
-            enabled: yes
-            state: started
-          notify:
-            - disable ntpd
-            - disable timesyncd
+    - name: enable chronyd
+      service:
+        name: chronyd
+        enabled: yes
+        state: started
+      notify:
+        - disable ntpd
+        - disable timesyncd
+      when:
+        - ntp_daemon_type == "chronyd"

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -36,6 +36,15 @@
     - ntp_service_enabled
     - ntp_daemon_type not in ['chronyd', 'ntpd', 'timesyncd']
 
+# Since NTPd can not be installed on Atomic...
+- name: abort if ntp_daemon_type is ntp on Atomic
+  fail:
+    msg: installation can't happen on Atomic and ntpd needs to be installed
+  when:
+    - is_atomic
+    - ansible_os_family == 'RedHat'
+    - ntp_daemon_type == 'ntpd'
+
 - name: make sure journal_size configured
   debug:
     msg: "WARNING: journal_size is configured to {{ journal_size }}, which is less than 5GB. This is not recommended and can lead to severe issues."


### PR DESCRIPTION
Since Atomic doesn't allow any installations and NTPd is not present
on Atomic image we are using, abort when ntp_daemon_type is set to ntpd.

https://github.com/ceph/ceph-ansible/issues/3572