### PR TITLE
setup_ntp: call handler to disable ntpd if chronyd used

### DIFF
--- a/roles/ceph-infra/tasks/setup_ntp.yml
+++ b/roles/ceph-infra/tasks/setup_ntp.yml
@@ -56,5 +56,5 @@
             enabled: yes
             state: started
           notify:
-            - disable chronyd
+            - disable ntpd
             - disable timesyncd


### PR DESCRIPTION
The task setup chronyd called the handler disable chronyd, which of
course defeats the purpose.

Changing the task to disable ntpd instead fixes the issue of chronyd
being disabled after it got enabled.

Fixes: #3582

Signed-off-by: Patrick C. F. Ernzer pcfe@redhat.com