### PR TITLE
Fix uses of default(omit) with string concatenation

### DIFF
--- a/roles/ceph-common/tasks/installs/install_debian_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_packages.yml
@@ -4,4 +4,4 @@
     name: "{{ debian_ceph_pkgs | unique }}"
     update_cache: no
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
+    default_release: "{{ ceph_stable_release_uca | default('') }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"

--- a/roles/ceph-mds/tasks/non_containerized.yml
+++ b/roles/ceph-mds/tasks/non_containerized.yml
@@ -3,7 +3,7 @@
   apt:
     name: ceph-mds
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
+    default_release: "{{ ceph_stable_release_uca | default('') }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
   when:
     - mds_group_name in group_names
     - ansible_os_family == 'Debian'

--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -10,7 +10,7 @@
   apt:
     name: ceph-mgr
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-    default_release: "{{ ceph_stable_release_uca | default(omit) }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
+    default_release: "{{ ceph_stable_release_uca | default('') }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else ''}}"
   when:
     - ansible_os_family == 'Debian'
 


### PR DESCRIPTION
When {{omit}} is concatenated with another string, it expands to something
like __omit_place_holder__63eea0d96dd6ed867b95405e11d87dddf61f448d.
However, in these use-cases we need an empty string.

Regression introduced in d53f55e807e.

Signed-off-by: Leah Neukirchen <leah.neukirchen@mayflower.de>