### PR TITLE
mon: do not hardcode ceph uid

### DIFF
--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -97,8 +97,8 @@
   command: >
     {{ ceph_mon_cmd }}
     --cluster {{ cluster }}
-    --setuser 167
-    --setgroup 167
+    --setuser "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    --setgroup "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     --mkfs
     -i {{ monitor_name }}
     --fsid {{ fsid }}
@@ -112,8 +112,8 @@
   command: >
     {{ ceph_mon_cmd }}
     --cluster {{ cluster }}
-    --setuser ceph
-    --setgroup ceph
+    --setuser "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    --setgroup "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     --mkfs
     -i {{ monitor_name }}
     --fsid {{ fsid }}


### PR DESCRIPTION
167 is the ceph uid for Red Hat based system, thus trying to deploy a
monitor on Debian fail since the ceph user id on that system is 64045.
This commit uses the ceph_uid variable which contains the right uid
based on system/container detection.

Closes: https://github.com/ceph/ceph-ansible/issues/3589
Signed-off-by: Sébastien Han <seb@redhat.com>