### PR TITLE
osd: add possibility to exclude device in osd_auto_discovery

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -370,6 +370,9 @@ dummy:
 #osd_mount_options_xfs: noatime,largeio,inode64,swalloc
 #osd_objectstore: bluestore
 
+# Any device containing these patterns in their path will be excluded.
+#osd_auto_discovery_exclude: ['dm-', 'loop']
+
 # xattrs. by default, 'filestore xattr use omap' is set to 'true' if
 # 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can
 # be set to 'true' or 'false' to explicitly override those

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -370,6 +370,9 @@ ceph_rhcs_version: 3
 #osd_mount_options_xfs: noatime,largeio,inode64,swalloc
 #osd_objectstore: bluestore
 
+# Any device containing these patterns in their path will be excluded.
+#osd_auto_discovery_exclude: ['dm-', 'loop']
+
 # xattrs. by default, 'filestore xattr use omap' is set to 'true' if
 # 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can
 # be set to 'true' or 'false' to explicitly override those

--- a/raw_install_python.yml
+++ b/raw_install_python.yml
@@ -19,7 +19,7 @@
   register: result
   when:
     - systempython.stat is undefined or not systempython.stat.exists
-  until: (result is succeeded) or ('Failed' not in result.stdout)
+  until: (result is succeeded) and ('Failed' not in result.stdout)
 
 - name: install python for opensuse
   raw: zypper -n install python-base creates=/usr/bin/python2.7

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -362,6 +362,9 @@ osd_mkfs_options_xfs: -f -i size=2048
 osd_mount_options_xfs: noatime,largeio,inode64,swalloc
 osd_objectstore: bluestore
 
+# Any device containing these patterns in their path will be excluded.
+osd_auto_discovery_exclude: ['dm-', 'loop']
+
 # xattrs. by default, 'filestore xattr use omap' is set to 'true' if
 # 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can
 # be set to 'true' or 'false' to explicitly override those

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -184,7 +184,7 @@
     - item.value.sectors != "0"
     - item.value.partitions|count == 0
     - item.value.holders|count == 0
-    - "'dm-' not in item.key"
+    - item.key not in osd_auto_discovery_exclude
 
 - name: set_fact ceph_uid for debian based system - non container
   set_fact:


### PR DESCRIPTION
Add a new `osd_auto_discovery_exclude` to give the possibility of
excluding some devices in auto_discovery scenario.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>