### PR TITLE
Fixes: #3065 check_socket_non_container.yml: add space in stat outputs

### DIFF
--- a/roles/ceph-defaults/tasks/check_socket_non_container.yml
+++ b/roles/ceph-defaults/tasks/check_socket_non_container.yml
@@ -1,6 +1,6 @@
 ---
 - name: check for a ceph mon socket
-  shell: stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-mon*.asok
+  shell: stat --printf="%n " {{ rbd_client_admin_socket_path }}/{{ cluster }}-mon*.asok
   changed_when: false
   failed_when: false
   always_run: true
@@ -29,7 +29,7 @@
 
 - name: check for a ceph osd socket
   shell: |
-    stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-osd*.asok
+    stat --printf="%n " {{ rbd_client_admin_socket_path }}/{{ cluster }}-osd*.asok
   changed_when: false
   failed_when: false
   always_run: true
@@ -58,7 +58,7 @@
 
 - name: check for a ceph mds socket
   shell: |
-    stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-mds*.asok
+    stat --printf="%n " {{ rbd_client_admin_socket_path }}/{{ cluster }}-mds*.asok
   changed_when: false
   failed_when: false
   always_run: true
@@ -87,7 +87,7 @@
 
 - name: check for a ceph rgw socket
   shell: |
-    stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-client.rgw*.asok
+    stat --printf="%n " {{ rbd_client_admin_socket_path }}/{{ cluster }}-client.rgw*.asok
   changed_when: false
   failed_when: false
   always_run: true
@@ -116,7 +116,7 @@
 
 - name: check for a ceph mgr socket
   shell: |
-    stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-mgr*.asok
+    stat --printf="%n " {{ rbd_client_admin_socket_path }}/{{ cluster }}-mgr*.asok
   changed_when: false
   failed_when: false
   always_run: true
@@ -145,7 +145,7 @@
 
 - name: check for a ceph rbd mirror socket
   shell: |
-    stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-client.rbd-mirror*.asok
+    stat --printf="%n " {{ rbd_client_admin_socket_path }}/{{ cluster }}-client.rbd-mirror*.asok
   changed_when: false
   failed_when: false
   always_run: true


### PR DESCRIPTION
Problem: ```stat --printf=%n``` for OSD sockets produces one concatenated string
 of multiple paths, consequently in the next ansible task ```fuser``` command
 fails with non-zero exit code and triggers next task deleting of non-existed
 path.

Solution: add space to separate multiple sockets in stat output by modifying the
 command to ```stat --printf="%n "```. ```fuser``` can handle multiple space
 separated arguments. For consistency modify all usages of stat in current file,
 although this issue can happen only with OSD. It's unlikely that there will be
 multiple sockets on one machine for MON, MDS, RGW or other Ceph services.

Why this solution: simple quick fix, minimal probability to introduce new bug.
 May uncover other hidden bugs :-)
Alternatives: PR #3071, which does a lot of additional improvements.

Signed-off-by: G-Tarik <gtarik@gmail.com>