### PR TITLE
fix mistake in task that aborts when ntpd is chosen on Atomic

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -37,7 +37,7 @@
     - ntp_daemon_type not in ['chronyd', 'ntpd', 'timesyncd']
 
 # Since NTPd can not be installed on Atomic...
-- name: abort if ntp_daemon_type is ntp on Atomic
+- name: abort if ntp_daemon_type is ntpd on Atomic
   fail:
     msg: installation can't happen on Atomic and ntpd needs to be installed
   when:


### PR DESCRIPTION
Since it's already confusing whether ntp_daemon_type should be "ntp" or
"ntpd", fix the mistake in the title of the task that aborts if
ntp_daemon_type is set to "ntpd" and OS being used is Atomic.