### PR TITLE
ceph-infra: Remove restart firewalld handler

### DIFF
--- a/roles/ceph-infra/handlers/main.yml
+++ b/roles/ceph-infra/handlers/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: restart firewalld
-  service:
-    name: firewalld
-    state: restarted
-    enabled: yes
-
 - name: disable ntpd
   failed_when: false
   service:

--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -27,7 +27,6 @@
       permanent: true
       immediate: true
       state: enabled
-    notify: restart firewalld
     with_items:
       - { 'service': 'ceph-mon', 'zone': "{{ ceph_mon_firewall_zone }}" }
       - { 'service': 'ceph', 'zone': "{{ ceph_mgr_firewall_zone }}" }
@@ -45,7 +44,6 @@
       permanent: true
       immediate: true
       state: enabled
-    notify: restart firewalld
     when:
       - mgr_group_name is defined
       - mgr_group_name in group_names
@@ -63,7 +61,6 @@
     with_items:
       - "{{ public_network }}"
       - "{{ cluster_network }}"
-    notify: restart firewalld
     when:
       - osd_group_name is defined
       - osd_group_name in group_names
@@ -78,7 +75,6 @@
       permanent: true
       immediate: true
       state: enabled
-    notify: restart firewalld
     when:
       - rgw_group_name is defined
       - rgw_group_name in group_names
@@ -93,7 +89,6 @@
       permanent: true
       immediate: true
       state: enabled
-    notify: restart firewalld
     when:
       - mds_group_name is defined
       - mds_group_name in group_names
@@ -108,7 +103,6 @@
       permanent: true
       immediate: true
       state: enabled
-    notify: restart firewalld
     when:
       - nfs_group_name is defined
       - nfs_group_name in group_names
@@ -123,7 +117,6 @@
       permanent: true
       immediate: true
       state: enabled
-    notify: restart firewalld
     when:
       - nfs_group_name is defined
       - nfs_group_name in group_names
@@ -138,7 +131,6 @@
       permanent: true
       immediate: true
       state: enabled
-    notify: restart firewalld
     when:
       - rbdmirror_group_name is defined
       - rbdmirror_group_name in group_names
@@ -153,7 +145,6 @@
       permanent: true
       immediate: true
       state: enabled
-    notify: restart firewalld
     when:
       - iscsi_gw_group_name is defined
       - iscsi_gw_group_name in group_names
@@ -168,7 +159,6 @@
       permanent: true
       immediate: true
       state: enabled
-    notify: restart firewalld
     when:
       - iscsi_gw_group_name is defined
       - iscsi_gw_group_name in group_names


### PR DESCRIPTION
There's no need to restart firewalld service when a new rule is
added due to the usage of the immediate flag.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>