### PR TITLE
ceph_key: fix rstrip for python 3

### DIFF
--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -678,8 +678,8 @@ def run_module():
         end=str(endd),
         delta=str(delta),
         rc=rc,
-        stdout=out.rstrip(b"\r\n"),
-        stderr=err.rstrip(b"\r\n"),
+        stdout=out.rstrip("\r\n"),
+        stderr=err.rstrip("\r\n"),
         changed=True,
     )
 


### PR DESCRIPTION
Removing bytes literals since rstrip only supports type String or None.

Backporting f5c2ca37 to stable 3.2

Fixes  #3565