### PR TITLE
Convert interface names to underscores in ceph-validate tasks 

### DIFF
--- a/roles/ceph-validate/tasks/check_eth_mon.yml
+++ b/roles/ceph-validate/tasks/check_eth_mon.yml
@@ -9,18 +9,18 @@
   fail:
     msg: "{{ monitor_interface }} is not active on {{ inventory_hostname }}"
   when:
-    - not hostvars[inventory_hostname]['ansible_' + monitor_interface]['active']
+    - not hostvars[inventory_hostname]['ansible_' + (monitor_interface | replace('-', '_'))]['active']
 
 - name: "fail if {{ monitor_interface }} does not have any ip v4 address on {{ inventory_hostname }}"
   fail:
     msg: "{{ monitor_interface }} does not have any IPv4 address on {{ inventory_hostname }}"
   when:
     - ip_version == "ipv4"
-    - hostvars[inventory_hostname]['ansible_' + monitor_interface]['ipv4'] is not defined
+    - hostvars[inventory_hostname]['ansible_' + (monitor_interface | replace('-', '_'))]['ipv4'] is not defined
 
 - name: "fail if {{ monitor_interface }} does not have any ip v6 address on {{ inventory_hostname }}"
   fail:
     msg: "{{ monitor_interface }} does not have any IPv6 address on {{ inventory_hostname }}"
   when:
     - ip_version == "ipv6"
-    - hostvars[inventory_hostname]['ansible_' + monitor_interface]['ipv6'] is not defined
+    - hostvars[inventory_hostname]['ansible_' + (monitor_interface | replace('-', '_'))]['ipv6'] is not defined

--- a/roles/ceph-validate/tasks/check_eth_rgw.yml
+++ b/roles/ceph-validate/tasks/check_eth_rgw.yml
@@ -9,18 +9,18 @@
   fail:
     msg: "{{ radosgw_interface }} is not active on {{ inventory_hostname }}"
   when:
-    - hostvars[inventory_hostname]['ansible_' + radosgw_interface]['active'] == "false"
+    - hostvars[inventory_hostname]['ansible_' + (radosgw_interface | replace('-', '_'))]['active'] == "false"
 
 - name: "fail if {{ radosgw_interface }} does not have any ip v4 address on {{ inventory_hostname }}"
   fail:
     msg: "{{ radosgw_interface }} does not have any IPv4 address on {{ inventory_hostname }}"
   when:
     - ip_version == "ipv4"
-    - hostvars[inventory_hostname]['ansible_' + radosgw_interface]['ipv4'] is not defined
+    - hostvars[inventory_hostname]['ansible_' + (radosgw_interface | replace('-', '_'))]['ipv4'] is not defined
 
 - name: "fail if {{ radosgw_interface }} does not have any ip v6 address on {{ inventory_hostname }}"
   fail:
     msg: "{{ radosgw_interface }} does not have any IPv6 address on {{ inventory_hostname }}"
   when:
     - ip_version == "ipv6"
-    - hostvars[inventory_hostname]['ansible_' + radosgw_interface]['ipv6'] is not defined
+    - hostvars[inventory_hostname]['ansible_' + (radosgw_interface | replace('-', '_'))]['ipv6'] is not defined


### PR DESCRIPTION
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1540881#c7
Signed-off-by: Tomas Petr tpetr@redhat.com