### PR TITLE
osd: make the 'wait for all osd to be up' task configurable

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -266,3 +266,10 @@ dummy:
 #  Service:
 #    PrivateDevices: False
 
+
+###########
+#  CHECK  #
+###########
+
+#nb_retry_wait_osd_up: 60
+#delay_wait_osd_up: 10

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -257,3 +257,11 @@ ceph_osd_docker_run_script_path: "/usr/share" # script called by systemd to run 
 #ceph_osd_systemd_overrides:
 #  Service:
 #    PrivateDevices: False
+
+
+###########
+#  CHECK  #
+###########
+
+nb_retry_wait_osd_up: 60
+delay_wait_osd_up: 10

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -5,8 +5,8 @@
     test "$({{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["osdmap"]["num_osds"])')" =
     "$({{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["osdmap"]["num_up_osds"])')"
   register: wait_for_all_osds_up
-  retries: 30
-  delay: 10
+  retries: "{{ nb_retry_wait_osd_up }}"
+  delay: "{{ delay_wait_osd_up }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   until: wait_for_all_osds_up.rc == 0


### PR DESCRIPTION
introduce two new variables to make the check that 'wait for all osd to
be up' configurable.
It's possible that for some deployments, OSDs can take longer to be seen
as UP and IN.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1676763

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>