### PR TITLE
common: do not override ceph_release when ceph_repository is 'rhcs'

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -49,7 +49,7 @@
     ceph_release: "{{ ceph_stable_release }}"
   when:
     - ceph_origin == 'repository'
-    - ceph_repository != 'dev'
+    - ceph_repository not in ['dev', 'rhcs']
   tags:
     - always
 


### PR DESCRIPTION
We shouldn't reset `ceph_release` with `ceph_stable_release` when
`ceph_repository` is `rhcs`

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1645379

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>