### PR TITLE
site.yml: do not bootstrap mgrs on monitors by default

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -126,6 +126,7 @@
         name: ceph-mon
     - import_role:
         name: ceph-mgr
+      when: groups.get(mgr_group_name, []) | length == 0
 
 - hosts: mons
   any_errors_fatal: true

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -106,6 +106,7 @@
         name: ceph-mon
     - import_role:
         name: ceph-mgr
+      when: groups.get(mgr_group_name, []) | length == 0
 
   post_tasks:
     - name: set ceph monitor install 'Complete'

--- a/tests/functional/all_daemons/container/hosts
+++ b/tests/functional/all_daemons/container/hosts
@@ -3,6 +3,9 @@ mon0 monitor_address=192.168.17.10
 mon1 monitor_interface="{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 mon2 monitor_address=192.168.17.12
 
+[mgrs]
+mgr0
+
 [osds]
 osd0 osd_crush_location="{ 'root': 'HDD', 'rack': 'mon-rackkkk', 'pod': 'monpod', 'host': 'osd0' }"
 osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"

--- a/tests/functional/all_daemons/container/hosts-ubuntu
+++ b/tests/functional/all_daemons/container/hosts-ubuntu
@@ -3,6 +3,9 @@ mon0 monitor_address=192.168.17.10
 mon1 monitor_interface="{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 mon2 monitor_address=192.168.17.12
 
+[mgrs]
+mgr0
+
 [osds]
 osd0 osd_crush_location="{ 'root': 'HDD', 'rack': 'mon-rackkkk', 'pod': 'monpod', 'host': 'osd0' }"
 osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"

--- a/tests/functional/all_daemons/container/vagrant_variables.yml
+++ b/tests/functional/all_daemons/container/vagrant_variables.yml
@@ -12,7 +12,7 @@ nfs_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2
 iscsi_gw_vms: 1
-mgr_vms: 0
+mgr_vms: 1
 
 # SUBNETS TO USE FOR THE VMS
 public_subnet: 192.168.17

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -3,6 +3,9 @@ mon0 monitor_address=192.168.1.10
 mon1 monitor_interface="{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 mon2 monitor_address=192.168.1.12
 
+[mgrs]
+mgr0
+
 [osds]
 osd0 osd_crush_location="{ 'root': 'HDD', 'rack': 'mon-rackkkk', 'pod': 'monpod', 'host': 'osd0' }"
 osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"

--- a/tests/functional/all_daemons/hosts-switch-to-containers
+++ b/tests/functional/all_daemons/hosts-switch-to-containers
@@ -6,6 +6,9 @@ mon0 monitor_address=192.168.1.10
 mon1 monitor_interface="{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 mon2 monitor_address=192.168.1.12
 
+[mgrs]
+mgr0
+
 [osds]
 osd0
 

--- a/tests/functional/all_daemons/hosts-ubuntu
+++ b/tests/functional/all_daemons/hosts-ubuntu
@@ -3,6 +3,9 @@ mon0 monitor_address=192.168.1.10
 mon1 monitor_interface=ens6
 mon2 monitor_address=192.168.1.12
 
+[mgrs]
+mgr0
+
 [osds]
 osd0 osd_crush_location="{ 'root': 'HDD', 'rack': 'mon-rackkkk', 'pod': 'monpod', 'host': 'osd0' }"
 osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -12,7 +12,7 @@ nfs_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2
 iscsi_gw_vms: 1
-mgr_vms: 0
+mgr_vms: 1
 
 # INSTALL SOURCE OF CEPH
 # valid values are 'stable' and 'dev'


### PR DESCRIPTION
Let's bootstrap mgrs on monitors only if there's no mgrs section in
inventory hostfile.

Closes: #3613

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>