### PR TITLE
ceph-osd: Drop memory flag with bluestore

### DIFF
--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -75,7 +75,9 @@ fi
   --net=host \
   --privileged=true \
   --pid=host \
+  {% if osd_objectstore == 'filestore' -%}
   --memory={{ ceph_osd_docker_memory_limit }} \
+  {% endif -%}
   {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_osd_docker_cpu_limit }} \
   {% else -%}


### PR DESCRIPTION
As discussed in #3617 we don't need to use the container `--memory` flag on the OSD when using bluestore.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>