### PR TITLE
facts: fix auto_discovery exclude

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -371,7 +371,7 @@ dummy:
 #osd_objectstore: bluestore
 
 # Any device containing these patterns in their path will be excluded.
-#osd_auto_discovery_exclude: ['dm-', 'loop']
+#osd_auto_discovery_exclude: "dm-*|loop*"
 
 # xattrs. by default, 'filestore xattr use omap' is set to 'true' if
 # 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -371,7 +371,7 @@ ceph_rhcs_version: 3
 #osd_objectstore: bluestore
 
 # Any device containing these patterns in their path will be excluded.
-#osd_auto_discovery_exclude: ['dm-', 'loop']
+#osd_auto_discovery_exclude: "dm-*|loop*"
 
 # xattrs. by default, 'filestore xattr use omap' is set to 'true' if
 # 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -363,7 +363,7 @@ osd_mount_options_xfs: noatime,largeio,inode64,swalloc
 osd_objectstore: bluestore
 
 # Any device containing these patterns in their path will be excluded.
-osd_auto_discovery_exclude: ['dm-', 'loop']
+osd_auto_discovery_exclude: "dm-*|loop*"
 
 # xattrs. by default, 'filestore xattr use omap' is set to 'true' if
 # 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -184,7 +184,7 @@
     - item.value.sectors != "0"
     - item.value.partitions|count == 0
     - item.value.holders|count == 0
-    - item.key not in osd_auto_discovery_exclude
+    - item.key is not match osd_auto_discovery_exclude
 
 - name: set_fact ceph_uid for debian based system - non container
   set_fact:


### PR DESCRIPTION
the previous approach was wrong.
checking if `item.key` is in `osd_auto_discovery_exclude` (`['dm-',
'loop']`) is incorrect because it will obviously not match. Therefore,
the condition will return `True` whatever the device we are checking.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>