### PR TITLE
ceph-radosgw bz#1683290

### DIFF
--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -18,10 +18,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -v /var/run/ceph:/var/run/ceph:z \
   -v /etc/localtime:/etc/localtime:ro \
   {% if ansible_distribution == 'RedHat' -%}
-  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:ro \
-  -v /etc/pki/ca-trust/source/anchors:/etc/pki/ca-trust/source/anchors:ro \
-  {% elif ansible_distribution == 'Ubuntu' -%}
-  -v /etc/ssl/certs:/etc/ssl/certs:ro \
+  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:z \
   {% endif -%}
   -e CEPH_DAEMON=RGW \
   -e CLUSTER={{ cluster }} \

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -17,6 +17,12 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -v /etc/ceph:/etc/ceph:z \
   -v /var/run/ceph:/var/run/ceph:z \
   -v /etc/localtime:/etc/localtime:ro \
+  {% if ansible_distribution == 'RedHat' -%}
+  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:ro \
+  -v /etc/pki/ca-trust/source/anchors:/etc/pki/ca-trust/source/anchors:ro \
+  {% elif ansible_distribution == 'Ubuntu' -%}
+  -v /etc/ssl/certs:/etc/ssl/certs:ro \
+  {% endif -%}
   -e CEPH_DAEMON=RGW \
   -e CLUSTER={{ cluster }} \
   -e RGW_NAME={{ ansible_hostname }}.${INST_NAME} \


### PR DESCRIPTION
Added to the ceph-radosgw service template the ca-trust volume avoiding to expose useless information.
This bug is referred to the following bugzilla:

https://bugzilla.redhat.com/show_bug.cgi?id=1683290

Signed-off-by: fpantano <fpantano@redhat.com>