### PR TITLE
mon: do not create unnecessarily mgr keyrings

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -46,8 +46,7 @@
       CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
       CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     with_items:
-      - "{{ groups.get(mgr_group_name, []) }}" # this honors the condition where mgrs run on separate machines
-      - "{{ groups.get(mon_group_name, []) if groups.get(mgr_group_name, []) | length == 0 else [] }}" # this honors the new rule where mgrs are always collocated with mons
+      - "{{ groups.get(mon_group_name) if groups.get(mgr_group_name, []) | length == 0 else groups.get(mgr_group_name, []) }}"
     run_once: True
     delegate_to: "{{ groups[mon_group_name][0] }}"
 
@@ -57,8 +56,7 @@
       dest: "{{ fetch_directory }}/{{ fsid }}/{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
       flat: yes
     with_items:
-      - "{{ groups.get(mgr_group_name, []) }}" # this honors the condition where mgrs run on separate machines
-      - "{{ groups.get(mon_group_name, []) if groups.get(mgr_group_name, []) | length == 0 else [] }}" # this honors the new rule where mgrs are always collocated with mons
+      - "{{ groups.get(mon_group_name) if groups.get(mgr_group_name, []) | length == 0 else groups.get(mgr_group_name, []) }}"
     delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
     - cephx

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -47,7 +47,8 @@
       CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     with_items:
       - "{{ groups.get(mgr_group_name, []) }}" # this honors the condition where mgrs run on separate machines
-      - "{{ groups.get(mon_group_name, []) }}" # this honors the new rule where mgrs are always collocated with mons
+      - "{{ groups.get(mon_group_name, []) if groups.get(mgr_group_name, []) | length == 0 else [] }}" # this honors the new rule where mgrs are always collocated with mons
+    run_once: True
     delegate_to: "{{ groups[mon_group_name][0] }}"
 
   - name: copy ceph mgr key(s) to the ansible server
@@ -57,7 +58,7 @@
       flat: yes
     with_items:
       - "{{ groups.get(mgr_group_name, []) }}" # this honors the condition where mgrs run on separate machines
-      - "{{ groups.get(mon_group_name, []) }}" # this honors the new rule where mgrs are always collocated with mons
+      - "{{ groups.get(mon_group_name, []) if groups.get(mgr_group_name, []) | length == 0 else [] }}" # this honors the new rule where mgrs are always collocated with mons
     delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
     - cephx

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -1,5 +1,7 @@
 ---
 containerized_deployment: False
+ceph_origin: repository
+ceph_repository: community
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"


### PR DESCRIPTION
there's no need to generate mgr keyrings 'mgr.monX' when mgrs aren't
collocated with monitors.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>