### PR TITLE
Extends check_devices tasks to non-collocated an lvm-batch scenarios

### DIFF
--- a/roles/ceph-validate/tasks/check_devices.yml
+++ b/roles/ceph-validate/tasks/check_devices.yml
@@ -1,17 +1,21 @@
 ---
-- name: validate devices is actually a device
-  parted:
-    device: "{{ item }}"
-    unit: MiB
-  register: devices_parted
-  with_items: "{{ devices }}"
+- name: devices validation
+  block:
+    - name: validate devices is actually a device
+      parted:
+        device: "{{ item }}"
+        unit: MiB
+      register: devices_parted
+      with_items: "{{ devices }}"
 
-- name: fail if one of the devices is not a device
-  fail:
-    msg: "{{ item }} is not a block special file!"
+    - name: fail if one of the devices is not a device
+      fail:
+        msg: "{{ item }} is not a block special file!"
+      when:
+        - item.failed
+      with_items: "{{ devices_parted.results }}"
   when:
-    - item.failed
-  with_items: "{{ devices_parted.results }}"
+    - devices is defined
 
 - name: validate dedicated_device is/are actually device(s)
   parted:
@@ -30,9 +34,9 @@
     - osd_scenario == 'non-collocated'
     - item.failed
 
-- name: fail if dedicated_device is not the size length as devices
+- name: fail if number of dedicated_devices is not equal to number of devices
   fail:
-    msg: "dedicated_device lengtth must be identical to devices's length"
+    msg: "Number of dedicated_devices must be equal to number of devices. dedicated_devices: {{ dedicated_devices | length }}, devices: {{ devices | length }}"
   when:
     - osd_scenario == 'non-collocated'
     - dedicated_devices|length != devices|length

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -61,7 +61,6 @@
   when:
     - osd_group_name in group_names
     - not osd_auto_discovery | default(False)
-    - osd_scenario != "lvm" and devices is not defined
 
 - name: include check_eth_mon.yml
   include_tasks: check_eth_mon.yml


### PR DESCRIPTION
Tuned name of a task and error message to make it more user understandable

Fixes BZ 1648168 - ceph-validate : devices are not validated in non-collocated and lvm_batch scenario

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1648168

Signed-off-by: VasishtaShastry <vipin.indiasmg@gmail.com>