### PR TITLE
mon: Add mds permissions to client.admin

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -31,6 +31,11 @@ dummy:
 #  - nodelete
 #  - nosizechange
 
+#client_admin_ceph_authtool_cap:
+#  mon: allow *
+#  osd: allow *
+#  mds: allow *
+#  mgr: allow *
 
 ###############
 # CRUSH RULES #

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -23,6 +23,11 @@ secure_cluster_flags:
   - nodelete
   - nosizechange
 
+client_admin_ceph_authtool_cap:
+  mon: allow *
+  osd: allow *
+  mds: allow *
+  mgr: allow *
 
 ###############
 # CRUSH RULES #

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -46,17 +46,6 @@
     mode: "u=rwX,g=rX,o=rX"
     recurse: true
 
-- name: set_fact client_admin_ceph_authtool_cap
-  set_fact:
-    client_admin_ceph_authtool_cap:
-      mon: allow *
-      osd: allow *
-      mds: allow *
-      mgr: allow *
-  when:
-    - cephx
-    - admin_secret != 'admin_secret'
-
 - name: create custom admin keyring
   ceph_key:
     name: client.admin

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -51,7 +51,7 @@
     client_admin_ceph_authtool_cap:
       mon: allow *
       osd: allow *
-      mds: allow
+      mds: allow *
       mgr: allow *
   when:
     - cephx


### PR DESCRIPTION
The administrator keyring needs full capabilities on mds like mon,
osd and mgr.
Whithout this, the client.admin key won't be able to run commands
against mds (like ceph tell mds.0 session ls)

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1672878

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>