### PR TITLE
Backport: Set permissions on monitor directory to u=rwX,g=rX,o=rX 

### DIFF
--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -45,7 +45,7 @@
     state: directory
     owner: "ceph"
     group: "ceph"
-    mode: "0755"
+    mode: "u=rwX,g=rX,o=rX"
     recurse: true
 
 - name: set_fact client_admin_ceph_authtool_cap


### PR DESCRIPTION
Set directories to 755 and files to 644 to /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }} recursively instead of setting files and directories to 755 recursively. The ceph mon process writes files to this path with permissions 644. This update stops ansible from updating the permissions in /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }} every time ceph mon writes a file and increases idempotency. Backport of https://github.com/ceph/ceph-ansible/pull/3636 to the stable-3.2 branch.

Signed-off-by: Kevin Coakley <kcoakley@sdsc.edu>