### PR TITLE
cv: expose host ipc namespace to ceph-volume container

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -189,7 +189,7 @@ def container_exec(binary, container_image):
     '''
     container_binary = os.getenv('CEPH_CONTAINER_BINARY')
     command_exec = [container_binary, 'run',
-                    '--rm', '--privileged', '--net=host',
+                    '--rm', '--privileged', '--net=host', '--ipc=host',
                     '-v', '/run/lock/lvm:/run/lock/lvm:z',
                     '-v', '/var/run/udev/:/var/run/udev/:z',
                     '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',


### PR DESCRIPTION
this is needed to properly handle semaphore synchronization for udev
actions via dmcrypt/cryptsetup.

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>