### PR TITLE
[skip ci] cv: expose host ipc namespace to ceph-volume container

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -189,7 +189,7 @@ def container_exec(binary, container_image):
     '''
     container_binary = os.getenv('CEPH_CONTAINER_BINARY')
     command_exec = [container_binary, 'run',
-                    '--rm', '--privileged', '--net=host',
+                    '--rm', '--privileged', '--net=host', '--ipc=host',
                     '-v', '/run/lock/lvm:/run/lock/lvm:z',
                     '-v', '/var/run/udev/:/var/run/udev/:z',
                     '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',

--- a/library/test_ceph_volume.py
+++ b/library/test_ceph_volume.py
@@ -42,7 +42,7 @@ class TestCephVolumeModule(object):
     def test_container_exec(self):
         fake_binary = "ceph-volume"
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
-        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
+        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host', '--ipc=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
                                  '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
@@ -58,7 +58,7 @@ class TestCephVolumeModule(object):
         fake_module = MagicMock()
         fake_module.params = {'data': '/dev/sda'}
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
-        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
+        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host', '--ipc=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
                                  '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
@@ -126,7 +126,7 @@ class TestCephVolumeModule(object):
         fake_module = MagicMock()
         fake_module.params = {'cluster': 'ceph', 'data': '/dev/sda'}
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
-        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
+        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host', '--ipc=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
                                  '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
@@ -158,7 +158,7 @@ class TestCephVolumeModule(object):
     def test_list_storage_inventory_container(self):
         fake_module = MagicMock()
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
-        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
+        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host', '--ipc=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
                                  '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
@@ -181,7 +181,7 @@ class TestCephVolumeModule(object):
 
         fake_action = "create"
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
-        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
+        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host', '--ipc=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
                                  '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
@@ -229,7 +229,7 @@ class TestCephVolumeModule(object):
 
         fake_action = "prepare"
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
-        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
+        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host', '--ipc=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
                                  '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501
@@ -278,7 +278,7 @@ class TestCephVolumeModule(object):
                               'batch_devices': ["/dev/sda", "/dev/sdb"]}
 
         fake_container_image = "docker.io/ceph/daemon:latest-luminous"
-        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host',  # noqa E501
+        expected_command_list = ['docker', 'run', '--rm', '--privileged', '--net=host', '--ipc=host',  # noqa E501
                                  '-v', '/run/lock/lvm:/run/lock/lvm:z',
                                  '-v', '/var/run/udev/:/var/run/udev/:z',
                                  '-v', '/dev:/dev', '-v', '/etc/ceph:/etc/ceph:z',  # noqa E501

--- a/tests/functional/bs-lvm-osds/container/hosts
+++ b/tests/functional/bs-lvm-osds/container/hosts
@@ -3,3 +3,4 @@ mon0
 
 [osds]
 osd0
+osd1 lvm_volumes="[{'data': 'data-lv1', 'data_vg': 'test_group'},{'data': 'data-lv2', 'data_vg': 'test_group'}]" dmcrypt=True

--- a/tests/functional/bs-lvm-osds/container/vagrant_variables.yml
+++ b/tests/functional/bs-lvm-osds/container/vagrant_variables.yml
@@ -5,7 +5,7 @@ docker: true
 
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 1
-osd_vms: 1
+osd_vms: 2
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0

--- a/tests/functional/bs-lvm-osds/hosts
+++ b/tests/functional/bs-lvm-osds/hosts
@@ -3,3 +3,4 @@ mon0
 
 [osds]
 osd0
+osd1 lvm_volumes="[{'data': 'data-lv1', 'data_vg': 'test_group'},{'data': 'data-lv2', 'data_vg': 'test_group'}]" dmcrypt=True

--- a/tests/functional/bs-lvm-osds/vagrant_variables.yml
+++ b/tests/functional/bs-lvm-osds/vagrant_variables.yml
@@ -5,7 +5,7 @@ docker: false
 
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 1
-osd_vms: 1
+osd_vms: 2
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0


### PR DESCRIPTION
- this is needed to properly handle semaphore synchronization for udev
actions via dmcrypt/cryptsetup.
- add lvm+bluestore+dmcrypt testing in the CI
- update ceph-volume tests

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1683770