### PR TITLE
mergify: need 2 approvals to merge a 'skip ci' PR

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,7 +15,7 @@ pull_request_rules:
     conditions:
       - label!=DNM
       - title~=\[skip ci\]
-      - '#approved-reviews-by>=1'
+      - '#approved-reviews-by>=2'
     actions:
       merge:
         method: rebase


### PR DESCRIPTION
This will avoid merging PR with 1 approval + [skip ci]

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>