### PR TITLE
osd: add ipc=host in systemd template for containers

### DIFF
--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -75,6 +75,7 @@ fi
   --net=host \
   --privileged=true \
   --pid=host \
+  --ipc=host \
   {% if osd_objectstore == 'filestore' -%}
   --memory={{ ceph_osd_docker_memory_limit }} \
   {% endif -%}

--- a/tox.ini
+++ b/tox.ini
@@ -318,7 +318,6 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/reboot.yml
 
   # wait 30sec for services to be ready
-  sleep 30
   # retest to ensure cluster came back up correctly after rebooting
   testinfra -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
 


### PR DESCRIPTION
in addition to 15812970f033206b8680cc68351952d49cc18314

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>