### PR TITLE
mds: allow cephFS pool to be created with specific rule_name

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -350,9 +350,24 @@ dummy:
 #cephfs_data: cephfs_data # name of the data pool for a given filesystem
 #cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
+#cephfs_data_pool:
+#  name: "{{ cephfs_data }}"
+#  pgs: "{{ osd_pool_default_pg_num }}"
+#  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_min_size }}"
+#  rule_name: "replicated_rule"
+#
+#cephfs_metadata_pool:
+#  name: "{{ cephfs_metadata }}"
+#  pgs: "{{ osd_pool_default_pg_num }}"
+#  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_min_size }}"
+#  rule_name: "replicated_rule"
+#
+#
 #cephfs_pools:
-#  - { name: "{{ cephfs_data }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}", min_size: "{{ osd_pool_default_min_size }}"}
-#  - { name: "{{ cephfs_metadata }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}", min_size: "{{ osd_pool_default_min_size }}"}
+#  - "{{ cephfs_data_pool }}"
+#  - "{{ cephfs_metadata_pool }}"
 
 ## OSD options
 #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -350,9 +350,24 @@ ceph_rhcs_version: 3
 #cephfs_data: cephfs_data # name of the data pool for a given filesystem
 #cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
+#cephfs_data_pool:
+#  name: "{{ cephfs_data }}"
+#  pgs: "{{ osd_pool_default_pg_num }}"
+#  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_min_size }}"
+#  rule_name: "replicated_rule"
+#
+#cephfs_metadata_pool:
+#  name: "{{ cephfs_metadata }}"
+#  pgs: "{{ osd_pool_default_pg_num }}"
+#  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_min_size }}"
+#  rule_name: "replicated_rule"
+#
+#
 #cephfs_pools:
-#  - { name: "{{ cephfs_data }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}", min_size: "{{ osd_pool_default_min_size }}"}
-#  - { name: "{{ cephfs_metadata }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}", min_size: "{{ osd_pool_default_min_size }}"}
+#  - "{{ cephfs_data_pool }}"
+#  - "{{ cephfs_metadata_pool }}"
 
 ## OSD options
 #

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -342,9 +342,24 @@ cephfs: cephfs # name of the ceph filesystem
 cephfs_data: cephfs_data # name of the data pool for a given filesystem
 cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
+cephfs_data_pool:
+  name: "{{ cephfs_data }}"
+  pgs: "{{ osd_pool_default_pg_num }}"
+  size: "{{ osd_pool_default_size }}"
+  min_size: "{{ osd_pool_default_min_size }}"
+  rule_name: "replicated_rule"
+
+cephfs_metadata_pool:
+  name: "{{ cephfs_metadata }}"
+  pgs: "{{ osd_pool_default_pg_num }}"
+  size: "{{ osd_pool_default_size }}"
+  min_size: "{{ osd_pool_default_min_size }}"
+  rule_name: "replicated_rule"
+
+
 cephfs_pools:
-  - { name: "{{ cephfs_data }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}", min_size: "{{ osd_pool_default_min_size }}"}
-  - { name: "{{ cephfs_metadata }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}", min_size: "{{ osd_pool_default_min_size }}"}
+  - "{{ cephfs_data_pool }}"
+  - "{{ cephfs_metadata_pool }}"
 
 ## OSD options
 #

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -21,9 +21,20 @@
   delegate_to: "{{ groups[mon_group_name][0] }}"
   block:
     - name: create filesystem pools
-      command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool create {{ item.name }} {{ item.pgs | default(osd_pool_default_pg_num) }}"
+      command: >
+        {{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
+        osd pool create {{ item.name }}
+        {{ item.pg_num | default(item.pgs) | default(osd_pool_default_pg_num) }}
+        {{ item.pgp_num | default(item.pgs) | default(item.pg_num) | default(osd_pool_default_pg_num) }}
+        {{ 'replicated_rule' if not item.rule_name | default('replicated_rule') else item.rule_name | default('replicated_rule') }}
+        {{ 1 if item.type|default(1) == 'replicated' else 3 if item.type|default(1) == 'erasure' else item.type|default(1) }}
+        {%- if (item.type | default("1") == '3' or item.type | default("1") == 'erasure') and item.erasure_profile != '' %}
+        {{ item.erasure_profile }}
+        {%- endif %}
+        {{ item.expected_num_objects | default('') }}
       changed_when: false
-      with_items: "{{ cephfs_pools }}"
+      with_items:
+        - "{{ cephfs_pools }}"
 
     - name: customize pool size
       command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} size {{ item.size | default(osd_pool_default_size) }}"


### PR DESCRIPTION
Allow pools  cephfs_data, cephfs_metadata to be created with specific rule_name.

example group_vars/all.yml
```
##########
# CEPHFS #
##########
cephfs: cephfs # name of the ceph filesystem
cephfs_data: cephfs_data # name of the data pool for a given filesystem
cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem

cephfs_data_pool:
  name: "{{cephfs_data}}"
  pg_num: "64"
  pgp_num: "64"
#  pgs: "64"
  rule_name: "replicated_rack"
  type: 1
  erasure_profile: ""
  expected_num_objects: ""

cephfs_metadata_pool:
  name: "{{cephfs_metadata}}"
  pg_num: "64"
  pgp_num: "64"
#  pgs: "64"
  rule_name: "replicated_rack"
  type: 1
  erasure_profile: ""
  expected_num_objects: ""


cephfs_pools:
  - "{{ cephfs_data_pool }}"
  - "{{ cephfs_metadata_pool }}"
```

