### PR TITLE
Add changed_when: false to the "get osd ids" statement

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -37,6 +37,7 @@
 - name: get osd ids
   shell: |
     ls /var/lib/ceph/osd/ | sed 's/.*-//'
+  changed_when: false
   register: osd_ids_non_container
 
 - name: set_fact docker_exec_start_osd


### PR DESCRIPTION
The "get osd ids" statement only registers the osd_ids_non_container variable. Running "ls /var/lib/ceph/osd/ | sed 's/.*-//'" should never produce a change on the system. Adding changed_went: false prevents irrelevant change messages from Ansible.

Signed-off-by: Kevin Coakley <kcoakley@sdsc.edu>