### PR TITLE
Customize pools min_size

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -352,8 +352,8 @@ dummy:
 #cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
 #cephfs_pools:
-#  - { name: "{{ cephfs_data }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}" }
-#  - { name: "{{ cephfs_metadata }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}" }
+#  - { name: "{{ cephfs_data }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}", min_size: "{{ osd_pool_default_size }}" }
+#  - { name: "{{ cephfs_metadata }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}", min_size: "{{ osd_pool_default_size }}" }
 
 ## OSD options
 #
@@ -583,6 +583,7 @@ dummy:
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_cinder_pool:
 #  name: "volumes"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -593,6 +594,7 @@ dummy:
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_nova_pool:
 #  name: "vms"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -603,6 +605,7 @@ dummy:
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_cinder_backup_pool:
 #  name: "backups"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -613,6 +616,7 @@ dummy:
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_gnocchi_pool:
 #  name: "metrics"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -623,6 +627,7 @@ dummy:
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_cephfs_data_pool:
 #  name: "manila_data"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -633,6 +638,7 @@ dummy:
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_cephfs_metadata_pool:
 #  name: "manila_metadata"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -643,6 +649,7 @@ dummy:
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 
 #openstack_pools:
 #  - "{{ openstack_glance_pool }}"

--- a/group_vars/clients.yml.sample
+++ b/group_vars/clients.yml.sample
@@ -28,6 +28,7 @@ dummy:
 #  erasure_profile: ""
 #  expected_num_objects: ""
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #test2:
 #  name: "test2"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -38,6 +39,7 @@ dummy:
 #  erasure_profile: ""
 #  expected_num_objects: ""
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #pools:
 #  - "{{ test }}"
 #  - "{{ test2 }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -352,8 +352,8 @@ ceph_rhcs_version: 3
 #cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
 #cephfs_pools:
-#  - { name: "{{ cephfs_data }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}" }
-#  - { name: "{{ cephfs_metadata }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}" }
+#  - { name: "{{ cephfs_data }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}",min_size: "{{ osd_pool_default_min_size }}" }
+#  - { name: "{{ cephfs_metadata }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}", min_size: "{{ osd_pool_default_min_size }}" }
 
 ## OSD options
 #
@@ -583,6 +583,7 @@ ceph_docker_registry: "registry.access.redhat.com/rhceph/"
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_cinder_pool:
 #  name: "volumes"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -593,6 +594,7 @@ ceph_docker_registry: "registry.access.redhat.com/rhceph/"
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_nova_pool:
 #  name: "vms"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -603,6 +605,7 @@ ceph_docker_registry: "registry.access.redhat.com/rhceph/"
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_cinder_backup_pool:
 #  name: "backups"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -613,6 +616,7 @@ ceph_docker_registry: "registry.access.redhat.com/rhceph/"
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_gnocchi_pool:
 #  name: "metrics"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -623,6 +627,7 @@ ceph_docker_registry: "registry.access.redhat.com/rhceph/"
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_cephfs_data_pool:
 #  name: "manila_data"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -633,6 +638,7 @@ ceph_docker_registry: "registry.access.redhat.com/rhceph/"
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 #openstack_cephfs_metadata_pool:
 #  name: "manila_metadata"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -643,6 +649,7 @@ ceph_docker_registry: "registry.access.redhat.com/rhceph/"
 #  expected_num_objects: ""
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
+#  min_size: "{{ osd_pool_default_size }}"
 
 #openstack_pools:
 #  - "{{ openstack_glance_pool }}"

--- a/roles/ceph-client/defaults/main.yml
+++ b/roles/ceph-client/defaults/main.yml
@@ -20,6 +20,7 @@ test:
   erasure_profile: ""
   expected_num_objects: ""
   size: "{{ osd_pool_default_size }}"
+  min_size: "{{ osd_pool_default_min_size }}"
 test2:
   name: "test2"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -30,6 +31,7 @@ test2:
   erasure_profile: ""
   expected_num_objects: ""
   size: "{{ osd_pool_default_size }}"
+  min_size: "{{ osd_pool_default_min_size }}"
 pools:
   - "{{ test }}"
   - "{{ test2 }}"

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -113,6 +113,17 @@
         - pools | length > 0
         - item.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
 
+    - name: customize pool min_size
+      command: >
+        {{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }}
+        osd pool set {{ item.name }} min_size {{ item.min_size | default(osd_pool_default_min_size) }}
+      with_items: "{{ pools | unique }}"
+      delegate_to: "{{ delegated_node }}"
+      changed_when: false
+      when:
+        - pools | length > 0
+        - item.min_size | default(osd_pool_default_min_size) != ceph_osd_pool_default_min_size
+
     - name: assign application to pool(s)
       command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"
       with_items: "{{ pools | unique }}"
@@ -120,7 +131,6 @@
       delegate_to: "{{ delegated_node }}"
       when:
         - item.application is defined
-
 
 - name: get client cephx keys
   copy:

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -344,8 +344,8 @@ cephfs_data: cephfs_data # name of the data pool for a given filesystem
 cephfs_metadata: cephfs_metadata # name of the metadata pool for a given filesystem
 
 cephfs_pools:
-  - { name: "{{ cephfs_data }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}" }
-  - { name: "{{ cephfs_metadata }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}" }
+  - { name: "{{ cephfs_data }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}", min_size: "{{ osd_pool_default_min_size }}"}
+  - { name: "{{ cephfs_metadata }}", pgs: "{{ osd_pool_default_pg_num }}", size: "{{ osd_pool_default_size }}", min_size: "{{ osd_pool_default_min_size }}"}
 
 ## OSD options
 #
@@ -575,6 +575,7 @@ openstack_glance_pool:
   expected_num_objects: ""
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
+  min_size: "{{ osd_pool_default_min_size }}"
 openstack_cinder_pool:
   name: "volumes"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -585,6 +586,7 @@ openstack_cinder_pool:
   expected_num_objects: ""
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
+  min_size: "{{ osd_pool_default_min_size }}"
 openstack_nova_pool:
   name: "vms"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -595,6 +597,7 @@ openstack_nova_pool:
   expected_num_objects: ""
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
+  min_size: "{{ osd_pool_default_min_size }}"
 openstack_cinder_backup_pool:
   name: "backups"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -605,6 +608,7 @@ openstack_cinder_backup_pool:
   expected_num_objects: ""
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
+  min_size: "{{ osd_pool_default_min_size }}"
 openstack_gnocchi_pool:
   name: "metrics"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -615,6 +619,7 @@ openstack_gnocchi_pool:
   expected_num_objects: ""
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
+  min_size: "{{ osd_pool_default_min_size }}"
 openstack_cephfs_data_pool:
   name: "manila_data"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -625,6 +630,7 @@ openstack_cephfs_data_pool:
   expected_num_objects: ""
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
+  min_size: "{{ osd_pool_default_min_size }}"
 openstack_cephfs_metadata_pool:
   name: "manila_metadata"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -635,6 +641,7 @@ openstack_cephfs_metadata_pool:
   expected_num_objects: ""
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
+  min_size: "{{ osd_pool_default_min_size }}"
 
 openstack_pools:
   - "{{ openstack_glance_pool }}"

--- a/roles/ceph-defaults/vars/main.yml
+++ b/roles/ceph-defaults/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 ceph_osd_pool_default_size: 3
+ceph_osd_pool_default_min_size: 0
 ceph_osd_pool_default_pg_num: 8

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -245,6 +245,10 @@
   set_fact:
     osd_pool_default_size: "{{ ceph_conf_overrides.get('global', {}).get('osd_pool_default_size', ceph_osd_pool_default_size) }}"
 
+- name: set_fact osd_pool_default_min_size
+  set_fact:
+    osd_pool_default_min_size: "{{ ceph_conf_overrides.get('global', {}).get('osd_pool_default_min_size', ceph_osd_pool_default_min_size) }}"
+
 - name: import_tasks set_monitor_address.yml
   import_tasks: set_monitor_address.yml
 

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -16,6 +16,14 @@
       when:
         - item.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
 
+    - name: customize pool min_size
+      command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} min_size {{ item.min_size | default(osd_pool_default_min_size) }}"
+      with_items: "{{ cephfs_pools | unique }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      changed_when: false
+      when:
+        - item.min_size | default(osd_pool_default_min_size) != ceph_osd_pool_default_min_size
+
 - name: check if ceph filesystem already exists
   command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} fs get {{ cephfs }}"
   register: check_existing_cephfs

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -52,6 +52,16 @@
       when:
         - item.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
 
+    - name: customize pool min_size
+      command: >
+        {{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
+        osd pool set {{ item.name }} min_size {{ item.min_size | default(osd_pool_default_min_size) }}
+      with_items: "{{ openstack_pools | unique }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      changed_when: false
+      when:
+        - item.min_size | default(osd_pool_default_min_size) != ceph_osd_pool_default_min_size
+
     - name: assign application to pool(s)
       command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"
       with_items: "{{ openstack_pools | unique }}"


### PR DESCRIPTION
Let user decide what min_size a pool should have.


```
kuberbd:
  name: "kuberbd"
  size: "2"
  min_size: "1"
  pg_num: "64"
  pgp_num: "64"
  rule_name: "replicated_rack"
  type: 1
  erasure_profile: ""
  expected_num_objects: ""
  application: "rbd"
```

Change is for any kind of pool 
openstack_pools
cephfs_data, cephfs_metadata
client.pools(clients.yml) - like kuberbd example
