### PR TITLE
purge: fix purge of lvm devices

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -118,7 +118,7 @@
 - name: purge ceph rbd-mirror cluster
 
   vars:
-    rbdmirror_group_name: rbd-mirrors
+    rbdmirror_group_name: rbdmirrors
 
   hosts:
     - "{{ rbdmirror_group_name|default('rbdmirrors') }}"

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -131,7 +131,7 @@
 
   - name: stop ceph rbd mirror with systemd
     service:
-      name: ceph-rbd-mirror@admin.service
+      name: "ceph-rbd-mirror@rbd-mirror.{{ ansible_hostname }}"
       state: stopped
     failed_when: false
 

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -573,7 +573,7 @@
       state: absent
 
   - name: clean apt
-    shell: apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    command: apt-get clean
     when: ansible_pkg_mgr == 'apt'
 
   - name: purge rh_storage.repo file in /etc/yum.repos.d

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -304,7 +304,7 @@
     register: ceph_lockbox_partition_to_erase_path
 
   - name: see if ceph-volume is installed
-    command: "command -v ceph-volume"
+    shell: "command -v ceph-volume"
     failed_when: false
     register: ceph_volume_present
 


### PR DESCRIPTION
using `shell` module seems to be the only way to make this task working
on rhel based distribution AND debian based distributions.

on ubuntu, using `command` ansible module fails like following
(not due to `sudo` usage or not):
```
ok: [osd1] => changed=false
  cmd: command -v ceph-volume
  failed_when_result: false
  msg: '[Errno 2] No such file or directory: ''command'': ''command'''
  rc: 2
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1653307

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>