### PR TITLE
purge: do not blindly remove everything in /tmp/*

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -573,7 +573,7 @@
       state: absent
 
   - name: clean apt
-    shell: apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    command: apt-get clean
     when: ansible_pkg_mgr == 'apt'
 
   - name: purge rh_storage.repo file in /etc/yum.repos.d


### PR DESCRIPTION
/tmp/* isn't specific to ceph, let's not remove things this way.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>