### PR TITLE
add-osd: gather facts in second part of playbook

### DIFF
--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -55,7 +55,27 @@
   gather_facts: False
   become: True
 
+  vars:
+    delegate_facts_host: True
+
   pre_tasks:
+
+    - name: gather facts
+      setup:
+      when:
+        - not delegate_facts_host | bool
+
+    - name: gather and delegate facts
+      setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: True
+      with_items:
+        - "{{ groups['mons'] }}"
+        - "{{ groups['osds'] }}"
+      run_once: True
+      when:
+        - delegate_facts_host | bool
+
     # this task is needed so we can skip the openstack_config.yml include in roles/ceph-osd
     - name: set_fact add_osd
       set_fact:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 # These are Python requirements needed to run the functional tests
 six==1.10.0
-testinfra
+testinfra==1.19.0
 pytest-xdist
 pytest==3.6.1
 notario>=0.0.13

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands=
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
   # test that the cluster can be redeployed in a healthy state
-  testinfra -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
+  py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
 
 [purge-lvm]
 commands=
@@ -99,7 +99,7 @@ commands=
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
   # test that the cluster can be redeployed in a healthy state
-  testinfra -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
+  py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
 
 # extra commands for performing a rolling update
 [update]
@@ -116,7 +116,7 @@ commands=
       ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
   "
 
-  bash -c "CEPH_STABLE_RELEASE={env:UPDATE_CEPH_STABLE_RELEASE:nautilus} testinfra -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests"
+  bash -c "CEPH_STABLE_RELEASE={env:UPDATE_CEPH_STABLE_RELEASE:nautilus} py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests"
 
 [shrink-mon]
 commands=
@@ -150,7 +150,7 @@ commands=
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
 
-  testinfra -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-switch-to-containers {toxinidir}/tests/functional/tests
+  py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-switch-to-containers {toxinidir}/tests/functional/tests
 
 [add-osds]
 commands=
@@ -167,7 +167,7 @@ commands=
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       "
-  testinfra -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-2 {toxinidir}/tests/functional/tests
+  py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-2 {toxinidir}/tests/functional/tests
 
 [rgw-multisite]
 commands=
@@ -312,14 +312,14 @@ commands=
   # wait 30sec for services to be ready
   sleep 30
   # test cluster state using ceph-ansible tests
-  testinfra -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
+  py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
 
   # reboot all vms
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/reboot.yml
 
   # wait 30sec for services to be ready
   # retest to ensure cluster came back up correctly after rebooting
-  testinfra -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
+  py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
 
   # handlers/idempotency test
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} \


### PR DESCRIPTION
otherwise, it will end up with error like following:

```
FAILED! => {"msg": "'ansible.vars.hostvars.HostVarsVars object' has no attribute 'ansible_hostname'"}
```

because facts won't have been gathered.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1670663

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>