### PR TITLE
fix pool min_size customization

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -122,7 +122,7 @@
       changed_when: false
       when:
         - pools | length > 0
-        - item.min_size | default(osd_pool_default_min_size) != ceph_osd_pool_default_min_size
+        - item.min_size | default(osd_pool_default_min_size) > ceph_osd_pool_default_min_size
 
     - name: assign application to pool(s)
       command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -22,7 +22,7 @@
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
       when:
-        - item.min_size | default(osd_pool_default_min_size) != ceph_osd_pool_default_min_size
+        - item.min_size | default(osd_pool_default_min_size) > ceph_osd_pool_default_min_size
 
 - name: check if ceph filesystem already exists
   command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} fs get {{ cephfs }}"

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -60,7 +60,7 @@
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
       when:
-        - item.min_size | default(osd_pool_default_min_size) != ceph_osd_pool_default_min_size
+        - item.min_size | default(osd_pool_default_min_size) > ceph_osd_pool_default_min_size
 
     - name: assign application to pool(s)
       command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"


### PR DESCRIPTION
b8d580b3f48c69ba9882df773c4d144b73d01c95 introduced a bug when
`min_size` isn't set (default to 0).

Typical error:

```
Error EINVAL: pool min_size must be between 1 and 1
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>