### PR TITLE
Add CONTAINER_IMAGE env var to ceph daemons

### DIFF
--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -23,6 +23,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   -v /etc/ceph:/etc/ceph \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=RBD_TARGET_API \
+  -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   --name=rbd-target-api \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop rbd-target-api

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -23,6 +23,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   -v /etc/ceph:/etc/ceph \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=RBD_TARGET_GW \
+  -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   --name=rbd-target-gw \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop rbd-target-gw

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   -v /etc/ceph:/etc/ceph \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=TCMU_RUNNER \
+  -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   --name=tcmu-runner \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop tcmu-runner

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -19,6 +19,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -v /etc/localtime:/etc/localtime:ro \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=MDS \
+  -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   {{ ceph_mds_docker_extra_env }} \
   --name=ceph-mds-{{ ansible_hostname }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -19,6 +19,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -v /etc/localtime:/etc/localtime:ro \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=MGR \
+  -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   {{ ceph_mgr_docker_extra_env }} \
   --name=ceph-mgr-{{ ansible_hostname }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -30,6 +30,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
   -e MON_PORT={{ ceph_mon_container_listen_port }} \
   -e CEPH_PUBLIC_NETWORK={{ public_network | regex_replace(' ', '') }} \
   -e CEPH_DAEMON=MON \
+  -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   {{ ceph_mon_docker_extra_env }} \
   {{ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStop=-/usr/bin/{{ container_binary }} stop ceph-mon-%i

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -v /etc/localtime:/etc/localtime:ro \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=NFS \
+  -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   {{ ceph_nfs_docker_extra_env }} \
   --name=ceph-nfs-{{ ceph_nfs_service_suffix | default(ansible_hostname) }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -117,6 +117,7 @@ fi
   $DOCKER_ENV \
   -e CEPH_DAEMON=OSD_CEPH_DISK_ACTIVATE \
   -e OSD_DEVICE=/dev/"${1}" \
+  -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   --name=ceph-osd-{{ ansible_hostname }}-"${1}" \
   {% endif -%}
   {{ ceph_osd_docker_extra_env }} \

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -19,6 +19,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -v /etc/localtime:/etc/localtime:ro \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=RBD_MIRROR \
+  -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   --name=ceph-rbd-mirror-{{ ansible_hostname }} \
   {{ ceph_rbd_mirror_docker_extra_env }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -24,6 +24,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -e CLUSTER={{ cluster }} \
   -e RGW_NAME={{ ansible_hostname }}.${INST_NAME} \
   -e RGW_CIVETWEB_PORT=${INST_PORT} \
+  -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   --name=ceph-rgw-{{ ansible_hostname }}-${INST_NAME} \
   {{ ceph_rgw_docker_extra_env }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}


### PR DESCRIPTION
Ceph daemons will set the CONTAINER_IMAGE environment variable value
in the daemon metadata.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>