### PR TITLE
Remove trailing forward slash in ceph_docker_registry variable from g…

### DIFF
--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -544,9 +544,9 @@ ceph_rhcs_version: 3
 ##########
 #docker_exec_cmd:
 #docker: false
-ceph_docker_image: "rhceph-3-rhel7"
+ceph_docker_image: "rhceph/rhceph-3-rhel7"
 ceph_docker_image_tag: "latest"
-ceph_docker_registry: "registry.access.redhat.com/rhceph/"
+ceph_docker_registry: "registry.access.redhat.com"
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -2,7 +2,7 @@ ceph_repository: rhcs
 ceph_origin: repository
 fetch_directory: ~/ceph-ansible-keys
 ceph_rhcs_version: 3
-ceph_docker_image: "rhceph-3-rhel7"
+ceph_docker_image: "rhceph/rhceph-3-rhel7"
 ceph_docker_image_tag: "latest"
-ceph_docker_registry: "registry.access.redhat.com/rhceph/"
+ceph_docker_registry: "registry.access.redhat.com"
 # END OF FILE, DO NOT TOUCH ME!


### PR DESCRIPTION
Remove trailing forward slash in ceph_docker_registry variable from group_vars/rhcs.yml.sample file.

This had caused the docker pull command in site-docker.yml.sample to fail due to the double forward slash // when rendered by Ansible to the command line.
For example: timeout 300s docker pull registry.access.redhat.com/rhceph//rhceph-3-rhel7:latest which is incorrect syntax.
Is not affected when using docker.io defaults for registry due to lack of trailing forward slash in the ceph_docker_registry variable.

Also fixed rhcs_edits.txt for variable ceph_docker_registry.

Signed-off-by: Phuong Nguyen <pnguyen@redhat.com>