### PR TITLE
tests: test upgrade from nautilus to nautilus

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -256,7 +256,6 @@ setenv=
   dev: UPDATE_CEPH_DEV_BRANCH = master
   dev: UPDATE_CEPH_DEV_SHA1 = latest
   dev: CEPH_STABLE_RELEASE = nautilus
-  update: CEPH_STABLE_RELEASE = mimic
   update: ROLLING_UPDATE = True
 
   ooo_collocation: CEPH_DOCKER_IMAGE_TAG = v3.0.3-stable-3.0-luminous-centos-7-x86_64


### PR DESCRIPTION
since ceph-ansible@master isn't able to deploy releases prior to
nautilus, we can't really test upgrade from luminous to nautilus at the
moment.
Waiting for a solution, let's at least test a rolling upgrade from
nautilus to nautilus (at least to make the job passing the ci...)

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>