### PR TITLE
tests: test upgrade from luminous to luminous

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -222,7 +222,6 @@ setenv=
   lvm_osds: CEPH_STABLE_RELEASE = luminous
   rhcs: CEPH_STABLE_RELEASE = luminous
   update: ROLLING_UPDATE = True
-  update: CEPH_STABLE_RELEASE = jewel
   container-update: CEPH_DOCKER_IMAGE_TAG = latest-jewel
   container-update: CEPH_DOCKER_IMAGE_TAG_BIS = latest-jewel-bis
   ooo_collocation: CEPH_DOCKER_IMAGE_TAG = v3.0.3-stable-3.0-luminous-centos-7-x86_64


### PR DESCRIPTION
since ceph-ansible@stable-3.2 isn't able to deploy releases prior to
luminous, we can't really test upgrade from jewel to luminous at the
moment.
Waiting for a solution, let's at least test a rolling upgrade from
luminous to luminous (at least to make the job passing the ci...)

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>