### PR TITLE
systemd/service: Set docker.service conditionally

### DIFF
--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -1,6 +1,8 @@
 [Unit]
 Description=RBD Target API Service
+{% if container_binary == 'docker' %}
 After=docker.service
+{% endif %}
 
 [Service]
 EnvironmentFile=-/etc/environment

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -1,6 +1,8 @@
 [Unit]
 Description=RBD Target Gateway Service
+{% if container_binary == 'docker' %}
 After=docker.service
+{% endif %}
 
 [Service]
 EnvironmentFile=-/etc/environment

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -1,6 +1,8 @@
 [Unit]
 Description=TCMU Runner
+{% if container_binary == 'docker' %}
 After=docker.service
+{% endif %}
 
 [Service]
 EnvironmentFile=-/etc/environment

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -1,6 +1,8 @@
 [Unit]
 Description=Ceph MDS
+{% if container_binary == 'docker' %}
 After=docker.service
+{% endif %}
 
 [Service]
 EnvironmentFile=-/etc/environment

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -1,6 +1,8 @@
 [Unit]
 Description=Ceph Manager
+{% if container_binary == 'docker' %}
 After=docker.service
+{% endif %}
 
 [Service]
 EnvironmentFile=-/etc/environment

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -1,6 +1,8 @@
 [Unit]
 Description=Ceph Monitor
+{% if container_binary == 'docker' %}
 After=docker.service
+{% endif %}
 
 [Service]
 EnvironmentFile=-/etc/environment

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -1,7 +1,9 @@
 [Unit]
 Description=NFS-Ganesha file server
 Documentation=http://github.com/nfs-ganesha/nfs-ganesha/wiki
+{% if container_binary == 'docker' %}
 After=docker.service
+{% endif %}
 
 [Service]
 EnvironmentFile=-/etc/environment

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -1,7 +1,9 @@
 # {{ ansible_managed }}
 [Unit]
 Description=Ceph OSD
+{% if container_binary == 'docker' %}
 After=docker.service
+{% endif %}
 
 [Service]
 EnvironmentFile=-/etc/environment

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -1,6 +1,8 @@
 [Unit]
 Description=Ceph RBD mirror
+{% if container_binary == 'docker' %}
 After=docker.service
+{% endif %}
 
 [Service]
 EnvironmentFile=-/etc/environment

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -1,6 +1,8 @@
 [Unit]
 Description=Ceph RGW
+{% if container_binary == 'docker' %}
 After=docker.service
+{% endif %}
 
 [Service]
 EnvironmentFile=/var/lib/ceph/radosgw/ceph-%i/EnvironmentFile


### PR DESCRIPTION
We don't need to set After=docker.service when the container_binary
variable isn't set to docker.
It doesn't break anything currently but it could be confusing when
using podman.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>