### PR TITLE
ceph-osd: Install numactl package when needed

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -12,6 +12,17 @@
     - not containerized_deployment
     - ansible_os_family != 'ClearLinux'
 
+- name: install numactl when needed
+  package:
+    name: numactl
+  register: result
+  until: result is succeeded
+  when:
+    - containerized_deployment
+    - ceph_osd_numactl_opts != ""
+  tags:
+    - with_pkg
+
 - name: include_tasks common.yml
   include_tasks: common.yml
 


### PR DESCRIPTION
With 3e32dce we can run OSD containers with numactl support.
When using numactl command in a containerized deployment we need to
be sure that the corresponding package is installed on the host.
The package installation is only executed when the
ceph_osd_numactl_opts variable isn't empty.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>