### PR TITLE
ceph-validate: fail if there's no ipaddr available in monitor_address…

### DIFF
--- a/roles/ceph-validate/tasks/check_ipaddr_mon.yml
+++ b/roles/ceph-validate/tasks/check_ipaddr_mon.yml
@@ -1,0 +1,6 @@
+---
+- name: "fail if {{ inventory_hostname }} does not have any {{ ip_version }} address on {{ monitor_address_block }}"
+  fail:
+    msg: "{{ inventory_hostname }} does not have any {{ ip_version }} address on {{ monitor_address_block }}"
+  when:
+    - hostvars[inventory_hostname]['ansible_all_' + ip_version + '_addresses'] | ipaddr(hostvars[inventory_hostname]['monitor_address_block']) | length == 0

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -70,6 +70,14 @@
     - monitor_address == "0.0.0.0"
     - monitor_address_block == "subnet"
 
+- name: include check_ipaddr_mon.yml
+  include_tasks: check_ipaddr_mon.yml
+  when:
+    - mon_group_name in group_names
+    - monitor_interface == "interface"
+    - monitor_address == "0.0.0.0"
+    - monitor_address_block != "subnet"
+
 - name: include check_eth_rgw.yml
   include_tasks: check_eth_rgw.yml
   when:


### PR DESCRIPTION
…_block subnet

When using monitor_address_block to determine the ip address of the
monitor node, we need an ip address available in that cidr to be
present in the ansible facts (ansible_all_ipv[46]_addresses).
Currently we don't check if there's an ip address available during
the ceph-validate role.
As a result, the ceph-config role fails due to an empty list during
ceph.conf template creation but the error isn't explicit.

TASK [ceph-config : generate ceph.conf configuration file] *****
fatal: [0]: FAILED! => {"msg": "No first item, sequence was empty."}

With this patch we will fail before the ceph deployment with an
explicit failure message.

Resolves: rhbz#1673687

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>