### PR TITLE
a full stop should not be part of the filename

### DIFF
--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -121,7 +121,7 @@ caps:
 
 - name: create monitor initial keyring
   ceph_key:
-    name: mon.
+    name: mon
     state: present
     secret: AQAin8tUMICVFBAALRHNrV0Z4MXupRw4v9JQ6Q==
     caps:

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -13,7 +13,7 @@
 
 - name: create monitor initial keyring
   ceph_key:
-    name: mon.
+    name: mon
     state: present
     dest: "/var/lib/ceph/tmp/"
     secret: "{{ monitor_keyring.stdout }}"


### PR DESCRIPTION
Besides, ceph_key.py takes care of adding a full stop since elsewhere
full stop is not made part of the filename.