### PR TITLE
Change docker_container parameter network to network_mode

### DIFF
--- a/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
+++ b/roles/ceph-mon/tasks/docker/start_docker_monitor.yml
@@ -4,7 +4,7 @@
     name: populate-kv-store
     image: "{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
     command: populate_kvstore
-    network: host
+    network_mode: host
     env:
       KV_TYPE: "{{kv_type}}"
       KV_IP: "{{kv_endpoint}}"
@@ -20,7 +20,7 @@
     name: populate-kv-store
     image: "{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
     command: populate_kvstore
-    network: host
+    network_mode: host
     env:
       KV_TYPE: "{{kv_type}}"
       KV_IP: "{{kv_endpoint}}"

--- a/roles/ceph-restapi/tasks/docker/start_docker_restapi.yml
+++ b/roles/ceph-restapi/tasks/docker/start_docker_restapi.yml
@@ -3,7 +3,7 @@
   docker_container:
     image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
     name: "ceph-restapi-{{ ansible_hostname }}"
-    network: host
+    network_mode: host
     expose: "{{ ceph_restapi_port }}"
     state: running
     env: "RESTAPI_IP={{ hostvars[inventory_hostname]['ansible_' + ceph_restapi_docker_interface]['ipv4']['address'] }},CEPH_DAEMON=RESTAPI,{{ ceph_restapi_docker_extra_env }}"


### PR DESCRIPTION
Addressing "populate kv_store with custom ceph.conf":
Unsupported parameters for (docker_container) module. Looking at
https://docs.ansible.com/ansible/latest/modules/docker_container_module.html
shows that the correct parameter is network_mode, not network.

Signed-off-by: Gregory Orange <gregoryo2014@users.noreply.github.com>