### PR TITLE
ceph_volume: fix rstrip for python 3

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -630,8 +630,8 @@ def run_module():
         end=str(endd),
         delta=str(delta),
         rc=rc,
-        stdout=out.rstrip(b'\r\n'),
-        stderr=err.rstrip(b'\r\n'),
+        stdout=out.rstrip('\r\n'),
+        stderr=err.rstrip('\r\n'),
         changed=changed,
     )
 


### PR DESCRIPTION
Since the same effect as described in #3565 also applies to ceph_volume it would be nice if this could be backported to stable-3.2 (in master this was already changed in a96e910114529aba0fe29edb11b314ae742ece45).