### PR TITLE
ceph_crush: fix rstrip for python 3

### DIFF
--- a/library/ceph_crush.py
+++ b/library/ceph_crush.py
@@ -145,7 +145,7 @@ def exec_commands(module, cmd_list):
     Creates Ceph commands
     '''
     for cmd in cmd_list:
-        rc, out, err = module.run_command(cmd, encoding=None)
+        rc, out, err = module.run_command(cmd)
     return rc, cmd, out, err
 
 
@@ -193,8 +193,8 @@ def run_module():
         end=str(endd),
         delta=str(delta),
         rc=rc,
-        stdout=out.rstrip(b"\r\n"),
-        stderr=err.rstrip(b"\r\n"),
+        stdout=out.rstrip("\r\n"),
+        stderr=err.rstrip("\r\n"),
         changed=True,
     )
 


### PR DESCRIPTION
Removing bytes literals since rstrip only supports type String or None.

Please backport to stable-3.2 as discussed in #3725