### PR TITLE
rolling_update: migrate ceph-disk osds to ceph-volume

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -844,7 +844,7 @@
       when: containerized_deployment
 
     - name: non container | disallow pre-nautilus OSDs and enable all new nautilus-only functionality
-      command: ceph osd require-osd-release nautilus
+      command: "ceph --cluster {{ cluster }} osd require-osd-release nautilus"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
       when: not containerized_deployment
@@ -856,7 +856,7 @@
       when: containerized_deployment
 
     - name: non container | enable msgr2 protocol
-      command: ceph mon enable-msgr2
+      command: "ceph --cluster {{ cluster }} mon enable-msgr2"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
       when: not containerized_deployment

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -413,6 +413,22 @@
       when:
         - containerized_deployment
 
+    - name: scan ceph-disk osds with ceph-volume if deploying nautilus
+      command: "ceph-volume --cluster={{ cluster }} simple scan"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+      when:
+        - ceph_release in ["nautilus", "octopus"]
+        - not containerized_deployment
+
+    - name: activate scanned ceph-disk osds and migrate to ceph-volume if deploying nautilus
+      command: "ceph-volume --cluster={{ cluster }} simple activate --all"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+      when:
+        - ceph_release in ["nautilus", "octopus"]
+        - not containerized_deployment
+
     - name: set_fact docker_exec_cmd_osd
       set_fact:
         docker_exec_cmd_update_osd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -359,6 +359,12 @@
       changed_when: false
       when: containerized_deployment
 
+    - name: set num_osds for container
+      set_fact:
+        num_osds: "{{ osd_names.stdout_lines|default([])|length }}"
+      when:
+        - containerized_deployment
+
     - name: stop ceph osd
       systemd:
         name: ceph-osd@{{ item }}
@@ -366,6 +372,12 @@
         enabled: no
         masked: yes
       with_items: "{{ osd_ids.stdout_lines }}"
+      when:
+        - not containerized_deployment
+
+    - name: set num_osds for non container
+      set_fact:
+        num_osds: "{{ osd_ids.stdout_lines|default([])|length }}"
       when:
         - not containerized_deployment
 

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -7,6 +7,9 @@
 - name: config file operations related to OSDs
   when:
     - inventory_hostname in groups.get(osd_group_name, [])
+    # the rolling_update.yml playbook sets num_osds to the number of currently
+    # running osds
+    - not rolling_update
   block:
   - name: count number of osds for lvm scenario
     set_fact:

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -50,6 +50,7 @@
   include_tasks: scenarios/lvm.yml
   when:
     - lvm_volumes|length > 0
+    - not rolling_update|default(False)
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 
@@ -57,6 +58,7 @@
   include_tasks: scenarios/lvm-batch.yml
   when:
     - devices|length > 0
+    - not rolling_update|default(False)
   # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
   static: False
 

--- a/tests/functional/migrate_ceph_disk_to_ceph_volume/Vagrantfile
+++ b/tests/functional/migrate_ceph_disk_to_ceph_volume/Vagrantfile
@@ -1,0 +1,1 @@
+../../../Vagrantfile

--- a/tests/functional/migrate_ceph_disk_to_ceph_volume/group_vars/all
+++ b/tests/functional/migrate_ceph_disk_to_ceph_volume/group_vars/all
@@ -1,0 +1,22 @@
+---
+
+ceph_origin: repository
+ceph_repository: community
+cluster: test
+public_network: "192.168.1.0/24"
+cluster_network: "192.168.2.0/24"
+monitor_interface: eth1
+journal_size: 100
+osd_objectstore: "bluestore"
+devices:
+  - '/dev/sdb'
+  - '/dev/sdc'
+osd_scenario: "collocated"
+copy_admin_key: false
+os_tuning_params:
+  - { name: kernel.pid_max, value: 4194303 }
+  - { name: fs.file-max, value: 26234859 }
+ceph_conf_overrides:
+  global:
+    osd_pool_default_pg_num: 8
+    osd_pool_default_size: 1

--- a/tests/functional/migrate_ceph_disk_to_ceph_volume/hosts
+++ b/tests/functional/migrate_ceph_disk_to_ceph_volume/hosts
@@ -1,0 +1,10 @@
+[mons]
+mon0
+mon1
+mon2
+
+[osds]
+osd0 
+
+[mgrs]
+mon0

--- a/tests/functional/migrate_ceph_disk_to_ceph_volume/vagrant_variables.yml
+++ b/tests/functional/migrate_ceph_disk_to_ceph_volume/vagrant_variables.yml
@@ -1,0 +1,73 @@
+---
+
+# DEPLOY CONTAINERIZED DAEMONS
+docker: false
+
+# DEFINE THE NUMBER OF VMS TO RUN
+mon_vms: 3
+osd_vms: 1
+mds_vms: 0
+rgw_vms: 0
+nfs_vms: 0
+rbd_mirror_vms: 0
+client_vms: 0
+iscsi_gw_vms: 0
+mgr_vms: 0
+
+
+# INSTALL SOURCE OF CEPH
+# valid values are 'stable' and 'dev'
+ceph_install_source: stable
+
+# SUBNETS TO USE FOR THE VMS
+public_subnet: 192.168.1
+cluster_subnet: 192.168.2
+
+# MEMORY
+# set 1024 for CentOS
+memory: 512
+
+# Ethernet interface name
+# use eth1 for libvirt and ubuntu precise, enp0s8 for CentOS and ubuntu xenial
+eth: 'eth1'
+
+# Disks
+# For libvirt use disks: "[ '/dev/vdb', '/dev/vdc' ]"
+# For CentOS7 use disks: "[ '/dev/sda', '/dev/sdb' ]"
+disks: "[ '/dev/sdb', '/dev/sdc' ]"
+
+# VAGRANT BOX
+# Ceph boxes are *strongly* suggested. They are under better control and will
+# not get updated frequently unless required for build systems. These are (for
+# now):
+#
+# * ceph/ubuntu-xenial
+#
+# Ubuntu: ceph/ubuntu-xenial bento/ubuntu-16.04 or ubuntu/trusty64 or ubuntu/wily64
+# CentOS: bento/centos-7.1 or puppetlabs/centos-7.0-64-puppet
+# libvirt CentOS: centos/7
+# parallels Ubuntu: parallels/ubuntu-14.04
+# Debian: deb/jessie-amd64 - be careful the storage controller is named 'SATA Controller'
+# For more boxes have a look at:
+#   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
+#   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
+vagrant_box: centos/7
+#ssh_private_key_path: "~/.ssh/id_rsa"
+# The sync directory changes based on vagrant box
+# Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
+#vagrant_sync_dir: /home/vagrant/sync
+#vagrant_sync_dir: /
+# Disables synced folder creation. Not needed for testing, will skip mounting
+# the vagrant directory on the remote box regardless of the provider.
+vagrant_disable_synced_folder: true
+# VAGRANT URL
+# This is a URL to download an image from an alternate location.  vagrant_box
+# above should be set to the filename of the image.
+# Fedora virtualbox: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
+# Fedora libvirt: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-libvirt.box
+# vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
+
+os_tuning_params:
+  - { name: kernel.pid_max, value: 4194303 }
+  - { name: fs.file-max, value: 26234859 }
+

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,81 @@ envlist = {dev,rhcs}-{centos,ubuntu}-{container,non_container}-{all_daemons,coll
   {dev,rhcs}-{centos,ubuntu}-non_container-{switch_to_containers}
   dev-rhel-container-podman
   infra_lv_create
+  migrate_ceph_disk_to_ceph_volume
 
 skipsdist = True
+
+# a test scenario that deploys a luminous cluster with ceph-disk osds
+# and then upgrades to nautilus and migrates those osds to ceph-volume
+[testenv:migrate_ceph_disk_to_ceph_volume]
+whitelist_externals =
+    vagrant
+    bash
+    cp
+    git
+    pip
+passenv=*
+setenv=
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_CONFIG = -F {toxinidir}/ansible.cfg
+  ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
+  ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/plugins/callback
+  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  CEPH_STABLE_RELEASE = luminous
+  # only available for ansible >= 2.5
+  ANSIBLE_STDOUT_CALLBACK = yaml
+changedir={toxinidir}/tests/functional/migrate_ceph_disk_to_ceph_volume
+commands=
+  vagrant up --no-provision {posargs:--provider=virtualbox}
+  bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
+
+  # use the stable-3.2 branch to deploy a luminous cluster
+  git clone -b {env:CEPH_ANSIBLE_BRANCH:stable-3.2} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
+
+  ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/setup.yml
+
+  # deploy the cluster
+  ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
+      delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
+      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:luminous} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      copy_admin_key={env:COPY_ADMIN_KEY:False} \
+  "
+
+  # wait 30sec for services to be ready
+  sleep 30
+  # test cluster state using ceph-ansible tests
+  py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/tests
+
+  # install ceph-ansible@master requirements
+  pip install -r {toxinidir}/tests/requirements.txt
+
+  # migrate osds to ceph-volume and upgrade to nautilus
+  cp {toxinidir}/infrastructure-playbooks/rolling_update.yml {toxinidir}/rolling_update.yml
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/rolling_update.yml --extra-vars "\
+      ireallymeanit=yes \
+      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:UPDATE_CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:UPDATE_CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      ceph_stable_release=nautilus \
+      osd_scenario=lvm \
+  "
+
+  # test cluster state again using ceph-ansible tests
+  bash -c "CEPH_STABLE_RELEASE=nautilus py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests"
+
+  # reboot all vms
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/reboot.yml
+
+  # retest to ensure cluster came back up correctly after rebooting
+  bash -c "CEPH_STABLE_RELEASE=nautilus py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {toxinidir}/tests/functional/tests"
+
+  vagrant destroy --force
 
 # a test scenario for the lv-create.yml and lv-teardown playbooks
 [testenv:infra_lv_create]


### PR DESCRIPTION
When upgrading to nautlius run ``ceph-volume simple scan`` and
``ceph-volume simple activate --all`` to migrate any running
ceph-disk osds to ceph-volume.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1656460

Signed-off-by: Andrew Schoen <aschoen@redhat.com>