### PR TITLE
add luminous/mimic to nautilus upgrade support

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -48,6 +48,7 @@
     - "{{ rbd_mirror_group_name|default('rbdmirrors') }}"
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ client_group_name|default('clients') }}"
+    - "{{ iscsi_gw_group_name|default('iscsigws') }}"
 
   become: True
   gather_facts: False

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -557,19 +557,30 @@
   serial: 1
   become: True
   tasks:
-    - name: stop ceph rgw
-      systemd:
-        name: ceph-radosgw@rgw.{{ ansible_hostname }}
-        state: stopped
-        enabled: no
-        masked: yes
-      when:
-        - not containerized_deployment
 
     - import_role:
         name: ceph-defaults
     - import_role:
         name: ceph-facts
+
+    - name: stop ceph rgw when upgrading from stable-3.2
+      systemd:
+        name: ceph-radosgw@rgw.{{ ansible_hostname }}
+        state: stopped
+        enabled: no
+        masked: yes
+      ignore_errors: True
+
+    - name: stop ceph rgw
+      systemd:
+        name: ceph-radosgw@rgw.{{ ansible_hostname }}.{{ item.instance_name }}
+        state: stopped
+        enabled: no
+        masked: yes
+      with_items: "{{ rgw_instances }}"
+      when:
+        - not containerized_deployment
+
     - import_role:
         name: ceph-handler
     - import_role:
@@ -582,15 +593,6 @@
         name: ceph-config
     - import_role:
         name: ceph-rgw
-
-    - name: start ceph rgw
-      systemd:
-        name: ceph-radosgw@rgw.{{ ansible_hostname }}
-        state: started
-        enabled: yes
-        masked: no
-      when:
-        - not containerized_deployment
 
     - name: restart containerized ceph rgw
       systemd:

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -214,7 +214,6 @@
         caps:
           mon: "allow profile {{ item.0 }}"
         cluster: "{{ cluster }}"
-        containerized: "{{ 'docker exec ceph-mon-' + hostvars[item.1]['ansible_hostname'] if containerized_deployment else None }}"
       when:
         - cephx
       delegate_to: "{{ item.1 }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -608,22 +608,12 @@
   serial: 1
   become: True
   tasks:
-    # NOTE(leseb): these tasks have a 'failed_when: false'
-    # in case we run before luminous or after
-    - name: stop ceph rbd mirror before luminous
-      systemd:
-        name: "ceph-rbd-mirror@{{ ceph_rbd_mirror_local_user }}"
-        state: stopped
-        enabled: no
-      failed_when: false
-
-    - name: stop ceph rbd mirror for and after luminous
+    - name: stop ceph rbd mirror
       systemd:
         name: "ceph-rbd-mirror@rbd-mirror.{{ ansible_hostname }}"
         state: stopped
         enabled: no
         masked: yes
-      failed_when: false
 
     - import_role:
         name: ceph-defaults

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -83,13 +83,18 @@
   become: True
   tasks:
     - name: set mon_host_count
-      set_fact: mon_host_count={{ groups[mon_group_name] | length }}
+      set_fact:
+        mon_host_count: "{{ groups[mon_group_name] | length }}"
 
     - name: fail when less than three monitors
       fail:
         msg: "Upgrade of cluster with less than three monitors is not supported."
       when:
         - mon_host_count | int < 3
+
+    - name: select a running monitor
+      set_fact:
+        mon_host: "{{ groups[mon_group_name] | difference([inventory_hostname]) | last }}"
 
     - name: stop ceph mon - shortname
       systemd:
@@ -138,6 +143,27 @@
         name: ceph-mgr
       when: groups.get(mgr_group_name, []) | length == 0
 
+    - name: set osd flags
+      command: ceph --cluster {{ cluster }} osd set {{ item }}
+      with_items:
+        - noout
+        - norebalance
+      delegate_to: "{{ mon_host }}"
+      when:
+        - inventory_hostname == groups[mon_group_name][0]
+        - not containerized_deployment
+
+    - name: set containerized osd flags
+      command: >
+        {{ container_binary }} exec ceph-mon-{{ hostvars[mon_host]['ansible_hostname'] }} ceph --cluster {{ cluster }} osd set {{ item }}
+      with_items:
+        - noout
+        - norebalance
+      delegate_to: "{{ mon_host }}"
+      when:
+        - inventory_hostname == groups[mon_group_name][0]
+        - containerized_deployment
+
     - name: start ceph mon
       systemd:
         name: ceph-mon@{{ monitor_name }}
@@ -173,13 +199,6 @@
       ignore_errors: True # if no mgr collocated with mons
       when:
         - containerized_deployment
-
-    - name: set mon_host_count
-      set_fact: mon_host_count={{ groups[mon_group_name] | length }}
-
-    - name: select a running monitor
-      set_fact:
-        mon_host: "{{ groups[mon_group_name] | difference([inventory_hostname]) | last }}"
 
     - name: non container | waiting for the monitor to join the quorum...
       command: ceph --cluster "{{ cluster }}" -s --format json
@@ -222,22 +241,6 @@
         - ['bootstrap-rbd', 'bootstrap-rbd-mirror']
         - "{{ groups[mon_group_name] | difference([mon_host]) }}" # so the key goes on all the nodes
 
-    - name: set osd flags
-      command: ceph --cluster {{ cluster }} osd set {{ item }}
-      with_items:
-        - noout
-        - norebalance
-      delegate_to: "{{ mon_host }}"
-      when: not containerized_deployment
-
-    - name: set containerized osd flags
-      command: >
-        {{ container_binary }} exec ceph-mon-{{ hostvars[mon_host]['ansible_hostname'] }} ceph --cluster {{ cluster }} osd set {{ item }}
-      with_items:
-        - noout
-        - norebalance
-      delegate_to: "{{ mon_host }}"
-      when: containerized_deployment
 
 
 - name: upgrade ceph mgr node

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -797,6 +797,27 @@
         name: ceph-client
 
 
+    - name: container | enable msgr2 protocol
+      command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph mon enable-msgr2"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: True
+      when: containerized_deployment
+
+    - name: non container | enable msgr2 protocol
+      command: ceph mon enable-msgr2
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: True
+      when: not containerized_deployment
+
+    - import_role:
+        name: ceph-handler
+    - name: import_role ceph-config
+      import_role:
+        name: ceph-config
+      vars:
+        msgr2_migration: True
+
+
 - name: show ceph status
   hosts:
     - "{{ mon_group_name|default('mons') }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -96,32 +96,39 @@
       set_fact:
         mon_host: "{{ groups[mon_group_name] | difference([inventory_hostname]) | last }}"
 
+    # NOTE: we mask the service so the RPM can't restart it
+    # after the package gets upgraded
     - name: stop ceph mon - shortname
       systemd:
         name: ceph-mon@{{ ansible_hostname }}
         state: stopped
-        enabled: yes
+        enabled: no
+        masked: yes
       ignore_errors: True
       when:
         - not containerized_deployment
 
+    # NOTE: we mask the service so the RPM can't restart it
+    # after the package gets upgraded
     - name: stop ceph mon - fqdn
       systemd:
         name: ceph-mon@{{ ansible_fqdn }}
         state: stopped
-        enabled: yes
+        enabled: no
+        masked: yes
       ignore_errors: True
       when:
         - not containerized_deployment
 
-    - name: stop ceph mgr
+    # only mask the service for mgr because it must be upgraded
+    # after ALL monitors, even when collocated
+    - name: mask the mgr service
       systemd:
         name: ceph-mgr@{{ ansible_hostname }}
-        state: stopped
-        enabled: yes
-      ignore_errors: True # if no mgr collocated with mons
+        masked: yes
       when:
-        - not containerized_deployment
+        - inventory_hostname in groups[mgr_group_name]
+          or groups[mgr_group_name] | length == 0
 
     - import_role:
         name: ceph-defaults
@@ -187,16 +194,6 @@
         state: restarted
         enabled: yes
         daemon_reload: yes
-      when:
-        - containerized_deployment
-
-    - name: restart containerized ceph mgr
-      systemd:
-        name: ceph-mgr@{{ monitor_name }}
-        state: restarted
-        enabled: yes
-        daemon_reload: yes
-      ignore_errors: True # if no mgr collocated with mons
       when:
         - containerized_deployment
 
@@ -329,7 +326,8 @@
       systemd:
         name: ceph-mgr@{{ ansible_hostname }}
         state: stopped
-        enabled: yes
+        enabled: no
+        masked: yes
       failed_when: false
       when:
         - not containerized_deployment
@@ -350,23 +348,6 @@
         name: ceph-config
     - import_role:
         name: ceph-mgr
-
-    - name: start ceph mgr
-      systemd:
-        name: ceph-mgr@{{ ansible_hostname }}
-        state: started
-        enabled: yes
-      when:
-        - not containerized_deployment
-
-    - name: restart containerized ceph mgr
-      systemd:
-        name: ceph-mgr@{{ ansible_hostname }}
-        state: restarted
-        enabled: yes
-        daemon_reload: yes
-      when:
-        - containerized_deployment
 
 
 - name: upgrade ceph osds cluster
@@ -396,7 +377,8 @@
       systemd:
         name: ceph-osd@{{ item }}
         state: stopped
-        enabled: yes
+        enabled: no
+        masked: yes
       with_items: "{{ osd_ids.stdout_lines }}"
       when:
         - not containerized_deployment
@@ -429,6 +411,7 @@
         name: ceph-osd@{{ item }}
         state: started
         enabled: yes
+        masked: no
       with_items: "{{ osd_ids.stdout_lines }}"
       when:
         - not containerized_deployment
@@ -438,6 +421,7 @@
         name: "{{ item }}"
         state: restarted
         enabled: yes
+        masked: no
         daemon_reload: yes
       with_items: "{{ osd_names.stdout_lines }}"
       when:
@@ -544,7 +528,8 @@
       systemd:
         name: ceph-mds@{{ ansible_hostname }}
         state: stopped
-        enabled: yes
+        enabled: no
+        masked: yes
       when:
         - not containerized_deployment
 
@@ -570,6 +555,7 @@
         name: ceph-mds@{{ ansible_hostname }}
         state: started
         enabled: yes
+        masked: no
       when:
         - not containerized_deployment
 
@@ -578,6 +564,7 @@
         name: ceph-mds@{{ ansible_hostname }}
         state: restarted
         enabled: yes
+        masked: no
         daemon_reload: yes
       when:
         - containerized_deployment
@@ -595,7 +582,8 @@
       systemd:
         name: ceph-radosgw@rgw.{{ ansible_hostname }}
         state: stopped
-        enabled: yes
+        enabled: no
+        masked: yes
       when:
         - not containerized_deployment
 
@@ -621,6 +609,7 @@
         name: ceph-radosgw@rgw.{{ ansible_hostname }}
         state: started
         enabled: yes
+        masked: no
       when:
         - not containerized_deployment
 
@@ -629,6 +618,7 @@
         name: ceph-radosgw@rgw.{{ ansible_hostname }}.{{ item.instance_name }}
         state: restarted
         enabled: yes
+        masked: no
         daemon_reload: yes
       with_items: "{{ rgw_instances }}"
       when:
@@ -656,7 +646,8 @@
       systemd:
         name: "ceph-rbd-mirror@rbd-mirror.{{ ansible_hostname }}"
         state: stopped
-        enabled: yes
+        enabled: no
+        masked: yes
       failed_when: false
 
     - import_role:
@@ -681,6 +672,7 @@
         name: "ceph-rbd-mirror@rbd-mirror.{{ ansible_hostname }}"
         state: started
         enabled: yes
+        masked: no
       when:
         - not containerized_deployment
 
@@ -689,6 +681,7 @@
         name: ceph-rbd-mirror@rbd-mirror.{{ ansible_hostname }}
         state: restarted
         enabled: yes
+        masked: no
         daemon_reload: yes
       when:
         - containerized_deployment
@@ -709,7 +702,8 @@
       systemd:
         name: nfs-ganesha
         state: stopped
-        enabled: yes
+        enabled: no
+        masked: yes
       failed_when: false
       when:
         - not containerized_deployment
@@ -736,6 +730,7 @@
         name: nfs-ganesha
         state: started
         enabled: yes
+        masked: no
       when:
         - not containerized_deployment
         - ceph_nfs_enable_service
@@ -745,6 +740,7 @@
         name: ceph-nfs@{{ ceph_nfs_service_suffix | default(ansible_hostname) }}
         state: restarted
         enabled: yes
+        masked: no
         daemon_reload: yes
       when:
         - ceph_nfs_enable_service
@@ -767,7 +763,8 @@
       systemd:
         name: rbd-target-gw
         state: stopped
-        enabled: yes
+        enabled: no
+        masked: yes
       failed_when: false
       when:
         - not containerized_deployment
@@ -794,6 +791,7 @@
         name: rbd-target-gw
         state: started
         enabled: yes
+        masked: no
       when:
         - not containerized_deployment
 

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -796,6 +796,27 @@
     - import_role:
         name: ceph-client
 
+- name: complete upgrade
+  hosts:
+    - all
+  become: True
+  tasks:
+    - import_role:
+        name: ceph-defaults
+    - import_role:
+        name: ceph-facts
+
+    - name: container | disallow pre-nautilus OSDs and enable all new nautilus-only functionality
+      command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph osd require-osd-release nautilus"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: True
+      when: containerized_deployment
+
+    - name: non container | disallow pre-nautilus OSDs and enable all new nautilus-only functionality
+      command: ceph osd require-osd-release nautilus
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: True
+      when: not containerized_deployment
 
     - name: container | enable msgr2 protocol
       command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph mon enable-msgr2"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -97,6 +97,43 @@
       set_fact:
         mon_host: "{{ groups[mon_group_name] | difference([inventory_hostname]) | last }}"
 
+    - import_role:
+        name: ceph-defaults
+    - import_role:
+        name: ceph-facts
+
+    - name: ensure /var/lib/ceph/bootstrap-rbd-mirror is present
+      file:
+        path: /var/lib/ceph/bootstrap-rbd-mirror
+        owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        mode: '755'
+        state: directory
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups[mon_group_name] }}"
+      when:
+        - cephx
+        - inventory_hostname == groups[mon_group_name][0]
+
+    - name: create potentially missing keys (rbd and rbd-mirror)
+      ceph_key:
+        name: "client.{{ item.0 }}"
+        state: present
+        dest: "/var/lib/ceph/{{ item.0 }}/"
+        caps:
+          mon: "allow profile {{ item.0 }}"
+        cluster: "{{ cluster }}"
+      delegate_to: "{{ item.1 }}"
+      with_nested:
+        - ['bootstrap-rbd', 'bootstrap-rbd-mirror']
+        - "{{ groups[mon_group_name] }}" # so the key goes on all the nodes
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+      when:
+        - cephx
+        - inventory_hostname == groups[mon_group_name][0]
+
     # NOTE: we mask the service so the RPM can't restart it
     # after the package gets upgraded
     - name: stop ceph mon - shortname
@@ -131,10 +168,6 @@
         - inventory_hostname in groups[mgr_group_name]
           or groups[mgr_group_name] | length == 0
 
-    - import_role:
-        name: ceph-defaults
-    - import_role:
-        name: ceph-facts
     - import_role:
         name: ceph-handler
     - import_role:
@@ -209,7 +242,7 @@
 
     - name: container | waiting for the containerized monitor to join the quorum...
       command: >
-        {{ container_binary }} exec ceph-mon-{{ hostvars[inventory_hostname]['ansible_hostname'] }} ceph --cluster "{{ cluster }}" -s --format json
+        {{ container_binary }} exec ceph-mon-{{ hostvars[mon_host]['ansible_hostname'] }} ceph --cluster "{{ cluster }}" -s --format json
       register: ceph_health_raw
       until: >
         hostvars[inventory_hostname]['ansible_hostname'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"] or
@@ -219,36 +252,6 @@
       delegate_to: "{{ mon_host }}"
       when:
         - containerized_deployment
-
-    - name: ensure /var/lib/ceph/bootstrap-rbd-mirror is present
-      file:
-        path: /var/lib/ceph/bootstrap-rbd-mirror
-        owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-        group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-        mode: '755'
-        state: directory
-      when:
-        - cephx
-      delegate_to: "{{ item }}"
-      with_items: "{{ groups[mon_group_name] }}"
-      when:
-        - inventory_hostname == groups[mon_group_name][0]
-
-    - name: create potentially missing keys (rbd and rbd-mirror)
-      ceph_key:
-        name: "client.{{ item.0 }}"
-        state: present
-        dest: "/var/lib/ceph/{{ item.0 }}/"
-        caps:
-          mon: "allow profile {{ item.0 }}"
-        cluster: "{{ cluster }}"
-      when:
-        - cephx
-      delegate_to: "{{ item.1 }}"
-      ignore_errors: True # this might fail for upgrade from J to L on rbd-mirror and also on partially updated clusters
-      with_nested:
-        - ['bootstrap-rbd', 'bootstrap-rbd-mirror']
-        - "{{ groups[mon_group_name] | difference([inventory_hostname]) }}" # so the key goes on all the nodes
 
 - name: upgrade ceph mgr nodes when implicitly collocated on monitors
   vars:

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -185,8 +185,8 @@
       command: ceph --cluster "{{ cluster }}" -s --format json
       register: ceph_health_raw
       until: >
-        hostvars[mon_host]['ansible_hostname'] in (ceph_health_raw.stdout | default('{}') |  from_json)["quorum_names"] or
-        hostvars[mon_host]['ansible_fqdn'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"]
+        hostvars[inventory_hostname]['ansible_hostname'] in (ceph_health_raw.stdout | default('{}') |  from_json)["quorum_names"] or
+        hostvars[inventory_hostname]['ansible_fqdn'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"]
       retries: "{{ health_mon_check_retries }}"
       delay: "{{ health_mon_check_delay }}"
       delegate_to: "{{ mon_host }}"
@@ -195,11 +195,11 @@
 
     - name: container | waiting for the containerized monitor to join the quorum...
       command: >
-        {{ container_binary }} exec ceph-mon-{{ hostvars[mon_host]['ansible_hostname'] }} ceph --cluster "{{ cluster }}" -s --format json
+        {{ container_binary }} exec ceph-mon-{{ hostvars[inventory_hostname]['ansible_hostname'] }} ceph --cluster "{{ cluster }}" -s --format json
       register: ceph_health_raw
       until: >
-        hostvars[mon_host]['ansible_hostname'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"] or
-        hostvars[mon_host]['ansible_fqdn'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"]
+        hostvars[inventory_hostname]['ansible_hostname'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"] or
+        hostvars[inventory_hostname]['ansible_fqdn'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"]
       retries: "{{ health_mon_check_retries }}"
       delay: "{{ health_mon_check_delay }}"
       delegate_to: "{{ mon_host }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -146,9 +146,6 @@
         name: ceph-config
     - import_role:
         name: ceph-mon
-    - import_role:
-        name: ceph-mgr
-      when: groups.get(mgr_group_name, []) | length == 0
 
     - name: set osd flags
       command: ceph --cluster {{ cluster }} osd set {{ item }}
@@ -250,11 +247,47 @@
       ignore_errors: True # this might fail for upgrade from J to L on rbd-mirror and also on partially updated clusters
       with_nested:
         - ['bootstrap-rbd', 'bootstrap-rbd-mirror']
-        - "{{ groups[mon_group_name] | difference([mon_host]) }}" # so the key goes on all the nodes
+        - "{{ groups[mon_group_name] | difference([inventory_hostname]) }}" # so the key goes on all the nodes
 
+- name: upgrade ceph mgr nodes when implicitly collocated on monitors
+  vars:
+    health_mon_check_retries: 5
+    health_mon_check_delay: 15
+    upgrade_ceph_packages: True
+  hosts:
+    - "{{ mon_group_name|default('mons') }}"
+  serial: 1
+  become: True
+  tasks:
+    - name: upgrade mgrs when no mgr group explicitly defined in inventory
+      when:
+        - groups.get(mgr_group_name, []) | length == 0
+      block:
+        - name: stop ceph mgr
+          systemd:
+            name: ceph-mgr@{{ ansible_hostname }}
+            state: stopped
+            enabled: yes
+            masked: yes
 
+        - import_role:
+            name: ceph-defaults
+        - import_role:
+            name: ceph-facts
+        - import_role:
+            name: ceph-handler
+        - import_role:
+            name: ceph-common
+          when: not containerized_deployment
+        - import_role:
+            name: ceph-container-common
+          when: containerized_deployment
+        - import_role:
+            name: ceph-config
+        - import_role:
+            name: ceph-mgr
 
-- name: upgrade ceph mgr node
+- name: upgrade ceph mgr nodes
   vars:
     upgrade_ceph_packages: True
     ceph_release: "{{ ceph_stable_release }}"
@@ -263,76 +296,6 @@
   serial: 1
   become: True
   tasks:
-    - import_role:
-        name: ceph-defaults
-    - import_role:
-        name: ceph-facts
-
-    - name: non container - get current fsid
-      command: "ceph --cluster {{ cluster }} fsid"
-      register: cluster_uuid_non_container
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-      when:
-        - not containerized_deployment
-
-    - name: container - get current fsid
-      command: >
-        {{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph --cluster {{ cluster }} fsid
-      register: cluster_uuid_container
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-      when:
-        - containerized_deployment
-
-    - name: set_fact ceph_cluster_fsid
-      set_fact:
-        ceph_cluster_fsid: "{{ cluster_uuid_container.stdout if containerized_deployment else cluster_uuid_non_container.stdout }}"
-
-    - name: create ceph mgr keyring(s) when mon is not containerized
-      ceph_key:
-        name: "mgr.{{ hostvars[item]['ansible_hostname'] }}"
-        state: present
-        caps:
-          mon: allow profile mgr
-          osd: allow *
-          mds: allow *
-        cluster: "{{ cluster }}"
-      when:
-        - not containerized_deployment
-        - cephx
-        - groups.get(mgr_group_name, []) | length > 0
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-      with_items: "{{ groups.get(mgr_group_name, []) }}"
-
-    - name: create ceph mgr keyring(s) when mon is containerized
-      ceph_key:
-        name: "mgr.{{ hostvars[item]['ansible_hostname'] }}"
-        state: present
-        caps:
-          mon: allow profile mgr
-          osd: allow *
-          mds: allow *
-        cluster: "{{ cluster }}"
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-        CEPH_UID: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-      when:
-        - containerized_deployment
-        - cephx
-        - groups.get(mgr_group_name, []) | length > 0
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-      with_items: "{{ groups.get(mgr_group_name, []) }}"
-
-    - name: fetch ceph mgr key(s)
-      fetch:
-        src: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
-        dest: "{{ fetch_directory }}/{{ ceph_cluster_fsid }}/{{ ceph_conf_key_directory }}/"
-        flat: yes
-        fail_on_missing: no
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-      with_items:
-        - "{{ groups.get(mgr_group_name, []) }}"
-
     # The following task has a failed_when: false
     # to handle the scenario where no mgr existed before the upgrade
     # or if we run a Ceph cluster before Luminous
@@ -343,8 +306,6 @@
         enabled: no
         masked: yes
       failed_when: false
-      when:
-        - not containerized_deployment
 
     - import_role:
         name: ceph-defaults

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -222,6 +222,20 @@
       when:
         - containerized_deployment
 
+    - name: ensure /var/lib/ceph/bootstrap-rbd-mirror is present
+      file:
+        path: /var/lib/ceph/bootstrap-rbd-mirror
+        owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        mode: '755'
+        state: directory
+      when:
+        - cephx
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups[mon_group_name] }}"
+      when:
+        - inventory_hostname == groups[mon_group_name][0]
+
     - name: create potentially missing keys (rbd and rbd-mirror)
       ceph_key:
         name: "client.{{ item.0 }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -855,4 +855,10 @@
 
     - name: show ceph status
       command: "{{ docker_exec_cmd_status|default('') }} ceph --cluster {{ cluster }} -s"
+      run_once: True
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+
+    - name: show all daemons version
+      command: "{{ docker_exec_cmd_status|default('') }} ceph --cluster {{ cluster }} versions"
+      run_once: True
       delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -185,6 +185,18 @@ CEPH_INITIAL_KEYS = ['client.admin', 'client.bootstrap-mds', 'client.bootstrap-m
                      'client.bootstrap-osd', 'client.bootstrap-rbd', 'client.bootstrap-rbd-mirror', 'client.bootstrap-rgw']  # noqa E501
 
 
+def str_to_bool(val):
+    try:
+        val = val.lower()
+    except AttributeError:
+        val = str(val).lower()
+    if val == 'true':
+        return True
+    elif val == 'false':
+        return False
+    else:
+        raise ValueError("Invalid input value: %s" % val)
+
 def fatal(message, module):
     '''
     Report a fatal error and exit
@@ -478,7 +490,7 @@ def lookup_ceph_initial_entities(module, out):
     else:
         fatal("'auth_dump' key not present in json output:", module)  # noqa E501
 
-    if len(entities) != len(CEPH_INITIAL_KEYS):
+    if len(entities) != len(CEPH_INITIAL_KEYS) and not str_to_bool(os.environ.get('CEPH_ROLLING_UPDATE', False)):
         # must be missing in auth_dump, as if it were in CEPH_INITIAL_KEYS
         # it'd be in entities from the above test. Report what's missing.
         missing = []

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -47,7 +47,11 @@ mon cluster log file = /dev/null
 {% endif %}
 mon host = {% if nb_mon > 0 %}
 {% for host in _monitor_addresses -%}
+{% if msgr2_migration | default(False) or not rolling_update %}
 [{{ "v2:" + host.addr + mon_host_v2_suffix }},{{ "v1:" + host.addr + mon_host_v1_suffix }}]
+{%- else -%}
+{{ host.addr }}
+{%- endif %}
 {%- if not loop.last -%},{%- endif %}
 {%- endfor %}
 {% elif nb_mon == 0 and inventory_hostname in groups.get(client_group_name, []) %}

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -81,6 +81,19 @@
   when:
     - (cephx or generate_fsid)
 
+- name: get current fsid
+  command: "{{ timeout_command }} {{ docker_exec_cmd }} ceph --cluster {{ cluster }} daemon mon.{{ hostvars[mon_host | default(groups[mon_group_name][0])]['ansible_hostname'] }} config get fsid"
+  register: rolling_update_fsid
+  delegate_to: "{{ mon_host | default(groups[mon_group_name][0]) }}"
+  when:
+    - rolling_update
+
+- name: set_fact fsid
+  set_fact:
+    fsid: "{{ (rolling_update_fsid.stdout | from_json).fsid }}"
+  when:
+    - rolling_update
+
 - name: set_fact ceph_current_status (convert to json)
   set_fact:
     ceph_current_status: "{{ ceph_current_status.stdout | from_json }}"
@@ -109,6 +122,7 @@
   when:
     - generate_fsid
     - ceph_current_status.fsid is undefined
+    - not rolling_update
 
 - name: set_fact mds_name ansible_hostname
   set_fact:

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -41,8 +41,7 @@
 
 - name: set_fact docker_exec_cmd
   set_fact:
-    docker_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
+    docker_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] if not rolling_update else hostvars[mon_host | default(groups[mon_group_name][0])]['ansible_hostname'] }}"
   when:
     - containerized_deployment
     - groups.get(mon_group_name, []) | length > 0

--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -1,461 +1,469 @@
 ---
-- name: update apt cache
-  apt:
-    update-cache: yes
-  when:
-    - ansible_os_family == 'Debian'
-  register: result
-  until: result is succeeded
+- name: handlers
+  when: not rolling_update
+  block:
+    - name: update apt cache
+      apt:
+        update-cache: yes
+      when:
+        - ansible_os_family == 'Debian'
+      register: result
+      until: result is succeeded
 
-# We only want to restart on hosts that have called the handler.
-# This var is set when he handler is called, and unset after the
-# restart to ensure only the correct hosts are restarted.
-- name: set _mon_handler_called before restart
-  set_fact:
-     _mon_handler_called: True
-  listen: "restart ceph mons"
+    # We only want to restart on hosts that have called the handler.
+    # This var is set when he handler is called, and unset after the
+    # restart to ensure only the correct hosts are restarted.
+    - name: set _mon_handler_called before restart
+      set_fact:
+         _mon_handler_called: True
+      listen: "restart ceph mons"
 
-- name: copy mon restart script
-  template:
-    src: restart_mon_daemon.sh.j2
-    dest: /tmp/restart_mon_daemon.sh
-    owner: root
-    group: root
-    mode: 0750
-  listen: "restart ceph mons"
-  when:
-    - mon_group_name in group_names
+    - name: copy mon restart script
+      template:
+        src: restart_mon_daemon.sh.j2
+        dest: /tmp/restart_mon_daemon.sh
+        owner: root
+        group: root
+        mode: 0750
+      listen: "restart ceph mons"
+      when:
+        - mon_group_name in group_names
+        - not rolling_update
 
-- name: restart ceph mon daemon(s) - non container
-  command: /usr/bin/env bash /tmp/restart_mon_daemon.sh
-  listen: "restart ceph mons"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - mon_group_name in group_names
-    - not containerized_deployment
-    - hostvars[item]['_mon_handler_called'] | default(False)
-    - mon_socket_stat.rc == 0
-  with_items: "{{ groups[mon_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph mon daemon(s) - non container
+      command: /usr/bin/env bash /tmp/restart_mon_daemon.sh
+      listen: "restart ceph mons"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - mon_group_name in group_names
+        - not containerized_deployment
+        - hostvars[item]['_mon_handler_called'] | default(False)
+        - mon_socket_stat.rc == 0
+        - not rolling_update
+      with_items: "{{ groups[mon_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: restart ceph mon daemon(s) - container
-  command: /usr/bin/env bash /tmp/restart_mon_daemon.sh
-  listen: "restart ceph mons"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - mon_group_name in group_names
-    - containerized_deployment
-    - ceph_mon_container_stat.get('rc') == 0
-    - hostvars[item]['_mon_handler_called'] | default(False)
-    - ceph_mon_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ groups[mon_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph mon daemon(s) - container
+      command: /usr/bin/env bash /tmp/restart_mon_daemon.sh
+      listen: "restart ceph mons"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - mon_group_name in group_names
+        - containerized_deployment
+        - ceph_mon_container_stat.get('rc') == 0
+        - hostvars[item]['_mon_handler_called'] | default(False)
+        - ceph_mon_container_stat.get('stdout_lines', [])|length != 0
+        - not rolling_update
+      with_items: "{{ groups[mon_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: set _mon_handler_called after restart
-  set_fact:
-     _mon_handler_called: False
-  listen: "restart ceph mons"
+    - name: set _mon_handler_called after restart
+      set_fact:
+         _mon_handler_called: False
+      listen: "restart ceph mons"
 
-- name: set _osd_handler_called before restart
-  set_fact:
-     _osd_handler_called: True
-  listen: "restart ceph osds"
+    - name: set _osd_handler_called before restart
+      set_fact:
+         _osd_handler_called: True
+      listen: "restart ceph osds"
 
-# This does not just restart OSDs but everything else too. Unfortunately
-# at this time the ansible role does not have an OSD id list to use
-# for restarting them specifically.
-# This does not need to run during a rolling update as the playbook will
-# restart all OSDs using the tasks "start ceph osd" or
-# "restart containerized ceph osd"
-- name: copy osd restart script
-  template:
-    src: restart_osd_daemon.sh.j2
-    dest: /tmp/restart_osd_daemon.sh
-    owner: root
-    group: root
-    mode: 0750
-  listen: "restart ceph osds"
-  when:
-    - osd_group_name in group_names
-    - not rolling_update
+    # This does not just restart OSDs but everything else too. Unfortunately
+    # at this time the ansible role does not have an OSD id list to use
+    # for restarting them specifically.
+    # This does not need to run during a rolling update as the playbook will
+    # restart all OSDs using the tasks "start ceph osd" or
+    # "restart containerized ceph osd"
+    - name: copy osd restart script
+      template:
+        src: restart_osd_daemon.sh.j2
+        dest: /tmp/restart_osd_daemon.sh
+        owner: root
+        group: root
+        mode: 0750
+      listen: "restart ceph osds"
+      when:
+        - osd_group_name in group_names
+        - not rolling_update
 
-- name: restart ceph osds daemon(s) - non container
-  command: /usr/bin/env bash /tmp/restart_osd_daemon.sh
-  listen: "restart ceph osds"
-  when:
-    - osd_group_name in group_names
-    - not containerized_deployment
-    - not rolling_update
-    # We do not want to run these checks on initial deployment (`socket_osd_container.results[n].rc == 0`)
-    # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
-    - osd_socket_stat.rc == 0
-    - ceph_current_status.fsid is defined
-    - handler_health_osd_check
-    - hostvars[item]['_osd_handler_called'] | default(False)
-  with_items: "{{ groups[osd_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph osds daemon(s) - non container
+      command: /usr/bin/env bash /tmp/restart_osd_daemon.sh
+      listen: "restart ceph osds"
+      when:
+        - osd_group_name in group_names
+        - not containerized_deployment
+        - not rolling_update
+        # We do not want to run these checks on initial deployment (`socket_osd_container.results[n].rc == 0`)
+        # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
+        - osd_socket_stat.rc == 0
+        - ceph_current_status.fsid is defined
+        - handler_health_osd_check
+        - hostvars[item]['_osd_handler_called'] | default(False)
+      with_items: "{{ groups[osd_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: restart ceph osds daemon(s) - container
-  command: /usr/bin/env bash /tmp/restart_osd_daemon.sh
-  listen: "restart ceph osds"
-  when:
-    # We do not want to run these checks on initial deployment (`socket_osd_container_stat.results[n].rc == 0`)
-    # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
-    - osd_group_name in group_names
-    - containerized_deployment
-    - not rolling_update
-    - inventory_hostname == groups.get(osd_group_name) | last
-    - ceph_osd_container_stat.get('rc') == 0
-    - ceph_osd_container_stat.get('stdout_lines', [])|length != 0
-    - handler_health_osd_check
-    - hostvars[item]['_osd_handler_called'] | default(False)
-  with_items: "{{ groups[osd_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph osds daemon(s) - container
+      command: /usr/bin/env bash /tmp/restart_osd_daemon.sh
+      listen: "restart ceph osds"
+      when:
+        # We do not want to run these checks on initial deployment (`socket_osd_container_stat.results[n].rc == 0`)
+        # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
+        - osd_group_name in group_names
+        - containerized_deployment
+        - not rolling_update
+        - inventory_hostname == groups.get(osd_group_name) | last
+        - ceph_osd_container_stat.get('rc') == 0
+        - ceph_osd_container_stat.get('stdout_lines', [])|length != 0
+        - handler_health_osd_check
+        - hostvars[item]['_osd_handler_called'] | default(False)
+      with_items: "{{ groups[osd_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: set _osd_handler_called after restart
-  set_fact:
-     _osd_handler_called: False
-  listen: "restart ceph osds"
+    - name: set _osd_handler_called after restart
+      set_fact:
+         _osd_handler_called: False
+      listen: "restart ceph osds"
 
-- name: set _mds_handler_called before restart
-  set_fact:
-     _mds_handler_called: True
-  listen: "restart ceph mdss"
+    - name: set _mds_handler_called before restart
+      set_fact:
+         _mds_handler_called: True
+      listen: "restart ceph mdss"
 
-- name: copy mds restart script
-  template:
-    src: restart_mds_daemon.sh.j2
-    dest: /tmp/restart_mds_daemon.sh
-    owner: root
-    group: root
-    mode: 0750
-  listen: "restart ceph mdss"
-  when:
-    - mds_group_name in group_names
+    - name: copy mds restart script
+      template:
+        src: restart_mds_daemon.sh.j2
+        dest: /tmp/restart_mds_daemon.sh
+        owner: root
+        group: root
+        mode: 0750
+      listen: "restart ceph mdss"
+      when:
+        - mds_group_name in group_names
 
-- name: restart ceph mds daemon(s) - non container
-  command: /usr/bin/env bash /tmp/restart_mds_daemon.sh
-  listen: "restart ceph mdss"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - mds_group_name in group_names
-    - not containerized_deployment
-    - hostvars[item]['_mds_handler_called'] | default(False)
-    - mds_socket_stat.rc == 0
-  with_items: "{{ groups[mds_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph mds daemon(s) - non container
+      command: /usr/bin/env bash /tmp/restart_mds_daemon.sh
+      listen: "restart ceph mdss"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - mds_group_name in group_names
+        - not containerized_deployment
+        - hostvars[item]['_mds_handler_called'] | default(False)
+        - mds_socket_stat.rc == 0
+      with_items: "{{ groups[mds_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: restart ceph mds daemon(s) - container
-  command: /usr/bin/env bash /tmp/restart_mds_daemon.sh
-  listen: "restart ceph mdss"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - mds_group_name in group_names
-    - containerized_deployment
-    - ceph_mds_container_stat.get('rc') == 0
-    - hostvars[item]['_mds_handler_called'] | default(False)
-    - ceph_mds_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ groups[mds_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph mds daemon(s) - container
+      command: /usr/bin/env bash /tmp/restart_mds_daemon.sh
+      listen: "restart ceph mdss"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - mds_group_name in group_names
+        - containerized_deployment
+        - ceph_mds_container_stat.get('rc') == 0
+        - hostvars[item]['_mds_handler_called'] | default(False)
+        - ceph_mds_container_stat.get('stdout_lines', [])|length != 0
+      with_items: "{{ groups[mds_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: set _mds_handler_called after restart
-  set_fact:
-     _mds_handler_called: False
-  listen: "restart ceph mdss"
+    - name: set _mds_handler_called after restart
+      set_fact:
+         _mds_handler_called: False
+      listen: "restart ceph mdss"
 
-- name: set _rgw_handler_called before restart
-  set_fact:
-     _rgw_handler_called: True
-  listen: "restart ceph rgws"
+    - name: set _rgw_handler_called before restart
+      set_fact:
+         _rgw_handler_called: True
+      listen: "restart ceph rgws"
 
-- name: copy rgw restart script
-  template:
-    src: restart_rgw_daemon.sh.j2
-    dest: /tmp/restart_rgw_daemon.sh
-    owner: root
-    group: root
-    mode: 0750
-  listen: "restart ceph rgws"
-  when:
-    - rgw_group_name in group_names
+    - name: copy rgw restart script
+      template:
+        src: restart_rgw_daemon.sh.j2
+        dest: /tmp/restart_rgw_daemon.sh
+        owner: root
+        group: root
+        mode: 0750
+      listen: "restart ceph rgws"
+      when:
+        - rgw_group_name in group_names
 
-- name: restart ceph rgw daemon(s) - non container
-  command: /usr/bin/env bash /tmp/restart_rgw_daemon.sh
-  listen: "restart ceph rgws"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - rgw_group_name in group_names
-    - not containerized_deployment
-    - hostvars[item]['_rgw_handler_called'] | default(False)
-    - rgw_socket_stat.rc == 0
-  with_items: "{{ groups[rgw_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph rgw daemon(s) - non container
+      command: /usr/bin/env bash /tmp/restart_rgw_daemon.sh
+      listen: "restart ceph rgws"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - rgw_group_name in group_names
+        - not containerized_deployment
+        - hostvars[item]['_rgw_handler_called'] | default(False)
+        - rgw_socket_stat.rc == 0
+      with_items: "{{ groups[rgw_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: restart ceph rgw daemon(s) - container
-  command: /usr/bin/env bash /tmp/restart_rgw_daemon.sh
-  listen: "restart ceph rgws"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - rgw_group_name in group_names
-    - containerized_deployment
-    - ceph_rgw_container_stat.get('rc') == 0
-    - hostvars[item]['_rgw_handler_called'] | default(False)
-    - ceph_rgw_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ groups[rgw_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph rgw daemon(s) - container
+      command: /usr/bin/env bash /tmp/restart_rgw_daemon.sh
+      listen: "restart ceph rgws"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - rgw_group_name in group_names
+        - containerized_deployment
+        - ceph_rgw_container_stat.get('rc') == 0
+        - hostvars[item]['_rgw_handler_called'] | default(False)
+        - ceph_rgw_container_stat.get('stdout_lines', [])|length != 0
+      with_items: "{{ groups[rgw_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: set _rgw_handler_called after restart
-  set_fact:
-     _rgw_handler_called: False
-  listen: "restart ceph rgws"
+    - name: set _rgw_handler_called after restart
+      set_fact:
+         _rgw_handler_called: False
+      listen: "restart ceph rgws"
 
-- name: set _nfs_handler_called before restart
-  set_fact:
-     _nfs_handler_called: True
-  listen: "restart ceph nfss"
+    - name: set _nfs_handler_called before restart
+      set_fact:
+         _nfs_handler_called: True
+      listen: "restart ceph nfss"
 
-- name: copy nfs restart script
-  template:
-    src: restart_nfs_daemon.sh.j2
-    dest: /tmp/restart_nfs_daemon.sh
-    owner: root
-    group: root
-    mode: 0750
-  listen: "restart ceph nfss"
-  when:
-    - nfs_group_name in group_names
+    - name: copy nfs restart script
+      template:
+        src: restart_nfs_daemon.sh.j2
+        dest: /tmp/restart_nfs_daemon.sh
+        owner: root
+        group: root
+        mode: 0750
+      listen: "restart ceph nfss"
+      when:
+        - nfs_group_name in group_names
 
-- name: restart ceph nfs daemon(s) - non container
-  command: /usr/bin/env bash /tmp/restart_nfs_daemon.sh
-  listen: "restart ceph nfss"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - nfs_group_name in group_names
-    - not containerized_deployment
-    - hostvars[item]['_nfs_handler_called'] | default(False)
-    - nfs_socket_stat.rc == 0
-  with_items: "{{ groups[nfs_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph nfs daemon(s) - non container
+      command: /usr/bin/env bash /tmp/restart_nfs_daemon.sh
+      listen: "restart ceph nfss"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - nfs_group_name in group_names
+        - not containerized_deployment
+        - hostvars[item]['_nfs_handler_called'] | default(False)
+        - nfs_socket_stat.rc == 0
+      with_items: "{{ groups[nfs_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: restart ceph nfs daemon(s) - container
-  command: /usr/bin/env bash /tmp/restart_nfs_daemon.sh
-  listen: "restart ceph nfss"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - nfs_group_name in group_names
-    - containerized_deployment
-    - ceph_nfs_container_stat.get('rc') == 0
-    - hostvars[item]['_nfs_handler_called'] | default(False)
-    - ceph_nfs_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ groups[nfs_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph nfs daemon(s) - container
+      command: /usr/bin/env bash /tmp/restart_nfs_daemon.sh
+      listen: "restart ceph nfss"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - nfs_group_name in group_names
+        - containerized_deployment
+        - ceph_nfs_container_stat.get('rc') == 0
+        - hostvars[item]['_nfs_handler_called'] | default(False)
+        - ceph_nfs_container_stat.get('stdout_lines', [])|length != 0
+      with_items: "{{ groups[nfs_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: set _nfs_handler_called after restart
-  set_fact:
-     _nfs_handler_called: False
-  listen: "restart ceph nfss"
+    - name: set _nfs_handler_called after restart
+      set_fact:
+         _nfs_handler_called: False
+      listen: "restart ceph nfss"
 
-- name: set _rbdmirror_handler_called before restart
-  set_fact:
-     _rbdmirror_handler_called: True
-  listen: "restart ceph rbdmirrors"
+    - name: set _rbdmirror_handler_called before restart
+      set_fact:
+         _rbdmirror_handler_called: True
+      listen: "restart ceph rbdmirrors"
 
-- name: copy rbd mirror restart script
-  template:
-    src: restart_rbd_mirror_daemon.sh.j2
-    dest: /tmp/restart_rbd_mirror_daemon.sh
-    owner: root
-    group: root
-    mode: 0750
-  listen: "restart ceph rbdmirrors"
-  when:
-    - rbdmirror_group_name in group_names
+    - name: copy rbd mirror restart script
+      template:
+        src: restart_rbd_mirror_daemon.sh.j2
+        dest: /tmp/restart_rbd_mirror_daemon.sh
+        owner: root
+        group: root
+        mode: 0750
+      listen: "restart ceph rbdmirrors"
+      when:
+        - rbdmirror_group_name in group_names
 
-- name: restart ceph rbd mirror daemon(s) - non container
-  command: /usr/bin/env bash /tmp/restart_rbd_mirror_daemon.sh
-  listen: "restart ceph rbdmirrors"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - rbdmirror_group_name in group_names
-    - not containerized_deployment
-    - hostvars[item]['_rbdmirror_handler_called'] | default(False)
-    - rbd_mirror_socket_stat.rc == 0
-  with_items: "{{ groups[rbdmirror_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph rbd mirror daemon(s) - non container
+      command: /usr/bin/env bash /tmp/restart_rbd_mirror_daemon.sh
+      listen: "restart ceph rbdmirrors"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - rbdmirror_group_name in group_names
+        - not containerized_deployment
+        - hostvars[item]['_rbdmirror_handler_called'] | default(False)
+        - rbd_mirror_socket_stat.rc == 0
+      with_items: "{{ groups[rbdmirror_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: restart ceph rbd mirror daemon(s) - container
-  command: /usr/bin/env bash /tmp/restart_rbd_mirror_daemon.sh
-  listen: "restart ceph rbdmirrors"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - rbdmirror_group_name in group_names
-    - containerized_deployment
-    - ceph_rbd_mirror_container_stat.get('rc') == 0
-    - hostvars[item]['_rbdmirror_handler_called'] | default(False)
-    - ceph_rbd_mirror_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ groups[rbdmirror_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph rbd mirror daemon(s) - container
+      command: /usr/bin/env bash /tmp/restart_rbd_mirror_daemon.sh
+      listen: "restart ceph rbdmirrors"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - rbdmirror_group_name in group_names
+        - containerized_deployment
+        - ceph_rbd_mirror_container_stat.get('rc') == 0
+        - hostvars[item]['_rbdmirror_handler_called'] | default(False)
+        - ceph_rbd_mirror_container_stat.get('stdout_lines', [])|length != 0
+      with_items: "{{ groups[rbdmirror_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: set _rbdmirror_handler_called after restart
-  set_fact:
-     _rbdmirror_handler_called: False
-  listen: "restart ceph rbdmirrors"
+    - name: set _rbdmirror_handler_called after restart
+      set_fact:
+         _rbdmirror_handler_called: False
+      listen: "restart ceph rbdmirrors"
 
-- name: set _mgr_handler_called before restart
-  set_fact:
-     _mgr_handler_called: True
-  listen: "restart ceph mgrs"
+    - name: set _mgr_handler_called before restart
+      set_fact:
+         _mgr_handler_called: True
+      listen: "restart ceph mgrs"
 
-- name: copy mgr restart script
-  template:
-    src: restart_mgr_daemon.sh.j2
-    dest: /tmp/restart_mgr_daemon.sh
-    owner: root
-    group: root
-    mode: 0750
-  listen: "restart ceph mgrs"
-  when:
-    - mgr_group_name in group_names
+    - name: copy mgr restart script
+      template:
+        src: restart_mgr_daemon.sh.j2
+        dest: /tmp/restart_mgr_daemon.sh
+        owner: root
+        group: root
+        mode: 0750
+      listen: "restart ceph mgrs"
+      when:
+        - mgr_group_name in group_names
 
-- name: restart ceph mgr daemon(s) - non container
-  command: /usr/bin/env bash /tmp/restart_mgr_daemon.sh
-  listen: "restart ceph mgrs"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - mgr_group_name in group_names
-    - not containerized_deployment
-    - hostvars[item]['_mgr_handler_called'] | default(False)
-    - mgr_socket_stat.rc == 0
-  with_items: "{{ groups[mgr_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph mgr daemon(s) - non container
+      command: /usr/bin/env bash /tmp/restart_mgr_daemon.sh
+      listen: "restart ceph mgrs"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - mgr_group_name in group_names
+        - not containerized_deployment
+        - hostvars[item]['_mgr_handler_called'] | default(False)
+        - mgr_socket_stat.rc == 0
+        - not rolling_update
+      with_items: "{{ groups[mgr_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: restart ceph mgr daemon(s) - container
-  command: /usr/bin/env bash /tmp/restart_mgr_daemon.sh
-  listen: "restart ceph mgrs"
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - mgr_group_name in group_names
-    - containerized_deployment
-    - ceph_mgr_container_stat.get('rc') == 0
-    - hostvars[item]['_mgr_handler_called'] | default(False)
-    - ceph_mgr_container_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ groups[mgr_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart ceph mgr daemon(s) - container
+      command: /usr/bin/env bash /tmp/restart_mgr_daemon.sh
+      listen: "restart ceph mgrs"
+      when:
+        # We do not want to run these checks on initial deployment (`socket.rc == 0`)
+        - mgr_group_name in group_names
+        - containerized_deployment
+        - ceph_mgr_container_stat.get('rc') == 0
+        - hostvars[item]['_mgr_handler_called'] | default(False)
+        - ceph_mgr_container_stat.get('stdout_lines', [])|length != 0
+        - not rolling_update
+      with_items: "{{ groups[mgr_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: set _mgr_handler_called after restart
-  set_fact:
-     _mgr_handler_called: False
-  listen: "restart ceph mgrs"
+    - name: set _mgr_handler_called after restart
+      set_fact:
+         _mgr_handler_called: False
+      listen: "restart ceph mgrs"
 
-- name: set _tcmu_runner_handler_called before restart
-  set_fact:
-     _tcmu_runner_handler_called: True
-  listen: "restart ceph tcmu-runner"
+    - name: set _tcmu_runner_handler_called before restart
+      set_fact:
+         _tcmu_runner_handler_called: True
+      listen: "restart ceph tcmu-runner"
 
-- name: copy tcmu-runner restart script
-  template:
-    src: restart_tcmu_runner.sh.j2
-    dest: /tmp/restart_tcmu_runner.sh
-    owner: root
-    group: root
-    mode: 0750
-  listen: "restart ceph tcmu-runner"
-  when:
-    - iscsi_gw_group_name in group_names
+    - name: copy tcmu-runner restart script
+      template:
+        src: restart_tcmu_runner.sh.j2
+        dest: /tmp/restart_tcmu_runner.sh
+        owner: root
+        group: root
+        mode: 0750
+      listen: "restart ceph tcmu-runner"
+      when:
+        - iscsi_gw_group_name in group_names
 
-- name: restart tcmu-runner
-  command: /usr/bin/env bash /tmp/restart_tcmu_runner.sh
-  listen: "restart ceph tcmu-runner"
-  when:
-    - iscsi_gw_group_name in group_names
-    - ceph_tcmu_runner_stat.get('rc') == 0
-    - hostvars[item]['_tcmu_runner_handler_called'] | default(False)
-    - ceph_tcmu_runner_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ groups[iscsi_gw_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart tcmu-runner
+      command: /usr/bin/env bash /tmp/restart_tcmu_runner.sh
+      listen: "restart ceph tcmu-runner"
+      when:
+        - iscsi_gw_group_name in group_names
+        - ceph_tcmu_runner_stat.get('rc') == 0
+        - hostvars[item]['_tcmu_runner_handler_called'] | default(False)
+        - ceph_tcmu_runner_stat.get('stdout_lines', [])|length != 0
+      with_items: "{{ groups[iscsi_gw_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: set _tcmu_runner_handler_called after restart
-  set_fact:
-     _tcmu_runner_handler_called: False
-  listen: "restart ceph tcmu-runner"
+    - name: set _tcmu_runner_handler_called after restart
+      set_fact:
+         _tcmu_runner_handler_called: False
+      listen: "restart ceph tcmu-runner"
 
-- name: set _rbd_target_gw_handler_called before restart
-  set_fact:
-     _rbd_target_gw_handler_called: True
-  listen: "restart ceph rbd-target-gw"
+    - name: set _rbd_target_gw_handler_called before restart
+      set_fact:
+         _rbd_target_gw_handler_called: True
+      listen: "restart ceph rbd-target-gw"
 
-- name: copy rbd-target-gw restart script
-  template:
-    src: restart_rbd_target_gw.sh.j2
-    dest: /tmp/restart_rbd_target_gw.sh
-    owner: root
-    group: root
-    mode: 0750
-  listen: "restart ceph rbd-target-gw"
-  when:
-    - iscsi_gw_group_name in group_names
+    - name: copy rbd-target-gw restart script
+      template:
+        src: restart_rbd_target_gw.sh.j2
+        dest: /tmp/restart_rbd_target_gw.sh
+        owner: root
+        group: root
+        mode: 0750
+      listen: "restart ceph rbd-target-gw"
+      when:
+        - iscsi_gw_group_name in group_names
 
-- name: restart rbd-target-gw
-  command: /usr/bin/env bash /tmp/restart_rbd_target_gw.sh
-  listen: "restart ceph rbd-target-gw"
-  when:
-    - iscsi_gw_group_name in group_names
-    - ceph_rbd_target_gw_stat.get('rc') == 0
-    - hostvars[item]['_rbd_target_gw_handler_called'] | default(False)
-    - ceph_rbd_target_gw_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ groups[iscsi_gw_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart rbd-target-gw
+      command: /usr/bin/env bash /tmp/restart_rbd_target_gw.sh
+      listen: "restart ceph rbd-target-gw"
+      when:
+        - iscsi_gw_group_name in group_names
+        - ceph_rbd_target_gw_stat.get('rc') == 0
+        - hostvars[item]['_rbd_target_gw_handler_called'] | default(False)
+        - ceph_rbd_target_gw_stat.get('stdout_lines', [])|length != 0
+      with_items: "{{ groups[iscsi_gw_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: set _rbd_target_gw_handler_called after restart
-  set_fact:
-     _rbd_target_gw_handler_called: False
-  listen: "restart ceph rbd-target-gw"
+    - name: set _rbd_target_gw_handler_called after restart
+      set_fact:
+         _rbd_target_gw_handler_called: False
+      listen: "restart ceph rbd-target-gw"
 
-- name: set _rbd_target_api_handler_called before restart
-  set_fact:
-     _rbd_target_api_handler_called: True
-  listen: "restart ceph rbd-target-api"
+    - name: set _rbd_target_api_handler_called before restart
+      set_fact:
+         _rbd_target_api_handler_called: True
+      listen: "restart ceph rbd-target-api"
 
-- name: copy rbd-target-api restart script
-  template:
-    src: restart_rbd_target_api.sh.j2
-    dest: /tmp/restart_rbd_target_api.sh
-    owner: root
-    group: root
-    mode: 0750
-  listen: "restart ceph rbd-target-api"
-  when:
-    - iscsi_gw_group_name in group_names
+    - name: copy rbd-target-api restart script
+      template:
+        src: restart_rbd_target_api.sh.j2
+        dest: /tmp/restart_rbd_target_api.sh
+        owner: root
+        group: root
+        mode: 0750
+      listen: "restart ceph rbd-target-api"
+      when:
+        - iscsi_gw_group_name in group_names
 
-- name: restart rbd-target-api
-  command: /usr/bin/env bash /tmp/restart_rbd_target_api.sh
-  listen: "restart ceph rbd-target-api"
-  when:
-    - iscsi_gw_group_name in group_names
-    - ceph_rbd_target_api_stat.get('rc') == 0
-    - hostvars[item]['_rbd_target_api_handler_called'] | default(False)
-    - ceph_rbd_target_api_stat.get('stdout_lines', [])|length != 0
-  with_items: "{{ groups[iscsi_gw_group_name] }}"
-  delegate_to: "{{ item }}"
-  run_once: True
+    - name: restart rbd-target-api
+      command: /usr/bin/env bash /tmp/restart_rbd_target_api.sh
+      listen: "restart ceph rbd-target-api"
+      when:
+        - iscsi_gw_group_name in group_names
+        - ceph_rbd_target_api_stat.get('rc') == 0
+        - hostvars[item]['_rbd_target_api_handler_called'] | default(False)
+        - ceph_rbd_target_api_stat.get('stdout_lines', [])|length != 0
+      with_items: "{{ groups[iscsi_gw_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: True
 
-- name: set _rbd_target_api_handler_called after restart
-  set_fact:
-     _rbd_target_api_handler_called: False
-  listen: "restart ceph rbd-target-api"
+    - name: set _rbd_target_api_handler_called after restart
+      set_fact:
+         _rbd_target_api_handler_called: False
+      listen: "restart ceph rbd-target-api"

--- a/roles/ceph-iscsi-gw/tasks/container/containerized.yml
+++ b/roles/ceph-iscsi-gw/tasks/container/containerized.yml
@@ -19,6 +19,7 @@
     name: "{{ item }}"
     state: started
     enabled: yes
+    masked: no
     daemon_reload: yes
   with_items:
     - tcmu-runner

--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -66,10 +66,12 @@
   service:
     name: rbd-target-gw
     enabled: yes
+    masked: no
     state: started
 
 - name: enable the rbd-target-api service and make sure it is running
   service:
     name: rbd-target-api
     enabled: yes
+    masked: no
     state: started

--- a/roles/ceph-mds/tasks/containerized.yml
+++ b/roles/ceph-mds/tasks/containerized.yml
@@ -61,6 +61,7 @@
     name: ceph-mds@{{ ansible_hostname }}
     state: started
     enabled: yes
+    masked: no
     daemon_reload: yes
 
 - name: wait for mds socket to exist

--- a/roles/ceph-mds/tasks/main.yml
+++ b/roles/ceph-mds/tasks/main.yml
@@ -3,6 +3,7 @@
   include_tasks: create_mds_filesystems.yml
   when:
     - inventory_hostname == groups[mds_group_name] | first
+    - not rolling_update
 
 - name: set_fact docker_exec_cmd
   set_fact:

--- a/roles/ceph-mds/tasks/non_containerized.yml
+++ b/roles/ceph-mds/tasks/non_containerized.yml
@@ -58,4 +58,5 @@
     name: ceph-mds@{{ mds_name }}
     state: started
     enabled: yes
+    masked: no
   changed_when: false

--- a/roles/ceph-mgr/tasks/start_mgr.yml
+++ b/roles/ceph-mgr/tasks/start_mgr.yml
@@ -35,4 +35,5 @@
     name: ceph-mgr@{{ ansible_hostname }}
     state: started
     enabled: yes
+    masked: no
     daemon_reload: yes

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -16,21 +16,19 @@
   delay: "{{ handler_health_mon_check_delay }}"
   changed_when: false
 
-- name: fetch ceph initial keys
-  ceph_key:
-    state: fetch_initial_keys
-    cluster: "{{ cluster }}"
-    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0400"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-    CEPH_ROLLING_UPDATE: "{{ rolling_update }}"
-  when:
-    - cephx
-
 - block:
+  - name: fetch ceph initial keys
+    ceph_key:
+      state: fetch_initial_keys
+      cluster: "{{ cluster }}"
+      owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+      group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+      mode: "0400"
+    environment:
+      CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+      CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+      CEPH_ROLLING_UPDATE: "{{ rolling_update }}"
+
   - name: create ceph mgr keyring(s)
     ceph_key:
       name: "mgr.{{ hostvars[item]['ansible_hostname'] }}"
@@ -62,7 +60,6 @@
     delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
     - cephx
-    - not rolling_update
 
 - name: copy keys to the ansible server
   fetch:

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -26,6 +26,7 @@
   environment:
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+    CEPH_ROLLING_UPDATE: "{{ rolling_update }}"
   when:
     - cephx
 

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -36,4 +36,5 @@
     name: ceph-mon@{{ monitor_name if not containerized_deployment else ansible_hostname }}
     state: started
     enabled: yes
+    masked: no
     daemon_reload: yes

--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -83,6 +83,7 @@
     name: ceph-nfs@{{ ceph_nfs_service_suffix | default(ansible_hostname) }}
     state: started
     enabled: yes
+    masked: no
     daemon_reload: yes
   when:
     - containerized_deployment
@@ -93,6 +94,7 @@
     name: nfs-ganesha
     state: started
     enabled: yes
+    masked: no
   when:
     - not containerized_deployment
     - ceph_nfs_enable_service

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -76,6 +76,7 @@
     name: ceph-osd@{{ item | regex_replace('/dev/', '') if osd_scenario != 'lvm' and containerized_deployment else item }}
     state: started
     enabled: yes
+    masked: no
     daemon_reload: yes
   with_items: "{{ devices if osd_scenario != 'lvm' and containerized_deployment else ((ceph_osd_ids.stdout | from_json).keys() | list) if osd_scenario == 'lvm' and not containerized_deployment else osd_ids_non_container.stdout_lines }}"
 

--- a/roles/ceph-rbd-mirror/tasks/docker/start_docker_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/start_docker_rbd_mirror.yml
@@ -16,4 +16,5 @@
     name: ceph-rbd-mirror@rbd-mirror.{{ ansible_hostname }}
     state: started
     enabled: yes
+    masked: no
     daemon_reload: yes

--- a/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/start_rbd_mirror.yml
@@ -29,6 +29,7 @@
     name: "ceph-rbd-mirror.target"
     state: started
     enabled: yes
+    masked: no
   changed_when: false
 
 - name: start and add the rbd-mirror service instance
@@ -36,4 +37,5 @@
     name: "ceph-rbd-mirror@rbd-mirror.{{ ansible_hostname }}"
     state: started
     enabled: yes
+    masked: no
   changed_when: false

--- a/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
+++ b/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
@@ -22,21 +22,6 @@
   notify:
     - restart ceph rgws
 
-# For backward compatibility
-- name: disable old systemd unit ('ceph-rgw@'|'ceph-radosgw@radosgw.'|'ceph-radosgw@') if present
-  systemd:
-    name: "{{ item }}"
-    state: stopped
-    enabled: no
-    masked: yes
-    daemon_reload: yes
-  with_items:
-    - "ceph-rgw@{{ ansible_hostname }}"
-    - "ceph-radosgw@{{ ansible_hostname }}.service"
-    - "ceph-radosgw@radosgw.{{ ansible_hostname }}.service"
-    - ceph-radosgw@radosgw.gateway.service
-  ignore_errors: true
-
 - name: systemd start rgw container
   systemd:
     name: ceph-radosgw@rgw.{{ ansible_hostname }}.{{ item.instance_name }}

--- a/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
+++ b/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
@@ -28,6 +28,7 @@
     name: "{{ item }}"
     state: stopped
     enabled: no
+    masked: yes
     daemon_reload: yes
   with_items:
     - "ceph-rgw@{{ ansible_hostname }}"
@@ -41,5 +42,6 @@
     name: ceph-radosgw@rgw.{{ ansible_hostname }}.{{ item.instance_name }}
     state: started
     enabled: yes
+    masked: no
     daemon_reload: yes
   with_items: "{{ rgw_instances }}"

--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -31,6 +31,8 @@
       changed_when: false
       with_dict: "{{ rgw_create_pools }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      register: result
+      until: result is succeeded
       run_once: true
 
     - name: customize pool size
@@ -39,5 +41,7 @@
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
       run_once: true
+      register: result
+      until: result is succeeded
       when:
         - item.size | default(osd_pool_default_size) != ceph_osd_pool_default_size

--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -22,7 +22,7 @@
   include_tasks: multisite/main.yml
   when: rgw_multisite
 
-- name: rgw pool realted tasks
+- name: rgw pool related tasks
   when:
     - rgw_create_pools is defined
   block:

--- a/roles/ceph-rgw/tasks/start_radosgw.yml
+++ b/roles/ceph-rgw/tasks/start_radosgw.yml
@@ -20,6 +20,7 @@
     name: ceph-radosgw@rgw.{{ ansible_hostname }}.{{ item.instance_name }}
     state: started
     enabled: yes
+    masked: no
   with_items: "{{ rgw_instances }}"
 
 - name: enable the ceph-radosgw.target service

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -1,0 +1,87 @@
+[tox]
+envlist = dev-{centos,ubuntu}-{container,non_container}-update
+
+skipsdist = True
+
+[testenv]
+whitelist_externals =
+    vagrant
+    bash
+    cp
+    git
+    pip
+passenv=*
+setenv=
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
+  ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
+  ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/plugins/callback
+  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  ANSIBLE_CACHE_PLUGIN = memory
+  ANSIBLE_GATHERING = implicit
+  # only available for ansible >= 2.5
+  ANSIBLE_STDOUT_CALLBACK = yaml
+#  non_container: DEV_SETUP = True
+  centos: CEPH_ANSIBLE_VAGRANT_BOX = centos/7
+  fedora: CEPH_ANSIBLE_VAGRANT_BOX = fedora/29-atomic-host
+  # Set the vagrant box image to use
+  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/7
+  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/atomic-host
+  ubuntu: CEPH_ANSIBLE_VAGRANT_BOX = guits/ubuntu-bionic64
+
+  # Set the ansible inventory host file to be used according to which distrib we are running on
+  ubuntu: _INVENTORY = hosts-ubuntu
+  INVENTORY = {env:_INVENTORY:hosts}
+  container: CONTAINER_DIR = /container
+  container: PLAYBOOK = site-docker.yml.sample
+  non_container: PLAYBOOK = site.yml.sample
+
+  CEPH_DOCKER_IMAGE_TAG = latest-mimic
+  CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-mimic
+  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
+  UPDATE_CEPH_DEV_BRANCH = master
+  UPDATE_CEPH_DEV_SHA1 = latest
+  CEPH_STABLE_RELEASE = mimic
+  ROLLING_UPDATE = True
+
+changedir={toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
+commands=
+  vagrant up --no-provision {posargs:--provider=virtualbox}
+  bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
+
+  # use the stable-3.2 branch to deploy a luminous cluster
+  git clone -b {env:CEPH_ANSIBLE_BRANCH:stable-3.2} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
+
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {envdir}/tmp/ceph-ansible/tests/functional/setup.yml
+
+  # configure lvm
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {envdir}/tmp/ceph-ansible/tests/functional/lvm_setup.yml
+
+   # deploy the cluster
+  ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
+      delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
+      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:mimic} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-mimic} \
+      copy_admin_key={env:COPY_ADMIN_KEY:False} \
+  "
+
+  pip install -r {toxinidir}/tests/requirements.txt
+  cp {toxinidir}/infrastructure-playbooks/rolling_update.yml {toxinidir}/rolling_update.yml
+  non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup=True change_dir={changedir} ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/rolling_update.yml --extra-vars "\
+      ireallymeanit=yes \
+      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:UPDATE_CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:UPDATE_CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
+      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
+  "
+
+  bash -c "CEPH_STABLE_RELEASE={env:UPDATE_CEPH_STABLE_RELEASE:nautilus} py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests"
+
+  vagrant destroy --force


### PR DESCRIPTION
This PR adds the nautilus upgrade support.

A couple of fixes were required:
- ceph_key module: don't fail in the `lookup_ceph_initial_entities()` when the expected keyring list doesn't match what is found in the cluster during the rolling_update sequence,
- mask the systemd unit services to prevent the packaging from restarting services,
- introduce msgr2 protocol support,
- ensure mgrs are upgraded after ALL monitors,
- do not trigger handlers when running rolling_update since we manager stop/start of services in the playbook.

This commit also split the tox file to be more readable since it's became too big.