### PR TITLE
purge-docker-cluster: Remove ceph-osd service

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -445,11 +445,6 @@
           state: absent
         with_items:
           - "{{ resolved_parent_device }}"
-
-      - name: remove ceph osd service
-        file:
-          path: /etc/systemd/system/ceph-osd@.service
-          state: absent
     when:
       - osd_scenario != "lvm"
 
@@ -483,6 +478,11 @@
         with_items: "{{ devices | default([]) }}"
     when:
       - osd_scenario == "lvm"
+
+  - name: remove ceph osd service
+    file:
+      path: /etc/systemd/system/ceph-osd@.service
+      state: absent
 
   - name: remove ceph osd image
     docker_image:


### PR DESCRIPTION
The systemd ceph-osd@.service file used for starting the ceph osd
containers is used in all osd_scenarios.
Currently purging a containerized deployment using the lvm scenario
didn't remove the ceph-osd systemd service.
If the next deployment is a non-containerized deployment, the OSDs
won't be online because the file is still present and override the
one from the package.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>