### PR TITLE
ceph-osd: Ensure lvm2 is installed

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -23,6 +23,17 @@
   tags:
     - with_pkg
 
+- name: install lvm2
+  package:
+    name: lvm2
+  register: result
+  until: result is succeeded
+  when:
+    - osd_scenario == 'lvm'
+    - not is_atomic
+  tags:
+    - with_pkg
+
 - name: include_tasks common.yml
   include_tasks: common.yml
 


### PR DESCRIPTION
When using osd_scenario lvm, we never check if the lvm2 package is
present on the host.
When using containerized deployment and docker on CentOS/RedHat this
package will be automatically installed as a dependency but not for
Ubuntu distribution.
OSD deployed via ceph-volume require the lvmetad.socket to be active
and running.

Resolves: #3728

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>