### PR TITLE
defaults: change default value for ceph_docker_image_tag

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -541,7 +541,7 @@ dummy:
 #docker_exec_cmd:
 #docker: false
 #ceph_docker_image: "ceph/daemon"
-#ceph_docker_image_tag: latest
+#ceph_docker_image_tag: latest-mimic
 #ceph_docker_registry: docker.io
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 #ceph_client_docker_image: "{{ ceph_docker_image }}"

--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -123,7 +123,7 @@ dummy:
 ##########
 
 #ceph_docker_image: "ceph/daemon"
-#ceph_docker_image_tag: latest
+#ceph_docker_image_tag: latest-mimic
 #ceph_nfs_docker_extra_env:
 #ceph_config_keys: [] # DON'T TOUCH ME
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -533,7 +533,7 @@ ceph_tcmalloc_max_total_thread_cache: 0
 docker_exec_cmd:
 docker: false
 ceph_docker_image: "ceph/daemon"
-ceph_docker_image_tag: latest
+ceph_docker_image_tag: latest-mimic
 ceph_docker_registry: docker.io
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 ceph_client_docker_image: "{{ ceph_docker_image }}"

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -115,6 +115,6 @@ rgw_client_name: client.rgw.{{ ansible_hostname }}
 ##########
 
 ceph_docker_image: "ceph/daemon"
-ceph_docker_image_tag: latest
+ceph_docker_image_tag: latest-mimic
 ceph_nfs_docker_extra_env:
 ceph_config_keys: [] # DON'T TOUCH ME


### PR DESCRIPTION
Since nautilus has been released, it's now the latest stable release, it
means the tag `latest` now refers to nautilus.

`stable-3.2` isn't intended to deploy nautilus, therefore, we should
change the default value for this variable to the latest release
stable-3.2 is able to deploy (mimic).

Closes: #3734

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>