### PR TITLE
cpuset support for RGW service

### DIFF
--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -59,6 +59,7 @@ dummy:
 # These options can be passed using the 'ceph_rgw_docker_extra_env' variable.
 #ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_rgw_docker_cpu_limit: 1
+#ceph_rgw_docker_cpuset_cpus: "0,2,4,6,8,10,12,14,16"
 
 #ceph_rgw_docker_extra_env:
 #ceph_config_keys: [] # DON'T TOUCH ME

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -51,6 +51,7 @@ copy_admin_key: false
 # These options can be passed using the 'ceph_rgw_docker_extra_env' variable.
 ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_rgw_docker_cpu_limit: 1
+#ceph_rgw_docker_cpuset_cpus: "0,2,4,6,8,10,12,14,16"
 
 ceph_rgw_docker_extra_env:
 ceph_config_keys: [] # DON'T TOUCH ME

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -15,6 +15,9 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   {% else -%}
   --cpu-quota={{ ceph_rgw_docker_cpu_limit * 100000 }} \
   {% endif -%}
+  {% if ceph_rgw_docker_cpuset_cpus is defined -%}
+  --cpuset-cpus='{{ ceph_rgw_docker_cpuset_cpus }}' \
+  {% endif -%}
   -v /var/lib/ceph:/var/lib/ceph:z \
   -v /etc/ceph:/etc/ceph:z \
   -v /var/run/ceph:/var/run/ceph:z \


### PR DESCRIPTION
The OSD already supports cpuset to be used for containerized deployments
through the use of the ceph_osd_docker_cpuset_cpus variable. This adds similar
support to the RGW service for containerized deployments by setting a new
variable named ceph_rgw_docker_cpuset_cpus. Like the OSD, there are times where
using distinct cores has advantages over using the CFS in kernel scheduler.

ceph_rgw_docker_cpuset_cpus accepts a comma delimited set of CPU ids