### PR TITLE
travis: Remove galaxy lint rules repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ notifications:
 install:
   - pip install -r requirements.txt
   - pip install ansible-lint pytest
-  - git clone https://github.com/ansible/galaxy-lint-rules
 script:
   - pytest -vvvv library/
-  - for i in $(ls -1 roles/); do ansible-lint -x 204 -v -r galaxy-lint-rules/rules roles/$i/ ; done
+  - for i in $(ls -1 roles/); do ansible-lint -x 204 -v roles/$i/ ; done


### PR DESCRIPTION
The galaxy-lint-rules github repository isn't used anymore and has
been archived.
All the rules are now part of the ansible-lint project.

https://github.com/ansible/galaxy-lint-rules
https://github.com/ansible/ansible-lint

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>