### PR TITLE
Add uca as acceptable ceph_repository value to validate.py

### DIFF
--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -134,7 +134,7 @@ def ceph_origin_choices(value):
 
 
 def ceph_repository_choices(value):
-    assert value in ['community', 'rhcs', 'dev', 'custom'], "ceph_repository must be either 'community', 'rhcs', 'dev', or 'custom'"
+    assert value in ['community', 'rhcs', 'dev', 'uca', 'custom'], "ceph_repository must be either 'community', 'rhcs', 'dev', 'uca', or 'custom'"
 
 
 def ceph_repository_type_choices(value):


### PR DESCRIPTION
When I set:
```
ceph_repository: uca
```
I get:
`ceph_repository must be either 'community', 'rhcs', 'dev', or 'custom'`

http://docs.ceph.com/ceph-ansible/stable-3.2/installation/methods.html says that uca is acceptable, and when I make this change, my entire build works fine. Pushing the change to validate.py to allow it.