### PR TITLE
tests/functional: Use the ansible reboot module

### DIFF
--- a/tests/functional/reboot.yml
+++ b/tests/functional/reboot.yml
@@ -2,21 +2,8 @@
 - hosts: all
   gather_facts: true
   tasks:
-    # why sleep 2? see here: https://github.com/ansible/ansible/issues/14413
     - name: reboot the machines
-      shell: sleep 2 && shutdown -r now
+      reboot:
+        reboot_timeout: 180
+        test_command: uptime
       become: yes
-      async: 1
-      poll: 0
-
-    - name: waiting 3 minutes for the machines to come back
-      local_action:
-        module: wait_for
-        host: "{{ ansible_default_ipv4.address }}"
-        port: 22
-        state: started
-        delay: 30
-        timeout: 180
-
-    - name: uptime
-      command: uptime


### PR DESCRIPTION
Ansible 2.7 introduces the reboot module so we don't need to use the
shell/reboot + wait_for tasks.

https://docs.ansible.com/ansible/latest/modules/reboot_module.html

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>