### PR TITLE
tox: Fix container purge jobs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -239,10 +239,10 @@ setenv=
   INVENTORY = {env:_INVENTORY:hosts}
   container: CONTAINER_DIR = /container
   container: PLAYBOOK = site-docker.yml.sample
+  container: PURGE_PLAYBOOK = purge-docker-cluster.yml
   storage_inventory: COPY_ADMIN_KEY = True
   podman: PLAYBOOK = site-docker.yml.sample
   non_container: PLAYBOOK = site.yml.sample
-  container-purge_cluster: PURGE_PLAYBOOK = purge-docker-cluster.yml
   shrink_mon: MON_TO_KILL = mon2
   shrink_osd: COPY_ADMIN_KEY = True
 


### PR DESCRIPTION
On containerized CI jobs the playbook executed is purge-cluster.yml
but it should be set to purge-docker-cluster.yml

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>