### PR TITLE
container: Add python3-docker on Ubuntu bionic

### DIFF
--- a/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
@@ -29,10 +29,19 @@
         update_cache: yes
       register: result
       until: result is succeeded
-      tags:
-        with_pkg
+
+    - name: install python3-docker on bionic
+      package:
+        name: python3-docker
+        state: present
+        update_cache: yes
+      register: result
+      until: result is succeeded
+      when: ansible_lsb.codename == 'bionic'
   when:
     - ansible_distribution == 'Ubuntu'
+  tags:
+    with_pkg
 
 # ensure extras enabled for docker
 - name: enable extras on centos


### PR DESCRIPTION
When installing python-minimal on Ubuntu bionic, this will add the
/usr/bin/python symlink to the default python interpreter.
On bionic, this isn't python2 but python3.

$ /usr/bin/python --version
Python 3.6.7

The python docker library is only installed for python2 which causes
issues when running the purge-docker-cluster playbook. This playbook
uses the ansible docker modules and requires to have python bindings
installed on the remote host.
Without the bindings we can see python error reported by the docker
module.

msg: Failed to import docker or docker-py - No module named 'docker'.
Try `pip install docker` or `pip install docker-py` (Python 2.6)

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>