### PR TITLE
tests: add mgr and nfs nodes in all_daemons

### DIFF
--- a/tests/functional/all_daemons/container/vagrant_variables.yml
+++ b/tests/functional/all_daemons/container/vagrant_variables.yml
@@ -8,7 +8,7 @@ mon_vms: 3
 osd_vms: 2
 mds_vms: 1
 rgw_vms: 1
-nfs_vms: 0
+nfs_vms: 1
 rbd_mirror_vms: 1
 client_vms: 2
 iscsi_gw_vms: 1

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -8,11 +8,11 @@ mon_vms: 3
 osd_vms: 2
 mds_vms: 1
 rgw_vms: 1
-nfs_vms: 0
+nfs_vms: 1
 rbd_mirror_vms: 1
 client_vms: 2
 iscsi_gw_vms: 1
-mgr_vms: 0
+mgr_vms: 1
 
 # INSTALL SOURCE OF CEPH
 # valid values are 'stable' and 'dev'


### PR DESCRIPTION
even not used, we need to fire up those VMs to be able to perform the
upgrade in the CI.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>