### PR TITLE
iscsi: fix permission denied error

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/deploy_ssl_keys.yml
+++ b/roles/ceph-iscsi-gw/tasks/deploy_ssl_keys.yml
@@ -18,16 +18,23 @@
   register: crt_files_exist
 
 - name: create ssl crt/key files
-  local_action:
-    module: shell openssl req -newkey rsa:2048 -nodes -keyout {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.key -x509 -days 365 -out {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.crt -subj "/C=US/ST=./L=./O=RedHat/OU=Linux/CN={{ ansible_hostname }}"
+  command: >
+    openssl req -newkey rsa:2048 -nodes -keyout {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.key
+     -x509 -days 365 -out {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.crt
+     -subj "/C=US/ST=./L=./O=RedHat/OU=Linux/CN={{ ansible_hostname }}"
+  delegate_to: localhost
+  become: False
   run_once: True
   with_items: "{{ crt_files_exist.results }}"
   when:
     - item.stat.exists == false
 
 - name: create pem
-  local_action:
-    module: shell cat {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.crt {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.key > {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.pem
+  shell: >
+    cat {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.crt
+    {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.key > {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.pem
+  delegate_to: localhost
+  become: False
   run_once: True
   register: pem
   with_items: "{{ crt_files_exist.results }}"
@@ -35,8 +42,11 @@
     - item.stat.exists == false
 
 - name: create public key from pem
-  local_action:
-    module: shell openssl x509 -inform pem -in {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.pem -pubkey -noout > {{ fetch_directory }}/{{ fsid }}/iscsi-gateway-pub.key
+  shell: >
+    openssl x509 -inform pem -in {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.pem
+    -pubkey -noout > {{ fetch_directory }}/{{ fsid }}/iscsi-gateway-pub.key
+  delegate_to: localhost
+  become: False
   run_once: True
   when:
     - pem.changed
@@ -48,5 +58,6 @@
     owner: root
     group: root
     mode: 0400
+  delegate_to: localhost
   changed_when: false
   with_items: "{{ crt_files }}"

--- a/roles/ceph-iscsi-gw/tasks/deploy_ssl_keys.yml
+++ b/roles/ceph-iscsi-gw/tasks/deploy_ssl_keys.yml
@@ -58,6 +58,5 @@
     owner: root
     group: root
     mode: 0400
-  delegate_to: localhost
   changed_when: false
   with_items: "{{ crt_files }}"


### PR DESCRIPTION
Typical error:
```
fatal: [iscsi-gw0]: FAILED! =>
  msg: 'an error occurred while trying to read the file ''/home/guits/ceph-ansible/tests/functional/all_daemons/fetch/e5f4ab94-c099-4781-b592-dbd440a9d6f3/iscsi-gateway.key'': [Errno 13] Permission denied: b''/home/guits/ceph-ansible/tests/functional/all_daemons/fetch/e5f4ab94-c099-4781-b592-dbd440a9d6f3/iscsi-gateway.key'''
```

`become: True` is not needed on the following task:

`copy crt file(s) to gateway nodes`.

Since it's already set in the main playbook (site.yml/site-container.yml)

The thing is that the files get generated in the 'fetch_directory' with
root user because there is a 'delegate_to' + we run the playbook with
`become: True` (from main playbook).

The idea here is to create files under ansible user so we can open them
later to copy them on the remote machine.