### PR TITLE
tox: Set nautilus as default release

### DIFF
--- a/tests/functional/lvm-auto-discovery/container/group_vars/all
+++ b/tests/functional/lvm-auto-discovery/container/group_vars/all
@@ -6,7 +6,7 @@ docker: True
 
 containerized_deployment: True
 ceph_origin: repository
-ceph_repository: dev
+ceph_repository: community
 cluster: ceph
 public_network: "192.168.39.0/24"
 cluster_network: "192.168.40.0/24"

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = dev-{centos,ubuntu}-{container,non_container}-update
+envlist = nautilus-{centos,ubuntu}-{container,non_container}-update
 
 skipsdist = True
 
@@ -38,9 +38,7 @@ setenv=
 
   CEPH_DOCKER_IMAGE_TAG = latest-mimic
   CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-mimic
-  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
-  UPDATE_CEPH_DEV_BRANCH = master
-  UPDATE_CEPH_DEV_SHA1 = latest
+  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-nautilus
   CEPH_STABLE_RELEASE = mimic
   ROLLING_UPDATE = True
 
@@ -71,15 +69,12 @@ commands=
 
   pip install -r {toxinidir}/tests/requirements.txt
   cp {toxinidir}/infrastructure-playbooks/rolling_update.yml {toxinidir}/rolling_update.yml
-  non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup=True change_dir={changedir} ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/rolling_update.yml --extra-vars "\
       ireallymeanit=yes \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:UPDATE_CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:UPDATE_CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
   "
 
   bash -c "CEPH_STABLE_RELEASE={env:UPDATE_CEPH_STABLE_RELEASE:nautilus} py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = {dev,rhcs}-{centos,ubuntu}-{container,non_container}-{all_daemons,collocation,update,bluestore_lvm_osds,lvm_osds,shrink_mon,shrink_osd,lvm_batch,add_osds,rgw_multisite,purge,storage_inventory,lvm_auto_discovery}
-  {dev,rhcs}-{centos,ubuntu}-container-{ooo_collocation,podman}
-  {dev,rhcs}-{centos,ubuntu}-non_container-{switch_to_containers}
+envlist = {nautilus,rhcs}-{centos,ubuntu}-{container,non_container}-{all_daemons,collocation,update,bluestore_lvm_osds,lvm_osds,shrink_mon,shrink_osd,lvm_batch,add_osds,rgw_multisite,purge,storage_inventory,lvm_auto_discovery}
+  {nautilus,rhcs}-{centos,ubuntu}-container-{ooo_collocation,podman}
+  {nautilus,rhcs}-{centos,ubuntu}-non_container-{switch_to_containers}
   dev-rhel-container-podman
   infra_lv_create
 
@@ -67,8 +67,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
   # test that the cluster can be redeployed in a healthy state
   py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
@@ -95,8 +93,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
   # test that the cluster can be redeployed in a healthy state
   py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
@@ -105,15 +101,12 @@ commands=
 [update]
 commands=
   cp {toxinidir}/infrastructure-playbooks/rolling_update.yml {toxinidir}/rolling_update.yml
-  ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "change_dir={changedir} ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/rolling_update.yml --extra-vars "\
       ireallymeanit=yes \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:UPDATE_CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:UPDATE_CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
   "
 
   bash -c "CEPH_STABLE_RELEASE={env:UPDATE_CEPH_STABLE_RELEASE:nautilus} py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests"
@@ -146,8 +139,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
 
   py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-switch-to-containers {toxinidir}/tests/functional/tests
@@ -164,8 +155,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       "
   py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-2 {toxinidir}/tests/functional/tests
 
@@ -174,7 +163,6 @@ commands=
   bash -c "cd {changedir}/secondary && vagrant up --no-provision {posargs:--provider=virtualbox}"
   bash -c "cd {changedir}/secondary && bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}/secondary"
   ansible-playbook --ssh-extra-args='-F {changedir}/secondary/vagrant_ssh_config' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/setup.yml
-  ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir}/secondary ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
   ansible-playbook --ssh-extra-args='-F {changedir}/secondary/vagrant_ssh_config' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/lvm_setup.yml
   # ensure the rule isn't already present
   ansible -i localhost, all -c local -b -m iptables -a 'chain=FORWARD protocol=tcp source=192.168.0.0/16 destination=192.168.0.0/16 jump=ACCEPT action=insert rule_num=1 state=absent'
@@ -186,8 +174,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       "
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rgw_multisite.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest}"
   ansible-playbook -vv --ssh-extra-args='-F {changedir}/secondary/vagrant_ssh_config' -i {changedir}/secondary/hosts {toxinidir}/tests/functional/rgw_multisite.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest}"
@@ -247,15 +233,13 @@ setenv=
   shrink_osd: COPY_ADMIN_KEY = True
 
   rhcs: CEPH_STABLE_RELEASE = luminous
-  lvm_osds: CEPH_STABLE_RELEASE = luminous
+  lvm_osds: CEPH_STABLE_RELEASE = nautilus
 
   rhcs: CEPH_STABLE_RELEASE = luminous
-  dev: CEPH_DOCKER_IMAGE_TAG = latest-master
-  dev: CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-master
-  dev: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
-  dev: UPDATE_CEPH_DEV_BRANCH = master
-  dev: UPDATE_CEPH_DEV_SHA1 = latest
-  dev: CEPH_STABLE_RELEASE = nautilus
+  nautilus: CEPH_DOCKER_IMAGE_TAG = latest-nautilus
+  nautilus: CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-nautilus
+  nautilus: UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-nautilus
+  nautilus: CEPH_STABLE_RELEASE = nautilus
   update: CEPH_STABLE_RELEASE = mimic
   update: ROLLING_UPDATE = True
 
@@ -283,7 +267,6 @@ changedir=
 
 commands=
   rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
-  !update: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
 
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
@@ -304,8 +287,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       copy_admin_key={env:COPY_ADMIN_KEY:False} \
   "
 
@@ -330,8 +311,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-bis-master} # not ideal but what can we do? \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       copy_admin_key={env:COPY_ADMIN_KEY:False} " \
       --extra-vars @ceph-override.json
 


### PR DESCRIPTION
On stable-4.0 branch we don't want to use dev setup but stable
release (nautilus).
Also update the container image tag to reflect this change.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>