### PR TITLE
container-common: Enable docker on boot for ubuntu

### DIFF
--- a/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
@@ -42,6 +42,12 @@
       until: result is succeeded
       when: ansible_lsb.codename == 'bionic'
 
+    - name: start docker service
+      service:
+        name: docker
+        state: started
+        enabled: true
+
 # ensure extras enabled for docker
 - name: enable extras on centos
   yum_repository:


### PR DESCRIPTION
docker daemon is automatically started during package installation
but the service isn't enabled on boot.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>