### PR TITLE
ceph-volume: Add PYTHONIOENCODING env variable

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -37,6 +37,7 @@
       CEPH_VOLUME_DEBUG: 1
       CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
       CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+      PYTHONIOENCODING: utf-8
     when:
       - devices | default([]) | length > 0
       - osd_scenario == 'lvm'
@@ -57,6 +58,7 @@
       CEPH_VOLUME_DEBUG: 1
       CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
       CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+      PYTHONIOENCODING: utf-8
     when:
       - devices | default([]) | length > 0
       - osd_scenario == 'lvm'

--- a/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
@@ -15,3 +15,4 @@
     CEPH_VOLUME_DEBUG: 1
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+    PYTHONIOENCODING: utf-8

--- a/roles/ceph-osd/tasks/scenarios/lvm.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm.yml
@@ -18,5 +18,6 @@
     CEPH_VOLUME_DEBUG: 1
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+    PYTHONIOENCODING: utf-8
   with_items: "{{ lvm_volumes }}"
   tags: prepare_osd


### PR DESCRIPTION
Since https://github.com/ceph/ceph/commit/77912c0 ceph-volume uses
stdout encoding based on LC_CTYPE and PYTHONIOENCODING environment
variables.
Thoses variables aren't set when using ansible.
Currently this commit breaks non containerized deployment on Ubuntu.

```console
TASK [use ceph-volume to create bluestore osds] ********************
failed: [ubuntu] (item={u'data': u'/dev/sdb'}) => changed=true 
  cmd:
  - ceph-volume
  - --cluster
  - ceph
  - lvm
  - create
  - --bluestore
  - --data
  - /dev/sdb
  delta: '0:00:05.935833'
  end: '2019-04-01 19:59:35.991202'
  item:
    data: /dev/sdb
  msg: non-zero return code
  rc: 1
  start: '2019-04-01 19:59:30.055369'
  stderr: |-
    Traceback (most recent call last):
      File "/usr/sbin/ceph-volume", line 11, in <module>
        load_entry_point('ceph-volume==1.0.0', 'console_scripts', 'ceph-volume')()
      File "/usr/lib/python2.7/dist-packages/ceph_volume/main.py", line 38, in __init__
        self.main(self.argv)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/decorators.py", line 59, in newfunc
        return f(*a, **kw)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/main.py", line 148, in main
        terminal.dispatch(self.mapper, subcommand_args)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/terminal.py", line 205, in dispatch
        instance.main()
      File "/usr/lib/python2.7/dist-packages/ceph_volume/devices/lvm/main.py", line 40, in main
        terminal.dispatch(self.mapper, self.argv)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/terminal.py", line 205, in dispatch
        instance.main()
      File "/usr/lib/python2.7/dist-packages/ceph_volume/devices/lvm/create.py", line 69, in main
        self.create(args)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/decorators.py", line 16, in is_root
        return func(*a, **kw)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/devices/lvm/create.py", line 32, in create
        Activate([]).activate(args)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/decorators.py", line 16, in is_root
        return func(*a, **kw)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/devices/lvm/activate.py", line 263, in activate
        activate_bluestore(lvs, no_systemd=args.no_systemd)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/devices/lvm/activate.py", line 190, in activate_bluestore
        systemctl.enable_volume(osd_id, osd_fsid, 'lvm')
      File "/usr/lib/python2.7/dist-packages/ceph_volume/systemd/systemctl.py", line 82, in enable_volume
        return enable(volume_unit % (device_type, id_, fsid))
      File "/usr/lib/python2.7/dist-packages/ceph_volume/systemd/systemctl.py", line 22, in enable
        process.run(['systemctl', 'enable', unit])
      File "/usr/lib/python2.7/dist-packages/ceph_volume/process.py", line 137, in run
        log_descriptors(reads, process, terminal_logging)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/process.py", line 59, in log_descriptors
        log_output(descriptor_name, message, terminal_logging, True)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/process.py", line 32, in log_output
        getattr(terminal, descriptor)(message)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/terminal.py", line 130, in stderr
        return _Write(prefix=yellow(' stderr: ')).raw(msg)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/terminal.py", line 117, in raw
        self.write(string)
      File "/usr/lib/python2.7/dist-packages/ceph_volume/terminal.py", line 120, in write
        self._writer.write(self.prefix + line + self.suffix)
      File "/usr/lib/python2.7/codecs.py", line 369, in write
        data, consumed = self.encode(object, self.errors)
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 132: ordinal not in range(128)
  stderr_lines:
  - 'Traceback (most recent call last):'
  - '  File "/usr/sbin/ceph-volume", line 11, in <module>'
  - '    load_entry_point(''ceph-volume==1.0.0'', ''console_scripts'', ''ceph-volume'')()'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/main.py", line 38, in __init__'
  - '    self.main(self.argv)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/decorators.py", line 59, in newfunc'
  - '    return f(*a, **kw)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/main.py", line 148, in main'
  - '    terminal.dispatch(self.mapper, subcommand_args)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/terminal.py", line 205, in dispatch'
  - '    instance.main()'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/devices/lvm/main.py", line 40, in main'
  - '    terminal.dispatch(self.mapper, self.argv)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/terminal.py", line 205, in dispatch'
  - '    instance.main()'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/devices/lvm/create.py", line 69, in main'
  - '    self.create(args)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/decorators.py", line 16, in is_root'
  - '    return func(*a, **kw)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/devices/lvm/create.py", line 32, in create'
  - '    Activate([]).activate(args)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/decorators.py", line 16, in is_root'
  - '    return func(*a, **kw)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/devices/lvm/activate.py", line 263, in activate'
  - '    activate_bluestore(lvs, no_systemd=args.no_systemd)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/devices/lvm/activate.py", line 190, in activate_bluestore'
  - '    systemctl.enable_volume(osd_id, osd_fsid, ''lvm'')'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/systemd/systemctl.py", line 82, in enable_volume'
  - '    return enable(volume_unit % (device_type, id_, fsid))'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/systemd/systemctl.py", line 22, in enable'
  - '    process.run([''systemctl'', ''enable'', unit])'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/process.py", line 137, in run'
  - '    log_descriptors(reads, process, terminal_logging)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/process.py", line 59, in log_descriptors'
  - '    log_output(descriptor_name, message, terminal_logging, True)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/process.py", line 32, in log_output'
  - '    getattr(terminal, descriptor)(message)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/terminal.py", line 130, in stderr'
  - '    return _Write(prefix=yellow('' stderr: '')).raw(msg)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/terminal.py", line 117, in raw'
  - '    self.write(string)'
  - '  File "/usr/lib/python2.7/dist-packages/ceph_volume/terminal.py", line 120, in write'
  - '    self._writer.write(self.prefix + line + self.suffix)'
  - '  File "/usr/lib/python2.7/codecs.py", line 369, in write'
  - '    data, consumed = self.encode(object, self.errors)'
  - 'UnicodeDecodeError: ''ascii'' codec can''t decode byte 0xe2 in position 132: ordinal not in range(128)'
  stdout: |-
    Running command: /usr/bin/ceph-authtool --gen-print-key
    Running command: /usr/bin/ceph --cluster ceph --name client.bootstrap-osd --keyring /var/lib/ceph/bootstrap-osd/ceph.keyring -i - osd new 176d5eca-ad92-446a-8001-29b9ebc6aad7
    Running command: /sbin/vgcreate -s 1G --force --yes ceph-53e8a338-153b-4206-8432-675fa137e05b /dev/sdb
     stdout: Physical volume "/dev/sdb" successfully created.
     stdout: Volume group "ceph-53e8a338-153b-4206-8432-675fa137e05b" successfully created
    Running command: /sbin/lvcreate --yes -l 100%FREE -n osd-block-176d5eca-ad92-446a-8001-29b9ebc6aad7 ceph-53e8a338-153b-4206-8432-675fa137e05b
     stdout: Logical volume "osd-block-176d5eca-ad92-446a-8001-29b9ebc6aad7" created.
    Running command: /usr/bin/ceph-authtool --gen-print-key
    Running command: /bin/mount -t tmpfs tmpfs /var/lib/ceph/osd/ceph-1
    --> Absolute path not found for executable: restorecon
    --> Ensure $PATH environment variable contains common executable locations
    Running command: /bin/chown -h ceph:ceph /dev/ceph-53e8a338-153b-4206-8432-675fa137e05b/osd-block-176d5eca-ad92-446a-8001-29b9ebc6aad7
    Running command: /bin/chown -R ceph:ceph /dev/dm-0
    Running command: /bin/ln -s /dev/ceph-53e8a338-153b-4206-8432-675fa137e05b/osd-block-176d5eca-ad92-446a-8001-29b9ebc6aad7 /var/lib/ceph/osd/ceph-1/block
    Running command: /usr/bin/ceph --cluster ceph --name client.bootstrap-osd --keyring /var/lib/ceph/bootstrap-osd/ceph.keyring mon getmap -o /var/lib/ceph/osd/ceph-1/activate.monmap
     stderr: got monmap epoch 1
    Running command: /usr/bin/ceph-authtool /var/lib/ceph/osd/ceph-1/keyring --create-keyring --name osd.1 --add-key AQCibaJcO/fGJRAAeTGWNEKPmozq/OSXfkq34g==
     stdout: creating /var/lib/ceph/osd/ceph-1/keyring
     stdout: added entity osd.1 auth(key=AQCibaJcO/fGJRAAeTGWNEKPmozq/OSXfkq34g==)
    Running command: /bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-1/keyring
    Running command: /bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-1/
    Running command: /usr/bin/ceph-osd --cluster ceph --osd-objectstore bluestore --mkfs -i 1 --monmap /var/lib/ceph/osd/ceph-1/activate.monmap --keyfile - --osd-data /var/lib/ceph/osd/ceph-1/ --osd-uuid 176d5eca-ad92-446a-8001-29b9ebc6aad7 --setuser ceph --setgroup ceph
    --> ceph-volume lvm prepare successful for: /dev/sdb
    Running command: /bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-1
    Running command: /usr/bin/ceph-bluestore-tool --cluster=ceph prime-osd-dir --dev /dev/ceph-53e8a338-153b-4206-8432-675fa137e05b/osd-block-176d5eca-ad92-446a-8001-29b9ebc6aad7 --path /var/lib/ceph/osd/ceph-1 --no-mon-config
    Running command: /bin/ln -snf /dev/ceph-53e8a338-153b-4206-8432-675fa137e05b/osd-block-176d5eca-ad92-446a-8001-29b9ebc6aad7 /var/lib/ceph/osd/ceph-1/block
    Running command: /bin/chown -h ceph:ceph /var/lib/ceph/osd/ceph-1/block
    Running command: /bin/chown -R ceph:ceph /dev/dm-0
    Running command: /bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-1
    Running command: /bin/systemctl enable ceph-volume@lvm-1-176d5eca-ad92-446a-8001-29b9ebc6aad7
    --> Was unable to complete a new OSD, will rollback changes
    Running command: /usr/bin/ceph --cluster ceph --name client.bootstrap-osd --keyring /var/lib/ceph/bootstrap-osd/ceph.keyring osd purge-new osd.1 --yes-i-really-mean-it
     stderr: purged osd.1
     stderr:
  stdout_lines: <omitted>
```

Note that the task is failing on ansible side due to the stdout
decoding but the osd creation is successful.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>