### PR TITLE
[backport] osd: backward compatibility with old disk_list.sh location (stable-3.1)

### DIFF
--- a/roles/ceph-osd/tasks/docker/start_docker_osd.yml
+++ b/roles/ceph-osd/tasks/docker/start_docker_osd.yml
@@ -10,11 +10,21 @@
   when:
     - ceph_docker_on_openstack
 
+- name: test if the container image has directory {{ container_bin_path }}
+  command: "docker run --rm --net=host --entrypoint=test {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} -d {{ container_bin_path }}"
+  changed_when: false
+  failed_when: false
+  register: test_container_bin_path
+  when:
+    - osd_scenario != 'lvm'
+
 - name: test if the container image has the disk_list function
-  command: docker run --rm --entrypoint=stat {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} disk_list.sh
+  command: "docker run --rm --net=host --entrypoint=stat {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} {{ container_bin_path + '/disk_list.sh' if test_container_bin_path.rc == 0 else 'disk_list.sh' }}"
   changed_when: false
   failed_when: false
   register: disk_list
+  when:
+    - osd_scenario != 'lvm'
 
 - name: generate ceph osd docker run script
   become: true

--- a/roles/ceph-osd/vars/main.yml
+++ b/roles/ceph-osd/vars/main.yml
@@ -1,0 +1,2 @@
+---
+container_bin_path: /opt/ceph-container/bin


### PR DESCRIPTION
Since all files in container image have moved to `/opt/ceph-container`
this check must look for new AND the old path so it's backward
compatible. Otherwise it could end up by templating an inconsistent
`ceph-osd-run.sh`.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 987bdac963cee8d8aba1f10659f23bb68c2b1d1b)