### PR TITLE
purge: fix lvm-batch purge osd

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -323,6 +323,7 @@
       CEPH_VOLUME_DEBUG: 1
     with_items: "{{ lvm_volumes }}"
     when:
+      - lvm_volumes | default([]) | length > 0
       - osd_scenario == "lvm"
       - ceph_volume_present.rc == 0
 
@@ -334,6 +335,7 @@
       CEPH_VOLUME_DEBUG: 1
     with_items: "{{ devices | default([]) }}"
     when:
+      - devices | default([]) | length > 0
       - osd_scenario == "lvm"
       - ceph_volume_present.rc == 0
 

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -466,6 +466,7 @@
           CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
           CEPH_CONTAINER_BINARY: "{{ container_binary }}"
         with_items: "{{ lvm_volumes }}"
+        when: lvm_volumes | default([]) | length > 0
 
       - name: zap and destroy osds created by ceph-volume with devices
         ceph_volume:
@@ -476,6 +477,7 @@
           CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
           CEPH_CONTAINER_BINARY: "{{ container_binary }}"
         with_items: "{{ devices | default([]) }}"
+        when: devices | default([]) | length > 0
     when:
       - osd_scenario == "lvm"
 


### PR DESCRIPTION
`lvm_volumes` and/or `devices` variable(s) can be undefined depending on
the scenario chosen.

These tasks should be run only if these variable are defined, otherwise
it ends up with undefined variable errors.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1653307

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>