### PR TITLE
tests: retry to fire up VMs on vagrant failure

### DIFF
--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+retries=0
+until [ $retries -ge 5 ]
+do
+  echo "Attempting to start VMs. Attempts: $retries"
+  timeout 10m vagrant up "$@" && break
+  retries=$[$retries+1]
+  sleep 5
+done
+
+sleep 10

--- a/tox.ini
+++ b/tox.ini
@@ -265,7 +265,7 @@ commands=
   rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
   !update: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
 
-  vagrant up --no-provision {posargs:--provider=virtualbox}
+  bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   # configure lvm


### PR DESCRIPTION
Add a script to retry several times to fire up VMs to avoid vagrant
failures.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
Co-authored-by: Andrew Schoen <aschoen@redhat.com>