### PR TITLE
tests: fix shrink_osd scenario (stable-3.1)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -129,6 +129,11 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/shrink-osd.yml --extra-vars "\
       ireallymeanit=yes \
       osd_to_kill=0 \
+      ceph_stable_release={env:UPDATE_CEPH_STABLE_RELEASE:luminous} \
+      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-luminous} \
   "
 
 [switch-to-containers]


### PR DESCRIPTION
the wrong image version was used to run shrink_osd playbook.
in stable-3.1 we should use a luminous image, not nautilus which doesn't
have ceph-disk binary anymore.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>