### PR TITLE
tests: fix shrink_mon scenario (stable-3.1)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -121,7 +121,7 @@ commands=
   cp {toxinidir}/infrastructure-playbooks/shrink-mon.yml {toxinidir}/shrink-mon.yml
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/shrink-mon.yml --extra-vars "\
       ireallymeanit=yes \
-      mon_to_kill={env:MON_TO_KILL:ceph-mon2} \
+      mon_to_kill={env:MON_TO_KILL:mon2} \
   "
 [shrink-osd]
 commands=


### PR DESCRIPTION
since the node names have changed recently (the 'ceph-' prefix has been
removed), we must change the name in the shrink_mon playbook command
here.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>