### PR TITLE
mds: allow adding mds with a --limit run

### DIFF
--- a/roles/ceph-mds/tasks/main.yml
+++ b/roles/ceph-mds/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: include create_mds_filesystems.yml
   include_tasks: create_mds_filesystems.yml
   when:
+    - groups[mon_group_name] | intersect(ansible_play_hosts) | length > 0
     - inventory_hostname == groups[mds_group_name] | first
     - not rolling_update
 


### PR DESCRIPTION
When running main playbook with --limit on a mds node,
create_mds_filesystems.yml shouldn't be played since no monitors are in
the play batch.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>