### PR TITLE
tests: pin pytest-xdist to 1.27.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 # These are Python requirements needed to run the functional tests
 six==1.10.0
 testinfra==1.19.0
-pytest-xdist
+pytest-xdist==1.27.0
 pytest==3.6.1
 notario>=0.0.13
 ansible~=2.7,<2.8

--- a/tox.ini
+++ b/tox.ini
@@ -290,9 +290,9 @@ commands=
   "
 
   # wait 30sec for services to be ready
-  all_daemons: sleep 30
+  sleep 30
   # test cluster state using ceph-ansible tests
-  all_daemons: py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
+  py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} {toxinidir}/tests/functional/tests
 
   # reboot all vms
   all_daemons: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/reboot.yml


### PR DESCRIPTION
looks like newer version of pytest-xdist requires pytest>=4.4.0

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>