### PR TITLE
tox: Fix container purge jobs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -181,6 +181,7 @@ setenv=
 
   container-shrink: MON_TO_KILL = mon2
   container-shrink_osd: COPY_ADMIN_KEY = True
+  container: PURGE_PLAYBOOK = purge-docker-cluster.yml
   shrink_osd: COPY_ADMIN_KEY = True
 
   rhcs: CEPH_STABLE_RELEASE = luminous


### PR DESCRIPTION
On containerized CI jobs the playbook executed is purge-cluster.yml
but it should be set to purge-docker-cluster.yml

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit bd0869cd01090e135a9312a6890ed7611f8e3a1c)