### PR TITLE
add-osds: don't hardcode group names

### DIFF
--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -31,21 +31,21 @@
       when:
         - not delegate_facts_host | bool
 
+    - import_role:
+        name: ceph-defaults
+
     - name: gather and delegate facts
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items:
-        - "{{ groups['mons'] }}"
-        - "{{ groups['osds'] }}"
+        - "{{ groups[mon_group_name] }}"
+        - "{{ groups[osd_group_name] }}"
       run_once: True
       when:
         - delegate_facts_host | bool
 
   tasks:
-    - import_role:
-        name: ceph-defaults
-
     - import_role:
         name: ceph-facts
 
@@ -66,13 +66,16 @@
       when:
         - not delegate_facts_host | bool
 
+    - import_role:
+        name: ceph-defaults
+
     - name: gather and delegate facts
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items:
-        - "{{ groups['mons'] }}"
-        - "{{ groups['osds'] }}"
+        - "{{ groups[mon_group_name] }}"
+        - "{{ groups[osd_group_name] }}"
       run_once: True
       when:
         - delegate_facts_host | bool
@@ -89,9 +92,6 @@
       changed_when: False
 
   tasks:
-    - import_role:
-        name: ceph-defaults
-
     - import_role:
         name: ceph-facts
 

--- a/tests/functional/add-osds/container/vagrant_variables.yml
+++ b/tests/functional/add-osds/container/vagrant_variables.yml
@@ -1,7 +1,7 @@
 ---
 
 # DEPLOY CONTAINERIZED DAEMONS
-docker: false
+docker: true
 
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 1


### PR DESCRIPTION
Instead of hardcoding group names, import ceph-defaults earlier. Also,
rectify a minor mistake in vagrant_varaibles.yml for containerized
version of add_osds.