### PR TITLE
tests: run lvm_setup.yml on secondary cluster

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -148,7 +148,10 @@ commands=
   bash -c "cd {changedir}/secondary && vagrant up --no-provision {posargs:--provider=virtualbox}"
   bash -c "cd {changedir}/secondary && bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}/secondary"
   ansible-playbook --ssh-extra-args='-F {changedir}/secondary/vagrant_ssh_config' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/setup.yml
-  ansible -i localhost, all -c local -b -m iptables -a 'chain=FORWARD protocol=tcp source=192.168.0.0/16 destination=192.168.0.0/16 jump=ACCEPT action=insert rule_num=1'
+  ansible-playbook --ssh-extra-args='-F {changedir}/secondary/vagrant_ssh_config' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  # ensure the rule isn't already present
+  ansible -i localhost, all -c local -b -m iptables -a 'chain=FORWARD protocol=tcp source=192.168.0.0/16 destination=192.168.0.0/16 jump=ACCEPT action=insert rule_num=1 state=absent'
+  ansible -i localhost, all -c local -b -m iptables -a 'chain=FORWARD protocol=tcp source=192.168.0.0/16 destination=192.168.0.0/16 jump=ACCEPT action=insert rule_num=1 state=present'
   ansible-playbook --ssh-extra-args='-F {changedir}/secondary/vagrant_ssh_config' -vv -i {changedir}/secondary/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/secondary/fetch} \


### PR DESCRIPTION
otherwise ceph-osd fails:

```
ceph-volume lvm prepare: error: Unable to proceed with non-existing device: test_group/data-lv2
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>