### PR TITLE
ceph-rgw: Fix bad paths which depend on the cluster name

### DIFF
--- a/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
+++ b/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
@@ -2,7 +2,7 @@
 - name: generate environment file
   become: true
   copy:
-    dest: "/var/lib/ceph/radosgw/ceph-rgw.{{ ansible_hostname }}.{{ item.instance_name }}/EnvironmentFile"
+    dest: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}.{{ item.instance_name }}/EnvironmentFile"
     owner: "root"
     group: "root"
     mode: "0644"

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -6,7 +6,7 @@ After=docker.service
 {% set cpu_limit = ansible_processor_vcpus|int if ceph_rgw_docker_cpu_limit|int > ansible_processor_vcpus|int else ceph_rgw_docker_cpu_limit|int %}
 
 [Service]
-EnvironmentFile=/var/lib/ceph/radosgw/ceph-%i/EnvironmentFile
+EnvironmentFile=/var/lib/ceph/radosgw/{{ cluster }}-%i/EnvironmentFile
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \


### PR DESCRIPTION
Hi,

According to my tests (in branch stable-4.0 with the docker image ceph/daemon:v4.0.0rc1-stable-4.0-nautilus-centos-7-x86_64), this PR fixes a problem of paths which depend on the cluster name. Here is the `all.yml` I have used to make a deployment:

```yml
containerized_deployment: true
ceph_docker_registry: 'docker.io'
ceph_docker_image: 'ceph/daemon'
ceph_docker_image_tag: 'v4.0.0rc1-stable-4.0-nautilus-centos-7-x86_64'

cluster: 'ceph-m'
public_network: '10.111.222.0/24'
cluster_network: '10.111.222.0/24'
osd_objectstore: 'bluestore'
osd_scenario: 'lvm'

# It's a test in only all-in-one VM with 1 OSD.
lvm_volumes:
  - db_vg: 'vg-ssd'
    db: 'blockdb'
    data_vg: 'vg-osd'
    data: 'data'

ceph_conf_overrides:
  global:
    mon_allow_pool_delete: 'true'
    osd_pool_default_size: 1
    osd_pool_default_min_size: 1
    osd_crush_update_on_start: 'true'
    osd_pool_default_pg_num: 8
    osd_pool_default_ppg_num: 8
    rgw_realm: 'denmark'
    rgw_zonegroup: 'copenhagen'
    rgw_zone: 'zone-m'

radosgw_civetweb_port: 80
radosgw_civetweb_num_threads: 150
email_address: 'foo@dom.tld'

ntp_service_enabled: false
```

And my `hosts` file:

```yml
[mons]
ceph01.virt.priv    monitor_address=10.111.222.51

[mgrs]
ceph01.virt.priv

[osds]
ceph01.virt.priv

[rgws]
ceph01.virt.priv    radosgw_address=10.111.222.51
```

HTH