### PR TITLE
mgr: wait for all mgr to be available

### DIFF
--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -18,5 +18,6 @@
 - name: include mgr_modules.yml
   include_tasks: mgr_modules.yml
   when:
-    - ceph_mgr_modules|length > 0
-    - inventory_hostname == groups[mgr_group_name][0]
+    - ceph_mgr_modules | length > 0
+    - ((groups[mgr_group_name] | default([]) | length == 0 and inventory_hostname == groups[mon_group_name] | last) or
+      (groups[mgr_group_name] | default([]) | length > 0 and inventory_hostname == groups[mgr_group_name] | last))

--- a/roles/ceph-mgr/tasks/mgr_modules.yml
+++ b/roles/ceph-mgr/tasks/mgr_modules.yml
@@ -1,4 +1,14 @@
 ---
+- name: wait for all mgr to be up
+  shell: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} mgr dump -f json | python -c 'import sys, json; print(json.load(sys.stdin)[\"available\"])'"
+  register: mgr_dump
+  retries: 30
+  delay: 5
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  until:
+    - mgr_dump.rc == 0
+    - mgr_dump.stdout | bool
+
 - name: get enabled modules from ceph-mgr
   command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} --format json mgr module ls"
   changed_when: false


### PR DESCRIPTION
When mgrs are implicitly collocated on monitors (no mgrs in mgrs group).
That include was skipped because of this condition :

`inventory_hostname == groups[mgr_group_name][0]`

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>