### PR TITLE
tests: fix update job

### DIFF
--- a/tox-update.ini
+++ b/tox-update.ini
@@ -48,7 +48,7 @@ commands=
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   # use the stable-3.2 branch to deploy a luminous cluster
-  git clone -b {env:CEPH_ANSIBLE_BRANCH:stable-3.2} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  git clone -b stable-3.2 --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
   pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {envdir}/tmp/ceph-ansible/tests/functional/setup.yml


### PR DESCRIPTION
jenkins sets `CEPH_ANSIBLE_BRANCH` to `stable-4.0`, this makes all
nightly job failing.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>