### PR TITLE
tests: fix update job

### DIFF
--- a/tox-update.ini
+++ b/tox-update.ini
@@ -47,8 +47,8 @@ commands=
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
-  # use the stable-3.1 branch to deploy a luminous cluster
-  git clone -b {env:CEPH_ANSIBLE_BRANCH:stable-3.1} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  # use the stable-3.1 branch to deploy a jewel cluster
+  git clone -b stable-3.1 --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
   pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
 
   ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons/{env:INVENTORY} {envdir}/tmp/ceph-ansible/tests/functional/setup.yml


### PR DESCRIPTION
jenkins sets CEPH_ANSIBLE_BRANCH to stable-3.2, this makes all
nightly job failing.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>