### PR TITLE
mon: remove useless delegate_to

### DIFF
--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -22,10 +22,9 @@
 
 - name: include secure_cluster.yml
   include_tasks: secure_cluster.yml
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  run_once: true
   when:
     - secure_cluster
+    - inventory_hostname == groups[mon_group_name] | first
 
 - name: crush_rules.yml
   include_tasks: crush_rules.yml


### PR DESCRIPTION
Let's use a condition to run this task only on the first mon.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>