### PR TITLE
ansible: use bool filter on boolean variables

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -254,7 +254,7 @@
       - wait for server to boot
       - remove data
     when:
-      - reboot_osd_node
+      - reboot_osd_node | bool
       - remove_osd_mountpoints.failed is defined
 
   - name: wipe table on dm-crypt devices
@@ -522,7 +522,7 @@
       state: absent
     when:
       - ansible_pkg_mgr == 'yum'
-      - purge_all_packages == true
+      - purge_all_packages | bool
 
   - name: purge remaining ceph packages with dnf
     dnf:
@@ -530,7 +530,7 @@
       state: absent
     when:
       - ansible_pkg_mgr == 'dnf'
-      - purge_all_packages == true
+      - purge_all_packages | bool
 
   - name: purge remaining ceph packages with apt
     apt:
@@ -538,7 +538,7 @@
       state: absent
     when:
       - ansible_pkg_mgr == 'apt'
-      - purge_all_packages == true
+      - purge_all_packages | bool
 
   - name: remove config
     file:

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -531,7 +531,7 @@
       name: docker
       state: stopped
       enabled: no
-    when: not is_atomic
+    when: not is_atomic | bool
     ignore_errors: true
 
   - name: debian based systems tasks
@@ -603,7 +603,7 @@
           ansible_pkg_mgr == "dnf"
     when:
       ansible_os_family == 'RedHat' and
-      not is_atomic
+      not is_atomic | bool
 
 - name: purge ceph directories
 

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -88,7 +88,7 @@
         path: /etc/profile.d/ceph-aliases.sh
         state: absent
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
     - name: set mon_host_count
       set_fact:
@@ -119,7 +119,7 @@
       delegate_to: "{{ item }}"
       with_items: "{{ groups[mon_group_name] }}"
       when:
-        - cephx
+        - cephx | bool
         - inventory_hostname == groups[mon_group_name][0]
 
     - name: create potentially missing keys (rbd and rbd-mirror)
@@ -138,7 +138,7 @@
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
         CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       when:
-        - cephx
+        - cephx | bool
         - inventory_hostname == groups[mon_group_name][0]
 
     # NOTE: we mask the service so the RPM can't restart it
@@ -151,7 +151,7 @@
         masked: yes
       ignore_errors: True
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     # NOTE: we mask the service so the RPM can't restart it
     # after the package gets upgraded
@@ -163,7 +163,7 @@
         masked: yes
       ignore_errors: True
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     # only mask the service for mgr because it must be upgraded
     # after ALL monitors, even when collocated
@@ -179,10 +179,10 @@
         name: ceph-handler
     - import_role:
         name: ceph-common
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
     - import_role:
         name: ceph-container-common
-      when: containerized_deployment
+      when: containerized_deployment | bool
     - import_role:
         name: ceph-config
     - import_role:
@@ -196,7 +196,7 @@
       delegate_to: "{{ mon_host }}"
       when:
         - inventory_hostname == groups[mon_group_name][0]
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - name: set containerized osd flags
       command: >
@@ -207,7 +207,7 @@
       delegate_to: "{{ mon_host }}"
       when:
         - inventory_hostname == groups[mon_group_name][0]
-        - containerized_deployment
+        - containerized_deployment | bool
 
     - name: start ceph mon
       systemd:
@@ -215,7 +215,7 @@
         state: started
         enabled: yes
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - name: start ceph mgr
       systemd:
@@ -224,7 +224,7 @@
         enabled: yes
       ignore_errors: True # if no mgr collocated with mons
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - name: restart containerized ceph mon
       systemd:
@@ -233,7 +233,7 @@
         enabled: yes
         daemon_reload: yes
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
     - name: non container | waiting for the monitor to join the quorum...
       command: ceph --cluster "{{ cluster }}" -s --format json
@@ -245,7 +245,7 @@
       delay: "{{ health_mon_check_delay }}"
       delegate_to: "{{ mon_host }}"
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - name: container | waiting for the containerized monitor to join the quorum...
       command: >
@@ -258,7 +258,7 @@
       delay: "{{ health_mon_check_delay }}"
       delegate_to: "{{ mon_host }}"
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
 - name: upgrade ceph mgr nodes when implicitly collocated on monitors
   vars:
@@ -289,10 +289,10 @@
             name: ceph-handler
         - import_role:
             name: ceph-common
-          when: not containerized_deployment
+          when: not containerized_deployment | bool
         - import_role:
             name: ceph-container-common
-          when: containerized_deployment
+          when: containerized_deployment | bool
         - import_role:
             name: ceph-config
         - import_role:
@@ -326,10 +326,10 @@
         name: ceph-handler
     - import_role:
         name: ceph-common
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
     - import_role:
         name: ceph-container-common
-      when: containerized_deployment
+      when: containerized_deployment | bool
     - import_role:
         name: ceph-config
     - import_role:
@@ -351,13 +351,13 @@
       shell: "if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi"
       register: osd_ids
       changed_when: false
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
 
     - name: get osd unit names - container
       shell: systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-osd@([a-z0-9]+).service"
       register: osd_names
       changed_when: false
-      when: containerized_deployment
+      when: containerized_deployment | bool
 
     - name: stop ceph osd
       systemd:
@@ -367,7 +367,7 @@
         masked: yes
       with_items: "{{ osd_ids.stdout_lines }}"
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - import_role:
         name: ceph-defaults
@@ -377,10 +377,10 @@
         name: ceph-handler
     - import_role:
         name: ceph-common
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
     - import_role:
         name: ceph-container-common
-      when: containerized_deployment
+      when: containerized_deployment | bool
     - import_role:
         name: ceph-config
     - import_role:
@@ -390,7 +390,7 @@
       shell: "if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi"
       register: osd_ids
       changed_when: false
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
 
     - name: start ceph osd
       systemd:
@@ -400,7 +400,7 @@
         masked: no
       with_items: "{{ osd_ids.stdout_lines }}"
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - name: restart containerized ceph osd
       systemd:
@@ -411,13 +411,13 @@
         daemon_reload: yes
       with_items: "{{ osd_names.stdout_lines }}"
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
     - name: set_fact docker_exec_cmd_osd
       set_fact:
         docker_exec_cmd_update_osd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
     - name: get osd versions
       command: "{{ docker_exec_cmd_update_osd|default('') }} ceph --cluster {{ cluster }} versions"
@@ -474,7 +474,7 @@
       set_fact:
         docker_exec_cmd_update_osd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
     - name: unset osd flags
       command: "{{ docker_exec_cmd_update_osd|default('') }} ceph osd unset {{ item }} --cluster {{ cluster }}"
@@ -517,7 +517,7 @@
         enabled: no
         masked: yes
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - import_role:
         name: ceph-defaults
@@ -527,10 +527,10 @@
         name: ceph-handler
     - import_role:
         name: ceph-common
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
     - import_role:
         name: ceph-container-common
-      when: containerized_deployment
+      when: containerized_deployment | bool
     - import_role:
         name: ceph-config
     - import_role:
@@ -543,7 +543,7 @@
         enabled: yes
         masked: no
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - name: restart ceph mds
       systemd:
@@ -553,7 +553,7 @@
         masked: no
         daemon_reload: yes
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
 
 - name: upgrade ceph rgws cluster
@@ -586,16 +586,16 @@
         masked: yes
       with_items: "{{ rgw_instances }}"
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - import_role:
         name: ceph-handler
     - import_role:
         name: ceph-common
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
     - import_role:
         name: ceph-container-common
-      when: containerized_deployment
+      when: containerized_deployment | bool
     - import_role:
         name: ceph-config
     - import_role:
@@ -610,7 +610,7 @@
         daemon_reload: yes
       with_items: "{{ rgw_instances }}"
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
 
 - name: upgrade ceph rbd mirror node
@@ -636,10 +636,10 @@
         name: ceph-handler
     - import_role:
         name: ceph-common
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
     - import_role:
         name: ceph-container-common
-      when: containerized_deployment
+      when: containerized_deployment | bool
     - import_role:
         name: ceph-config
     - import_role:
@@ -652,7 +652,7 @@
         enabled: yes
         masked: no
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - name: restart containerized ceph rbd mirror
       systemd:
@@ -662,7 +662,7 @@
         masked: no
         daemon_reload: yes
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
 
 - name: upgrade ceph nfs node
@@ -684,7 +684,7 @@
         masked: yes
       failed_when: false
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - import_role:
         name: ceph-defaults
@@ -694,10 +694,10 @@
         name: ceph-handler
     - import_role:
         name: ceph-common
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
     - import_role:
         name: ceph-container-common
-      when: containerized_deployment
+      when: containerized_deployment | bool
     - import_role:
         name: ceph-config
     - import_role:
@@ -710,8 +710,8 @@
         enabled: yes
         masked: no
       when:
-        - not containerized_deployment
-        - ceph_nfs_enable_service
+        - not containerized_deployment | bool
+        - ceph_nfs_enable_service | bool
 
     - name: systemd restart nfs container
       systemd:
@@ -721,8 +721,8 @@
         masked: no
         daemon_reload: yes
       when:
-        - ceph_nfs_enable_service
-        - containerized_deployment
+        - ceph_nfs_enable_service | bool
+        - containerized_deployment | bool
 
 
 - name: upgrade ceph iscsi gateway node
@@ -745,7 +745,7 @@
         masked: yes
       failed_when: false
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - import_role:
         name: ceph-defaults
@@ -755,10 +755,10 @@
         name: ceph-handler
     - import_role:
         name: ceph-common
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
     - import_role:
         name: ceph-container-common
-      when: containerized_deployment
+      when: containerized_deployment | bool
     - import_role:
         name: ceph-config
     - import_role:
@@ -771,7 +771,7 @@
         enabled: yes
         masked: no
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
 
 - name: upgrade ceph client node
@@ -790,10 +790,10 @@
         name: ceph-handler
     - import_role:
         name: ceph-common
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
     - import_role:
         name: ceph-container-common
-      when: containerized_deployment
+      when: containerized_deployment | bool
     - import_role:
         name: ceph-config
     - import_role:
@@ -813,25 +813,25 @@
       command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph osd require-osd-release nautilus"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
-      when: containerized_deployment
+      when: containerized_deployment | bool
 
     - name: non container | disallow pre-nautilus OSDs and enable all new nautilus-only functionality
       command: ceph osd require-osd-release nautilus
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
 
     - name: container | enable msgr2 protocol
       command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph mon enable-msgr2"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
-      when: containerized_deployment
+      when: containerized_deployment | bool
 
     - name: non container | enable msgr2 protocol
       command: ceph mon enable-msgr2
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
-      when: not containerized_deployment
+      when: not containerized_deployment | bool
 
     - import_role:
         name: ceph-handler
@@ -854,7 +854,7 @@
       set_fact:
         docker_exec_cmd_status: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
     - name: show ceph status
       command: "{{ docker_exec_cmd_status|default('') }} ceph --cluster {{ cluster }} -s"

--- a/infrastructure-playbooks/shrink-mon.yml
+++ b/infrastructure-playbooks/shrink-mon.yml
@@ -84,7 +84,7 @@
     - name: "set_fact docker_exec_cmd build {{ container_binary }} exec command (containerized)"
       set_fact:
         docker_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[mon_host]['ansible_hostname'] }}"
-      when: containerized_deployment
+      when: containerized_deployment | bool
 
     - name: exit playbook, if can not connect to the cluster
       command: "{{ docker_exec_cmd }} timeout 5 ceph --cluster {{ cluster }} health"

--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -66,7 +66,7 @@
     - name: set_fact docker_exec_cmd build docker exec command (containerized)
       set_fact:
         docker_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
-      when: containerized_deployment
+      when: containerized_deployment | bool
 
     - name: exit playbook, if can not connect to the cluster
       command: "{{ docker_exec_cmd }} timeout 5 ceph --cluster {{ cluster }} health"

--- a/infrastructure-playbooks/untested-by-ci/cluster-os-migration.yml
+++ b/infrastructure-playbooks/untested-by-ci/cluster-os-migration.yml
@@ -29,11 +29,13 @@
       register: mon_archive_leftover
 
     - fail: msg="Looks like an archive is already there, please remove it!"
-      when: migration_completed.stat.exists == False and mon_archive_leftover.stat.exists == True
+      when:
+        - not migration_completed.stat.exists | bool
+        - mon_archive_leftover.stat.exists | bool
 
     - name: Compress the store as much as possible
       command: ceph tell mon.{{ ansible_hostname }} compact
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Check if sysvinit
       stat: >
@@ -55,7 +57,10 @@
 
     # can't complete the condition since the previous taks never ran...
     - fail: msg="Something is terribly wrong here, sysvinit is configured, the service is started BUT the init script does not return 0, GO FIX YOUR SETUP!"
-      when: ceph_status_sysvinit.rc != 0 and migration_completed.stat.exists == False and monsysvinit.stat.exists == True
+      when:
+        - ceph_status_sysvinit.rc != 0
+        - not migration_completed.stat.exists | bool
+        - monsysvinit.stat.exists | bool
 
     - name: Check if init does what it is supposed to do (upstart)
       shell: >
@@ -64,21 +69,28 @@
       changed_when: False
 
     - fail: msg="Something is terribly wrong here, upstart is configured, the service is started BUT the init script does not return 0, GO FIX YOUR SETUP!"
-      when: ceph_status_upstart.rc != 0 and migration_completed.stat.exists == False and monupstart.stat.exists == True
+      when:
+        - ceph_status_upstart.rc != 0
+        - not migration_completed.stat.exists | bool
+        - monupstart.stat.exists | bool
 
     - name: Restart the Monitor after compaction (Upstart)
       service: >
         name=ceph-mon
         state=restarted
         args=id={{ ansible_hostname }}
-      when: monupstart.stat.exists == True and migration_completed.stat.exists == False
+      when:
+        - monupstart.stat.exists | bool
+        - not migration_completed.stat.exists | bool
 
     - name: Restart the Monitor after compaction (Sysvinit)
       service: >
         name=ceph
         state=restarted
         args=mon
-      when: monsysvinit.stat.exists == True and migration_completed.stat.exists == False
+      when:
+        - monsysvinit.stat.exists | bool
+        - not migration_completed.stat.exists | bool
 
     - name: Wait for the monitor to be up again
       local_action:
@@ -86,21 +98,25 @@
         host: "{{ ansible_ssh_host | default(inventory_hostname) }}"
         port: 6789
         timeout: 10
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Stop the monitor (Upstart)
       service: >
         name=ceph-mon
         state=stopped
         args=id={{ ansible_hostname }}
-      when: monupstart.stat.exists == True and migration_completed.stat.exists == False
+      when:
+        - monupstart.stat.exists | bool
+        - not migration_completed.stat.exists | bool
 
     - name: Stop the monitor (Sysvinit)
       service: >
         name=ceph
         state=stopped
         args=mon
-      when: monsysvinit.stat.exists == True and migration_completed.stat.exists == False
+      when:
+        - monsysvinit.stat.exists | bool
+        - not migration_completed.stat.exists | bool
 
     - name: Wait for the monitor to be down
       local_action:
@@ -109,7 +125,7 @@
         port: 6789
         timeout: 10
         state: stopped
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Create a backup directory
       file: >
@@ -120,7 +136,7 @@
         mode=0644
       delegate_to: "{{ item }}"
       with_items: "{{ groups.backup[0] }}"
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     # NOTE (leseb): should we convert upstart to sysvinit here already?
     - name: Archive monitor stores
@@ -128,18 +144,18 @@
         tar -cpvzf - --one-file-system . /etc/ceph/* | cat > {{ ansible_hostname }}.tar
         chdir=/var/lib/ceph/
         creates={{ ansible_hostname }}.tar
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Scp the Monitor store
       fetch: >
         src=/var/lib/ceph/{{ ansible_hostname }}.tar
         dest={{ backup_dir }}/monitors-backups/{{ ansible_hostname }}.tar
         flat=yes
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Reboot the server
       command: reboot
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Wait for the server to come up
       local_action:
@@ -147,11 +163,11 @@
         port: 22
         delay: 10
         timeout: 3600
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Wait a bit more to be sure that the server is ready
       pause: seconds=20
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Check if sysvinit
       stat: >
@@ -170,14 +186,18 @@
         name=ceph-mon
         state=stopped
         args=id={{ ansible_hostname }}
-      when: monupstart.stat.exists == True and migration_completed.stat.exists == False
+      when:
+        - monupstart.stat.exists | bool
+        - not migration_completed.stat.exists | bool
 
     - name: Make sure the monitor is stopped (Sysvinit)
       service: >
         name=ceph
         state=stopped
         args=mon
-      when: monsysvinit.stat.exists == True and migration_completed.stat.exists == False
+      when:
+        - monsysvinit.stat.exists | bool
+        - not migration_completed.stat.exists | bool
 
     # NOTE (leseb): 'creates' was added in Ansible 1.6
     - name: Copy and unarchive the monitor store
@@ -187,17 +207,17 @@
         copy=yes
         mode=0600
         creates=etc/ceph/ceph.conf
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Copy keys and configs
       shell: >
         cp etc/ceph/* /etc/ceph/
         chdir=/var/lib/ceph/
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Configure RHEL7 for sysvinit
       shell: find -L /var/lib/ceph/mon/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -exec touch {}/sysvinit \; -exec rm {}/upstart \;
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     # NOTE (leseb): at this point the upstart and sysvinit checks are not necessary
     # so we directly call sysvinit
@@ -206,7 +226,7 @@
         name=ceph
         state=started
         args=mon
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Wait for the Monitor to be up again
       local_action:
@@ -214,7 +234,7 @@
         host: "{{ ansible_ssh_host | default(inventory_hostname) }}"
         port: 6789
         timeout: 10
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Waiting for the monitor to join the quorum...
       shell: >
@@ -225,7 +245,7 @@
       delay: 10
       delegate_to: "{{ item }}"
       with_items: "{{ groups.backup[0] }}"
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Done moving to the next monitor
       file: >
@@ -234,7 +254,7 @@
         owner=root
         group=root
         mode=0600
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
 - hosts: osds
   serial: 1
@@ -256,7 +276,9 @@
       register: osd_archive_leftover
 
     - fail: msg="Looks like an archive is already there, please remove it!"
-      when: migration_completed.stat.exists == False and osd_archive_leftover.stat.exists == True
+      when:
+        - not migration_completed.stat.exists | bool
+        - osd_archive_leftover.stat.exists | bool
 
     - name: Check if init does what it is supposed to do (Sysvinit)
       shell: >
@@ -266,7 +288,10 @@
 
     # can't complete the condition since the previous taks never ran...
     - fail: msg="Something is terribly wrong here, sysvinit is configured, the services are started BUT the init script does not return 0, GO FIX YOUR SETUP!"
-      when: ceph_status_sysvinit.rc != 0 and migration_completed.stat.exists == False and monsysvinit.stat.exists == True
+      when:
+        - ceph_status_sysvinit.rc != 0
+        - not migration_completed.stat.exists | bool
+        - monsysvinit.stat.exists | bool
 
     - name: Check if init does what it is supposed to do (upstart)
       shell: >
@@ -275,13 +300,16 @@
       changed_when: False
 
     - fail: msg="Something is terribly wrong here, upstart is configured, the services are started BUT the init script does not return 0, GO FIX YOUR SETUP!"
-      when: ceph_status_upstart.rc != 0 and migration_completed.stat.exists == False and monupstart.stat.exists == True
+      when:
+        - ceph_status_upstart.rc != 0
+        - not migration_completed.stat.exists | bool
+        - monupstart.stat.exists | bool
 
     - name: Set the noout flag
       command: ceph osd set noout
       delegate_to: "{{ item }}"
       with_items: "{{ groups[mon_group_name][0] }}"
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Check if sysvinit
       shell: stat /var/lib/ceph/osd/ceph-*/sysvinit
@@ -300,7 +328,7 @@
         tar -cpvzf - --one-file-system . /etc/ceph/ceph.conf | cat > {{ ansible_hostname }}.tar
         chdir=/var/lib/ceph/
         creates={{ ansible_hostname }}.tar
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Create backup directory
       file: >
@@ -311,32 +339,36 @@
         mode=0644
       delegate_to: "{{ item }}"
       with_items: "{{ groups.backup[0] }}"
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Scp OSDs dirs and configs
       fetch: >
         src=/var/lib/ceph/{{ ansible_hostname }}.tar
         dest={{ backup_dir }}/osds-backups/
         flat=yes
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Collect OSD ports
       shell: netstat -tlpn | awk -F ":" '/ceph-osd/ { sub (" .*", "", $2); print $2 }' | uniq
       register: osd_ports
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Gracefully stop the OSDs (Upstart)
       service: >
         name=ceph-osd-all
         state=stopped
-      when: osdupstart.rc == 0 and migration_completed.stat.exists == False
+      when:
+        - osdupstart.rc == 0
+        - not migration_completed.stat.exists | bool
 
     - name: Gracefully stop the OSDs (Sysvinit)
       service: >
         name=ceph
         state=stopped
         args=mon
-      when: osdsysvinit.rc == 0 and migration_completed.stat.exists == False
+      when:
+        - osdsysvinit.rc == 0
+        - not migration_completed.stat.exists | bool
 
     - name: Wait for the OSDs to be down
       local_action:
@@ -346,15 +378,15 @@
         timeout: 10
         state: stopped
       with_items: "{{ osd_ports.stdout_lines }}"
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Configure RHEL with sysvinit
       shell: find -L /var/lib/ceph/osd/ -mindepth 1 -maxdepth 1 -regextype posix-egrep -regex '.*/[A-Za-z0-9]+-[A-Za-z0-9._-]+' -exec touch {}/sysvinit \; -exec rm {}/upstart \;
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Reboot the server
       command: reboot
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Wait for the server to come up
       local_action:
@@ -362,11 +394,11 @@
         port: 22
         delay: 10
         timeout: 3600
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Wait a bit to be sure that the server is ready for scp
       pause: seconds=20
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     # NOTE (leseb): 'creates' was added in Ansible 1.6
     - name: Copy and unarchive the OSD configs
@@ -376,13 +408,13 @@
         copy=yes
         mode=0600
         creates=etc/ceph/ceph.conf
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Copy keys and configs
       shell: >
         cp etc/ceph/* /etc/ceph/
         chdir=/var/lib/ceph/
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     # NOTE (leseb): at this point the upstart and sysvinit checks are not necessary
     # so we directly call sysvinit
@@ -391,7 +423,7 @@
         name=ceph-osd-all
         state=started
         args=osd
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     # NOTE (leseb): this is tricky unless this is set into the ceph.conf
     # listened ports can be predicted, thus they will change after each restart
@@ -413,7 +445,7 @@
       delay: 10
       delegate_to: "{{ item }}"
       with_items: "{{ groups.backup[0] }}"
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Done moving to the next OSD
       file: >
@@ -422,13 +454,13 @@
         owner=root
         group=root
         mode=0600
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Unset the noout flag
       command: ceph osd unset noout
       delegate_to: "{{ item }}"
       with_items: "{{ groups[mon_group_name][0] }}"
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
 - hosts: rgws
   serial: 1
@@ -450,14 +482,16 @@
       register: rgw_archive_leftover
 
     - fail: msg="Looks like an archive is already there, please remove it!"
-      when: migration_completed.stat.exists == False and rgw_archive_leftover.stat.exists == True
+      when:
+        - not migration_completed.stat.exists | bool
+        - rgw_archive_leftover.stat.exists | bool
 
     - name: Archive rados gateway configs
       shell: >
         tar -cpvzf - --one-file-system . /etc/ceph/* | cat > {{ ansible_hostname }}.tar
         chdir=/var/lib/ceph/
         creates={{ ansible_hostname }}.tar
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Create backup directory
       file: >
@@ -468,14 +502,14 @@
         mode=0644
       delegate_to: "{{ item }}"
       with_items: "{{ groups.backup[0] }}"
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Scp RGWs dirs and configs
       fetch: >
         src=/var/lib/ceph/{{ ansible_hostname }}.tar
         dest={{ backup_dir }}/rgws-backups/
         flat=yes
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Gracefully stop the rados gateway
       service: >
@@ -483,7 +517,7 @@
         state=stopped
       with_items:
         - radosgw
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Wait for radosgw to be down
       local_action:
@@ -492,11 +526,11 @@
         path: /tmp/radosgw.sock
         state: absent
         timeout: 30
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Reboot the server
       command: reboot
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Wait for the server to come up
       local_action:
@@ -504,11 +538,11 @@
         port: 22
         delay: 10
         timeout: 3600
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Wait a bit to be sure that the server is ready for scp
       pause: seconds=20
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     # NOTE (leseb): 'creates' was added in Ansible 1.6
     - name: Copy and unarchive the OSD configs
@@ -518,7 +552,7 @@
         copy=yes
         mode=0600
         creates=etc/ceph/ceph.conf
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Copy keys and configs
       shell: >
@@ -526,7 +560,7 @@
         chdir=/var/lib/ceph/
       with_items:
         - cp etc/ceph/* /etc/ceph/
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Start rados gateway
       service: >
@@ -534,7 +568,7 @@
         state=started
       with_items:
         - radosgw
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Wait for radosgw to be up again
       local_action:
@@ -543,7 +577,7 @@
         path: /tmp/radosgw.sock
         state: present
         timeout: 30
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool
 
     - name: Done moving to the next rados gateway
       file: >
@@ -552,4 +586,4 @@
         owner=root
         group=root
         mode=0600
-      when: migration_completed.stat.exists == False
+      when: not migration_completed.stat.exists | bool

--- a/infrastructure-playbooks/untested-by-ci/migrate-journal-to-ssd.yml
+++ b/infrastructure-playbooks/untested-by-ci/migrate-journal-to-ssd.yml
@@ -52,7 +52,8 @@
     with_items: 
         osds_dir_stat.results
     when:
-      -  osds_dir_stat is defined and item.stat.exists == false
+      - osds_dir_stat is defined
+      - not item.stat.exists | bool
 
   - name: install sgdisk(gdisk)
     package:

--- a/infrastructure-playbooks/untested-by-ci/recover-osds-after-ssd-journal-failure.yml
+++ b/infrastructure-playbooks/untested-by-ci/recover-osds-after-ssd-journal-failure.yml
@@ -74,7 +74,7 @@
         osds_dir_stat.results
     when:
       - osds_dir_stat is defined 
-      - item.stat.exists == false
+      - not item.stat.exists | bool
 
   - name: install sgdisk(gdisk)
     package:

--- a/infrastructure-playbooks/untested-by-ci/replace-osd.yml
+++ b/infrastructure-playbooks/untested-by-ci/replace-osd.yml
@@ -62,7 +62,7 @@
     - name: set_fact docker_exec_cmd build docker exec command (containerized)
       set_fact:
         docker_exec_cmd: "docker exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
-      when: containerized_deployment
+      when: containerized_deployment | bool
 
     - name: exit playbook, if can not connect to the cluster
       command: "{{ docker_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} health"
@@ -91,15 +91,15 @@
       delegate_to: "{{ item }}"
       failed_when: false
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - name: fail when admin key is not present
       fail:
         msg: "The Ceph admin key is not present on the OSD node, please add it and remove it after the playbook is done."
       with_items: "{{ ceph_admin_key.results }}"
       when:
-        - not containerized_deployment
-        - item.stat.exists == false
+        - not containerized_deployment | bool
+        - not item.stat.exists | bool
 
     # NOTE(leseb): using '>' is the only way I could have the command working
     - name: find osd device based on the id
@@ -113,7 +113,7 @@
       register: osd_to_replace_disks
       delegate_to: "{{ item.0 }}"
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
     - name: zapping osd(s) - container
       shell: >
@@ -126,7 +126,7 @@
         - "{{ osd_to_replace_disks.results }}"
       delegate_to: "{{ item.0 }}"
       when:
-        - containerized_deployment
+        - containerized_deployment | bool
 
     - name: zapping osd(s) - non container
       command: ceph-disk zap --cluster {{ cluster }} {{ item.1 }}
@@ -136,7 +136,7 @@
         - "{{ osd_to_replace_disks.results }}"
       delegate_to: "{{ item.0 }}"
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - name: destroying osd(s)
       command: ceph-disk destroy --cluster {{ cluster }} --destroy-by-id {{ item.1 }} --zap
@@ -146,7 +146,7 @@
         - "{{ osd_to_replace.split(',') }}"
       delegate_to: "{{ item.0 }}"
       when:
-        - not containerized_deployment
+        - not containerized_deployment | bool
 
     - name: replace osd(s) - prepare - non container
       command: ceph-disk prepare {{ item.1 }}  --osd-id {{ item.2 }} --osd-uuid $(uuidgen)

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -51,7 +51,7 @@
   with_items: "{{ keys }}"
   delegate_to: "{{ delegated_node }}"
   when:
-    - cephx
+    - cephx | bool
     - keys | length > 0
     - inventory_hostname == groups.get('_filtered_clients') | first
 
@@ -63,13 +63,13 @@
   register: slurp_client_keys
   delegate_to: "{{ delegated_node }}"
   when:
-    - cephx
+    - cephx | bool
     - keys | length > 0
     - inventory_hostname == groups.get('_filtered_clients') | first
 
 - name: pool related tasks
   when:
-    - condition_copy_admin_key
+    - condition_copy_admin_key | bool
     - inventory_hostname == groups.get('_filtered_clients', []) | first
   block:
     - name: list existing pool(s)

--- a/roles/ceph-client/tasks/main.yml
+++ b/roles/ceph-client/tasks/main.yml
@@ -5,4 +5,4 @@
 - name: include create_users_keys.yml
   include_tasks: create_users_keys.yml
   when:
-    - user_config
+    - user_config | bool

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -7,5 +7,5 @@
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: "{{ ceph_keyring_permissions }}"
   when:
-    - cephx
-    - copy_admin_key
+    - cephx | bool
+    - copy_admin_key | bool

--- a/roles/ceph-common/tasks/installs/configure_redhat_local_installation.yml
+++ b/roles/ceph-common/tasks/installs/configure_redhat_local_installation.yml
@@ -4,13 +4,13 @@
     path: /tmp
     state: directory
   when:
-    - use_installer
+    - use_installer | bool
 
 - name: use mktemp to create name for rundep
   command: "mktemp /tmp/rundep.XXXXXXXX"
   register: rundep_location
   when:
-    - use_installer
+    - use_installer | bool
 
 - name: copy rundep
   copy:
@@ -18,14 +18,14 @@
     dest: "{{ item }}"
   with_items: "{{ (rundep_location|default({})).stdout_lines|default([]) }}"
   when:
-    - use_installer
+    - use_installer | bool
 
 - name: install ceph dependencies
   script: "{{ ansible_dir }}/rundep_installer.sh {{ item }}"
   become: true
   with_items: "{{ (rundep_location|default({})).stdout_lines|default([]) }}"
   when:
-    - use_installer
+    - use_installer | bool
 
 - name: ensure rsync is installed
   package:

--- a/roles/ceph-common/tasks/installs/install_debian_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_packages.yml
@@ -3,7 +3,7 @@
   apt:
     name: "{{ debian_ceph_pkgs | unique }}"
     update_cache: no
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+    state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default('') if ceph_origin == 'repository' and ceph_repository == 'uca' else '' }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else '' }}"
   register: result
   until: result is succeeded

--- a/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_debian_rhcs_packages.yml
@@ -2,6 +2,6 @@
 - name: install red hat storage ceph packages for debian
   apt:
     pkg: "{{ debian_ceph_pkgs | unique }}"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+    state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
   register: result
   until: result is succeeded

--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -20,6 +20,6 @@
 - name: install redhat ceph packages
   package:
     name: "{{ redhat_ceph_pkgs | unique }}"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+    state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
   register: result
   until: result is succeeded

--- a/roles/ceph-common/tasks/installs/install_suse_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_suse_packages.yml
@@ -9,6 +9,6 @@
 - name: install suse ceph packages
   package:
     name: "{{ suse_ceph_pkgs | unique }}"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+    state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
   register: result
   until: result is succeeded

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: include create_ceph_initial_dirs.yml
   include_tasks: create_ceph_initial_dirs.yml
   when:
-    - containerized_deployment|bool
+    - containerized_deployment | bool
 
 - name: config file operations related to OSDs
   when:
@@ -63,7 +63,7 @@
 # ceph-common
 - name: config file operation for non-containerized scenarios
   when:
-    - not containerized_deployment|bool
+    - not containerized_deployment | bool
   block:
   - name: create ceph conf directory
     file:
@@ -100,7 +100,7 @@
       mode: "0755"
     delegate_to: localhost
     when:
-      - ceph_conf_local
+      - ceph_conf_local | bool
 
   - name: "generate {{ cluster }}.conf configuration file locally"
     config_template:
@@ -114,11 +114,11 @@
       config_type: ini
     when:
       - inventory_hostname in groups[mon_group_name]
-      - ceph_conf_local
+      - ceph_conf_local | bool
 
 - name: config file operations for containerized scenarios
   when:
-    - containerized_deployment|bool
+    - containerized_deployment | bool
   block:
   - name: create a local fetch directory if it does not exist
     file:

--- a/roles/ceph-container-common/tasks/main.yml
+++ b/roles/ceph-container-common/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: include pre_requisites/prerequisites.yml
   include_tasks: pre_requisites/prerequisites.yml
   when:
-    - not is_atomic
+    - not is_atomic | bool
 
 - name: get docker version
   command: docker --version

--- a/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
@@ -50,7 +50,7 @@
     enabled: yes
   when:
     - ansible_distribution == 'CentOS'
-    - ceph_docker_enable_centos_extra_repo
+    - ceph_docker_enable_centos_extra_repo | bool
   tags:
     with_pkg
 
@@ -74,7 +74,7 @@
         - name: pause after docker install before starting (on openstack vms)
           pause: seconds=5
           when:
-            - ceph_docker_on_openstack
+            - ceph_docker_on_openstack | bool
           tags:
             with_pkg
 

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -20,7 +20,7 @@
 - name: set_fact container_binary
   set_fact:
     container_binary: "{{ 'podman' if (podman_binary.stat.exists and ansible_distribution == 'Fedora') or (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'docker' }}"
-  when: containerized_deployment
+  when: containerized_deployment | bool
 
 # Set ceph_release to ceph_stable by default
 - name: set_fact ceph_release ceph_stable_release
@@ -43,7 +43,7 @@
   set_fact:
     docker_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] if not rolling_update else hostvars[mon_host | default(groups[mon_group_name][0])]['ansible_hostname'] }}"
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
     - groups.get(mon_group_name, []) | length > 0
 
 # this task shouldn't run in a rolling_update situation
@@ -58,7 +58,7 @@
   run_once: true
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
-    - not rolling_update
+    - not rolling_update | bool
     - groups.get(mon_group_name, []) | length > 0
 
 # set this as a default when performing a rolling_update
@@ -85,19 +85,19 @@
   register: rolling_update_fsid
   delegate_to: "{{ mon_host | default(groups[mon_group_name][0]) }}"
   when:
-    - rolling_update
+    - rolling_update | bool
 
 - name: set_fact fsid
   set_fact:
     fsid: "{{ (rolling_update_fsid.stdout | from_json).fsid }}"
   when:
-    - rolling_update
+    - rolling_update | bool
 
 - name: set_fact ceph_current_status (convert to json)
   set_fact:
     ceph_current_status: "{{ ceph_current_status.stdout | from_json }}"
   when:
-    - not rolling_update
+    - not rolling_update | bool
     - ceph_current_status.rc == 0
 
 - name: set_fact fsid from ceph_current_status
@@ -108,9 +108,9 @@
 
 - name: fsid realted tasks
   when:
-    - generate_fsid
+    - generate_fsid | bool
     - ceph_current_status.fsid is undefined
-    - not rolling_update
+    - not rolling_update | bool
   block:
   - name: generate cluster fsid
     shell: python -c 'import uuid; print(str(uuid.uuid4()))'
@@ -200,28 +200,28 @@
   set_fact:
     ceph_uid: 64045
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
     - ansible_os_family == 'Debian'
 
 - name: set_fact ceph_uid for red hat or suse based system - non container
   set_fact:
     ceph_uid: 167
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
     - ansible_os_family in ['RedHat', 'Suse']
 
 - name: set_fact ceph_uid for debian based system - container
   set_fact:
     ceph_uid: 64045
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
     - ceph_docker_image_tag | string is search("ubuntu")
 
 - name: set_fact ceph_uid for red hat based system - container
   set_fact:
     ceph_uid: 167
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
     - (ceph_docker_image_tag | string is search("latest") or ceph_docker_image_tag | string is search("centos") or ceph_docker_image_tag | string is search("fedora")
       or (ansible_distribution == 'RedHat'))
 
@@ -229,7 +229,7 @@
   set_fact:
     ceph_uid: 167
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
     - ceph_docker_image is search("rhceph")
 
 - name: set_fact rgw_hostname
@@ -269,12 +269,12 @@
   register: crush_rule_variable
   changed_when: false
   failed_when: false
-  when: ceph_conf.stat.exists
+  when: ceph_conf.stat.exists | bool
 
 - name: set_fact osd_pool_default_crush_rule
   set_fact:
     osd_pool_default_crush_rule: "{% if crush_rule_variable.rc == 0 %}{{ crush_rule_variable.stdout.split(' = ')[1] }}{% else %}{{ ceph_osd_pool_default_crush_rule }}{% endif %}"
-  when: ceph_conf.stat.exists
+  when: ceph_conf.stat.exists | bool
 
 - name: import_tasks set_monitor_address.yml
   import_tasks: set_monitor_address.yml

--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: handlers
-  when: not rolling_update
+  when: not rolling_update | bool
   block:
     - name: update apt cache
       apt:
@@ -28,7 +28,7 @@
       listen: "restart ceph mons"
       when:
         - mon_group_name in group_names
-        - not rolling_update
+        - not rolling_update | bool
 
     - name: restart ceph mon daemon(s) - non container
       command: /usr/bin/env bash /tmp/restart_mon_daemon.sh
@@ -36,10 +36,10 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - mon_group_name in group_names
-        - not containerized_deployment
+        - not containerized_deployment | bool
         - hostvars[item]['_mon_handler_called'] | default(False)
         - mon_socket_stat.rc == 0
-        - not rolling_update
+        - not rolling_update | bool
       with_items: "{{ groups[mon_group_name] }}"
       delegate_to: "{{ item }}"
       run_once: True
@@ -50,11 +50,11 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - mon_group_name in group_names
-        - containerized_deployment
+        - containerized_deployment | bool
         - ceph_mon_container_stat.get('rc') == 0
         - hostvars[item]['_mon_handler_called'] | default(False)
         - ceph_mon_container_stat.get('stdout_lines', [])|length != 0
-        - not rolling_update
+        - not rolling_update | bool
       with_items: "{{ groups[mon_group_name] }}"
       delegate_to: "{{ item }}"
       run_once: True
@@ -85,20 +85,20 @@
       listen: "restart ceph osds"
       when:
         - osd_group_name in group_names
-        - not rolling_update
+        - not rolling_update | bool
 
     - name: restart ceph osds daemon(s) - non container
       command: /usr/bin/env bash /tmp/restart_osd_daemon.sh
       listen: "restart ceph osds"
       when:
         - osd_group_name in group_names
-        - not containerized_deployment
-        - not rolling_update
+        - not containerized_deployment | bool
+        - not rolling_update | bool
         # We do not want to run these checks on initial deployment (`socket_osd_container.results[n].rc == 0`)
         # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
         - osd_socket_stat.rc == 0
         - ceph_current_status.fsid is defined
-        - handler_health_osd_check
+        - handler_health_osd_check | bool
         - hostvars[item]['_osd_handler_called'] | default(False)
       with_items: "{{ groups[osd_group_name] }}"
       delegate_to: "{{ item }}"
@@ -111,12 +111,12 @@
         # We do not want to run these checks on initial deployment (`socket_osd_container_stat.results[n].rc == 0`)
         # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
         - osd_group_name in group_names
-        - containerized_deployment
-        - not rolling_update
+        - containerized_deployment | bool
+        - not rolling_update | bool
         - inventory_hostname == groups.get(osd_group_name) | last
         - ceph_osd_container_stat.get('rc') == 0
         - ceph_osd_container_stat.get('stdout_lines', [])|length != 0
-        - handler_health_osd_check
+        - handler_health_osd_check | bool
         - hostvars[item]['_osd_handler_called'] | default(False)
       with_items: "{{ groups[osd_group_name] }}"
       delegate_to: "{{ item }}"
@@ -149,7 +149,7 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - mds_group_name in group_names
-        - not containerized_deployment
+        - not containerized_deployment | bool
         - hostvars[item]['_mds_handler_called'] | default(False)
         - mds_socket_stat.rc == 0
       with_items: "{{ groups[mds_group_name] }}"
@@ -162,7 +162,7 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - mds_group_name in group_names
-        - containerized_deployment
+        - containerized_deployment | bool
         - ceph_mds_container_stat.get('rc') == 0
         - hostvars[item]['_mds_handler_called'] | default(False)
         - ceph_mds_container_stat.get('stdout_lines', [])|length != 0
@@ -197,7 +197,7 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - rgw_group_name in group_names
-        - not containerized_deployment
+        - not containerized_deployment | bool
         - hostvars[item]['_rgw_handler_called'] | default(False)
         - rgw_socket_stat.rc == 0
       with_items: "{{ groups[rgw_group_name] }}"
@@ -210,7 +210,7 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - rgw_group_name in group_names
-        - containerized_deployment
+        - containerized_deployment | bool
         - ceph_rgw_container_stat.get('rc') == 0
         - hostvars[item]['_rgw_handler_called'] | default(False)
         - ceph_rgw_container_stat.get('stdout_lines', [])|length != 0
@@ -245,7 +245,7 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - nfs_group_name in group_names
-        - not containerized_deployment
+        - not containerized_deployment | bool
         - hostvars[item]['_nfs_handler_called'] | default(False)
         - nfs_socket_stat.rc == 0
       with_items: "{{ groups[nfs_group_name] }}"
@@ -258,7 +258,7 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - nfs_group_name in group_names
-        - containerized_deployment
+        - containerized_deployment | bool
         - ceph_nfs_container_stat.get('rc') == 0
         - hostvars[item]['_nfs_handler_called'] | default(False)
         - ceph_nfs_container_stat.get('stdout_lines', [])|length != 0
@@ -293,7 +293,7 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - rbdmirror_group_name in group_names
-        - not containerized_deployment
+        - not containerized_deployment | bool
         - hostvars[item]['_rbdmirror_handler_called'] | default(False)
         - rbd_mirror_socket_stat.rc == 0
       with_items: "{{ groups[rbdmirror_group_name] }}"
@@ -306,7 +306,7 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - rbdmirror_group_name in group_names
-        - containerized_deployment
+        - containerized_deployment | bool
         - ceph_rbd_mirror_container_stat.get('rc') == 0
         - hostvars[item]['_rbdmirror_handler_called'] | default(False)
         - ceph_rbd_mirror_container_stat.get('stdout_lines', [])|length != 0
@@ -341,10 +341,10 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - mgr_group_name in group_names
-        - not containerized_deployment
+        - not containerized_deployment | bool
         - hostvars[item]['_mgr_handler_called'] | default(False)
         - mgr_socket_stat.rc == 0
-        - not rolling_update
+        - not rolling_update | bool
       with_items: "{{ groups[mgr_group_name] }}"
       delegate_to: "{{ item }}"
       run_once: True
@@ -355,11 +355,11 @@
       when:
         # We do not want to run these checks on initial deployment (`socket.rc == 0`)
         - mgr_group_name in group_names
-        - containerized_deployment
+        - containerized_deployment | bool
         - ceph_mgr_container_stat.get('rc') == 0
         - hostvars[item]['_mgr_handler_called'] | default(False)
         - ceph_mgr_container_stat.get('stdout_lines', [])|length != 0
-        - not rolling_update
+        - not rolling_update | bool
       with_items: "{{ groups[mgr_group_name] }}"
       delegate_to: "{{ item }}"
       run_once: True

--- a/roles/ceph-handler/tasks/check_running_cluster.yml
+++ b/roles/ceph-handler/tasks/check_running_cluster.yml
@@ -2,9 +2,9 @@
 - name: include check_running_containers.yml
   include_tasks: check_running_containers.yml
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
 
 - name: include check_socket_non_container.yml
   include_tasks: check_socket_non_container.yml
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool

--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -10,7 +10,7 @@
   tags:
     - firewall
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
 
 - when:
     - (firewalld_pkg_query.get('rc', 1) == 0

--- a/roles/ceph-infra/tasks/main.yml
+++ b/roles/ceph-infra/tasks/main.yml
@@ -2,11 +2,11 @@
 - name: include_tasks configure_firewall.yml
   include_tasks: configure_firewall.yml
   when:
-    - configure_firewall
+    - configure_firewall | bool
     - ansible_os_family in ['RedHat', 'Suse']
   tags: configure_firewall
 
 - name: include_tasks setup_ntp.yml
   include_tasks: setup_ntp.yml
-  when: ntp_service_enabled
+  when: ntp_service_enabled | bool
   tags: configure_ntp

--- a/roles/ceph-infra/tasks/setup_ntp.yml
+++ b/roles/ceph-infra/tasks/setup_ntp.yml
@@ -2,7 +2,7 @@
 # Installation of NTP daemons needs to be a separate task since installations
 # can't happen on Atomic
 - name: install the ntp daemon
-  when: not is_atomic
+  when: not is_atomic | bool
   block:
     - name: install ntpd
       package:

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -13,7 +13,7 @@
     group: "root"
     mode: "{{ ceph_keyring_permissions }}"
   when:
-    - cephx
+    - cephx | bool
 
 - name: deploy gateway settings, used by the ceph_iscsi_config modules
   template:
@@ -24,7 +24,7 @@
   set_fact:
     docker_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  when: containerized_deployment
+  when: containerized_deployment | bool
 
 - name: check if a rbd pool exists
   command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool ls --format json"

--- a/roles/ceph-iscsi-gw/tasks/main.yml
+++ b/roles/ceph-iscsi-gw/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: include non-container/prerequisites.yml
   include_tasks: non-container/prerequisites.yml
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
 
 # deploy_ssl_keys used the ansible controller to create self-signed crt/key/pub files
 # and transfers them to /etc/ceph directory on each controller. SSL certs are used by
@@ -13,14 +13,14 @@
 - name: include deploy_ssl_keys.yml
   include_tasks: deploy_ssl_keys.yml
   when:
-    - generate_crt|bool
+    - generate_crt | bool
 
 - name: include non-container/configure_iscsi.yml
   include_tasks: non-container/configure_iscsi.yml
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
 
 - name: include containerized.yml
   include_tasks: container/containerized.yml
   when:
-    - containerized_deployment
+    - containerized_deployment | bool

--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -38,7 +38,7 @@
     - name: install ceph iscsi package
       package:
         name: "{{ item }}"
-        state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+        state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
       register: result
       until: result is succeeded
       with_items:

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -21,5 +21,5 @@
     - { name: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
   when:
-    - cephx
-    - item.copy_key|bool
+    - cephx | bool
+    - item.copy_key | bool

--- a/roles/ceph-mds/tasks/containerized.yml
+++ b/roles/ceph-mds/tasks/containerized.yml
@@ -8,7 +8,7 @@
     admin_keyring:
       - "/etc/ceph/{{ cluster }}.client.admin.keyring"
   when:
-    - copy_admin_key
+    - copy_admin_key | bool
 
 - name: set_fact ceph_config_keys
   set_fact:
@@ -19,7 +19,7 @@
   set_fact:
     ceph_config_keys: "{{ ceph_config_keys + admin_keyring }}"
   when:
-    - copy_admin_key
+    - copy_admin_key | bool
 
 - name: stat for ceph config and keys
   stat:

--- a/roles/ceph-mds/tasks/main.yml
+++ b/roles/ceph-mds/tasks/main.yml
@@ -3,21 +3,21 @@
   include_tasks: create_mds_filesystems.yml
   when:
     - inventory_hostname == groups[mds_group_name] | first
-    - not rolling_update
+    - not rolling_update | bool
 
 - name: set_fact docker_exec_cmd
   set_fact:
     docker_exec_cmd: "{{ container_binary }} exec ceph-mds-{{ ansible_hostname }}"
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
 
 - name: include common.yml
   include_tasks: common.yml
 
 - name: non_containerized.yml
   include_tasks: non_containerized.yml
-  when: not containerized_deployment
+  when: not containerized_deployment | bool
 
 - name: containerized.yml
   include_tasks: containerized.yml
-  when: containerized_deployment
+  when: containerized_deployment | bool

--- a/roles/ceph-mds/tasks/non_containerized.yml
+++ b/roles/ceph-mds/tasks/non_containerized.yml
@@ -2,7 +2,7 @@
 - name: install ceph mds for debian
   apt:
     name: ceph-mds
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+    state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default('') if ceph_origin == 'repository' and ceph_repository == 'uca' else '' }}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else '' }}"
   when:
     - mds_group_name in group_names
@@ -13,7 +13,7 @@
 - name: install redhat ceph-mds package
   package:
     name: "ceph-mds"
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+    state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
   register: result
   until: result is succeeded
   when:
@@ -25,7 +25,7 @@
   args:
     creates: /var/lib/ceph/mds/{{ cluster }}-{{ mds_name }}/keyring
   changed_when: false
-  when: cephx
+  when: cephx | bool
 
 - name: set mds key permissions
   file:
@@ -33,7 +33,7 @@
     owner: "ceph"
     group: "ceph"
     mode: "0600"
-  when: cephx
+  when: cephx | bool
 
 - name: ensure systemd service override directory exists
   file:

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -38,9 +38,9 @@
     - { name: "/etc/ceph/{{ cluster }}.mgr.{{ ansible_hostname }}.keyring", dest: "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring", copy_key: "{{ True if groups.get(mgr_group_name, []) | length > 0 else False }}" }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", dest: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
   when:
-    - cephx
+    - cephx | bool
     - groups.get(mgr_group_name, []) | length > 0
-    - item.copy_key|bool
+    - item.copy_key | bool
 
 - name: set mgr key permissions
   file:
@@ -49,4 +49,4 @@
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: "{{ ceph_keyring_permissions }}"
   when:
-    - cephx
+    - cephx | bool

--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -3,14 +3,14 @@
   set_fact:
     docker_exec_cmd_mgr: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
 
 - name: include common.yml
   include_tasks: common.yml
 
 - name: include pre_requisite.yml
   include_tasks: pre_requisite.yml
-  when: not containerized_deployment
+  when: not containerized_deployment | bool
 
 - name: include start_mgr.yml
   include_tasks: start_mgr.yml

--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -2,7 +2,7 @@
 - name: install ceph-mgr package on RedHat or SUSE
   package:
     name: ceph-mgr
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+    state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
   register: result
   until: result is succeeded
   when:
@@ -11,7 +11,7 @@
 - name: install ceph mgr for debian
   apt:
     name: ceph-mgr
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+    state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
     default_release: "{{ ceph_stable_release_uca | default('') if ceph_origin == 'repository' and ceph_repository == 'uca' else ''}}{{ ansible_distribution_release ~ '-backports' if ceph_origin == 'distro' and ceph_use_distro_backports else '' }}"
   register: result
   until: result is succeeded

--- a/roles/ceph-mgr/tasks/start_mgr.yml
+++ b/roles/ceph-mgr/tasks/start_mgr.yml
@@ -26,7 +26,7 @@
     group: "root"
     mode: "0644"
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
   notify:
     - restart ceph mgrs
 

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -18,7 +18,7 @@
 
 - name: tasks for MONs when cephx is enabled
   when:
-    - cephx
+    - cephx | bool
   block:
   - name: fetch ceph initial keys
     ceph_key:

--- a/roles/ceph-mon/tasks/crush_rules.yml
+++ b/roles/ceph-mon/tasks/crush_rules.yml
@@ -8,7 +8,7 @@
   register: config_crush_hierarchy
   when:
     - inventory_hostname == groups.get(mon_group_name) | last
-    - create_crush_tree
+    - create_crush_tree | bool
     - hostvars[item]['osd_crush_location'] is defined
 
 - name: create configured crush rules

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -6,7 +6,7 @@
     header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ;
     print(base64.b64encode(header + key).decode())"
   register: monitor_keyring
-  when: cephx
+  when: cephx | bool
   run_once: true # must run on a single mon only
 
   # add code to read the key or/and try to find it on other nodes
@@ -27,15 +27,15 @@
   environment:
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-  when: cephx
+  when: cephx | bool
 
 - name: copy the initial key in /etc/ceph (for containers)
   command: >
     cp /var/lib/ceph/tmp/{{ cluster }}.mon..keyring /etc/ceph/{{ cluster }}.mon.keyring
   changed_when: false
   when:
-    - cephx
-    - containerized_deployment
+    - cephx | bool
+    - containerized_deployment | bool
 
 - name: create (and fix ownership of) monitor directory
   file:
@@ -62,7 +62,7 @@
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: create_custom_admin_secret
   when:
-    - cephx
+    - cephx | bool
     - admin_secret != 'admin_secret'
 
 - name: set_fact ceph-authtool container command
@@ -75,7 +75,7 @@
      /var/lib/ceph/tmp/{{ cluster }}.mon..keyring --import-keyring /etc/ceph/{{ cluster }}.client.admin.keyring
   when:
     - not create_custom_admin_secret.get('skipped')
-    - cephx
+    - cephx | bool
     - admin_secret != 'admin_secret'
 
 - name: set_fact ceph-mon container command
@@ -95,7 +95,7 @@
   args:
     creates: /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/keyring
   when:
-    - cephx
+    - cephx | bool
 
 - name: ceph monitor mkfs without keyring
   command: >
@@ -109,4 +109,4 @@
   args:
     creates: /var/lib/ceph/mon/{{ cluster }}-{{ monitor_name }}/store.db
   when:
-    - not cephx
+    - not cephx | bool

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -3,7 +3,7 @@
   set_fact:
     docker_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ ansible_hostname }}"
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
 
 - name: include deploy_monitors.yml
   include_tasks: deploy_monitors.yml
@@ -23,10 +23,10 @@
 - name: include secure_cluster.yml
   include_tasks: secure_cluster.yml
   when:
-    - secure_cluster
+    - secure_cluster | bool
     - inventory_hostname == groups[mon_group_name] | first
 
 - name: crush_rules.yml
   include_tasks: crush_rules.yml
   when:
-    - crush_rule_config
+    - crush_rule_config | bool

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -4,7 +4,7 @@
     state: directory
     path: "/etc/systemd/system/ceph-mon@.service.d/"
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
     - ceph_mon_systemd_overrides is defined
     - ansible_service_mgr == 'systemd'
 
@@ -15,7 +15,7 @@
     config_overrides: "{{ ceph_mon_systemd_overrides | default({}) }}"
     config_type: "ini"
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
     - ceph_mon_systemd_overrides is defined
     - ansible_service_mgr == 'systemd'
 
@@ -29,7 +29,7 @@
     mode: "0644"
   notify:
     - restart ceph mons
-  when: containerized_deployment
+  when: containerized_deployment | bool
 
 - name: start the monitor service
   systemd:

--- a/roles/ceph-nfs/tasks/common.yml
+++ b/roles/ceph-nfs/tasks/common.yml
@@ -10,5 +10,5 @@
     - { name: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
   when:
-    - cephx
-    - item.copy_key|bool
+    - cephx | bool
+    - item.copy_key | bool

--- a/roles/ceph-nfs/tasks/create_rgw_nfs_user.yml
+++ b/roles/ceph-nfs/tasks/create_rgw_nfs_user.yml
@@ -3,7 +3,7 @@
   set_fact:
     docker_exec_cmd_nfs: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
 
 - name: check if "{{ ceph_nfs_rgw_user }}" exists
   command: "{{ docker_exec_cmd_nfs | default('') }} radosgw-admin --cluster {{ cluster }} user info --uid={{ ceph_nfs_rgw_user }}"
@@ -13,7 +13,7 @@
   failed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
-    - nfs_obj_gw
+    - nfs_obj_gw | bool
 
 - name: create rgw nfs user "{{ ceph_nfs_rgw_user }}"
   command: "{{ docker_exec_cmd_nfs | default('') }} radosgw-admin --cluster {{ cluster }} user create --uid={{ ceph_nfs_rgw_user }} --display-name='RGW NFS User'"
@@ -22,7 +22,7 @@
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
-    - nfs_obj_gw
+    - nfs_obj_gw | bool
     - rgwuser_exists.get('rc', 1) != 0
 
 - name: set_fact ceph_nfs_rgw_access_key
@@ -30,7 +30,7 @@
     ceph_nfs_rgw_access_key: "{{ (rgwuser.stdout | from_json)['keys'][0]['access_key'] if rgwuser_exists.get('rc', 1) != 0 else (rgwuser_exists.stdout | from_json)['keys'][0]['access_key'] }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
-    - nfs_obj_gw
+    - nfs_obj_gw | bool
     - ceph_nfs_rgw_access_key is not defined
 
 - name: set_fact ceph_nfs_rgw_secret_key
@@ -38,5 +38,5 @@
     ceph_nfs_rgw_secret_key: "{{ (rgwuser.stdout | from_json)['keys'][0]['secret_key'] if rgwuser_exists.get('rc', 1) != 0 else (rgwuser_exists.stdout | from_json)['keys'][0]['secret_key'] }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
-    - nfs_obj_gw
+    - nfs_obj_gw | bool
     - ceph_nfs_rgw_secret_key is not defined

--- a/roles/ceph-nfs/tasks/main.yml
+++ b/roles/ceph-nfs/tasks/main.yml
@@ -3,7 +3,7 @@
   set_fact:
     docker_exec_cmd: "{{ container_binary }} exec ceph-nfs-{{ ansible_hostname }}"
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
 
 - name: include common.yml
   include_tasks: common.yml
@@ -11,12 +11,12 @@
 - name: include pre_requisite_non_container.yml
   include_tasks: pre_requisite_non_container.yml
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
 
 - name: include pre_requisite_container.yml
   include_tasks: pre_requisite_container.yml
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
 
 - name: include create_rgw_nfs_user.yml
   import_tasks: create_rgw_nfs_user.yml
@@ -25,7 +25,7 @@
 - name: include ganesha_selinux_fix.yml
   import_tasks: ganesha_selinux_fix.yml
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
     - ansible_os_family == 'RedHat'
     - ansible_distribution_version >= '7.4'
 

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -4,7 +4,7 @@
     admin_keyring:
       - "/etc/ceph/{{ cluster }}.client.admin.keyring"
   when:
-    - copy_admin_key
+    - copy_admin_key | bool
 
 - name: set_fact ceph_config_keys
   set_fact:
@@ -15,7 +15,7 @@
   set_fact:
     ceph_config_keys: "{{ ceph_config_keys + admin_keyring }}"
   when:
-    - copy_admin_key
+    - copy_admin_key | bool
 
 - name: stat for config and keys
   stat:
@@ -51,9 +51,9 @@
     group: "root"
     mode: "0644"
   when:
-    - ceph_nfs_dynamic_exports
+    - ceph_nfs_dynamic_exports | bool
 
 - name: reload dbus configuration
   command: "killall -SIGHUP dbus-daemon"
   when:
-    - ceph_nfs_dynamic_exports
+    - ceph_nfs_dynamic_exports | bool

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -42,11 +42,11 @@
     - { name: "/var/log/ceph", create: true }
     - { name: "/var/run/ceph", create: true }
   when:
-    - item.create|bool
+    - item.create | bool
 
 - name: cephx related tasks
   when:
-    - cephx
+    - cephx | bool
   block:
     - name: copy bootstrap cephx keys
       copy:
@@ -58,11 +58,11 @@
       with_items:
         - { name: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: "{{ nfs_obj_gw }}" }
       when:
-        - item.copy_key|bool
+        - item.copy_key | bool
 
     - name: nfs object gateway related tasks
       when:
-        - nfs_obj_gw
+        - nfs_obj_gw | bool
       block:
         - name: create rados gateway keyring
           command: ceph --cluster {{ cluster }} --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring auth get-or-create client.rgw.{{ ansible_hostname }} osd 'allow rwx' mon 'allow rw' -o /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}/keyring

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_debian.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_debian.yml
@@ -54,7 +54,7 @@
         - name: install jemalloc for debian
           apt:
             name: libjemalloc1
-            state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+            state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
             update_cache: yes
           register: result
           until: result is succeeded
@@ -64,14 +64,14 @@
             allow_unauthenticated: yes
           register: result
           until: result is succeeded
-          when: nfs_obj_gw
+          when: nfs_obj_gw | bool
         - name: install nfs rgw/cephfs gateway - debian
           apt:
             name: nfs-ganesha-ceph
             allow_unauthenticated: yes
           register: result
           until: result is succeeded
-          when: nfs_file_gw
+          when: nfs_file_gw | bool
 
     - name: debian based systems - rhcs installation
       when:
@@ -81,22 +81,22 @@
         - name: install red hat storage nfs gateway for debian
           apt:
             name: nfs-ganesha
-            state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+            state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
           register: result
           until: result is succeeded
         - name: install red hat storage nfs file gateway
           apt:
             name: nfs-ganesha-ceph
-            state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+            state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
           register: result
           until: result is succeeded
           when:
-            - nfs_file_gw
+            - nfs_file_gw | bool
         - name: install red hat storage nfs obj gateway
           apt:
             name: nfs-ganesha-rgw
-            state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+            state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
           register: result
           until: result is succeeded
           when:
-            - nfs_obj_gw
+            - nfs_obj_gw | bool

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
@@ -39,17 +39,17 @@
     - name: install nfs cephfs gateway
       package:
         name: nfs-ganesha-ceph
-        state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+        state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
       register: result
       until: result is succeeded
       when:
-        - nfs_file_gw
+        - nfs_file_gw | bool
 
     - name: install redhat nfs-ganesha-rgw and ceph-radosgw packages
       package:
         name: ['nfs-ganesha-rgw', 'ceph-radosgw']
-        state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+        state: "{{ (upgrade_ceph_packages | bool) | ternary('latest','present') }}"
       register: result
       until: result is succeeded
       when:
-        - nfs_obj_gw
+        - nfs_obj_gw | bool

--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -3,7 +3,7 @@
   set_fact:
     docker_exec_cmd_nfs: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
 
 - name: check if rados index object exists
   shell: "{{ docker_exec_cmd_nfs | default('') }} rados -p {{ cephfs_data }} --cluster {{ cluster }} ls|grep {{ ceph_nfs_rados_export_index }}"
@@ -12,14 +12,14 @@
   register: rados_index_exists
   check_mode: no
   when:
-    - ceph_nfs_rados_backend
+    - ceph_nfs_rados_backend | bool
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
 
 - name: create an empty rados index object
   command: "{{ docker_exec_cmd_nfs | default('') }} rados -p {{ cephfs_data }} --cluster {{ cluster }} put {{ ceph_nfs_rados_export_index }} /dev/null"
   when:
-    - ceph_nfs_rados_backend
+    - ceph_nfs_rados_backend | bool
     - rados_index_exists.rc != 0
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
@@ -52,7 +52,7 @@
     group: "root"
     mode: "0755"
   when:
-    - ceph_nfs_dynamic_exports
+    - ceph_nfs_dynamic_exports | bool
 
 - name: create exports dir index file
   copy:
@@ -63,7 +63,7 @@
     group: "root"
     mode: "0644"
   when:
-    - ceph_nfs_dynamic_exports
+    - ceph_nfs_dynamic_exports | bool
 
 - name: generate systemd unit file
   become: true
@@ -74,7 +74,7 @@
     group: "root"
     mode: "0644"
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
   notify:
     - restart ceph nfss
 
@@ -86,8 +86,8 @@
     masked: no
     daemon_reload: yes
   when:
-    - containerized_deployment
-    - ceph_nfs_enable_service
+    - containerized_deployment | bool
+    - ceph_nfs_enable_service | bool
 
 - name: start nfs gateway service
   systemd:
@@ -96,5 +96,5 @@
     enabled: yes
     masked: no
   when:
-    - not containerized_deployment
-    - ceph_nfs_enable_service
+    - not containerized_deployment | bool
+    - ceph_nfs_enable_service | bool

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -7,7 +7,7 @@
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: "0755"
   when:
-    - cephx
+    - cephx | bool
   with_items:
     - /var/lib/ceph/bootstrap-osd/
     - /var/lib/ceph/osd/
@@ -23,5 +23,5 @@
     - { name: "/var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
   when:
-    - cephx
-    - item.copy_key|bool
+    - cephx | bool
+    - item.copy_key | bool

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -9,7 +9,7 @@
   register: result
   until: result is succeeded
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
     - ansible_os_family != 'ClearLinux'
 
 - name: install numactl when needed
@@ -18,7 +18,7 @@
   register: result
   until: result is succeeded
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
     - ceph_osd_numactl_opts != ""
   tags:
     - with_pkg
@@ -29,7 +29,7 @@
   register: result
   until: result is succeeded
   when:
-    - not is_atomic
+    - not is_atomic | bool
   tags:
     - with_pkg
 
@@ -69,7 +69,7 @@
   with_items: "{{ openstack_keys }}"
   when:
     - not add_osd|default(False)
-    - openstack_config
+    - openstack_config | bool
     - item.get('mon_cap', None)
     # it's enough to assume we are running an old-fashionned syntax simply by checking the presence of mon_cap since every key needs this cap
 
@@ -85,5 +85,5 @@
   include_tasks: openstack_config.yml
   when:
     - not add_osd|default(False)
-    - openstack_config
+    - openstack_config | bool
     - inventory_hostname == groups[osd_group_name] | last

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -83,7 +83,7 @@
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   with_items: "{{ openstack_keys }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  when: cephx
+  when: cephx | bool
 
 - name: fetch openstack cephx key(s)
   fetch:
@@ -105,6 +105,6 @@
     - "{{ openstack_keys }}"
   delegate_to: "{{ item.0 }}"
   when:
-    - cephx
-    - openstack_config
+    - cephx | bool
+    - openstack_config | bool
     - item.0 != groups[mon_group_name]

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -1,7 +1,7 @@
 ---
 - name: container specific tasks
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
   block:
   - name: umount ceph disk (if on openstack)
     mount:
@@ -10,7 +10,7 @@
       fstype: ext3
       state: unmounted
     when:
-      - ceph_docker_on_openstack
+      - ceph_docker_on_openstack | bool
 
   - name: generate ceph osd docker run script
     become: true
@@ -52,7 +52,7 @@
   notify:
     - restart ceph osds
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
 
 - name: systemd start osd
   systemd:

--- a/roles/ceph-rbd-mirror/tasks/common.yml
+++ b/roles/ceph-rbd-mirror/tasks/common.yml
@@ -19,7 +19,7 @@
   args:
     creates: /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
 
 - name: set rbd-mirror key permissions
   file:
@@ -28,4 +28,4 @@
     group: "ceph"
     mode: "{{ ceph_keyring_permissions }}"
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool

--- a/roles/ceph-rbd-mirror/tasks/main.yml
+++ b/roles/ceph-rbd-mirror/tasks/main.yml
@@ -3,30 +3,30 @@
   set_fact:
     docker_exec_cmd: "{{ container_binary }} exec ceph-rbd-mirror-{{ ansible_hostname }}"
   when:
-    - containerized_deployment
+    - containerized_deployment | bool
 
 - name: include pre_requisite.yml
   include_tasks: pre_requisite.yml
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
 
 - name: include common.yml
   include_tasks: common.yml
   when:
-    - cephx
+    - cephx | bool
 
 - name: include start_rbd_mirror.yml
   include_tasks: start_rbd_mirror.yml
   when:
-    - not containerized_deployment
+    - not containerized_deployment | bool
 
 - name: include configure_mirroring.yml
   include_tasks: configure_mirroring.yml
   when:
-    - ceph_rbd_mirror_configure
-    - not containerized_deployment
+    - ceph_rbd_mirror_configure | bool
+    - not containerized_deployment | bool
 
 - name: include docker/main.yml
   include_tasks: docker/main.yml
   when:
-    - containerized_deployment
+    - containerized_deployment | bool

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -31,5 +31,5 @@
     - { name: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
     - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
   when:
-    - cephx
-    - item.copy_key|bool
+    - cephx | bool
+    - item.copy_key | bool

--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -4,23 +4,23 @@
 
 - name: include_tasks pre_requisite.yml
   include_tasks: pre_requisite.yml
-  when: not containerized_deployment
+  when: not containerized_deployment | bool
 
 - name: include_tasks openstack-keystone.yml
   include_tasks: openstack-keystone.yml
-  when: radosgw_keystone_ssl|bool
+  when: radosgw_keystone_ssl | bool
 
 - name: include_tasks start_radosgw.yml
   include_tasks: start_radosgw.yml
-  when: not containerized_deployment
+  when: not containerized_deployment | bool
 
 - name: include_tasks docker/main.yml
   include_tasks: docker/main.yml
-  when: containerized_deployment
+  when: containerized_deployment | bool
 
 - name: include_tasks multisite/main.yml
   include_tasks: multisite/main.yml
-  when: rgw_multisite
+  when: rgw_multisite | bool
 
 - name: rgw pool related tasks
   when:

--- a/roles/ceph-rgw/tasks/multisite/main.yml
+++ b/roles/ceph-rgw/tasks/multisite/main.yml
@@ -6,14 +6,14 @@
 - name: include_tasks master.yml
   include_tasks: master.yml
   when:
-    - rgw_zonemaster
-    - not rgw_zonesecondary
+    - rgw_zonemaster | bool
+    - not rgw_zonesecondary | bool
 
 - name: include_tasks secondary.yml
   include_tasks: secondary.yml
   when:
-    - not rgw_zonemaster
-    - rgw_zonesecondary
+    - not rgw_zonemaster | bool
+    - rgw_zonesecondary | bool
 
 # Continue with common tasks
 - name: add zone to rgw stanza in ceph.conf

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -6,7 +6,7 @@
   changed_when: false
   with_items: "{{ rgw_instances }}"
   when:
-    - cephx
+    - cephx | bool
 
 - name: set rados gateway instance key permissions
   file:
@@ -16,4 +16,4 @@
     mode: "0600"
   with_items: "{{ rgw_instances }}"
   when:
-    - cephx
+    - cephx | bool

--- a/roles/ceph-validate/tasks/check_rgw_multisite.yml
+++ b/roles/ceph-validate/tasks/check_rgw_multisite.yml
@@ -13,8 +13,8 @@
   fail:
     msg: "rgw_zonemaster and rgw_zonesecondary cannot both be true"
   when:
-    - rgw_zonemaster
-    - rgw_zonesecondary
+    - rgw_zonemaster | bool
+    - rgw_zonesecondary | bool
 
 - name: fail if rgw_zonegroup is not set
   fail:
@@ -45,19 +45,19 @@
   fail:
     msg: "rgw_pull_port has not been set by the user"
   when:
-    - rgw_zonesecondary
+    - rgw_zonesecondary | bool
     - rgw_pull_port is undefined
 
 - name: fail if rgw_pull_proto is not set
   fail:
     msg: "rgw_pull_proto has not been set by the user"
   when:
-    - rgw_zonesecondary
+    - rgw_zonesecondary | bool
     - rgw_pull_proto is undefined
 
 - name: fail if rgw_pullhost is not set
   fail:
     msg: "rgw_pullhost has not been set by the user"
   when:
-    - rgw_zonesecondary
+    - rgw_zonesecondary | bool
     - rgw_pullhost is undefined

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -8,7 +8,7 @@
     msg: "fqdn configuration is not supported anymore. Use 'use_fqdn_yes_i_am_sure: true' if you really want to use it. See release notes for more details"
   when:
     - mon_use_fqdn or mds_use_fqdn
-    - not use_fqdn_yes_i_am_sure
+    - not use_fqdn_yes_i_am_sure | bool
 
 - name: debian based systems tasks
   when:
@@ -33,7 +33,7 @@
   fail:
     msg: "ntp_daemon_type must be one of chronyd, ntpd, or timesyncd"
   when:
-    - ntp_service_enabled
+    - ntp_service_enabled | bool
     - ntp_daemon_type not in ['chronyd', 'ntpd', 'timesyncd']
 
 # Since NTPd can not be installed on Atomic...
@@ -91,7 +91,7 @@
   include_tasks: check_rgw_multisite.yml
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])
-    - rgw_multisite
+    - rgw_multisite | bool
 
 - name: include check_iscsi.yml
   include_tasks: check_iscsi.yml

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -89,7 +89,7 @@
       delay: 5
       changed_when: false
       when:
-        - is_atomic
+        - is_atomic | bool
         - (ceph_docker_dev_image is undefined or not ceph_docker_dev_image)
         - (not (inventory_hostname in groups.get('clients', [])) or (inventory_hostname == groups.get('clients', [''])|first))
 

--- a/tests/functional/dev_setup.yml
+++ b/tests/functional/dev_setup.yml
@@ -32,4 +32,4 @@
 
       - name: print contents of {{ group_vars_path }}
         command: "cat {{ group_vars_path }}"
-      when: dev_setup
+      when: dev_setup | bool

--- a/tests/functional/rgw_multisite.yml
+++ b/tests/functional/rgw_multisite.yml
@@ -22,13 +22,13 @@
       register: result
       until: result is succeeded
       when:
-        - not is_atomic
+        - not is_atomic | bool
 
     - name: generate and upload a random 10Mb file - containerized deployment
       command: >
         docker run --rm --name=rgw_multisite_test --entrypoint=/bin/bash {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} -c 'dd if=/dev/urandom of=/tmp/testinfra.img bs=1M count=10; {{ s3cmd_cmd }} mb s3://testinfra; {{ s3cmd_cmd }} put /tmp/testinfra.img s3://testinfra'
       when:
-        - rgw_zonemaster
+        - rgw_zonemaster | bool
         - containerized_deployment | default(False)
 
     - name: generate and upload a random a 10Mb file - non containerized

--- a/tests/functional/rhcs_setup.yml
+++ b/tests/functional/rhcs_setup.yml
@@ -65,7 +65,7 @@
         dest: /etc/yum.repos.d
         owner: root
         group: root
-      when: not is_atomic
+      when: not is_atomic | bool
 
     - name: enable the rhel-7-extras-nightly repo
       command: "yum-config-manager --enable rhel-7-extras-nightly"
@@ -107,7 +107,7 @@
         gpgcheck: no
         enabled: yes
       when:
-        - not is_atomic
+        - not is_atomic | bool
 
 - hosts: osds
   gather_facts: false
@@ -122,7 +122,7 @@
         gpgcheck: no
         enabled: yes
       when:
-        - not is_atomic
+        - not is_atomic | bool
 
     - name: set MTU on eth2
       command: "ifconfig eth2 mtu 1400 up"
@@ -140,4 +140,4 @@
         gpgcheck: no
         enabled: yes
       when:
-        - not is_atomic
+        - not is_atomic | bool

--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -22,7 +22,7 @@
       register: result
       until: result is succeeded
       when:
-        - not is_atomic
+        - not is_atomic | bool
 
     - name: centos based systems - configure repos
       block:
@@ -52,7 +52,7 @@
             state: absent
       when:
         - ansible_distribution == 'CentOS'
-        - not is_atomic
+        - not is_atomic | bool
 
     - name: resize logical volume for root partition to fill remaining free space
       lvol:
@@ -60,4 +60,4 @@
         vg: atomicos
         size: +100%FREE
         resizefs: yes
-      when: is_atomic
+      when: is_atomic | bool


### PR DESCRIPTION
Starting ansible 2.8 we now have a deprecation warning about bare
variables not using boolean filter.
This will break us in 2.12 if we don't adapt the code.

```console
[DEPRECATION WARNING]: evaluating dev_setup as a bare variable, this
behaviour will go away and you might need to add |bool to the
expression in the future. Also see CONDITIONAL_BARE_VARS configuration
toggle.. This feature will be removed in version 2.12. Deprecation
warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>