### PR TITLE
Fixed 10 issues of type: PYTHON_E402 throughout 3 files in repo.

### DIFF
--- a/library/ceph_add_users_buckets.py
+++ b/library/ceph_add_users_buckets.py
@@ -5,6 +5,10 @@
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from ansible.module_utils.basic import AnsibleModule
+from socket import error as socket_error
+import boto
+import radosgw
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
     'status': ['preview'],
@@ -287,10 +291,6 @@ added_buckets:
 
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from socket import error as socket_error
-import boto
-import radosgw
 
 
 def create_users(rgw, users, result):

--- a/library/ceph_crush.py
+++ b/library/ceph_crush.py
@@ -6,6 +6,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
 
+from ansible.module_utils.basic import AnsibleModule
+import datetime
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
@@ -62,8 +64,6 @@ EXAMPLES = '''
 
 RETURN = '''#  '''
 
-from ansible.module_utils.basic import AnsibleModule
-import datetime
 
 
 def fatal(message, module):

--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -1,4 +1,8 @@
 
+from notario.exceptions import Invalid
+from notario.validators import types, chainable, iterables
+from notario.decorators import optional
+from notario.store import store as notario_store
 from ansible.plugins.action import ActionBase
 from distutils.version import LooseVersion
 from ansible.module_utils.six import string_types
@@ -22,10 +26,6 @@ if LooseVersion(notario.__version__) < LooseVersion("0.0.13"):
     display.error(msg)
     raise SystemExit(msg)
 
-from notario.exceptions import Invalid
-from notario.validators import types, chainable, iterables
-from notario.decorators import optional
-from notario.store import store as notario_store
 
 
 CEPH_RELEASES = ['jewel', 'kraken', 'luminous', 'mimic', 'nautilus']


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.