### PR TITLE
[skip ci] tests: add more verbosity for ceph logs

### DIFF
--- a/tests/functional/all_daemons/ceph-override.json
+++ b/tests/functional/all_daemons/ceph-override.json
@@ -1,8 +1,13 @@
 {
 	"ceph_conf_overrides": {
 		"global": {
+			"debug_ms": 20,
 			"osd_pool_default_pg_num": 12,
 			"osd_pool_default_size": 1
+		},
+		"osd": {
+			"debug bluefs": 20,
+			"debug bluestore": 20
 		}
 	},
 	"cephfs_pools": [

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml
 
   # set up the cluster again
-  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars @ceph-override.json --extra-vars "\
       ceph_stable_release={env:CEPH_STABLE_RELEASE:nautilus} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \


### PR DESCRIPTION
To be reverted once the error reported in
https://tracker.ceph.com/issues/39156 is reproduced.

This commit will add more verbosity only in CI so we can get more
verbose logs when the error will show up.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>