### PR TITLE
osds: allow passing devices by path

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -165,7 +165,6 @@
     - devices is defined
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
-    - osd_scenario|default('dummy') != 'lvm'
 
 - name: set_fact build devices from resolved symlinks
   set_fact:
@@ -175,7 +174,6 @@
     - devices is defined
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
-    - osd_scenario|default('dummy') != 'lvm'
 
 - name: set_fact build final devices list
   set_fact:
@@ -184,7 +182,6 @@
     - devices is defined
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
-    - osd_scenario|default('dummy') != 'lvm'
 
 - name: set_fact devices generate device list when osd_auto_discovery
   set_fact:

--- a/tests/functional/lvm-batch/container/group_vars/all
+++ b/tests/functional/lvm-batch/container/group_vars/all
@@ -19,7 +19,7 @@ osd_scenario: lvm
 copy_admin_key: true
 devices:
   - /dev/sdb
-  - /dev/sdc
+  - /dev/disk/by-id/ata-QEMU_HARDDISK_QM00003
 os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:

--- a/tests/functional/lvm-batch/group_vars/all
+++ b/tests/functional/lvm-batch/group_vars/all
@@ -12,7 +12,7 @@ crush_device_class: test
 osd_scenario: lvm
 copy_admin_key: true
 devices:
-  - /dev/sdb 
+  - /dev/disk/by-id/ata-QEMU_HARDDISK_QM00002
   - /dev/sdc
 os_tuning_params:
   - { name: fs.file-max, value: 26234859 }


### PR DESCRIPTION
ceph-volume didn't work when the devices where passed by path.
Since it now support it, let's allow this feature in ceph-ansible

Closes: #3812

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>