### PR TITLE
update: fix undefined error when no mgr group is declared

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -172,8 +172,8 @@
         name: ceph-mgr@{{ ansible_hostname }}
         masked: yes
       when:
-        - inventory_hostname in groups[mgr_group_name]
-          or groups[mgr_group_name] | length == 0
+        - inventory_hostname in groups[mgr_group_name] | default([])
+          or groups[mgr_group_name] | default([]) | length == 0
 
     - import_role:
         name: ceph-handler


### PR DESCRIPTION
if mgr group isn't defined in inventory, that task will fail with
undefined error.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>