### PR TITLE
Toggle v2 and v1 protocols according to mon_host suffix variables

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -387,7 +387,7 @@ dummy:
 
 ## Rados Gateway options
 #
-#radosgw_frontend_type: beast # For additionnal frontends see: http://docs.ceph.com/docs/nautilus/radosgw/frontends/
+#radosgw_frontend_type: beast # For additional frontends see: http://docs.ceph.com/docs/nautilus/radosgw/frontends/
 
 #radosgw_civetweb_port: 8080
 #radosgw_civetweb_num_threads: 512
@@ -433,6 +433,10 @@ dummy:
 # Monitor handler checks
 #handler_health_mon_check_retries: 5
 #handler_health_mon_check_delay: 10
+
+# Monitor protocols
+#mon_host_v1_port: "6789"
+#mon_host_v2_port: "3300"
 #
 # OSD handler checks
 #handler_health_osd_check_retries: 40

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -387,7 +387,7 @@ ceph_rhcs_version: 3
 
 ## Rados Gateway options
 #
-#radosgw_frontend_type: beast # For additionnal frontends see: http://docs.ceph.com/docs/nautilus/radosgw/frontends/
+#radosgw_frontend_type: beast # For additional frontends see: http://docs.ceph.com/docs/nautilus/radosgw/frontends/
 
 #radosgw_civetweb_port: 8080
 #radosgw_civetweb_num_threads: 512
@@ -433,6 +433,10 @@ ceph_rhcs_version: 3
 # Monitor handler checks
 #handler_health_mon_check_retries: 5
 #handler_health_mon_check_delay: 10
+
+# Monitor protocols
+#mon_host_v1_port: "6789"
+#mon_host_v2_port: "3300"
 #
 # OSD handler checks
 #handler_health_osd_check_retries: 40

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -41,14 +41,17 @@ fsid = {{ fsid }}
 log file = /dev/null
 mon cluster log file = /dev/null
 {% endif %}
-{% if ceph_release not in ['jewel', 'kraken', 'luminous', 'mimic'] %}
-{% set mon_host_v1_suffix = ":6789" %}
-{% set mon_host_v2_suffix = ":3300" %}
-{% endif %}
+
 mon host = {% if nb_mon > 0 %}
 {% for host in _monitor_addresses -%}
 {% if msgr2_migration | default(False) or not rolling_update %}
-[{{ "v2:" + host.addr + mon_host_v2_suffix }},{{ "v1:" + host.addr + mon_host_v1_suffix }}]
+{%- if mon_host_v1_port and mon_host_v2_port -%}
+[{{ "v2:" + host.addr + ":" + mon_host_v2_port }},{{ "v1:" + host.addr + ":" + mon_host_v1_port }}]
+{%- elif not mon_host_v1_port and mon_host_v2_port -%}
+[{{ "v2:" + host.addr + ":" + mon_host_v2_port }}]
+{%- else -%}
+{{ host.addr }}
+{%- endif -%}
 {%- else -%}
 {{ host.addr }}
 {%- endif %}
@@ -76,7 +79,6 @@ rgw bucket default quota max objects = {{ rgw_bucket_default_quota_max_objects }
 admin socket = {{ rbd_client_admin_socket_path }}/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
 log file = {{ rbd_client_log_file }} # must be writable by QEMU and allowed by SELinux or AppArmor
 {% endif %}
-
 {% if inventory_hostname in groups.get(osd_group_name, []) %}
 {% if osd_objectstore == 'filestore' %}
 [osd]

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -379,7 +379,7 @@ mds_max_mds: 1
 
 ## Rados Gateway options
 #
-radosgw_frontend_type: beast # For additionnal frontends see: http://docs.ceph.com/docs/nautilus/radosgw/frontends/
+radosgw_frontend_type: beast # For additional frontends see: http://docs.ceph.com/docs/nautilus/radosgw/frontends/
 
 radosgw_civetweb_port: 8080
 radosgw_civetweb_num_threads: 512
@@ -425,6 +425,10 @@ email_address: foo@bar.com
 # Monitor handler checks
 handler_health_mon_check_retries: 5
 handler_health_mon_check_delay: 10
+
+# Monitor protocols
+mon_host_v1_port: "6789"
+mon_host_v2_port: "3300"
 #
 # OSD handler checks
 handler_health_osd_check_retries: 40


### PR DESCRIPTION
Allow users to define mon_host_v{1,2}_suffix variables to choose
what protocols enable in a fresh deployment. This removes release
check and uses the configuration defined in ceph-defaults role.

Signed-off-by: fpantano <fpantano@redhat.com>