### PR TITLE
switch-from-non-containerized: stop all osds

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -227,6 +227,21 @@
     - import_role:
         name: ceph-defaults
 
+    - name: collect running osds
+      shell: |
+        systemctl list-units | grep "loaded active" | grep -Eo 'ceph-osd@[0-9]+.service|ceph-volume|ceph\.target'
+      register: running_osds
+      changed_when: false
+      failed_when: false
+
+    - name: stop/disable/mask non-containerized ceph osd(s) (if any)
+      systemd:
+        name: "{{ item }}"
+        state: stopped
+        enabled: no
+      with_items: "{{ running_osds.stdout_lines | default([])}}"
+      when: running_osds != []
+
     - name: remove old ceph-osd systemd units
       file:
         path: "{{ item }}"


### PR DESCRIPTION
e6bfb84 introduced a regression in the switch from non containerized
to container deployment.
We need to stop all previous OSDs services. We just don't need the
ceph-disk pattern in the regex.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>