### PR TITLE
docs: Update ceph.conf supported section

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -235,11 +235,11 @@ new configuration options.
 
 The following sections in ``ceph.conf`` are supported:
 
-* ``[global]``,
+* ``[global]``
 * ``[mon]``
 * ``[osd]``
 * ``[mds]``
-* ``[rgw]``
+* ``[client.rgw.{instance_name}]``
 
 An example:
 


### PR DESCRIPTION
[rgw] isn't a valide section.
[client.rgw.{instance_name] should be used instead.

Resolves: #3841

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>