### PR TITLE
ceph-mon: increase timeout waiting for admin and bootstrap keys

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -1,6 +1,6 @@
 ---
 - name: collect admin and bootstrap keys
-  command: ceph-create-keys --cluster {{ cluster }} -i {{ monitor_name }} -t 30
+  command: ceph-create-keys --cluster {{ cluster }} -i {{ monitor_name }} -t 600
   changed_when: false
   check_mode: no
   when:


### PR DESCRIPTION
With a large and/or busy cluster, it can take significantly more than
30s for a restarted monitor to get to the point where
`ceph-create-keys` returns successfully. A recent upgrade of our
production cluster failed here because it took a couple of minutes for
the newly-upgraded `mon` to be ready. So increase the timeout
significantly.

This patch is applied to stable-3.2, because the affected code is
refactored in stable-4.0 and ceph-create-keys is no longer called, 
there or in master.

Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>