### PR TITLE
purge-cluster: remove python-ceph-argparse package

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -461,6 +461,7 @@
       - librados2
       - libradosstriper1
       - librbd1
+      - python-ceph-argparse
       - python-cephfs
       - python-rados
       - python-rbd


### PR DESCRIPTION
When using purge-cluster playbook with nautilus, there's still the
python-ceph-argparse package installed on the host preventing to
reinstall a ceph cluster with a different version (like luminous or
mimic)

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>