### PR TITLE
defaults: remove some package dependencies

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -76,23 +76,12 @@ dummy:
 ############
 # PACKAGES #
 ############
-#debian_package_dependencies:
-#  - python-pycurl
-
 #centos_package_dependencies:
-#  - python-pycurl
 #  - epel-release
-#  - python-setuptools
 #  - libselinux-python
 
-#redhat_package_dependencies:
-#  - python-pycurl
-#  - python-setuptools
-
 #suse_package_dependencies:
-#  - python-pycurl
 #  - python-xml
-#  - python-setuptools
 
 # Whether or not to install the ceph-test package.
 #ceph_test: false

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -76,23 +76,12 @@ fetch_directory: ~/ceph-ansible-keys
 ############
 # PACKAGES #
 ############
-#debian_package_dependencies:
-#  - python-pycurl
-
 #centos_package_dependencies:
-#  - python-pycurl
 #  - epel-release
-#  - python-setuptools
 #  - libselinux-python
 
-#redhat_package_dependencies:
-#  - python-pycurl
-#  - python-setuptools
-
 #suse_package_dependencies:
-#  - python-pycurl
 #  - python-xml
-#  - python-setuptools
 
 # Whether or not to install the ceph-test package.
 #ceph_test: false

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -11,15 +11,6 @@
   register: result
   until: result is succeeded
 
-- name: install dependencies
-  apt:
-    name: "{{ debian_package_dependencies }}"
-    state: present
-    update_cache: yes
-    cache_valid_time: 3600
-  register: result
-  until: result is succeeded
-
 - name: include install_debian_packages.yml
   include_tasks: install_debian_packages.yml
   when:

--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -1,13 +1,4 @@
 ---
-- name: install redhat dependencies
-  package:
-    name: "{{ redhat_package_dependencies }}"
-    state: present
-  register: result
-  until: result is succeeded
-  when:
-    - ansible_distribution == 'RedHat'
-
 - name: install centos dependencies
   yum:
     name: "{{ centos_package_dependencies }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -68,23 +68,12 @@ ceph_conf_local: false
 ############
 # PACKAGES #
 ############
-debian_package_dependencies:
-  - python-pycurl
-
 centos_package_dependencies:
-  - python-pycurl
   - epel-release
-  - python-setuptools
   - libselinux-python
 
-redhat_package_dependencies:
-  - python-pycurl
-  - python-setuptools
-
 suse_package_dependencies:
-  - python-pycurl
   - python-xml
-  - python-setuptools
 
 # Whether or not to install the ceph-test package.
 ceph_test: false


### PR DESCRIPTION
These packages aren't needed anymore.
They were needed for ceph-init-detect but as of ceph-init-detect doesn't exist
anymore.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1683885

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>