### PR TITLE
defaults: refact package dependencies installation.

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -76,9 +76,13 @@ dummy:
 ############
 # PACKAGES #
 ############
+#debian_package_dependencies: []
+
 #centos_package_dependencies:
 #  - epel-release
 #  - libselinux-python
+
+#redhat_package_dependencies: []
 
 #suse_package_dependencies:
 #  - python-xml

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -76,9 +76,13 @@ fetch_directory: ~/ceph-ansible-keys
 ############
 # PACKAGES #
 ############
+#debian_package_dependencies: []
+
 #centos_package_dependencies:
 #  - epel-release
 #  - libselinux-python
+
+#redhat_package_dependencies: []
 
 #suse_package_dependencies:
 #  - python-xml

--- a/roles/ceph-common/tasks/installs/install_on_debian.yml
+++ b/roles/ceph-common/tasks/installs/install_on_debian.yml
@@ -11,6 +11,15 @@
   register: result
   until: result is succeeded
 
+- name: install dependencies
+  apt:
+    name: "{{ debian_package_dependencies }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+  register: result
+  until: result is succeeded
+
 - name: include install_debian_packages.yml
   include_tasks: install_debian_packages.yml
   when:

--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -1,4 +1,13 @@
 ---
+- name: install redhat dependencies
+  package:
+    name: "{{ redhat_package_dependencies }}"
+    state: present
+  register: result
+  until: result is succeeded
+  when:
+    - ansible_distribution == 'RedHat'
+
 - name: install centos dependencies
   yum:
     name: "{{ centos_package_dependencies }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -68,9 +68,13 @@ ceph_conf_local: false
 ############
 # PACKAGES #
 ############
+debian_package_dependencies: []
+
 centos_package_dependencies:
   - epel-release
   - libselinux-python
+
+redhat_package_dependencies: []
 
 suse_package_dependencies:
   - python-xml


### PR DESCRIPTION
Because 5c98e361df5241fbfa5bd0a2ae1317219b7e1244 could be seen as a non
backward compatible change this commit reverts it and bring back package
dependencies installation support. Let's just change the default value instead.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>