### PR TITLE
update: refact msgr2 migration

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -337,6 +337,12 @@ dummy:
 #ip_version: ipv4
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 
+#mon_host_v1:
+#  enabled: True
+#  suffix: ':6789'
+#mon_host_v2:
+#  suffix: ':3300'
+
 ##########
 # CEPHFS #
 ##########

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -337,6 +337,12 @@ ceph_rhcs_version: 3
 #ip_version: ipv4
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 
+#mon_host_v1:
+#  enabled: True
+#  suffix: ':6789'
+#mon_host_v2:
+#  suffix: ':3300'
+
 ##########
 # CEPHFS #
 ##########

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -238,9 +238,10 @@
     - name: non container | waiting for the monitor to join the quorum...
       command: ceph --cluster "{{ cluster }}" -s --format json
       register: ceph_health_raw
-      until: >
-        hostvars[inventory_hostname]['ansible_hostname'] in (ceph_health_raw.stdout | default('{}') |  from_json)["quorum_names"] or
-        hostvars[inventory_hostname]['ansible_fqdn'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"]
+      until:
+        - ceph_health_raw.rc == 0
+        - (hostvars[inventory_hostname]['ansible_hostname'] in (ceph_health_raw.stdout | default('{}') |  from_json)["quorum_names"] or
+          hostvars[inventory_hostname]['ansible_fqdn'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"])
       retries: "{{ health_mon_check_retries }}"
       delay: "{{ health_mon_check_delay }}"
       delegate_to: "{{ mon_host }}"
@@ -252,8 +253,9 @@
         {{ container_binary }} exec ceph-mon-{{ hostvars[mon_host]['ansible_hostname'] }} ceph --cluster "{{ cluster }}" -s --format json
       register: ceph_health_raw
       until: >
-        hostvars[inventory_hostname]['ansible_hostname'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"] or
-        hostvars[inventory_hostname]['ansible_fqdn'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"]
+        - ceph_health_raw.rc == 0
+        - (hostvars[inventory_hostname]['ansible_hostname'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"] or
+          hostvars[inventory_hostname]['ansible_fqdn'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"])
       retries: "{{ health_mon_check_retries }}"
       delay: "{{ health_mon_check_delay }}"
       delegate_to: "{{ mon_host }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -236,7 +236,7 @@
         - containerized_deployment
 
     - name: non container | waiting for the monitor to join the quorum...
-      command: ceph --cluster "{{ cluster }}" -s --format json
+      command: ceph --cluster "{{ cluster }}" -m "{{ hostvars[groups[mon_group_name][0]]['_current_monitor_address'] }}" -s --format json
       register: ceph_health_raw
       until:
         - ceph_health_raw.rc == 0
@@ -244,21 +244,19 @@
           hostvars[inventory_hostname]['ansible_fqdn'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"])
       retries: "{{ health_mon_check_retries }}"
       delay: "{{ health_mon_check_delay }}"
-      delegate_to: "{{ mon_host }}"
       when:
         - not containerized_deployment
 
     - name: container | waiting for the containerized monitor to join the quorum...
       command: >
-        {{ container_binary }} exec ceph-mon-{{ hostvars[mon_host]['ansible_hostname'] }} ceph --cluster "{{ cluster }}" -s --format json
+        {{ container_binary }} exec ceph-mon-{{ ansible_hostname }} ceph --cluster "{{ cluster }}" -m "{{ hostvars[groups[mon_group_name][0]]['_current_monitor_address'] }}" -s --format json
       register: ceph_health_raw
-      until: >
+      until:
         - ceph_health_raw.rc == 0
         - (hostvars[inventory_hostname]['ansible_hostname'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"] or
           hostvars[inventory_hostname]['ansible_fqdn'] in (ceph_health_raw.stdout | default('{}') | from_json)["quorum_names"])
       retries: "{{ health_mon_check_retries }}"
       delay: "{{ health_mon_check_delay }}"
-      delegate_to: "{{ mon_host }}"
       when:
         - containerized_deployment
 

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -175,19 +175,6 @@
         - inventory_hostname in groups[mgr_group_name] | default([])
           or groups[mgr_group_name] | default([]) | length == 0
 
-    - import_role:
-        name: ceph-handler
-    - import_role:
-        name: ceph-common
-      when: not containerized_deployment
-    - import_role:
-        name: ceph-container-common
-      when: containerized_deployment
-    - import_role:
-        name: ceph-config
-    - import_role:
-        name: ceph-mon
-
     - name: set osd flags
       command: ceph --cluster {{ cluster }} osd set {{ item }}
       with_items:
@@ -208,6 +195,19 @@
       when:
         - inventory_hostname == groups[mon_group_name][0]
         - containerized_deployment
+
+    - import_role:
+        name: ceph-handler
+    - import_role:
+        name: ceph-common
+      when: not containerized_deployment
+    - import_role:
+        name: ceph-container-common
+      when: containerized_deployment
+    - import_role:
+        name: ceph-config
+    - import_role:
+        name: ceph-mon
 
     - name: start ceph mon
       systemd:

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -41,16 +41,17 @@ fsid = {{ fsid }}
 log file = /dev/null
 mon cluster log file = /dev/null
 {% endif %}
-{% if ceph_release not in ['jewel', 'kraken', 'luminous', 'mimic'] %}
-{% set mon_host_v1_suffix = ":6789" %}
-{% set mon_host_v2_suffix = ":3300" %}
-{% endif %}
 mon host = {% if nb_mon > 0 %}
 {% for host in _monitor_addresses -%}
-{% if msgr2_migration | default(False) or not rolling_update %}
-[{{ "v2:" + host.addr + mon_host_v2_suffix }},{{ "v1:" + host.addr + mon_host_v1_suffix }}]
-{%- else -%}
+{% if msgr2_migration | default(False) %}
+[{{ "v2:" + host.addr + mon_host_v2.suffix }},{{ "v1:" + host.addr + mon_host_v1.suffix }}]
+{%- elif not msgr2_migration | default(False) and rolling_update -%}
 {{ host.addr }}
+{%- else -%}
+{% if mon_host_v1.enabled %}
+{% set _v1 = ',v1:' + host.addr + mon_host_v1.suffix %}
+{% endif %}
+[{{ "v2:" + host.addr + mon_host_v2.suffix }}{{ _v1 | default('') }}]
 {%- endif %}
 {%- if not loop.last -%},{%- endif %}
 {%- endfor %}

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -329,6 +329,12 @@ monitor_address_block: subnet
 ip_version: ipv4
 mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 
+mon_host_v1:
+  enabled: True
+  suffix: ':6789'
+mon_host_v2:
+  suffix: ':3300'
+
 ##########
 # CEPHFS #
 ##########


### PR DESCRIPTION
this commit refact the msgr2 protocol introduction.

If it's a fresh install, let's go with v2 only.
If we upgrade to nautilus, we should go with v2+v1 syntax to ensure
nothing breaks.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>