### PR TITLE
allow using ansible 2.8

### DIFF
--- a/roles/ceph-agent/meta/main.yml
+++ b/roles/ceph-agent/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: Alfredo Deza
   description: Installs Ceph Storage Agent
   license: Apache
-  min_ansible_version: 2.4
+  min_ansible_version: 2.7
   platforms:
     - name: EL
       versions:

--- a/roles/ceph-client/meta/main.yml
+++ b/roles/ceph-client/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: Sébastien Han
   description: Installs A Ceph Client
   license: Apache
-  min_ansible_version: 2.4
+  min_ansible_version: 2.7
   platforms:
     - name: EL
       versions:

--- a/roles/ceph-common/meta/main.yml
+++ b/roles/ceph-common/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: Sébastien Han
   description: Installs Ceph
   license: Apache
-  min_ansible_version: 2.4
+  min_ansible_version: 2.7
   platforms:
     - name: EL
       versions:

--- a/roles/ceph-config/meta/main.yml
+++ b/roles/ceph-config/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: Guillaume Abrioux
   description: Handles ceph-ansible initial configuration
   license: Apache
-  min_ansible_version: 2.4
+  min_ansible_version: 2.7
   platforms:
     - name: EL
       versions:

--- a/roles/ceph-container-common/meta/main.yml
+++ b/roles/ceph-container-common/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: Sébastien Han
   description: Installs Ceph
   license: Apache
-  min_ansible_version: 2.4
+  min_ansible_version: 2.7
   platforms:
     - name: EL
       versions:

--- a/roles/ceph-defaults/meta/main.yml
+++ b/roles/ceph-defaults/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: Sébastien Han
   description: Handles ceph-ansible default vars for all roles
   license: Apache
-  min_ansible_version: 2.3
+  min_ansible_version: 2.7
   platforms:
     - name: Ubuntu
       versions:

--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -61,16 +61,16 @@
 
 - name: fail on unsupported ansible version (1.X)
   fail:
-    msg: "Ansible version must be >= 2.4.x, please update!"
+    msg: "Ansible version must be >= 2.7.x, please update!"
   when:
     - ansible_version.major|int < 2
 
 - name: fail on unsupported ansible version
   fail:
-    msg: "Ansible version must be 2.7!"
+    msg: "Ansible version must be 2.7 or 2.8!"
   when:
-    - ansible_version.major|int != 2
-    - ansible_version.minor|int != 7
+    - ansible_version.major|int == 2
+    - ansible_version.minor|int not in [7, 8]
 
 - name: fail if systemd is not present
   fail:


### PR DESCRIPTION
Currently we only support ansible 2.7
We plan to use 2.8 when it will be release so we have to support both
2.7 and 2.8.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1700548

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>