### PR TITLE
doc: update index.rst with current information for stable-4.0

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -71,13 +71,15 @@ The following branches should be used depending on your requirements. The ``stab
 branches have been QE tested and sometimes recieve backport fixes throughout their lifecycle.
 The ``master`` branch should be considered experimental and used with caution.
 
-- ``stable-3.0`` Supports for Ceph versions ``jewel`` and ``luminous``. This branch supports Ansible version ``2.4``.
+- ``stable-3.0`` Supports Ceph versions ``jewel`` and ``luminous``. This branch requires Ansible version ``2.4``.
 
-- ``stable-3.1`` Supports for Ceph version ``luminous`` and ``mimic``. This branch supports Ansible version ``2.4``.
+- ``stable-3.1`` Supports Ceph versions ``luminous`` and ``mimic``. This branch requires Ansible version ``2.4``.
 
-- ``stable-3.2`` Supports for Ceph version ``luminous`` and ``mimic``. This branch supports Ansible version ``2.6``.
+- ``stable-3.2`` Supports Ceph versions ``luminous`` and ``mimic``. This branch requires Ansible version ``2.6``.
 
-- ``master`` Supports for Ceph@master version. This branch supports Ansible version ``2.7``.
+- ``stable-4.0`` Supports Ceph version ``nautilus``. This branch requires Ansible version ``2.7``.
+
+- ``master`` Supports Ceph@master version. This branch requires Ansible version ``2.7``.
 
 Configuration and Usage
 =======================


### PR DESCRIPTION
I noticed today that stable-4.0 has been branched, but that the documentation hadn't yet been updated to include that fact. So I put together what I _think_ is the correct combination of supported Ceph versions and Ansible versions for each branch. If I got something wrong, please correct me!