### PR TITLE
validate: fix notario error

### DIFF
--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -111,7 +111,7 @@ class ActionModule(ActionBase):
             display.error(msg)
             reason = "[{}] Reason: {}".format(host, error.reason)
             try:
-                if "schema is missing" not in error.message:
+                if "schema is missing" not str(error):
                     for i in range(0, len(error.path)):
                         if i == 0:
                             given = "[{}] Given value for {}".format(


### PR DESCRIPTION
Typical error:

```
AttributeError: 'Invalid' object has no attribute 'message'
```

As of python 2.6, `BaseException.message` has been deprecated.
When using python3, it fails because it has been removed.

Let's use `str(error)` instead so we don't hit this error when using
python3.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>