### PR TITLE
validate: fix a typo

### DIFF
--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -111,7 +111,7 @@ class ActionModule(ActionBase):
             display.error(msg)
             reason = "[{}] Reason: {}".format(host, error.reason)
             try:
-                if "schema is missing" not str(error):
+                if "schema is missing" not in str(error):
                     for i in range(0, len(error.path)):
                         if i == 0:
                             given = "[{}] Given value for {}".format(


### PR DESCRIPTION
5aa27794615e7d4521b1dbf1444b61388aacb852 introduced a typo.
This commit fixes it.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>