### PR TITLE
ansible.cfg: Add library path to configuration

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,6 +3,7 @@
 
 [defaults]
 ansible_managed = Please do not change this file directly since it is managed by Ansible and will be overwritten
+library = ./library
 action_plugins = plugins/actions
 callback_plugins = plugins/callback
 roles_path = ./roles


### PR DESCRIPTION
Ceph module path needs to be configured if we want to avoid issues
like:

no action detected in task. This often indicates a misspelled module
name, or incorrect module path

Currently the ansible-lint command in Travis CI complains about that.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1668478

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit a1a871cadee5e86d181e1306c985e620b81fccac)