### PR TITLE
ceph-mds: Increase cpu limit to 4

### DIFF
--- a/group_vars/mdss.yml.sample
+++ b/group_vars/mdss.yml.sample
@@ -28,7 +28,7 @@ dummy:
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
 #ceph_mds_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
-#ceph_mds_docker_cpu_limit: 1
+#ceph_mds_docker_cpu_limit: 4
 
 # we currently for MDS_NAME to hostname because of a bug in ceph-docker
 # fix here: https://github.com/ceph/ceph-docker/pull/770

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -20,7 +20,7 @@ copy_admin_key: false
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
 ceph_mds_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
-ceph_mds_docker_cpu_limit: 1
+ceph_mds_docker_cpu_limit: 4
 
 # we currently for MDS_NAME to hostname because of a bug in ceph-docker
 # fix here: https://github.com/ceph/ceph-docker/pull/770

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -3,6 +3,7 @@ Description=Ceph MDS
 {% if container_binary == 'docker' %}
 After=docker.service
 {% endif %}
+{% set cpu_limit = ansible_processor_vcpus|int if ceph_mds_docker_cpu_limit|int > ansible_processor_vcpus|int else ceph_mds_docker_cpu_limit|int %}
 
 [Service]
 EnvironmentFile=-/etc/environment
@@ -11,9 +12,9 @@ ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mds-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_mds_docker_memory_limit }} \
   {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
-  --cpus={{ ceph_mds_docker_cpu_limit }} \
+  --cpus={{ cpu_limit }} \
   {% else -%}
-  --cpu-quota={{ ceph_mds_docker_cpu_limit * 100000 }} \
+  --cpu-quota={{ cpu_limit * 100000 }} \
   {% endif -%}
   -v /var/lib/ceph:/var/lib/ceph:z \
   -v /etc/ceph:/etc/ceph:z \


### PR DESCRIPTION
In containerized deployment the default mds cpu quota is too low
for production environment.
This is causing performance degradation compared to bare-metal.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1695850

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>