### PR TITLE
ceph-osd: Increase cpu limit to 4

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -122,7 +122,7 @@ dummy:
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
 #ceph_osd_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
-#ceph_osd_docker_cpu_limit: 1
+#ceph_osd_docker_cpu_limit: 4
 
 # The next two variables are undefined, and thus, unused by default.
 # If `lscpu | grep NUMA` returned the following:

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -114,7 +114,7 @@ ceph_config_keys: [] # DON'T TOUCH ME
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
 ceph_osd_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
-ceph_osd_docker_cpu_limit: 1
+ceph_osd_docker_cpu_limit: 4
 
 # The next two variables are undefined, and thus, unused by default.
 # If `lscpu | grep NUMA` returned the following:

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -5,6 +5,7 @@
 ########
 # MAIN #
 ########
+{% set cpu_limit = ansible_processor_vcpus|int if ceph_osd_docker_cpu_limit|int > ansible_processor_vcpus|int else ceph_osd_docker_cpu_limit|int %}
 
 {% if ceph_osd_numactl_opts != "" %}
 numactl \
@@ -20,9 +21,9 @@ numactl \
   --memory={{ ceph_osd_docker_memory_limit }} \
   {% endif -%}
   {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
-  --cpus={{ ceph_osd_docker_cpu_limit }} \
+  --cpus={{ cpu_limit }} \
   {% else -%}
-  --cpu-quota={{ ceph_osd_docker_cpu_limit * 100000 }} \
+  --cpu-quota={{ cpu_limit * 100000 }} \
   {% endif -%}
   {% if ceph_osd_docker_cpuset_cpus is defined -%}
   --cpuset-cpus='{{ ceph_osd_docker_cpuset_cpus }}' \


### PR DESCRIPTION
In containerized deployment the default osd cpu quota is too low
for production environment using NVMe devices.
This is causing performance degradation compared to bare-metal.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1695880

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>