### PR TITLE
Update group_vars according to defaults

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -356,15 +356,15 @@ dummy:
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 #  rule_name: "replicated_rule"
-#
+
 #cephfs_metadata_pool:
 #  name: "{{ cephfs_metadata }}"
 #  pgs: "{{ osd_pool_default_pg_num }}"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 #  rule_name: "replicated_rule"
-#
-#
+
+
 #cephfs_pools:
 #  - "{{ cephfs_data_pool }}"
 #  - "{{ cephfs_metadata_pool }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -356,15 +356,15 @@ ceph_rhcs_version: 3
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 #  rule_name: "replicated_rule"
-#
+
 #cephfs_metadata_pool:
 #  name: "{{ cephfs_metadata }}"
 #  pgs: "{{ osd_pool_default_pg_num }}"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 #  rule_name: "replicated_rule"
-#
-#
+
+
 #cephfs_pools:
 #  - "{{ cephfs_data_pool }}"
 #  - "{{ cephfs_metadata_pool }}"


### PR DESCRIPTION
b2f2426 didn't use the generate_group_vars_sample.sh script so we
currently have a difference between the content in group_vars and the
ceph-defaults/defaults directories.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>