### PR TITLE
ceph-osd: Fix merge conflict from mergify

### DIFF
--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -84,13 +84,8 @@ numactl \
   {% if osd_objectstore == 'filestore' -%}
   --memory={{ ceph_osd_docker_memory_limit }} \
   {% endif -%}
-<<<<<<< HEAD
   {% if ceph_docker_version.split('.')[0] is version_compare('13', '>=') -%}
-  --cpus={{ ceph_osd_docker_cpu_limit }} \
-=======
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ cpu_limit }} \
->>>>>>> c1710687... ceph-osd: Increase cpu limit to 4
   {% else -%}
   --cpu-quota={{ cpu_limit * 100000 }} \
   {% endif -%}


### PR DESCRIPTION
The PR #3916 was merged automatically by mergify even if there was a
confict in the ceph-osd-run.sh.j2 template.
This commit resolves the conflict.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>