### PR TITLE
revert osd_fsid zapping in shrink osd

### DIFF
--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -81,8 +81,35 @@
 
     - name: set_fact osd_hosts
       set_fact:
-        osd_hosts: "{{ osd_hosts | default([]) + [ [ (item.stdout | from_json).crush_location.host, (item.stdout | from_json).osd_fsid ] ] }}"
+        osd_hosts: "{{ osd_hosts | default([]) + [ (item.stdout | from_json).crush_location.host ] }}"
       with_items: "{{ find_osd_hosts.results }}"
+
+    - name: find lvm osd volumes on each host
+      ceph_volume:
+        action: "list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+      with_items: "{{ osd_hosts }}"
+      delegate_to: "{{ item }}"
+      register: osd_volumes
+
+    - name: filter osd volumes to kill by osd - non container
+      set_fact:
+        osd_volumes_to_kill_non_container: "{{ osd_volumes_to_kill_non_container | default([]) + [ (item.1.stdout|from_json)[item.0] ] }}"
+      with_together:
+        - "{{ osd_to_kill.split(',') }}"
+        - "{{ osd_volumes.results }}"
+
+    - name: generate (host / volume) pairs to zap - non container
+      set_fact:
+        osd_host_volumes_to_kill_non_container: "{%- set _val = namespace(devs=[]) -%}
+        {%- for host in osd_hosts -%}
+        {%- for dev in osd_volumes_to_kill_non_container[loop.index-1] -%}
+        {%- set _val.devs = _val.devs + [{\"host\": host, \"path\": dev.path}] -%}
+        {%- endfor -%}
+        {%- endfor -%}
+        {{ _val.devs }}"
 
     - name: mark osd(s) out of the cluster
       command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd out {{ item }}"
@@ -95,19 +122,20 @@
         name: ceph-osd@{{ item.0 }}
         state: stopped
         enabled: no
-      loop: "{{ osd_to_kill.split(',')|zip(osd_hosts)|list }}"
-      delegate_to: "{{ item.1.0 }}"
+      with_together:
+        - "{{ osd_to_kill.split(',') }}"
+        - "{{ osd_hosts }}"
+      delegate_to: "{{ item.1 }}"
 
     - name: zap osd devices
       ceph_volume:
         action: "zap"
-        osd_fsid: "{{ item.1 }}"
+        data: "{{ item.path }}"
       environment:
         CEPH_VOLUME_DEBUG: 1
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-      delegate_to: "{{ item.0 }}"
-      loop: "{{ osd_hosts }}"
+      delegate_to: "{{ item.host }}"
+      with_items: "{{ osd_host_volumes_to_kill_non_container }}"
 
     - name: purge osd(s) from the cluster
       command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd purge {{ item }} --yes-i-really-mean-it"

--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -48,10 +48,6 @@ options:
         description:
             - If data is a lv, this must be the name of the volume group it belongs to.
         required: false
-    osd_fsid:
-        description:
-            - The OSD FSID
-        required: false
     journal:
         description:
             - The logical volume name or partition to use as a filestore journal.
@@ -428,7 +424,7 @@ def zap_devices(module, container_image):
     '''
 
     # get module variables
-    data = module.params.get('data', None)
+    data = module.params['data']
     data_vg = module.params.get('data_vg', None)
     journal = module.params.get('journal', None)
     journal_vg = module.params.get('journal_vg', None)
@@ -436,19 +432,13 @@ def zap_devices(module, container_image):
     db_vg = module.params.get('db_vg', None)
     wal = module.params.get('wal', None)
     wal_vg = module.params.get('wal_vg', None)
-    osd_fsid = module.params.get('osd_fsid', None)
+    data = get_data(data, data_vg)
 
     # build the CLI
     action = 'zap'
     cmd = build_ceph_volume_cmd(action, container_image)
     cmd.append('--destroy')
-
-    if osd_fsid:
-        cmd.extend(['--osd-fsid', osd_fsid])
-
-    if data:
-        data = get_data(data, data_vg)
-        cmd.append(data)
+    cmd.append(data)
 
     if journal:
         journal = get_journal(journal, journal_vg)
@@ -488,7 +478,6 @@ def run_module():
         block_db_size=dict(type='str', required=False, default='-1'),
         report=dict(type='bool', required=False, default=False),
         containerized=dict(type='str', required=False, default=False),
-        osd_fsid=dict(type='str', required=False),
     )
 
     module = AnsibleModule(

--- a/library/test_ceph_volume.py
+++ b/library/test_ceph_volume.py
@@ -83,19 +83,6 @@ class TestCephVolumeModule(object):
         result = ceph_volume.zap_devices(fake_module, fake_container_image)
         assert result == expected_command_list
 
-    def test_zap_osd_fsid(self):
-        fake_module = MagicMock()
-        fake_module.params = {'osd_fsid': 'a_uuid'}
-        fake_container_image = None
-        expected_command_list = ['ceph-volume',
-                                 'lvm',
-                                 'zap',
-                                 '--destroy',
-                                 '--osd-fsid',
-                                 'a_uuid']
-        result = ceph_volume.zap_devices(fake_module, fake_container_image)
-        assert result == expected_command_list
-
     def test_activate_osd(self):
         expected_command_list = ['ceph-volume',
                                  'lvm',


### PR DESCRIPTION
This requires ceph-volume zap by osd_fsid feature that isn't available in ceph prior to 12.2.11.
RHCS 3.2z2 will ship with ceph luminous 12.2.8 so shrink-osd is broken.
Since these commits introduced a regression for 3.2z2 we should revert them and introduce them back for RHCS 3.3 once 3.2z2 is GA.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1702311