### PR TITLE
don't access other node's docker_exec_cmd variable

### DIFF
--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -22,7 +22,7 @@
   block:
     - name: create filesystem pools
       command: >
-        {{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
+        {{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }}
         osd pool create {{ item.name }}
         {{ item.pg_num | default(item.pgs) | default(osd_pool_default_pg_num) }}
         {{ item.pgp_num | default(item.pgs) | default(item.pg_num) | default(osd_pool_default_pg_num) }}

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -1,8 +1,7 @@
 ---
 - name: check if monitor initial keyring already exists
   command: >
-    {{  hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }}
-    ceph --cluster ceph --name mon. -k
+    {{ docker_exec_cmd | default('') }} ceph --cluster ceph --name mon. -k
     /var/lib/ceph/mon/{{ cluster }}-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}/keyring
     auth get-key mon.
   register: initial_mon_key

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -1,9 +1,9 @@
 ---
 - name: wait for all osd to be up
   shell: >
-    test "$({{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["osdmap"]["num_osds"])')" -gt 0 &&
-    test "$({{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["osdmap"]["num_osds"])')" =
-    "$({{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["osdmap"]["num_up_osds"])')"
+    test "$({{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["osdmap"]["num_osds"])')" -gt 0 &&
+    test "$({{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["osdmap"]["num_osds"])')" =
+    "$({{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["osdmap"]["num_up_osds"])')"
   register: wait_for_all_osds_up
   retries: "{{ nb_retry_wait_osd_up }}"
   delay: "{{ delay_wait_osd_up }}"
@@ -15,7 +15,7 @@
   block:
     - name: list existing pool(s)
       command: >
-        {{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
+        {{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }}
         osd pool get {{ item.name }} size
       with_items: "{{ openstack_pools | unique }}"
       register: created_pools
@@ -24,7 +24,7 @@
 
     - name: create openstack pool(s)
       command: >
-        {{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
+        {{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }}
         osd pool create {{ item.0.name }}
         {{ item.0.pg_num | default(osd_pool_default_pg_num) }}
         {{ item.0.pgp_num | default(item.0.pg_num) | default(osd_pool_default_pg_num) }}
@@ -43,7 +43,7 @@
 
     - name: customize pool size
       command: >
-        {{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
+        {{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }}
         osd pool set {{ item.name }} size {{ item.size | default(osd_pool_default_size) }}
       with_items: "{{ openstack_pools | unique }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -52,7 +52,7 @@
 
     - name: customize pool min_size
       command: >
-        {{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
+        {{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }}
         osd pool set {{ item.name }} min_size {{ item.min_size | default(osd_pool_default_min_size) }}
       with_items: "{{ openstack_pools | unique }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -60,7 +60,7 @@
       when: (item.min_size | default(osd_pool_default_min_size))|int > ceph_osd_pool_default_min_size
 
     - name: assign application to pool(s)
-      command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"
+      command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"
       with_items: "{{ openstack_pools | unique }}"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
Except for some corner case, it's not correct to access some other
node's copy of variable docker_exec_cmd. Therefore replace
`hostvars[groups[mon_group_name][0]]['docker_exec_cmd']`by
`docker_exec_cmd`.

Signed-off-by: Rishabh Dave <ridave@redhat.com>