### PR TITLE
tests: update testinfra release

### DIFF
--- a/tests/functional/tests/mon/test_mons.py
+++ b/tests/functional/tests/mon/test_mons.py
@@ -29,10 +29,10 @@ class TestMons(object):
         output = host.check_output(cmd)
         assert output.strip().startswith("cluster")
 
-    def test_ceph_config_has_inital_members_line(self, node, File, setup):
-        assert File(setup["conf_path"]).contains("^mon initial members = .*$")
+    def test_ceph_config_has_inital_members_line(self, node, host, setup):
+        assert host.file(setup["conf_path"]).contains("^mon initial members = .*$")
 
-    def test_initial_members_line_has_correct_value(self, node, host, File, setup):  # noqa E501
+    def test_initial_members_line_has_correct_value(self, node, host, setup):
         mon_initial_members_line = host.check_output("grep 'mon initial members = ' /etc/ceph/{cluster}.conf".format(cluster=setup['cluster_name']))  # noqa E501
         result = True
         for host in node["vars"]["groups"]["mons"]:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,8 @@
 # These are Python requirements needed to run the functional tests
 six==1.10.0
-testinfra==1.19.0
-pytest-xdist==1.27.0
-pytest==3.6.1
+testinfra
+pytest-xdist
+pytest
 notario>=0.0.13
 ansible~=2.7,<2.8
 netaddr


### PR DESCRIPTION
In order to support ansible 2.8 with testinfra we need to use the
latest release.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>