### PR TITLE
[skip ci] Use ceph-iscsi 3.x package names

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -11,10 +11,9 @@
         - name: set_fact ceph_iscsi_repos
           set_fact:
             ceph_iscsi_repos:
-              - ceph-iscsi-config
               - tcmu-runner
               - python-rtslib
-              - ceph-iscsi-cli
+              - ceph-iscsi
 
         - name: fetch ceph-iscsi-config development repository
           uri:
@@ -42,10 +41,9 @@
       until: result is succeeded
       with_items:
         - tcmu-runner
-        - ceph-iscsi-config
         - targetcli
         - python-rtslib
-        - ceph-iscsi-cli
+        - ceph-iscsi
 
 - name: check the status of the target.service override
   stat:


### PR DESCRIPTION
In ceph-iscsi 3.x ceph-iscsi-config and ceph-iscsi-cli are merged into a single ceph-iscsi package.

Fixes #3872