### PR TITLE
ansible: remove private and static attribute

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -48,16 +48,12 @@
   when:
     - lvm_volumes|length > 0
     - not rolling_update|default(False)
-  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
-  static: False
 
 - name: include_tasks scenarios/lvm-batch.yml
   include_tasks: scenarios/lvm-batch.yml
   when:
     - devices|length > 0
     - not rolling_update|default(False)
-  # Hard code this so we will skip the entire file instead of individual tasks (Default isn't Consistent)
-  static: False
 
 - name: include_tasks start_osds.yml
   include_tasks: start_osds.yml

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -161,7 +161,6 @@
         name: ceph-container-common
     - import_role:
         name: ceph-config
-        private: fals
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-mgr


### PR DESCRIPTION
This will be removed in ansible 2.8 and breaks the playbook execution
with this release.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>