### PR TITLE
Fix check mode support

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -147,6 +147,7 @@
 - name: resolve device link(s)
   command: readlink -f {{ item }}
   changed_when: false
+  check_mode: no
   with_items: "{{ devices }}"
   register: devices_prepare_canonicalize
   when:
@@ -256,6 +257,7 @@
   command: grep 'osd pool default crush rule' /etc/ceph/{{ cluster }}.conf
   register: crush_rule_variable
   changed_when: false
+  check_mode: no
   failed_when: false
   when: ceph_conf.stat.exists
 

--- a/roles/ceph-mgr/tasks/mgr_modules.yml
+++ b/roles/ceph-mgr/tasks/mgr_modules.yml
@@ -11,6 +11,7 @@
 
 - name: get enabled modules from ceph-mgr
   command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} --format json mgr module ls"
+  check_mode: no
   changed_when: false
   register: _ceph_mgr_modules
   delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
Adds "check_mode: no" to commands which register cluster state in a
variable and don't modify anything. These commands have to run in order
to support running the playbook in check mode.

Signed-off-by: Gaudenz Steinlin <gaudenz.steinlin@cloudscale.ch>