### PR TITLE
facts: fix external cluster bug

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -268,6 +268,7 @@
 
 - name: import_tasks set_monitor_address.yml
   import_tasks: set_monitor_address.yml
+  when: groups.get(mon_group_name, []) | length > 0
 
 - name: import_tasks set_radosgw_address.yml
   import_tasks: set_radosgw_address.yml


### PR DESCRIPTION
running an external ceph cluster deployment with (obviously) no
monitors defined in inventory breaks with an undefined error because
`_monitor_addresses` never get defined.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1707460

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>