### PR TITLE
Create CRUSH rules with device classes

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -43,14 +43,16 @@ dummy:
 
 #crush_rule_hdd:
 #  name: HDD
-#  root: HDD
+#  root: default
 #  type: host
+#  device_class: hdd
 #  default: false
 
 #crush_rule_ssd:
 #  name: SSD
-#  root: SSD
+#  root: default
 #  type: host
+#  device_class: ssd
 #  default: false
 
 #crush_rules:

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -35,14 +35,16 @@ crush_rule_config: false
 
 crush_rule_hdd:
   name: HDD
-  root: HDD
+  root: default
   type: host
+  device_class: hdd
   default: false
 
 crush_rule_ssd:
   name: SSD
-  root: SSD
+  root: default
   type: host
+  device_class: ssd
   default: false
 
 crush_rules:

--- a/roles/ceph-mon/tasks/crush_rules.yml
+++ b/roles/ceph-mon/tasks/crush_rules.yml
@@ -12,7 +12,7 @@
     - hostvars[item]['osd_crush_location'] is defined
 
 - name: create configured crush rules
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-simple {{ item.name }} {{ item.root }} {{ item.type }}"
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-replicated {{ item.name }} {{ item.root }} {{ item.type }} {{ item.device_class | default() }}"
   with_items: "{{ crush_rules | unique }}"
   changed_when: false
   when: inventory_hostname == groups.get(mon_group_name) | last

--- a/tests/functional/all_daemons/container/group_vars/mons
+++ b/tests/functional/all_daemons/container/group_vars/mons
@@ -3,8 +3,9 @@ create_crush_tree: True
 crush_rule_config: True
 crush_rule_hdd:
   name: HDD
-  root: HDD
+  root: default
   type: host
+  device_class: hdd
   default: true
 crush_rules:
   - "{{ crush_rule_hdd }}"

--- a/tests/functional/all_daemons/group_vars/mons
+++ b/tests/functional/all_daemons/group_vars/mons
@@ -3,8 +3,9 @@ create_crush_tree: True
 crush_rule_config: True
 crush_rule_hdd:
   name: HDD
-  root: HDD
+  root: default
   type: host
+  device_class: hdd
   default: true
 crush_rules:
   - "{{ crush_rule_hdd }}"


### PR DESCRIPTION
This allows to set an optional device class for CRUSH rules.

Signed-off-by: Gaudenz Steinlin <gaudenz.steinlin@cloudscale.ch>