### PR TITLE
reapply shrink-osds patches to handle the ceph-volume zap by osd_fsid feature

### DIFF
--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -81,35 +81,8 @@
 
     - name: set_fact osd_hosts
       set_fact:
-        osd_hosts: "{{ osd_hosts | default([]) + [ (item.stdout | from_json).crush_location.host ] }}"
+        osd_hosts: "{{ osd_hosts | default([]) + [ [ (item.stdout | from_json).crush_location.host, (item.stdout | from_json).osd_fsid ] ] }}"
       with_items: "{{ find_osd_hosts.results }}"
-
-    - name: find lvm osd volumes on each host
-      ceph_volume:
-        action: "list"
-      environment:
-        CEPH_VOLUME_DEBUG: 1
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-      with_items: "{{ osd_hosts }}"
-      delegate_to: "{{ item }}"
-      register: osd_volumes
-
-    - name: filter osd volumes to kill by osd - non container
-      set_fact:
-        osd_volumes_to_kill_non_container: "{{ osd_volumes_to_kill_non_container | default([]) + [ (item.1.stdout|from_json)[item.0] ] }}"
-      with_together:
-        - "{{ osd_to_kill.split(',') }}"
-        - "{{ osd_volumes.results }}"
-
-    - name: generate (host / volume) pairs to zap - non container
-      set_fact:
-        osd_host_volumes_to_kill_non_container: "{%- set _val = namespace(devs=[]) -%}
-        {%- for host in osd_hosts -%}
-        {%- for dev in osd_volumes_to_kill_non_container[loop.index-1] -%}
-        {%- set _val.devs = _val.devs + [{\"host\": host, \"path\": dev.path}] -%}
-        {%- endfor -%}
-        {%- endfor -%}
-        {{ _val.devs }}"
 
     - name: mark osd(s) out of the cluster
       command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd out {{ item }}"
@@ -122,20 +95,19 @@
         name: ceph-osd@{{ item.0 }}
         state: stopped
         enabled: no
-      with_together:
-        - "{{ osd_to_kill.split(',') }}"
-        - "{{ osd_hosts }}"
-      delegate_to: "{{ item.1 }}"
+      loop: "{{ osd_to_kill.split(',')|zip(osd_hosts)|list }}"
+      delegate_to: "{{ item.1.0 }}"
 
     - name: zap osd devices
       ceph_volume:
         action: "zap"
-        data: "{{ item.path }}"
+        osd_fsid: "{{ item.1 }}"
       environment:
         CEPH_VOLUME_DEBUG: 1
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-      delegate_to: "{{ item.host }}"
-      with_items: "{{ osd_host_volumes_to_kill_non_container }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+      delegate_to: "{{ item.0 }}"
+      loop: "{{ osd_hosts }}"
 
     - name: purge osd(s) from the cluster
       command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd purge {{ item }} --yes-i-really-mean-it"

--- a/library/test_ceph_volume.py
+++ b/library/test_ceph_volume.py
@@ -83,6 +83,19 @@ class TestCephVolumeModule(object):
         result = ceph_volume.zap_devices(fake_module, fake_container_image)
         assert result == expected_command_list
 
+    def test_zap_osd_fsid(self):
+        fake_module = MagicMock()
+        fake_module.params = {'osd_fsid': 'a_uuid'}
+        fake_container_image = None
+        expected_command_list = ['ceph-volume',
+                                 'lvm',
+                                 'zap',
+                                 '--destroy',
+                                 '--osd-fsid',
+                                 'a_uuid']
+        result = ceph_volume.zap_devices(fake_module, fake_container_image)
+        assert result == expected_command_list
+
     def test_activate_osd(self):
         expected_command_list = ['ceph-volume',
                                  'lvm',


### PR DESCRIPTION
This PR reapply the patches that were reverted for the 3.2z2 release.

This is to make ceph-ansible shrink-osd playbook handling the ceph-volume zap by osd_fsid feature.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1686306
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1572933
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1569413