### PR TITLE
[backport] osds: allow passing devices by path

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -164,7 +164,6 @@
     - devices is defined
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
-    - osd_scenario|default('dummy') != 'lvm'
 
 - name: set_fact build devices from resolved symlinks
   set_fact:
@@ -174,7 +173,6 @@
     - devices is defined
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
-    - osd_scenario|default('dummy') != 'lvm'
 
 - name: set_fact build final devices list
   set_fact:
@@ -183,7 +181,6 @@
     - devices is defined
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
-    - osd_scenario|default('dummy') != 'lvm'
 
 - name: set_fact ceph_uid for debian based system - non container
   set_fact:

--- a/tests/functional/lvm-batch/container/group_vars/all
+++ b/tests/functional/lvm-batch/container/group_vars/all
@@ -19,7 +19,7 @@ osd_scenario: lvm
 copy_admin_key: true
 devices:
   - /dev/sdb
-  - /dev/sdc
+  - /dev/disk/by-id/ata-QEMU_HARDDISK_QM00003
 os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:

--- a/tests/functional/lvm-batch/group_vars/all
+++ b/tests/functional/lvm-batch/group_vars/all
@@ -12,7 +12,7 @@ crush_device_class: test
 osd_scenario: lvm
 copy_admin_key: true
 devices:
-  - /dev/sdb 
+  - /dev/disk/by-id/ata-QEMU_HARDDISK_QM00002
   - /dev/sdc
 os_tuning_params:
   - { name: fs.file-max, value: 26234859 }


### PR DESCRIPTION
ceph-volume didn't work when the devices where passed by path.
Since it now support it, let's allow this feature in ceph-ansible

Closes: #3812

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 8f2c45dfd3d1d3875a480247ca047aa52d7cd1b1)