### PR TITLE
igw: Fix rolling update service ordering

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -737,9 +737,9 @@
         masked: yes
       failed_when: false
       with_items:
-        - tcmu-runner
         - rbd-target-api
         - rbd-target-gw
+        - tcmu-runner
       when: not containerized_deployment
 
     - import_role:


### PR DESCRIPTION
We must stop tcmu-runner after the other rbd-target-* services because
they may need to interact with tcmu-runner during shutdown. There is
also a bug in some kernels where IO can get stuck in the kernel and by
stopping rbd-target-* first we can make sure all IO is flushed.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1659611

Signed-off-by: Mike Christie <mchristi@redhat.com>