### PR TITLE
Set the rgw_create_pools pools application to rgw

### DIFF
--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -43,3 +43,12 @@
       register: result
       until: result is succeeded
       when: item.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
+
+    - name: set the rgw_create_pools pools application to rgw
+      command: "{{ docker_exec_cmd }} ceph --connect-timeout 5 --cluster {{ cluster }} osd pool application enable {{ item.key }} rgw"
+      changed_when: false
+      with_dict: "{{ rgw_create_pools }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      register: result
+      until: result is succeeded
+      run_once: true


### PR DESCRIPTION
Set the application to rgw for pools created from rgw_create_pools. On Ceph Nautilus the heath is set to HEALTH_WARN with the message "application not enabled on X pool(s)" if an application isn't specified for a pool.

Signed-off-by: Kevin Coakley <kcoakley@sdsc.edu>