### PR TITLE
Update RHCS version with Nautilus

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -166,23 +166,13 @@ dummy:
 #ceph_stable_redhat_distro: el7
 
 
-# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 1.3)
+# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)
 #
 # Enabled when ceph_repository == 'rhcs'
 #
-# This version is only supported on RHEL >= 7.1
-# As of RHEL 7.1, libceph.ko and rbd.ko are now included in Red Hat's kernel
-# packages natively. The RHEL 7.1 kernel packages are more stable and secure than
-# using these 3rd-party kmods with RHEL 7.0. Please update your systems to RHEL
-# 7.1 or later if you want to use the kernel RBD client.
+# This version is only supported on RHEL >= 8.0
 #
-# The CephFS kernel client is undergoing rapid development upstream, and we do
-# not recommend running the CephFS kernel module on RHEL 7's 3.10 kernel at this
-# time. Please use ELRepo's latest upstream 4.x kernels if you want to run CephFS
-# on RHEL 7.
-#
-#
-#ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(2) }}"
+#ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(4) }}"
 #valid_ceph_repository_type:
 #  - cdn
 #  - iso

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -166,23 +166,13 @@ ceph_repository: rhcs
 #ceph_stable_redhat_distro: el7
 
 
-# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 1.3)
+# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)
 #
 # Enabled when ceph_repository == 'rhcs'
 #
-# This version is only supported on RHEL >= 7.1
-# As of RHEL 7.1, libceph.ko and rbd.ko are now included in Red Hat's kernel
-# packages natively. The RHEL 7.1 kernel packages are more stable and secure than
-# using these 3rd-party kmods with RHEL 7.0. Please update your systems to RHEL
-# 7.1 or later if you want to use the kernel RBD client.
+# This version is only supported on RHEL >= 8.0
 #
-# The CephFS kernel client is undergoing rapid development upstream, and we do
-# not recommend running the CephFS kernel module on RHEL 7's 3.10 kernel at this
-# time. Please use ELRepo's latest upstream 4.x kernels if you want to run CephFS
-# on RHEL 7.
-#
-#
-ceph_rhcs_version: 3
+ceph_rhcs_version: 4
 #valid_ceph_repository_type:
 #  - cdn
 #  - iso
@@ -568,7 +558,7 @@ ceph_rhcs_version: 3
 ##########
 #docker_exec_cmd:
 #docker: false
-ceph_docker_image: "rhceph/rhceph-3-rhel7"
+ceph_docker_image: "rhceph/rhceph-4-rhel8"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.access.redhat.com"
 ## Client only docker image - defaults to {{ ceph_docker_image }}

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -1,8 +1,8 @@
 ceph_repository: rhcs
 ceph_origin: repository
 fetch_directory: ~/ceph-ansible-keys
-ceph_rhcs_version: 3
-ceph_docker_image: "rhceph/rhceph-3-rhel7"
+ceph_rhcs_version: 4
+ceph_docker_image: "rhceph/rhceph-4-rhel8"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.access.redhat.com"
 # END OF FILE, DO NOT TOUCH ME!

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
@@ -1,15 +1,15 @@
 ---
 - name: enable red hat storage monitor repository
   rhsm_repository:
-    name: "rhel-7-server-rhceph-{{ ceph_rhcs_version }}-mon-rpms"
+    name: "rhceph-{{ ceph_rhcs_version }}-mon-for-rhel-8-{{ ansible_architecture }}-rpms"
   when: (mon_group_name in group_names or mgr_group_name in group_names)
 
 - name: enable red hat storage osd repository
   rhsm_repository:
-    name: "rhel-7-server-rhceph-{{ ceph_rhcs_version }}-osd-rpms"
+    name: "rhceph-{{ ceph_rhcs_version }}-osd-for-rhel-8-{{ ansible_architecture }}-rpms"
   when: osd_group_name in group_names
 
 - name: enable red hat storage tools repository
   rhsm_repository:
-    name: "rhel-7-server-rhceph-{{ ceph_rhcs_version }}-tools-rpms"
+    name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_architecture }}-rpms"
   when: (rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names)

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -158,23 +158,13 @@ nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_s
 ceph_stable_redhat_distro: el7
 
 
-# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 1.3)
+# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)
 #
 # Enabled when ceph_repository == 'rhcs'
 #
-# This version is only supported on RHEL >= 7.1
-# As of RHEL 7.1, libceph.ko and rbd.ko are now included in Red Hat's kernel
-# packages natively. The RHEL 7.1 kernel packages are more stable and secure than
-# using these 3rd-party kmods with RHEL 7.0. Please update your systems to RHEL
-# 7.1 or later if you want to use the kernel RBD client.
+# This version is only supported on RHEL >= 8.0
 #
-# The CephFS kernel client is undergoing rapid development upstream, and we do
-# not recommend running the CephFS kernel module on RHEL 7's 3.10 kernel at this
-# time. Please use ELRepo's latest upstream 4.x kernels if you want to run CephFS
-# on RHEL 7.
-#
-#
-ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(2) }}"
+ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(4) }}"
 valid_ceph_repository_type:
   - cdn
   - iso


### PR DESCRIPTION
RHCS 4 will be based on Nautilus and only usable on RHEL 8.
Updated the default ceph_rhcs_version to 4 and update the rhcs
repositories to rhcs 4 with RHEL 8.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>