### PR TITLE
container-common: allow podman for other distros

### DIFF
--- a/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
@@ -40,8 +40,7 @@
     enabled: yes
   tags:
     with_pkg
-  when: not (ansible_os_family == 'RedHat' and
-             ansible_distribution_major_version == '8')
+  when: container_service_name == 'docker'
 
 - name: ensure tmpfiles.d is present
   lineinfile:

--- a/roles/ceph-container-common/vars/RedHat-8.yml
+++ b/roles/ceph-container-common/vars/RedHat-8.yml
@@ -1,3 +1,4 @@
 ---
 container_package_name: podman
+container_service_name: podman
 container_binding_name: podman


### PR DESCRIPTION
Currently podman installation is very tied to RHEL 8 even if we're
able to install it on Debian/Ubuntu distribution.
This patch changes the way we are starting or not the (fat) container
daemon. Before the condition was based on the distribution release
and now on the container_service_name variable.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>