### PR TITLE
Updated rbd_client_admin_socket_path to match ceph-common role

### DIFF
--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -3,9 +3,9 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "0755"
+    owner: "{{ ceph_uid if containerized_deployment else rbd_client_directory_owner }}"
+    group: "{{ ceph_uid if containerized_deployment else rbd_client_directory_group }}"
+    mode: "{{ rbd_client_directory_mode }}"
   with_items: "{{ rbd_client_admin_socket_path }}"
 
 - name: create rados gateway instance directories


### PR DESCRIPTION
Updated the owner, group and mode for rbd_client_admin_socket_path in order to match how rbd_client_admin_socket_path is defined in /roles/ceph-common/tasks/create_rbd_client_dir.yml. The default for the mode in the ceph-common role as defined by rbd_client_directory_mode is 0770 while the mode is hard coded as 0755 in the ceph-rgw role. This was causing a mode clash on /var/run/ceph when the ceph-rgw role is enabled.

Signed-off-by: Kevin Coakley <kcoakley@sdsc.edu>