### PR TITLE
ceph-nfs: fixed condition for "stable repos specific tasks"

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_debian.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_debian.yml
@@ -3,7 +3,8 @@
   when: ceph_origin == 'repository'
   block:
     - name: stable repos specific tasks
-      when: nfs_ganesha_stable
+      when:
+        - nfs_ganesha_stable
         - ceph_repository == 'community'
       block:
         - name: add nfs-ganesha stable repository


### PR DESCRIPTION
The old condition would resolve to
```
"when": "nfs_ganesha_stable - ceph_repository == 'community'"
```

now it is
```
"when": [
          "nfs_ganesha_stable",
          "ceph_repository == 'community'"
        ]
```

Please backport to stable-4.0