### PR TITLE
purge-docker-cluster: remove is_atomic condition

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -514,7 +514,6 @@
       name: docker
       state: stopped
       enabled: no
-    when: not is_atomic
     ignore_errors: true
 
   - name: remove docker on debian/ubuntu

--- a/roles/ceph-container-common/tasks/main.yml
+++ b/roles/ceph-container-common/tasks/main.yml
@@ -1,7 +1,22 @@
 ---
+- name: include specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_os_family }}.yml"
+
 - name: include pre_requisites/prerequisites.yml
   include_tasks: pre_requisites/prerequisites.yml
   when: not is_atomic
+
+- name: start container service
+  service:
+    name: '{{ container_service_name }}'
+    state: started
+    enabled: yes
+  tags:
+    with_pkg
+  when: container_service_name == 'docker'
 
 - name: get docker version
   command: docker --version

--- a/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
@@ -1,10 +1,4 @@
 ---
-- name: include specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_os_family }}.yml"
-
 - name: include remove_ceph_udev_rules.yml
   include_tasks: remove_ceph_udev_rules.yml
 
@@ -32,15 +26,6 @@
     name: ['{{ container_package_name }}', '{{ container_binding_name }}']
     update_cache: true
   tags: with_pkg
-
-- name: start container service
-  service:
-    name: '{{ container_service_name }}'
-    state: started
-    enabled: yes
-  tags:
-    with_pkg
-  when: container_service_name == 'docker'
 
 - name: ensure tmpfiles.d is present
   lineinfile:


### PR DESCRIPTION
There's no reason to not stop the docker service on atomic host. If
this tasks isn't executed then the /var/lib/docker directory removal
will fail.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>