### PR TITLE
common: install dependencies for apt modules

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_community_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_community_repository.yml
@@ -1,4 +1,11 @@
 ---
+- name: install dependencies for apt modules
+  package:
+    name: ['apt-transport-https', 'ca-certificates', 'gpg', 'software-properties-common']
+    update_cache: yes
+  register: result
+  until: result is succeeded
+
 - name: configure debian ceph community repository stable key
   apt_key:
     data: "{{ lookup('file', role_path+'/files/cephstable.asc') }}"

--- a/roles/ceph-container-common/tasks/pre_requisites/debian_prerequisites.yml
+++ b/roles/ceph-container-common/tasks/pre_requisites/debian_prerequisites.yml
@@ -6,7 +6,7 @@
 
 - name: allow apt to use a repository over https (debian)
   package:
-    name: ['apt-transport-https', 'ca-certificates', 'software-properties-common']
+    name: ['apt-transport-https', 'ca-certificates', 'gpg', 'software-properties-common']
     update_cache: yes
   register: result
   until: result is succeeded


### PR DESCRIPTION
When using a minimal Debian/Ubuntu distribution there's no
ca-certificates and gpg packages installed so the apt modules will
fail:

Failed to find required executable gpg in paths:
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

apt.cache.FetchFailedException:
W:https://download.ceph.com/debian-luminous/dists/bionic/InRelease:
No system certificates available. Try installing ca-certificates.

Resolves: #3994

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>