### PR TITLE
ceph-mgr: install python-routes for dashboard

### DIFF
--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -24,3 +24,12 @@
   register: result
   until: result is succeeded
   when: ansible_os_family == 'Debian'
+
+- name: install routes python library for dashboard module
+  apt:
+    name: python-routes
+  register: result
+  until: result is succeeded
+  when:
+    - ansible_os_family == 'Debian'
+    - "'ceph-mgr-dashboard' in ceph_mgr_packages"


### PR DESCRIPTION
The ceph mgr dashboard requires routes python library to be installed
on the system.

Resolves: #3995

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>