### PR TITLE
dashboard: move the call to ceph-node-exporter

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -115,10 +115,10 @@
     - import_role:
         name: ceph-handler
     - import_role:
+        name: ceph-container-common
+    - import_role:
         name: ceph-node-exporter
       when: dashboard_enabled
-    - import_role:
-        name: ceph-container-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -162,10 +162,10 @@
     - import_role:
         name: ceph-handler
     - import_role:
+        name: ceph-container-common
+    - import_role:
         name: ceph-node-exporter
       when: dashboard_enabled
-    - import_role:
-        name: ceph-container-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -204,10 +204,10 @@
     - import_role:
         name: ceph-handler
     - import_role:
+        name: ceph-container-common
+    - import_role:
         name: ceph-node-exporter
       when: dashboard_enabled
-    - import_role:
-        name: ceph-container-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -246,10 +246,10 @@
     - import_role:
         name: ceph-handler
     - import_role:
+        name: ceph-container-common
+    - import_role:
         name: ceph-node-exporter
       when: dashboard_enabled
-    - import_role:
-        name: ceph-container-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -288,10 +288,10 @@
     - import_role:
         name: ceph-handler
     - import_role:
+        name: ceph-container-common
+    - import_role:
         name: ceph-node-exporter
       when: dashboard_enabled
-    - import_role:
-        name: ceph-container-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -330,10 +330,10 @@
     - import_role:
         name: ceph-handler
     - import_role:
+        name: ceph-container-common
+    - import_role:
         name: ceph-node-exporter
       when: dashboard_enabled
-    - import_role:
-        name: ceph-container-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -372,10 +372,10 @@
     - import_role:
         name: ceph-handler
     - import_role:
+        name: ceph-container-common
+    - import_role:
         name: ceph-node-exporter
       when: dashboard_enabled
-    - import_role:
-        name: ceph-container-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -414,11 +414,11 @@
     - import_role:
         name: ceph-handler
     - import_role:
-        name: ceph-node-exporter
-      when: dashboard_enabled
-    - import_role:
         name: ceph-container-common
       when: inventory_hostname == groups.get('clients', ['']) | first
+    - import_role:
+        name: ceph-node-exporter
+      when: dashboard_enabled
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -459,10 +459,10 @@
     - import_role:
         name: ceph-handler
     - import_role:
+        name: ceph-container-common
+    - import_role:
         name: ceph-node-exporter
       when: dashboard_enabled
-    - import_role:
-        name: ceph-container-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -524,9 +524,9 @@
       - import_role:
           name: ceph-handler
       - import_role:
-          name: ceph-node-exporter
-      - import_role:
           name: ceph-container-common
+      - import_role:
+          name: ceph-node-exporter
       - import_role:
           name: ceph-config
         tags: ['ceph_update_config']


### PR DESCRIPTION
This moves the call to ceph-node-exporter role after
ceph-container-common, otherwise it will try to run container before
docker or podman are installed.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>