### PR TITLE
container-common: remove centos extras repo task

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -566,7 +566,6 @@ dummy:
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
 #ceph_client_docker_registry: "{{ ceph_docker_registry }}"
-#ceph_docker_enable_centos_extra_repo: false
 #ceph_docker_on_openstack: false
 #containerized_deployment: False
 #container_binary:

--- a/group_vars/docker-commons.yml.sample
+++ b/group_vars/docker-commons.yml.sample
@@ -8,7 +8,6 @@
 dummy:
 
 #ceph_docker_registry: docker.io
-#ceph_docker_enable_centos_extra_repo: false
 
 #mon_use_fqdn: false # if set to true, the MON name used will be the fqdn
 

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -566,7 +566,6 @@ ceph_docker_registry: "registry.access.redhat.com"
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
 #ceph_client_docker_registry: "{{ ceph_docker_registry }}"
-#ceph_docker_enable_centos_extra_repo: false
 #ceph_docker_on_openstack: false
 #containerized_deployment: False
 #container_binary:

--- a/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-common/tasks/pre_requisites/prerequisites.yml
@@ -15,18 +15,6 @@
     - container_package_name == 'docker-ce'
   tags: with_pkg
 
-# ensure extras enabled for docker
-- name: enable extras on centos
-  yum_repository:
-    name: extras
-    state: present
-    enabled: yes
-  when:
-    - ansible_distribution == 'CentOS'
-    - ceph_docker_enable_centos_extra_repo
-  tags:
-    with_pkg
-
 - name: install container package
   package:
     name: ['{{ container_package_name }}', '{{ container_binding_name }}']

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -558,7 +558,6 @@ ceph_docker_registry: docker.io
 ceph_client_docker_image: "{{ ceph_docker_image }}"
 ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
 ceph_client_docker_registry: "{{ ceph_docker_registry }}"
-ceph_docker_enable_centos_extra_repo: false
 ceph_docker_on_openstack: false
 containerized_deployment: False
 container_binary:


### PR DESCRIPTION
This task just doesn't work when using the variable
ceph_docker_enable_centos_extra_repo to true.

```console
fatal: [xxx]; FAILED! => {"changed": false, "msg": "Parameter 'baseurl', 'metalink' or 'mirrorlist' is required."}
```

The CentOS extras repository is enabled by default so it's pretty
safe to remove this task and the associated variable.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>