### PR TITLE
common: use gnupg instead of gpg

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_community_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_community_repository.yml
@@ -1,7 +1,7 @@
 ---
 - name: install dependencies for apt modules
   package:
-    name: ['apt-transport-https', 'ca-certificates', 'gpg', 'software-properties-common']
+    name: ['apt-transport-https', 'ca-certificates', 'gnupg', 'software-properties-common']
     update_cache: yes
   register: result
   until: result is succeeded

--- a/roles/ceph-container-common/tasks/pre_requisites/debian_prerequisites.yml
+++ b/roles/ceph-container-common/tasks/pre_requisites/debian_prerequisites.yml
@@ -6,7 +6,7 @@
 
 - name: allow apt to use a repository over https (debian)
   package:
-    name: ['apt-transport-https', 'ca-certificates', 'gpg', 'software-properties-common']
+    name: ['apt-transport-https', 'ca-certificates', 'gnupg', 'software-properties-common']
     update_cache: yes
   register: result
   until: result is succeeded


### PR DESCRIPTION
gpg package isn't available for all Debian/Ubuntu distribution but
gnupg is.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>