### PR TITLE
config: fix ipv6

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -10,6 +10,7 @@ auth supported = none
 {% endif %}
 {% if ip_version == 'ipv6'  %}
 ms bind ipv6 = true
+ms bind ipv4 = false
 {% endif %}
 {% if common_single_host_mode is defined and common_single_host_mode %}
 osd crush chooseleaf type = 0


### PR DESCRIPTION
As of nautilus, if you set `ms bind ipv6 = True` you must explicitly set
`ms bind ipv4 = False` too, otherwise OSDs will still try to pick up an
IPv4 address.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1710319

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>