### PR TITLE
ceph-prometheus: fix error in templates

### DIFF
--- a/roles/ceph-prometheus/tasks/main.yml
+++ b/roles/ceph-prometheus/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: write prometheus config file
   template:
     src: prometheus.yml.j2
-    dest: "{{ prometheus_conf_dir }}/"
+    dest: "{{ prometheus_conf_dir }}/prometheus.yml"
     owner: "{{ prometheus_user_id }}"
   notify: service handler
 
@@ -41,7 +41,7 @@
 - name: write alertmanager config file
   template:
     src: alertmanager.yml.j2
-    dest: "{{ alertmanager_conf_dir }}/"
+    dest: "{{ alertmanager_conf_dir }}/alertmanager.yml"
     owner: "root"
   notify: service handler
 

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -19,7 +19,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --name=alertmanager \
   --memory-swap={{ alertmanager_container_memory * 2 }}GB \
   {{ alertmanager_container_image }} \
   --config.file=/etc/alertmanager/alertmanager.yml \
-  --storage.path=/alertmanager"
+  --storage.path=/alertmanager
 ExecStop=/usr/bin/{{ container_binary }} stop alertmanager
 Restart=always
 RestartSec=10s

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -21,7 +21,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --name=prometheus \
   {{ prometheus_container_image }} \
   --config.file=/etc/prometheus/prometheus.yml \
   --storage.tsdb.path=/prometheus \
-  --web.external-url=http://{{ inventory_hostname }}:9090/"
+  --web.external-url=http://{{ inventory_hostname }}:9090/
 ExecStop=/usr/bin/{{ container_binary }} stop prometheus
 Restart=always
 RestartSec=10s


### PR DESCRIPTION
- remove trailing double quotes in jinja templates
- add jinja filename without .j2 suffix

Resolves: #4011

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>