### PR TITLE
dashboard: append mgr modules to ceph_mgr_modules

### DIFF
--- a/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -1,4 +1,14 @@
 ---
+- name: install ceph-grafana-dashboards package on RedHat or SUSE
+  package:
+    name: ceph-grafana-dashboards
+    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+  register: result
+  until: result is succeeded
+  when:
+    - not containerized_deployment
+    - ansible_os_family in ['RedHat', 'Suse']
+
 - name: make sure grafana is down
   service:
     name: grafana-server

--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -155,18 +155,19 @@
       - iscsi_gw_group_name in group_names
     tags: firewall
 
-  - block:
-      - name: open grafana port
-        firewalld:
-          port: "3000/tcp"
-          zone: "{{ ceph_dashboard_firewall_zone }}"
-          permanent: true
-          immediate: true
-          state: enabled
+  - name: open node_exporter port
+    firewalld:
+      port: "9100/tcp"
+      zone: "{{ ceph_dashboard_firewall_zone }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    when: dashboard_enabled | bool
 
-      - name: open node_exporter port
+  - block:
+      - name: open dashboard port
         firewalld:
-          port: "9100/tcp"
+          port: "{{ dashboard_port }}/tcp"
           zone: "{{ ceph_dashboard_firewall_zone }}"
           permanent: true
           immediate: true
@@ -179,6 +180,19 @@
           permanent: true
           immediate: true
           state: enabled
+    when:
+      - dashboard_enabled | bool
+      - mgr_group_name is defined
+      - mgr_group_name in group_names
+
+  - block:
+      - name: open grafana port
+        firewalld:
+          port: "3000/tcp"
+          zone: "{{ ceph_dashboard_firewall_zone }}"
+          permanent: true
+          immediate: true
+          state: enabled
 
       - name: open dashboard port
         firewalld:
@@ -187,6 +201,16 @@
           permanent: true
           immediate: true
           state: enabled
-    when: dashboard_enabled
+
+      - name: open alertmanager port
+        firewalld:
+          port: "9093/tcp"
+          zone: "{{ ceph_dashboard_firewall_zone }}"
+          permanent: true
+          immediate: true
+          state: enabled
+    when:
+      - dashboard_enabled | bool
+      - inventory_hostname in groups.get('grafana-server', [])
 
 - meta: flush_handlers

--- a/roles/ceph-mgr/tasks/mgr_modules.yml
+++ b/roles/ceph-mgr/tasks/mgr_modules.yml
@@ -1,4 +1,9 @@
 ---
+- name: append dashboard modules to ceph_mgr_modules
+  set_fact:
+    ceph_mgr_modules: "{{ (ceph_mgr_modules + [ 'dashboard', 'prometheus' ]) | unique }}"
+  when: dashboard_enabled | bool
+
 - name: wait for all mgr to be up
   shell: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} mgr dump -f json | python -c 'import sys, json; print(json.load(sys.stdin)[\"available\"])'"
   register: mgr_dump

--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -7,15 +7,6 @@
   until: result is succeeded
   when: ansible_os_family in ['RedHat', 'Suse']
 
-- name: install ceph-grafana-dashboards package on RedHat or SUSE
-  package:
-    name: ceph-grafana-dashboards
-    state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-  register: result
-  until: result is succeeded
-  when:
-    - ansible_os_family in ['RedHat', 'Suse']
-
 - name: install ceph-mgr packages for debian
   apt:
     name: '{{ ceph_mgr_packages }}'

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -559,7 +559,7 @@
           name: ceph-grafana
       when: dashboard_enabled
 
-- hosts: '{{ (groups["mgrs"] | default(groups["mons"]))[0] }}'
+- hosts: '{{ (groups["grafana-server"] | default(groups["mgrs"]) | default(groups["mons"]))[0] | default(omit) }}'
   become: true
   tasks:
     - block:

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -527,7 +527,7 @@
             name: ceph-grafana
       when: dashboard_enabled
 
-- hosts: '{{ (groups["mgrs"] | default(groups["mons"]))[0] }}'
+- hosts: '{{ (groups["grafana-server"] | default(groups["mgrs"]) | default(groups["mons"]))[0] | default(omit) }}'
   become: true
   tasks:
     - import_role:


### PR DESCRIPTION
when `dashboard_enabled` is `True`, let's append `dashboard` and
`prometheus` modules to `ceph_mgr_modules` so they are automatically
loaded.

Closes: #4026
Closes: #4023

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>