### PR TITLE
Fix systemd units and add the ability to deploy on a dedicated instance

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,7 @@ NOSDS           = settings['osd_vms']
 NMDSS           = settings['mds_vms']
 NRGWS           = settings['rgw_vms']
 NNFSS           = settings['nfs_vms']
+GRAFANA         = settings['grafana_server_vms']
 NRBD_MIRRORS    = settings['rbd_mirror_vms']
 CLIENTS         = settings['client_vms']
 NISCSI_GWS      = settings['iscsi_gw_vms']
@@ -54,8 +55,9 @@ ansible_provision = proc do |ansible|
     'nfss'             => (0..NNFSS - 1).map { |j| "#{LABEL_PREFIX}nfs#{j}" },
     'rbd_mirrors'      => (0..NRBD_MIRRORS - 1).map { |j| "#{LABEL_PREFIX}rbd_mirror#{j}" },
     'clients'          => (0..CLIENTS - 1).map { |j| "#{LABEL_PREFIX}client#{j}" },
-    'iscsigws'        => (0..NISCSI_GWS - 1).map { |j| "#{LABEL_PREFIX}iscsi_gw#{j}" },
-    'mgrs'             => (0..MGRS - 1).map { |j| "#{LABEL_PREFIX}mgr#{j}" }
+    'iscsigws'         => (0..NISCSI_GWS - 1).map { |j| "#{LABEL_PREFIX}iscsi_gw#{j}" },
+    'mgrs'             => (0..MGRS - 1).map { |j| "#{LABEL_PREFIX}mgr#{j}" },
+    'grafana-server'   => (0..GRAFANA - 1).map { |j| "#{LABEL_PREFIX}grafana#{j}" }
   }
 
   ansible.extra_vars = {
@@ -174,6 +176,41 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       provider.xvda_size = 4*1024
       # add some swap as the Linode distros require it
       provider.swap_size = 128
+    end
+  end
+
+  (0..GRAFANA - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}grafana#{i}" do |grf|
+      grf.vm.hostname = "#{LABEL_PREFIX}grafana#{i}"
+      if ASSIGN_STATIC_IP
+        grf.vm.network :private_network,
+          ip: "#{PUBLIC_SUBNET}.3#{i}"
+      end
+      # Virtualbox
+      grf.vm.provider :virtualbox do |vb|
+        vb.customize ['modifyvm', :id, '--memory', "#{MEMORY}"]
+      end
+
+      # VMware
+      grf.vm.provider :vmware_fusion do |v|
+        v.vmx['memsize'] = "#{MEMORY}"
+      end
+
+      # Libvirt
+      grf.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+
+      # Parallels
+      grf.vm.provider "parallels" do |prl|
+        prl.name = "ceph-grafana#{i}"
+        prl.memory = "#{MEMORY}"
+      end
+
+      grf.vm.provider :linode do |provider|
+        provider.label = grf.vm.hostname
+      end
     end
   end
 

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -55,6 +55,7 @@ dummy:
 #iscsi_gw_group_name: iscsigws
 #mgr_group_name: mgrs
 #rgwloadbalancer_group_name: rgwloadbalancers
+#grafana_server_group_name: grafana-server
 
 # If configure_firewall is true, then ansible will try to configure the
 # appropriate firewalling rules so that Ceph daemons can communicate

--- a/group_vars/dashboards.yml.sample
+++ b/group_vars/dashboards.yml.sample
@@ -18,4 +18,4 @@ dummy:
 #dashboard_rgw_api_scheme: ''
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
-
+#grafana_server_group_name: grafana-server

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -55,6 +55,7 @@ fetch_directory: ~/ceph-ansible-keys
 #iscsi_gw_group_name: iscsigws
 #mgr_group_name: mgrs
 #rgwloadbalancer_group_name: rgwloadbalancers
+#grafana_server_group_name: grafana-server
 
 # If configure_firewall is true, then ansible will try to configure the
 # appropriate firewalling rules so that Ceph daemons can communicate

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -90,13 +90,23 @@
   delegate_to: "{{ groups[mon_group_name][0] }}"
   until: ac_result.rc == 0
 
+- name: set grafana url to grafana instance
+  set_fact:
+    dashboard_url: "{{ groups[grafana_server_group_name][0] }}"
+  when: "{{  groups.grafana_server_group_name is defined and groups[grafana_server_group_name] | length > 0 }}"
+
+- name: set grafana url to mon
+  set_fact:
+    dashboard_url: "{{ groups[mon_group_name][0] }}"
+  when: "{{ groups.grafana_server_group_name is not defined or groups[grafana_server_group_name] | length == 0 }}"
+
 - name: set grafana url
-  command: "{{ container_exec_cmd }} ceph dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ groups['grafana-server'][0] }}:3000/"
+  command: "{{ container_exec_cmd }} ceph dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ dashboard_url }}:3000/"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   changed_when: false
 
 - name: set alertmanager host
-  command: "{{ container_exec_cmd }} ceph dashboard set-alertmanager-api-host {{ dashboard_protocol }}://{{ groups['grafana-server'][0] }}:9093/"
+  command: "{{ container_exec_cmd }} ceph dashboard set-alertmanager-api-host {{ dashboard_protocol }}://{{ dashboard_url }}:9093/"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   changed_when: false
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -47,6 +47,7 @@ client_group_name: clients
 iscsi_gw_group_name: iscsigws
 mgr_group_name: mgrs
 rgwloadbalancer_group_name: rgwloadbalancers
+grafana_server_group_name: grafana-server
 
 # If configure_firewall is true, then ansible will try to configure the
 # appropriate firewalling rules so that Ceph daemons can communicate

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -289,3 +289,8 @@
     set_fact:
       ntp_service_name: ntpd
     when: ansible_os_family in ['RedHat', 'Suse']
+
+- name: set grafana_server_addr fact
+  set_fact:
+    grafana_server_addr: "{{ (hostvars[groups[grafana_server_group_name][0] | default(groups[mgr_group_name][0])])['ansible_all_ipv4_addresses'] | ipaddr(public_network) | first }}"
+  when:  groups.get(grafana_server_group_name, []) | length > 0 or groups.get(mgr_group_name, []) | length > 0

--- a/roles/ceph-grafana/templates/datasources-ceph-dashboard.yml.j2
+++ b/roles/ceph-grafana/templates/datasources-ceph-dashboard.yml.j2
@@ -17,7 +17,7 @@ datasources:
   # <int> org id. will default to orgId 1 if not specified
   orgId: 1
   # <string> url
-  url: 'http://{{ groups["grafana-server"][0] }}:9090'
+  url: 'http://{{ grafana_server_addr | default(_current_monitor_address) }}:9090'
   # <bool> enable/disable basic auth
   basicAuth: false
   # <bool> mark as default datasource. Max one per org

--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -14,10 +14,10 @@ ExecStartPre=-/usr/bin/{{ container_binary }} rm -f node-exporter
 ExecStart=/usr/bin/{{ container_binary }} run --name=node-exporter \
   -v /proc:/host/proc:ro -v /sys:/host/sys:ro \
   --net=host \
+  {{ node_exporter_container_image }}
   --path.procfs=/host/proc \
   --path.sysfs=/host/sys \
   --no-collector.timex \
-    {{ node_exporter_container_image }}
 # Make sure the cfg80211 is loaded before running the container, the node
 # exporter needs this module loaded to test for presence of wi-fi devices
 ExecStartPre=/usr/sbin/modprobe cfg80211

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -9,6 +9,7 @@ After=network.target
 {% endif %}
 
 [Service]
+WorkingDirectory={{ alertmanager_data_dir }}
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f alertmanager
 ExecStart=/usr/bin/{{ container_binary }} run --name=alertmanager \

--- a/roles/ceph-prometheus/templates/prometheus.yml.j2
+++ b/roles/ceph-prometheus/templates/prometheus.yml.j2
@@ -19,18 +19,26 @@ scrape_configs:
 {% endfor %}
   - job_name: 'node'
     static_configs:
-{% for host in (groups['all'] | difference(groups['grafana-server'])) %}
+{% if grafana_server_group_name in groups %}
+{% for host in (groups['all'] | difference(groups[grafana_server_group_name])) %}
       - targets: ['{{ host }}:9100']
         labels:
           instance: "{{ hostvars[host]['ansible_nodename'] }}"
 {% endfor %}
   - job_name: 'grafana'
     static_configs:
-{% for host in groups['grafana-server'] %}
+{% for host in groups[grafana_server_group_name] %}
       - targets: ['{{ host }}:9100']
         labels:
           instance: "{{ hostvars[host]['ansible_nodename'] }}"
 {% endfor %}
+{% else %}
+{% for host in groups['all'] %}
+      - targets: ['{{ host }}:9100']
+        labels:
+          instance: "{{ hostvars[host]['ansible_nodename'] }}"
+{% endfor %}
+{% endif %}
 {% if 'iscsigws' in groups %}
   - job_name: 'iscsi-gws'
     static_configs:
@@ -44,4 +52,4 @@ alerting:
   alertmanagers:
   - scheme: http
     static_configs:
-    - targets: ['{{ groups["grafana-server"][0] }}:9093']
+    - targets: ['{{ grafana_server_addr | default(_current_monitor_address) }}:9093']

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -517,7 +517,7 @@
       run_once: true
       when: not ceph_status.failed
 
-- hosts: grafana-server
+- hosts: '{{ groups["grafana-server"][0] | default(groups["mgrs"][0]) | default(groups["mons"][0]) | default(omit) }}'
   become: true
   tasks:
     - block:
@@ -544,7 +544,7 @@
           name: ceph-grafana
       when: dashboard_enabled | bool
 
-- hosts: '{{ (groups["grafana-server"] | default(groups["mgrs"]) | default(groups["mons"]))[0] | default(omit) }}'
+- hosts: '{{ groups["grafana-server"][0] | default(groups["mgrs"][0]) | default(groups["mons"][0]) | default(omit) }}'
   become: true
   tasks:
     - block:

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -497,8 +497,7 @@
             name: ceph-node-exporter
       when: dashboard_enabled | bool
 
-
-- hosts: grafana-server
+- hosts: '{{ groups["grafana-server"][0] | default(groups["mgrs"][0]) | default(groups["mons"][0]) | default(omit) }}'
   become: true
   tasks:
     - block:
@@ -521,7 +520,7 @@
             name: ceph-grafana
       when: dashboard_enabled | bool
 
-- hosts: '{{ (groups["grafana-server"] | default(groups["mgrs"]) | default(groups["mons"]))[0] | default(omit) }}'
+- hosts: '{{ groups["grafana-server"][0] | default(groups["mgrs"][0]) | default(groups["mons"][0]) | default(omit) }}'
   become: true
   tasks:
     - import_role:

--- a/tests/functional/add-mdss/container/vagrant_variables.yml
+++ b/tests/functional/add-mdss/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 1
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/add-mdss/vagrant_variables.yml
+++ b/tests/functional/add-mdss/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 1
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/add-mgrs/container/vagrant_variables.yml
+++ b/tests/functional/add-mgrs/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/add-mgrs/vagrant_variables.yml
+++ b/tests/functional/add-mgrs/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/add-mons/container/vagrant_variables.yml
+++ b/tests/functional/add-mons/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/add-mons/vagrant_variables.yml
+++ b/tests/functional/add-mons/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/add-osds/container/vagrant_variables.yml
+++ b/tests/functional/add-osds/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 2
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/add-osds/vagrant_variables.yml
+++ b/tests/functional/add-osds/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 2
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/add-rbdmirrors/container/vagrant_variables.yml
+++ b/tests/functional/add-rbdmirrors/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/add-rbdmirrors/vagrant_variables.yml
+++ b/tests/functional/add-rbdmirrors/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/add-rgws/container/vagrant_variables.yml
+++ b/tests/functional/add-rgws/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 1
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/add-rgws/vagrant_variables.yml
+++ b/tests/functional/add-rgws/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 1
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/all_daemons/container/vagrant_variables.yml
+++ b/tests/functional/all_daemons/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 2
 mds_vms: 1
 rgw_vms: 1
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2
 iscsi_gw_vms: 1

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 2
 mds_vms: 1
 rgw_vms: 1
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2
 iscsi_gw_vms: 1

--- a/tests/functional/collocation/container/vagrant_variables.yml
+++ b/tests/functional/collocation/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 1
 rgw_vms: 1
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/collocation/vagrant_variables.yml
+++ b/tests/functional/collocation/vagrant_variables.yml
@@ -5,6 +5,7 @@ osd_vms: 1
 mds_vms: 1
 rgw_vms: 1
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/dashboard/container/vagrant_variables.yml
+++ b/tests/functional/dashboard/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 2
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/dashboard/vagrant_variables.yml
+++ b/tests/functional/dashboard/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 2
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 1
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/infra_lv_create/vagrant_variables.yml
+++ b/tests/functional/infra_lv_create/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/lvm-auto-discovery/container/vagrant_variables.yml
+++ b/tests/functional/lvm-auto-discovery/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/lvm-auto-discovery/vagrant_variables.yml
+++ b/tests/functional/lvm-auto-discovery/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/lvm-batch/container/vagrant_variables.yml
+++ b/tests/functional/lvm-batch/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/lvm-batch/vagrant_variables.yml
+++ b/tests/functional/lvm-batch/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/lvm-osds/container/vagrant_variables.yml
+++ b/tests/functional/lvm-osds/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 4
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/lvm-osds/vagrant_variables.yml
+++ b/tests/functional/lvm-osds/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 4
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/migrate_ceph_disk_to_ceph_volume/vagrant_variables.yml
+++ b/tests/functional/migrate_ceph_disk_to_ceph_volume/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/ooo-collocation/vagrant_variables.yml
+++ b/tests/functional/ooo-collocation/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 3
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 3
 iscsi_gw_vms: 0

--- a/tests/functional/podman/vagrant_variables.yml
+++ b/tests/functional/podman/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 2
 mds_vms: 1
 rgw_vms: 1
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2
 iscsi_gw_vms: 1

--- a/tests/functional/rgw-multisite/container/vagrant_variables.yml
+++ b/tests/functional/rgw-multisite/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/rgw-multisite/vagrant_variables.yml
+++ b/tests/functional/rgw-multisite/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/shrink_mon/container/vagrant_variables.yml
+++ b/tests/functional/shrink_mon/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/shrink_mon/vagrant_variables.yml
+++ b/tests/functional/shrink_mon/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/shrink_osd/container/vagrant_variables.yml
+++ b/tests/functional/shrink_osd/container/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 3
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/shrink_osd/vagrant_variables.yml
+++ b/tests/functional/shrink_osd/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 3
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -9,6 +9,7 @@ osd_vms: 3
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0


### PR DESCRIPTION
Few fixes on systemd unit templates for node_exporter and
alertmanager container parameters.
Added the ability to use a dedicated instance to deploy the
dashboard components (prometheus and grafana).

Signed-off-by: fpantano <fpantano@redhat.com>