### PR TITLE
[skip ci] vagrant: Default box to centos/7

### DIFF
--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -47,7 +47,7 @@ disks: [ '/dev/sdb', '/dev/sdc' ]
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: ceph/ubuntu-xenial
+vagrant_box: centos/7
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 vagrant_sync_dir: /home/vagrant/sync


### PR DESCRIPTION
We don't use ceph/ubuntu-xenial anymore but only centos/7 and
centos/atomic-host.
Changing the default to centos/7.

Resolves: #4036

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>