### PR TITLE
ceph-facts: generate fsid on mon node

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -107,8 +107,7 @@
   - name: generate cluster fsid
     shell: python -c 'import uuid; print(str(uuid.uuid4()))'
     register: cluster_uuid
-    delegate_to: localhost
-    become: false
+    delegate_to: "{{ groups[mon_group_name][0] }}"
     run_once: true
 
   - name: set_fact fsid


### PR DESCRIPTION
The fsid generation is done via a python command. When the ansible
controller node only have python3 available (like RHEL 8) then the
python command isn't necessarily present causing the fsid generation
to fail.
We already do some resource creation (like ceph keyring secret) with
the python command too but from the mon node so we should do the same
for fsid.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1714631

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>