### PR TITLE
update default rhcs values and docs

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -191,7 +191,7 @@ dummy:
 # on RHEL 7.
 #
 #
-#ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(2) }}"
+#ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(3) }}"
 #valid_ceph_repository_type:
 #  - cdn
 #  - iso

--- a/group_vars/iscsigws.yml.sample
+++ b/group_vars/iscsigws.yml.sample
@@ -84,7 +84,7 @@ dummy:
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
 
 # TCMU_RUNNER resource limitation

--- a/group_vars/mdss.yml.sample
+++ b/group_vars/mdss.yml.sample
@@ -25,7 +25,7 @@ dummy:
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
 #ceph_mds_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_mds_docker_cpu_limit: 4

--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -30,7 +30,7 @@ dummy:
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_mgr_docker_extra_env' variable.
 #ceph_mgr_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_mgr_docker_cpu_limit: 1

--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -75,7 +75,7 @@ dummy:
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_mon_docker_extra_env' variable.
 #ceph_mon_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_mon_docker_cpu_limit: 1

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -233,7 +233,7 @@ dummy:
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
 #ceph_osd_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_osd_docker_cpu_limit: 4

--- a/group_vars/rbdmirrors.yml.sample
+++ b/group_vars/rbdmirrors.yml.sample
@@ -49,7 +49,7 @@ dummy:
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_rbd_mirror_docker_extra_env' variable.
 #ceph_rbd_mirror_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_rbd_mirror_docker_cpu_limit: 1

--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -55,7 +55,7 @@ dummy:
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_rgw_docker_extra_env' variable.
 #ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 #ceph_rgw_docker_cpu_limit: 8

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -183,7 +183,7 @@ ceph_stable_redhat_distro: el7
 # on RHEL 7.
 #
 #
-ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(2) }}"
+ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(3) }}"
 valid_ceph_repository_type:
   - cdn
   - iso

--- a/roles/ceph-iscsi-gw/defaults/main.yml
+++ b/roles/ceph-iscsi-gw/defaults/main.yml
@@ -76,7 +76,7 @@ trusted_ip_list: 192.168.122.1
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
 
 # TCMU_RUNNER resource limitation

--- a/roles/ceph-mds/defaults/main.yml
+++ b/roles/ceph-mds/defaults/main.yml
@@ -17,7 +17,7 @@ copy_admin_key: false
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_mds_docker_extra_env' variable.
 ceph_mds_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_mds_docker_cpu_limit: 4

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -22,7 +22,7 @@ ceph_mgr_modules: [status]
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_mgr_docker_extra_env' variable.
 ceph_mgr_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_mgr_docker_cpu_limit: 1

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -67,7 +67,7 @@ create_crush_tree: false
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_mon_docker_extra_env' variable.
 ceph_mon_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_mon_docker_cpu_limit: 1

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -225,7 +225,7 @@ ceph_config_keys: [] # DON'T TOUCH ME
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_osd_docker_extra_env' variable.
 ceph_osd_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_osd_docker_cpu_limit: 4

--- a/roles/ceph-rbd-mirror/defaults/main.yml
+++ b/roles/ceph-rbd-mirror/defaults/main.yml
@@ -41,7 +41,7 @@ ceph_rbd_mirror_remote_user: ""
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_rbd_mirror_docker_extra_env' variable.
 ceph_rbd_mirror_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_rbd_mirror_docker_cpu_limit: 1

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -47,7 +47,7 @@ copy_admin_key: false
 
 # Resource limitation
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
-# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
+# Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/red_hat_ceph_storage_hardware_selection_guide/ceph-hardware-min-recommend
 # These options can be passed using the 'ceph_rgw_docker_extra_env' variable.
 ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
 ceph_rgw_docker_cpu_limit: 8


### PR DESCRIPTION
The RHCS documentation mentionned in the default values and
group_vars directory are referring to RHCS 2.x while it should be
3.x.

Revolves: https://bugzilla.redhat.com/show_bug.cgi?id=1702732

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>