### PR TITLE
ceph-nfs: use template module for configuration

### DIFF
--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -33,14 +33,12 @@
     mode: "0755"
 
 - name: generate ganesha configuration file
-  action: config_template
-  args:
+  template:
     src: "ganesha.conf.j2"
     dest: /etc/ganesha/ganesha.conf
     owner: "root"
     group: "root"
     mode: "0644"
-    config_type: ini
   notify: restart ceph nfss
 
 - name: create exports directory


### PR DESCRIPTION
789cef7 introduces a regression in the ganesha configuration file
generation. The new config_template module version broke it.
But the ganesha.conf file isn't an ini file and doesn't really
need to use the config_template module. Instead we can use the
classic template module.

Resolves: #4045

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>