### PR TITLE
Failing osd replacement

### DIFF
--- a/roles/ceph-osd/tasks/scenarios/collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/collocated.yml
@@ -4,7 +4,7 @@
 # starting the next task
 - name: prepare ceph containerized osd disk collocated
   shell: |
-    docker run --net=host \
+    docker run --rm --net=host \
     --pid=host \
     --privileged=true \
     --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.1 | regex_replace('/dev/', '') }} \
@@ -29,7 +29,7 @@
 
 - name: automatic prepare ceph containerized osd disk collocated
   shell: |
-    docker run --net=host \
+    docker run --rm --net=host \
     --pid=host \
     --privileged=true \
     --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.split('/')[-1] }} \

--- a/roles/ceph-osd/tasks/scenarios/collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/collocated.yml
@@ -29,7 +29,7 @@
 
 - name: automatic prepare ceph containerized osd disk collocated
   shell: |
-    docker run --rm --net=host \
+    docker run --net=host \
     --pid=host \
     --privileged=true \
     --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.split('/')[-1] }} \

--- a/roles/ceph-osd/tasks/scenarios/non-collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/non-collocated.yml
@@ -4,7 +4,7 @@
 # starting the next task
 - name: prepare ceph "{{ osd_objectstore }}" containerized osd disk(s) non-collocated
   shell: |
-    docker run --net=host \
+    docker run --rm --net=host \
     --pid=host \
     --privileged=true \
     --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.1 | regex_replace('/dev/', '') }} \
@@ -31,7 +31,7 @@
 
 - name: prepare ceph "{{ osd_objectstore }}" containerized osd disk(s) non-collocated with a dedicated device for db
   shell: |
-    docker run --net=host \
+    docker run --rm --net=host \
     --pid=host \
     --privileged=true \
     --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.1 | regex_replace('/dev/', '') }} \

--- a/roles/ceph-osd/tasks/scenarios/non-collocated.yml
+++ b/roles/ceph-osd/tasks/scenarios/non-collocated.yml
@@ -31,7 +31,7 @@
 
 - name: prepare ceph "{{ osd_objectstore }}" containerized osd disk(s) non-collocated with a dedicated device for db
   shell: |
-    docker run --rm --net=host \
+    docker run --net=host \
     --pid=host \
     --privileged=true \
     --name=ceph-osd-prepare-{{ ansible_hostname }}-{{ item.1 | regex_replace('/dev/', '') }} \


### PR DESCRIPTION
collocated.yml: adding --rm just to remove the container used to prepare the osd.

When add-osd.yml is used to add a new osd after an osd failure the execution of the playbook fails. The problem is that the container used to prepare the failed osd still exits (ceph-osd-prepare-ceph3-bs-vdb container for osd vdb). After deleting that container running the playbook again adds the new osd to the cluster.

Replacing a failed osd with a new one works fine with lvm but not using collated osds. This fix works with collocated scenario.

Fixes: #4041