### PR TITLE
ceph-handler: replace fuser by /proc/net/unix

### DIFF
--- a/roles/ceph-handler/tasks/check_socket_non_container.yml
+++ b/roles/ceph-handler/tasks/check_socket_non_container.yml
@@ -8,7 +8,7 @@
   when: inventory_hostname in groups.get(mon_group_name, [])
 
 - name: check if the ceph mon socket is in-use
-  command: fuser --silent {{ mon_socket_stat.stdout }}
+  command: grep -q {{ mon_socket_stat.stdout }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
@@ -36,7 +36,7 @@
   when: inventory_hostname in groups.get(osd_group_name, [])
 
 - name: check if the ceph osd socket is in-use
-  command: fuser --silent {{ osd_socket_stat.stdout }}
+  command: grep -q {{ osd_socket_stat.stdout }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
@@ -64,7 +64,7 @@
   when: inventory_hostname in groups.get(mds_group_name, [])
 
 - name: check if the ceph mds socket is in-use
-  command: fuser --silent {{ mds_socket_stat.stdout }}
+  command: grep -q {{ mds_socket_stat.stdout }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
@@ -92,7 +92,7 @@
   when: inventory_hostname in groups.get(rgw_group_name, [])
 
 - name: check if the ceph rgw socket is in-use
-  command: fuser --silent {{ rgw_socket_stat.stdout }}
+  command: grep -q {{ rgw_socket_stat.stdout }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
@@ -120,7 +120,7 @@
   when: inventory_hostname in groups.get(mgr_group_name, [])
 
 - name: check if the ceph mgr socket is in-use
-  command: fuser --silent {{ mgr_socket_stat.stdout }}
+  command: grep -q {{ mgr_socket_stat.stdout }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
@@ -148,7 +148,7 @@
   when: inventory_hostname in groups.get(rbdmirror_group_name, [])
 
 - name: check if the ceph rbd mirror socket is in-use
-  command: fuser --silent {{ rbd_mirror_socket_stat.stdout }}
+  command: grep -q {{ rbd_mirror_socket_stat.stdout }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
@@ -175,7 +175,7 @@
   when: inventory_hostname in groups.get(nfs_group_name, [])
 
 - name: check if the ceph nfs ganesha socket is in-use
-  command: fuser --silent {{ nfs_socket_stat.stdout }}
+  command: grep -q {{ nfs_socket_stat.stdout }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no


### PR DESCRIPTION
We're using fuser command to see if a process is using a ceph unix
socket file. But the fuser command runs through every PID present in
/proc/<PID> to see if one of them is using the file.
On a system running thousands processes, the fuser command can take
a long time to finish.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1717011

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>