### PR TITLE
podman: Add systemd dependency on network.target

### DIFF
--- a/roles/ceph-grafana/templates/grafana-server.service.j2
+++ b/roles/ceph-grafana/templates/grafana-server.service.j2
@@ -4,6 +4,8 @@
 Description=grafana-server
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -2,6 +2,8 @@
 Description=RBD Target API Service
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -2,6 +2,8 @@
 Description=RBD Target Gateway Service
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -2,6 +2,8 @@
 Description=TCMU Runner
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -2,6 +2,8 @@
 Description=Ceph MDS
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 {% set cpu_limit = ansible_processor_vcpus|int if ceph_mds_docker_cpu_limit|int > ansible_processor_vcpus|int else ceph_mds_docker_cpu_limit|int %}
 

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -2,6 +2,8 @@
 Description=Ceph Manager
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -2,6 +2,8 @@
 Description=Ceph Monitor
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -3,6 +3,8 @@ Description=NFS-Ganesha file server
 Documentation=http://github.com/nfs-ganesha/nfs-ganesha/wiki
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -4,6 +4,8 @@
 Description=Node Exporter
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -3,6 +3,8 @@
 Description=Ceph OSD
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -4,6 +4,8 @@
 Description=alertmanager
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -4,6 +4,8 @@
 Description=prometheus
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -2,6 +2,8 @@
 Description=Ceph RBD mirror
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 
 [Service]

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -2,6 +2,8 @@
 Description=Ceph RGW
 {% if container_binary == 'docker' %}
 After=docker.service
+{% else %}
+After=network.target
 {% endif %}
 {% set cpu_limit = ansible_processor_vcpus|int if ceph_rgw_docker_cpu_limit|int > ansible_processor_vcpus|int else ceph_rgw_docker_cpu_limit|int %}
 


### PR DESCRIPTION
When using podman, the systemd unit scripts don't have a dependency
on the network. So we're not sure that the network is up and running
when the containers are starting.
With docker this behaviour is already handled because the systemd
unit scripts depend on docker service which is started after the
network.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>