### PR TITLE
Enabled 'chrony' service instead of 'chronyd'.

### DIFF
--- a/roles/ceph-infra/tasks/setup_ntp.yml
+++ b/roles/ceph-infra/tasks/setup_ntp.yml
@@ -45,7 +45,7 @@
 
     - name: enable chronyd
       service:
-        name: chronyd
+        name: chrony
         enabled: yes
         state: started
       notify:


### PR DESCRIPTION
I tried the following configuration in file 'all.yml':

```
ntp_service_enabled: true
ntp_daemon_type: 'chronyd'
```

but it fails with the following message:

```
TASK [ceph-infra : enable chronyd] ************************************************************************************************************************************************
Friday 07 June 2019  09:05:52 +0200 (0:00:00.664)       0:02:01.979 ***********
fatal: [ceph-monitor03]: FAILED! => changed=false
  msg: 'Could not find the requested service chronyd: host'
fatal: [ceph-monitor02]: FAILED! => changed=false
  msg: 'Could not find the requested service chronyd: host'
fatal: [ceph-monitor01]: FAILED! => changed=false
  msg: 'Could not find the requested service chronyd: host'
[...]
```

With the change proposed it works fine.

OS: Ubuntu 18 bionic.
Ansible: 2.8
Branch: stable-4.0