### PR TITLE
spec: bring back possibility to install ceph with custom repo

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -49,7 +49,7 @@ pushd %{buildroot}%{_datarootdir}/ceph-ansible
   rm -r infrastructure-playbooks/untested-by-ci
   %if ! 0%{?fedora} && ! 0%{?centos}
     # remove ability to install ceph community version
-    rm roles/ceph-common/tasks/installs/redhat_{community,custom,dev}_repository.yml
+    rm roles/ceph-common/tasks/installs/redhat_{community,dev}_repository.yml
     # Ship only the Red Hat Ceph Storage config (overwrite upstream settings)
     cp group_vars/rhcs.yml.sample group_vars/all.yml.sample
   %endif


### PR DESCRIPTION
This can be seen as a regression for customers who were used to deploy
in offline environment with custom repositories.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1673254

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>