### PR TITLE
ceph-node-exporter: use modprobe ansible module

### DIFF
--- a/roles/ceph-node-exporter/tasks/setup_container.yml
+++ b/roles/ceph-node-exporter/tasks/setup_container.yml
@@ -7,6 +7,11 @@
     group: root
     mode: 0644
 
+- name: add the cfg80211 module
+  modprobe:
+    name: cfg80211
+    state: present
+
 - name: start the node_exporter service
   systemd:
     name: node_exporter

--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -18,9 +18,6 @@ ExecStart=/usr/bin/{{ container_binary }} run --name=node-exporter \
   --path.procfs=/host/proc \
   --path.sysfs=/host/sys \
   --no-collector.timex \
-# Make sure the cfg80211 is loaded before running the container, the node
-# exporter needs this module loaded to test for presence of wi-fi devices
-ExecStartPre=/usr/sbin/modprobe cfg80211
 ExecStop=-/usr/bin/{{ container_binary }} stop node-exporter
 Restart=always
 RestartSec=10s


### PR DESCRIPTION
Instead of using the modprobe command from the path in the systemd
unit script, we can use the modprobe ansible module.
That way we don't have to manage the binary path based on the linux
distribution.

Resolves: #4072

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>