### PR TITLE
ceph-node-exporter: Fix systemd template

### DIFF
--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -14,10 +14,10 @@ ExecStartPre=-/usr/bin/{{ container_binary }} rm -f node-exporter
 ExecStart=/usr/bin/{{ container_binary }} run --name=node-exporter \
   -v /proc:/host/proc:ro -v /sys:/host/sys:ro \
   --net=host \
-  {{ node_exporter_container_image }}
+  {{ node_exporter_container_image }} \
   --path.procfs=/host/proc \
   --path.sysfs=/host/sys \
-  --no-collector.timex \
+  --no-collector.timex
 ExecStop=-/usr/bin/{{ container_binary }} stop node-exporter
 Restart=always
 RestartSec=10s


### PR DESCRIPTION
069076b introduced a bug in the systemd unit script template. This
commit fixes the options used by the node-exporter container.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>