### PR TITLE
dashboard: add allow_embedding support

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -727,6 +727,7 @@ dummy:
 #grafana_plugins:
 #  - vonage-status-panel
 #  - grafana-piechart-panel
+#grafana_allow_embedding: True
 #prometheus_container_image: prom/prometheus:latest
 #prometheus_container_cpu_period: 100000
 #prometheus_container_cpu_cores: 2

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -727,6 +727,7 @@ ceph_docker_registry: "registry.access.redhat.com"
 #grafana_plugins:
 #  - vonage-status-panel
 #  - grafana-piechart-panel
+#grafana_allow_embedding: True
 #prometheus_container_image: prom/prometheus:latest
 #prometheus_container_cpu_period: 100000
 #prometheus_container_cpu_cores: 2

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -719,6 +719,7 @@ grafana_dashboards_path: "/etc/grafana/dashboards/ceph-dashboard"
 grafana_plugins:
   - vonage-status-panel
   - grafana-piechart-panel
+grafana_allow_embedding: True
 prometheus_container_image: prom/prometheus:latest
 prometheus_container_cpu_period: 100000
 prometheus_container_cpu_cores: 2

--- a/roles/ceph-grafana/templates/grafana.ini.j2
+++ b/roles/ceph-grafana/templates/grafana.ini.j2
@@ -24,3 +24,4 @@ protocol = {{ dashboard_protocol }}
 [security]
 admin_user = {{ grafana_admin_user }}
 admin_password = {{ grafana_admin_password }}
+allow_embedding = {{ grafana_allow_embedding }}


### PR DESCRIPTION
Add a variable to support the allow_embedding support.

See ceph/ceph-ansible/issues/4084 for details.

Fixes: #4084

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>