### PR TITLE
mon: enforce mon0 delegation for initial_mon_key register

### DIFF
--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -1,7 +1,7 @@
 ---
 - name: check if monitor initial keyring already exists
   command: >
-    {{ container_exec_cmd | default('') }} ceph --cluster ceph --name mon. -k
+    {{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster ceph --name mon. -k
     /var/lib/ceph/mon/{{ cluster }}-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}/keyring
     auth get-key mon.
   register: initial_mon_key


### PR DESCRIPTION
since this task is designed to be always run on the first monitor, let's
enforce the container name accordingly otherwise it could fail like
following:

```
fatal: [mon1 -> mon0]: FAILED! => changed=true
  cmd:
  - docker
  - exec
  - ceph-mon-mon1
  - ceph
  - --cluster
  - ceph
  - --name
  - mon.
  - -k
  - /var/lib/ceph/mon/ceph-mon0/keyring
  - auth
  - get-key
  - mon.
  delta: '0:00:00.085025'
  end: '2019-06-12 06:12:27.677936'
  msg: non-zero return code
  rc: 1
  start: '2019-06-12 06:12:27.592911'
  stderr: 'Error response from daemon: No such container: ceph-mon-mon1'
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>