### PR TITLE
ceph-infra: make chronyd default NTP daemon

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -100,7 +100,7 @@ dummy:
 
 # Set type of NTP client daemon to use, valid entries are chronyd, ntpd or timesyncd
 # Note that this selection is currently ignored on containerized deployments
-#ntp_daemon_type: timesyncd
+#ntp_daemon_type: chronyd
 
 
 # Set uid/gid to default '64045' for bootstrap directories.

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -100,7 +100,7 @@ fetch_directory: ~/ceph-ansible-keys
 
 # Set type of NTP client daemon to use, valid entries are chronyd, ntpd or timesyncd
 # Note that this selection is currently ignored on containerized deployments
-#ntp_daemon_type: timesyncd
+#ntp_daemon_type: chronyd
 
 
 # Set uid/gid to default '64045' for bootstrap directories.

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -92,7 +92,7 @@ ntp_service_enabled: true
 
 # Set type of NTP client daemon to use, valid entries are chronyd, ntpd or timesyncd
 # Note that this selection is currently ignored on containerized deployments
-ntp_daemon_type: timesyncd
+ntp_daemon_type: chronyd
 
 
 # Set uid/gid to default '64045' for bootstrap directories.

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -290,6 +290,18 @@
       ntp_service_name: ntpd
     when: ansible_os_family in ['RedHat', 'Suse']
 
+- name: set chrony daemon name RedHat and Ubuntu based OSs
+  block:
+    - name: set chronyd daemon name for RedHat based OSs
+      set_fact:
+        chrony_daemon_name: chronyd
+      when: ansible_os_family in ["RedHat", "Suse"]
+
+    - name: set chronyd daemon name for Ubuntu based OSs
+      set_fact:
+        chrony_daemon_name: chrony
+      when: ansible_os_family == "Debian"
+
 - name: set grafana_server_addr fact
   set_fact:
     grafana_server_addr: "{{ (hostvars[groups[grafana_server_group_name][0] | default(groups[mgr_group_name][0])])['ansible_all_ipv4_addresses'] | ipaddr(public_network) | first }}"

--- a/roles/ceph-infra/tasks/setup_ntp.yml
+++ b/roles/ceph-infra/tasks/setup_ntp.yml
@@ -45,7 +45,7 @@
 
     - name: enable chronyd
       service:
-        name: chronyd
+        name: "{{ chrony_daemon_name }}"
         enabled: yes
         state: started
       notify:


### PR DESCRIPTION
Since timesyncd is not available on RHEL-based OSs, change the default
to chronyd.

Fixes: https://github.com/ceph/ceph-ansible/issues/3628