### PR TITLE
tests: update docker image tag used in ooo job

### DIFF
--- a/tests/functional/ooo-collocation/hosts
+++ b/tests/functional/ooo-collocation/hosts
@@ -7,7 +7,6 @@ all:
         rgw_keystone_admin_password: RtYPg7AUdsZCGv4Z4rF8FvnaR, rgw_keystone_admin_project: service,
         rgw_keystone_admin_user: swift, rgw_keystone_api_version: 3, rgw_keystone_implicit_tenants: 'true',
         rgw_keystone_url: 'http://192.168.95.10:5000', rgw_s3_auth_use_keystone: 'true', rgw_keystone_revocation_interval: 0}
-    ceph_mgr_docker_extra_env: '-e MGR_DASHBOARD=0'
     cluster: mycluster
     ceph_docker_image: ceph/daemon
     ceph_docker_image_tag: latest-master

--- a/tests/functional/ooo-collocation/hosts
+++ b/tests/functional/ooo-collocation/hosts
@@ -10,7 +10,7 @@ all:
     ceph_mgr_docker_extra_env: '-e MGR_DASHBOARD=0'
     cluster: mycluster
     ceph_docker_image: ceph/daemon
-    ceph_docker_image_tag: v3.0.3-stable-3.0-luminous-centos-7-x86_64
+    ceph_docker_image_tag: latest-master
     ceph_docker_registry: docker.io
     ceph_origin: repository
     ceph_repository: community


### PR DESCRIPTION
ceph-ansible@master isn't intended to deploy luminous.
Let's use latest-master on ceph-ansible@master branch

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>