### PR TITLE
tox-dashboard: update for nautilus

### DIFF
--- a/tox-dashboard.ini
+++ b/tox-dashboard.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = dev-{centos,ubuntu}-{container,non_container}-dashboard
+envlist = nautilus-{centos,ubuntu}-{container,non_container}-dashboard
 
 skipsdist = True
 
@@ -37,10 +37,6 @@ setenv=
   non_container: PLAYBOOK = site.yml.sample
 
   CEPH_DOCKER_IMAGE_TAG = latest-nautilus
-  CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-nautilus
-  CEPH_DOCKER_IMAGE_TAG = latest-master
-  CEPH_DEV_BRANCH = master
-  CEPH_DEV_SHA1 = latest
   CEPH_STABLE_RELEASE = nautilus
 
 deps= -r{toxinidir}/tests/requirements.txt
@@ -54,16 +50,14 @@ commands=
   # configure lvm
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml --extra-vars "osd_scenario=lvm"
 
-  non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup=True change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK} --extra-vars "\
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
-      ceph_docker_image={env:UPDATE_CEPH_DOCKER_IMAGE:ceph/daemon} \
-      ceph_docker_image_tag={env:UPDATE_CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-nautilus} \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:nautilus} \
   "
 
-  bash -c "CEPH_STABLE_RELEASE={env:CEPH_STABLE_RELEASE:nautilus} py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests"
+  py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 
   vagrant destroy --force


### PR DESCRIPTION
We don't need to use dev_setup playbook on stable branch. We also
need to remove the dev container image variables and update the
value to match nautilus.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>