### PR TITLE
iscsi: assign application (rbd) to pool 'rbd'

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -38,6 +38,11 @@
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
 
+    - name: assign application rbd to pool 'rbd'
+      command: "{{ container_exec_cmd }} ceph --connect-timeout 5 --cluster {{ cluster }} osd pool application enable rbd rbd"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: True
+
     - name: customize pool size
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool set rbd size {{ rbd_pool_size | default(osd_pool_default_size) }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -17,6 +17,7 @@ openstack_glance_pool:
   erasure_profile: ""
   expected_num_objects: ""
   size: 1
+  application: rbd
 openstack_cinder_pool:
   name: "volumes"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -26,6 +27,7 @@ openstack_cinder_pool:
   erasure_profile: ""
   expected_num_objects: ""
   size: 1
+  application: rbd
 openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"


### PR DESCRIPTION
if we don't assign the rbd application tag on this pool,
the cluster will get `HEALTH_WARN` state like following:

```
HEALTH_WARN application not enabled on 1 pool(s)
POOL_APP_NOT_ENABLED application not enabled on 1 pool(s)
    application not enabled on pool 'rbd'
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>