### PR TITLE
ceph-infra: update cache for Ubuntu

### DIFF
--- a/roles/ceph-infra/tasks/main.yml
+++ b/roles/ceph-infra/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: update cache for Debian based OSs
+  apt:
+    update_cache: yes
+  when: ansible_os_family == "Debian"
+  register: result
+  until: result is succeeded
+
 - name: include_tasks configure_firewall.yml
   include_tasks: configure_firewall.yml
   when:


### PR DESCRIPTION
Ubuntu-based CI jobs often fail with error code 404 while installing
NTP daemons. Updating cache beforehand should fix the issue.