### PR TITLE
bugfix: syntax error when enabling crush_rule_config

### DIFF
--- a/roles/ceph-mon/tasks/crush_rules.yml
+++ b/roles/ceph-mon/tasks/crush_rules.yml
@@ -13,7 +13,7 @@
 
 - name: create configured crush rules
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-simple {{ item.name }} {{ item.root }} {{ item.type }}"
-  with_items: "{{ crush_rules | unique }}"
+  with_items: "{{ crush_rules }}"
   changed_when: false
   when: inventory_hostname == groups.get(mon_group_name) | last
 


### PR DESCRIPTION
With 'unique' filter, it will return error like 

  The task includes an option with an undefined variable. The error was: 
  'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'name'

And the following task also has no 'unique' filter.
So remove it.

Signed-off-by: Yang Jun <yangjun@qiyi.com>