### PR TITLE
dashboard: fix hosts sections in main playbook

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -521,30 +521,30 @@
   become: true
   tasks:
     - block:
-      - import_role:
-          name: ceph-defaults
-        tags: ['ceph_update_config']
-      - import_role:
-          name: ceph-facts
-        tags: ['ceph_update_config']
-      - import_role:
-          name: ceph-handler
-      - import_role:
-          name: ceph-container-engine
-      - import_role:
-          name: ceph-container-common
-      - import_role:
-          name: ceph-node-exporter
-      - import_role:
-          name: ceph-config
-        tags: ['ceph_update_config']
-      - import_role:
-          name: ceph-prometheus
-      - import_role:
-          name: ceph-grafana
+        - import_role:
+            name: ceph-defaults
+          tags: ['ceph_update_config']
+        - import_role:
+            name: ceph-facts
+          tags: ['ceph_update_config']
+        - import_role:
+            name: ceph-handler
+        - import_role:
+            name: ceph-container-engine
+        - import_role:
+            name: ceph-container-common
+        - import_role:
+            name: ceph-node-exporter
+        - import_role:
+            name: ceph-config
+          tags: ['ceph_update_config']
+        - import_role:
+            name: ceph-prometheus
+        - import_role:
+            name: ceph-grafana
       when: dashboard_enabled | bool
 
-- hosts: '{{ groups["grafana-server"][0] | default(groups["mgrs"][0]) | default(groups["mons"][0]) | default(omit) }}'
+- hosts: '{{ groups["mgrs"][0] | default(groups["mons"][0]) | default(omit) }}'
   become: true
   tasks:
     - block:

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -520,13 +520,13 @@
             name: ceph-grafana
       when: dashboard_enabled | bool
 
-- hosts: '{{ groups["grafana-server"][0] | default(groups["mgrs"][0]) | default(groups["mons"][0]) | default(omit) }}'
+- hosts: '{{ groups["mgrs"][0] | default(groups["mons"][0]) | default(omit) }}'
   become: true
   tasks:
-    - import_role:
-        name: ceph-defaults
-      tags: ['ceph_update_config']
-      when: dashboard_enabled | bool
-    - import_role:
-        name: ceph-dashboard
+    - block:
+        - import_role:
+            name: ceph-defaults
+          tags: ['ceph_update_config']
+        - import_role:
+            name: ceph-dashboard
       when: dashboard_enabled | bool


### PR DESCRIPTION
ceph-dashboard should be deployed on either a dedicated mgr node or a
mon if they are collocated.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>