### PR TITLE
tests: Update ansible ssh_args variable

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -31,7 +31,7 @@ timeout = 60
 [ssh_connection]
 # see: https://github.com/ansible/ansible/issues/11536
 control_path = %(directory)s/%%h-%%r-%%p
-ssh_args = -o ControlMaster=auto -o ControlPersist=600s
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
 pipelining = True
 
 # Option to retry failed ssh executions if the failure is encountered in ssh itself

--- a/roles/ceph-config/tasks/create_ceph_initial_dirs.yml
+++ b/roles/ceph-config/tasks/create_ceph_initial_dirs.yml
@@ -1,23 +1,4 @@
 ---
-- name: set_fact ceph_directories
-  set_fact:
-    ceph_directories:
-      - /etc/ceph
-      - /var/lib/ceph/
-      - /var/lib/ceph/mon
-      - /var/lib/ceph/osd
-      - /var/lib/ceph/mds
-      - /var/lib/ceph/tmp
-      - /var/lib/ceph/radosgw
-      - /var/lib/ceph/bootstrap-rgw
-      - /var/lib/ceph/bootstrap-mgr
-      - /var/lib/ceph/bootstrap-mds
-      - /var/lib/ceph/bootstrap-osd
-      - /var/lib/ceph/bootstrap-rbd
-      - /var/lib/ceph/bootstrap-rbd-mirror
-      - /var/run/ceph
-      - /var/log/ceph
-
 - name: create ceph initial directories
   file:
     path: "{{ item }}"
@@ -25,4 +6,19 @@
     owner: "{{ ceph_uid }}"
     group: "{{ ceph_uid }}"
     mode: 0755
-  with_items: "{{ ceph_directories }}"
+  loop:
+    - /etc/ceph
+    - /var/lib/ceph/
+    - /var/lib/ceph/mon
+    - /var/lib/ceph/osd
+    - /var/lib/ceph/mds
+    - /var/lib/ceph/tmp
+    - /var/lib/ceph/radosgw
+    - /var/lib/ceph/bootstrap-rgw
+    - /var/lib/ceph/bootstrap-mgr
+    - /var/lib/ceph/bootstrap-mds
+    - /var/lib/ceph/bootstrap-osd
+    - /var/lib/ceph/bootstrap-rbd
+    - /var/lib/ceph/bootstrap-rbd-mirror
+    - /var/run/ceph
+    - /var/log/ceph

--- a/tox-dashboard.ini
+++ b/tox-dashboard.ini
@@ -12,7 +12,7 @@ whitelist_externals =
     pip
 passenv=*
 setenv=
-  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
   ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/plugins/callback

--- a/tox-podman.ini
+++ b/tox-podman.ini
@@ -13,7 +13,7 @@ whitelist_externals =
 passenv=*
 sitepackages=True
 setenv=
-  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
   ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/plugins/callback

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -11,7 +11,7 @@ whitelist_externals =
     pip
 passenv=*
 setenv=
-  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
   ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/plugins/callback

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ whitelist_externals =
     pip
 passenv=*
 setenv=
-  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_CONFIG = -F {toxinidir}/ansible.cfg
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
   ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/plugins/callback
@@ -86,7 +86,7 @@ whitelist_externals =
     cat
 passenv=*
 setenv=
-  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_CONFIG = -F {toxinidir}/ansible.cfg
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
   ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/plugins/callback
@@ -330,7 +330,7 @@ whitelist_externals =
 passenv=*
 sitepackages=True
 setenv=
-  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
   ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/plugins/callback


### PR DESCRIPTION
Because we're using vagrant, a ssh config file will be created for
each nodes with options like user, host, port, identity, etc...
But via tox we're override ANSIBLE_SSH_ARGS to use this file. This
remove the default value set in ansible.cfg.

Also adding PreferredAuthentications=publickey because CentOS/RHEL
servers are configured with GSSAPIAuthenticationis enabled for ssh
server forcing the client to make a PTR DNS query.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>