### PR TITLE
remove ceph restapi references

### DIFF
--- a/contrib/push-roles-to-ansible-galaxy.sh
+++ b/contrib/push-roles-to-ansible-galaxy.sh
@@ -4,7 +4,7 @@ set -xe
 # VARIABLES
 BASEDIR=$(dirname "$0")
 LOCAL_BRANCH=$(cd $BASEDIR && git rev-parse --abbrev-ref HEAD)
-ROLES="ceph-common ceph-mon ceph-osd ceph-mds ceph-rgw ceph-restapi ceph-fetch-keys ceph-rbd-mirror ceph-client ceph-container-common ceph-mgr ceph-defaults ceph-config"
+ROLES="ceph-common ceph-mon ceph-osd ceph-mds ceph-rgw ceph-fetch-keys ceph-rbd-mirror ceph-client ceph-container-common ceph-mgr ceph-defaults ceph-config"
 
 
 # FUNCTIONS

--- a/infrastructure-playbooks/gather-ceph-logs.yml
+++ b/infrastructure-playbooks/gather-ceph-logs.yml
@@ -4,7 +4,6 @@
   - mdss
   - rgws
   - nfss
-  - restapis
   - rbdmirrors
   - clients
   - mgrs

--- a/tests/functional/lvm-auto-discovery/container/vagrant_variables.yml
+++ b/tests/functional/lvm-auto-discovery/container/vagrant_variables.yml
@@ -15,9 +15,6 @@ client_vms: 0
 iscsi_gw_vms: 0
 mgr_vms: 0
 
-# Deploy RESTAPI on each of the Monitors
-restapi: true
-
 # INSTALL SOURCE OF CEPH
 # valid values are 'stable' and 'dev'
 ceph_install_source: stable

--- a/tests/functional/lvm-batch/container/vagrant_variables.yml
+++ b/tests/functional/lvm-batch/container/vagrant_variables.yml
@@ -15,9 +15,6 @@ client_vms: 0
 iscsi_gw_vms: 0
 mgr_vms: 0
 
-# Deploy RESTAPI on each of the Monitors
-restapi: true
-
 # INSTALL SOURCE OF CEPH
 # valid values are 'stable' and 'dev'
 ceph_install_source: stable

--- a/tests/functional/lvm-osds/container/vagrant_variables.yml
+++ b/tests/functional/lvm-osds/container/vagrant_variables.yml
@@ -15,9 +15,6 @@ client_vms: 0
 iscsi_gw_vms: 0
 mgr_vms: 0
 
-# Deploy RESTAPI on each of the Monitors
-restapi: true
-
 # INSTALL SOURCE OF CEPH
 # valid values are 'stable' and 'dev'
 ceph_install_source: stable

--- a/tests/functional/rgw-multisite/container/secondary/vagrant_variables.yml
+++ b/tests/functional/rgw-multisite/container/secondary/vagrant_variables.yml
@@ -14,9 +14,6 @@ client_vms: 0
 iscsi_gw_vms: 0
 mgr_vms: 0
 
-# Deploy RESTAPI on each of the Monitors
-restapi: true
-
 # INSTALL SOURCE OF CEPH
 # valid values are 'stable' and 'dev'
 ceph_install_source: stable

--- a/tests/functional/rgw-multisite/container/vagrant_variables.yml
+++ b/tests/functional/rgw-multisite/container/vagrant_variables.yml
@@ -15,9 +15,6 @@ client_vms: 0
 iscsi_gw_vms: 0
 mgr_vms: 0
 
-# Deploy RESTAPI on each of the Monitors
-restapi: true
-
 # INSTALL SOURCE OF CEPH
 # valid values are 'stable' and 'dev'
 ceph_install_source: stable


### PR DESCRIPTION
The ceph restapi configuration was only available until Luminous
release so we don't need those leftovers for nautilus+.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>