### PR TITLE
Add installer phase for dashboard roles

### DIFF
--- a/plugins/callback/installer_checkpoint.py
+++ b/plugins/callback/installer_checkpoint.py
@@ -31,6 +31,9 @@ class CallbackModule(CallbackBase):
             'installer_phase_ceph_client',
             'installer_phase_ceph_iscsi_gw',
             'installer_phase_ceph_rgw_loadbalancer',
+            'installer_phase_ceph_dashboard',
+            'installer_phase_ceph_grafana',
+            'installer_phase_ceph_node_exporter',
         ]
 
         # Define the attributes of the installer phases
@@ -74,6 +77,18 @@ class CallbackModule(CallbackBase):
             'installer_phase_ceph_rgw_loadbalancer': {
                 'title': 'Install Ceph RGW LoadBalancer',
                 'playbook': 'roles/ceph-rgw-loadbalancer/tasks/main.yml'
+            },
+            'installer_phase_ceph_dashboard': {
+                'title': 'Install Ceph Dashboard',
+                'playbook': 'roles/ceph-dashboard/tasks/main.yml'
+            },
+            'installer_phase_ceph_grafana': {
+                'title': 'Install Ceph Grafana',
+                'playbook': 'roles/ceph-grafana/tasks/main.yml'
+            },
+            'installer_phase_ceph_node_exporter': {
+                'title': 'Install Ceph Node Exporter',
+                'playbook': 'roles/ceph-node-exporter/tasks/main.yml'
             },
         }
 

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -519,6 +519,15 @@
 
 - hosts: '{{ groups["grafana-server"][0] | default(groups["mgrs"][0]) | default(groups["mons"][0]) | default(omit) }}'
   become: true
+  pre_tasks:
+    - name: set ceph grafana install 'In Progress'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_grafana:
+            status: "In Progress"
+            start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+
   tasks:
     - block:
         - import_role:
@@ -544,8 +553,26 @@
             name: ceph-grafana
       when: dashboard_enabled | bool
 
+  post_tasks:
+    - name: set ceph grafana install 'Complete'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_grafana:
+            status: "Complete"
+            end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+
 - hosts: '{{ groups["mgrs"][0] | default(groups["mons"][0]) | default(omit) }}'
   become: true
+  pre_tasks:
+    - name: set ceph dashboard install 'In Progress'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_dashboard:
+            status: "In Progress"
+            start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+
   tasks:
     - block:
         - import_role:
@@ -554,3 +581,12 @@
         - import_role:
             name: ceph-dashboard
       when: dashboard_enabled | bool
+
+  post_tasks:
+    - name: set ceph dashboard install 'Complete'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_dashboard:
+            status: "Complete"
+            end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -483,6 +483,15 @@
 
 - hosts: all
   become: true
+  pre_tasks:
+    - name: set ceph node exporter install 'In Progress'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_node_exporter:
+            status: "In Progress"
+            start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+
   tasks:
     - block:
         - import_role:
@@ -497,8 +506,26 @@
             name: ceph-node-exporter
       when: dashboard_enabled | bool
 
+  post_tasks:
+    - name: set ceph node exporter install 'Complete'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_node_exporter:
+            status: "Complete"
+            end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+
 - hosts: '{{ groups["grafana-server"][0] | default(groups["mgrs"][0]) | default(groups["mons"][0]) | default(omit) }}'
   become: true
+  pre_tasks:
+    - name: set ceph grafana install 'In Progress'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_grafana:
+            status: "In Progress"
+            start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+
   tasks:
     - block:
         - import_role:
@@ -520,8 +547,26 @@
             name: ceph-grafana
       when: dashboard_enabled | bool
 
+  post_tasks:
+    - name: set ceph grafana install 'Complete'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_grafana:
+            status: "Complete"
+            end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+
 - hosts: '{{ groups["mgrs"][0] | default(groups["mons"][0]) | default(omit) }}'
   become: true
+  pre_tasks:
+    - name: set ceph dashboard install 'In Progress'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_dashboard:
+            status: "In Progress"
+            start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+
   tasks:
     - block:
         - import_role:
@@ -530,3 +575,12 @@
         - import_role:
             name: ceph-dashboard
       when: dashboard_enabled | bool
+
+  post_tasks:
+    - name: set ceph dashboard install 'Complete'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_dashboard:
+            status: "Complete"
+            end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"


### PR DESCRIPTION
This commits adds the support of the installer phase for dashboard,
grafana and node-exporter roles.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>