### PR TITLE
ceph-osd: do not relabel /run/udev in containerized context

### DIFF
--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -100,7 +100,7 @@ numactl \
   -v /var/lib/ceph:/var/lib/ceph:z \
   -v /etc/ceph:/etc/ceph:z \
   -v /var/run/ceph:/var/run/ceph:z \
-  -v /var/run/udev/:/var/run/udev/:z \
+  -v /var/run/udev/:/var/run/udev/ \
   {% if ansible_distribution == 'Ubuntu' -%}
   --security-opt apparmor:unconfined \
   {% endif -%}


### PR DESCRIPTION
Otherwise content in /run/udev is mislabeled and prevent some services
like NetworkManager from starting.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 80875adba791b732713f686a4e4eba182758dc9d)