### PR TITLE
roles: Remove useless become (true) flag

### DIFF
--- a/roles/ceph-common/tasks/installs/configure_redhat_local_installation.yml
+++ b/roles/ceph-common/tasks/installs/configure_redhat_local_installation.yml
@@ -19,7 +19,6 @@
 
 - name: install ceph dependencies
   script: "{{ ansible_dir }}/rundep_installer.sh {{ item }}"
-  become: true
   with_items: "{{ (rundep_location|default({})).stdout_lines|default([]) }}"
   when: use_installer | bool
 

--- a/roles/ceph-iscsi-gw/tasks/container/containerized.yml
+++ b/roles/ceph-iscsi-gw/tasks/container/containerized.yml
@@ -1,6 +1,5 @@
 ---
 - name: generate systemd unit files for tcmu-runner, rbd-target-api and rbd-target-gw
-  become: true
   template:
     src: "{{ role_path }}/templates/{{ item }}.service.j2"
     dest: /etc/systemd/system/{{ item }}.service

--- a/roles/ceph-mgr/tasks/start_mgr.yml
+++ b/roles/ceph-mgr/tasks/start_mgr.yml
@@ -18,7 +18,6 @@
     - ansible_service_mgr == 'systemd'
 
 - name: generate systemd unit file
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-mgr.service.j2"
     dest: /etc/systemd/system/ceph-mgr@.service

--- a/roles/ceph-mon/tasks/start_monitor.yml
+++ b/roles/ceph-mon/tasks/start_monitor.yml
@@ -20,7 +20,6 @@
     - ansible_service_mgr == 'systemd'
 
 - name: generate systemd unit file for mon container
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-mon.service.j2"
     dest: /etc/systemd/system/ceph-mon@.service

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -45,7 +45,6 @@
 - name: dbus related tasks
   block:
     - name: create dbus service file
-      become: true
       copy:
         src: "org.ganesha.nfsd.conf"
         dest: /etc/dbus-1/system.d/org.ganesha.nfsd.conf

--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -61,7 +61,6 @@
   when: ceph_nfs_dynamic_exports | bool
 
 - name: generate systemd unit file
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-nfs.service.j2"
     dest: /etc/systemd/system/ceph-nfs@.service

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -11,7 +11,6 @@
     when: ceph_docker_on_openstack | bool
 
   - name: generate ceph osd docker run script
-    become: true
     template:
       src: "{{ role_path }}/templates/ceph-osd-run.sh.j2"
       dest: "{{ ceph_osd_docker_run_script_path }}/ceph-osd-run.sh"
@@ -39,7 +38,6 @@
   register: ceph_osd_ids
 
 - name: generate systemd unit file
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-osd.service.j2"
     dest: /etc/systemd/system/ceph-osd@.service

--- a/roles/ceph-rbd-mirror/tasks/docker/start_docker_rbd_mirror.yml
+++ b/roles/ceph-rbd-mirror/tasks/docker/start_docker_rbd_mirror.yml
@@ -1,7 +1,6 @@
 ---
 # Use systemd to manage container on Atomic host
 - name: generate systemd unit file
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-rbd-mirror.service.j2"
     dest: /etc/systemd/system/ceph-rbd-mirror@.service

--- a/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
+++ b/roles/ceph-rgw/tasks/docker/start_docker_rgw.yml
@@ -1,6 +1,5 @@
 ---
 - name: generate environment file
-  become: true
   copy:
     dest: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}.{{ item.instance_name }}/EnvironmentFile"
     owner: "root"
@@ -12,7 +11,6 @@
   with_items: "{{ rgw_instances }}"
 
 - name: generate systemd unit file
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-radosgw.service.j2"
     dest: /etc/systemd/system/ceph-radosgw@.service


### PR DESCRIPTION
We already set the become flag to true at a play level in the site*
playbooks so we don't need to set it at a task level.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>