### PR TITLE
Set grafana_server_addr fact for ipv6 scenarios.

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -303,9 +303,18 @@
         chrony_daemon_name: chrony
       when: ansible_os_family == "Debian"
 
-- name: set grafana_server_addr fact
+- name: set grafana_server_addr fact - ipv4
   set_fact:
     grafana_server_addr: "{{ (hostvars[groups[grafana_server_group_name][0] if groups.get(grafana_server_group_name, []) | length > 0 else groups[mgr_group_name][0]])['ansible_all_ipv4_addresses'] | ipaddr(public_network) | first }}"
   when:
     - (groups.get(grafana_server_group_name, []) | length > 0 or groups.get(mgr_group_name, []) | length > 0)
+    - ip_version == 'ipv4'
+    - dashboard_enabled | bool
+
+- name: set grafana_server_addr fact - ipv6
+  set_fact:
+    grafana_server_addr: "{{ (hostvars[groups[grafana_server_group_name][0] if groups.get(grafana_server_group_name, []) | length > 0 else groups[mgr_group_name][0]])['ansible_all_ipv6_addresses'] | ipaddr(public_network) | last | ipwrap }}"
+  when:
+    - (groups.get(grafana_server_group_name, []) | length > 0 or groups.get(mgr_group_name, []) | length > 0)
+    - ip_version == 'ipv6'
     - dashboard_enabled | bool


### PR DESCRIPTION
As the [bz1721914](https://bugzilla.redhat.com/show_bug.cgi?id=1721914) describes, the grafana_server_addr
fact is not defined if ip_version used is ipv6.
This commit adds the ip_version condition to set
correctly this fact.

Signed-off-by: fmount <fpantano@redhat.com>