### PR TITLE
upgrade: add the possibility to upgrade even when HEALTH_WARN

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -118,7 +118,7 @@
             - name: fail if cluster isn't in an acceptable state
               fail:
                 msg: "cluster is not in an acceptable state!"
-          when: not (check_cluster_status.stdout | from_json).health.status == 'HEALTH_OK'
+          when: (check_cluster_status.stdout | from_json).health.status == 'HEALTH_ERR'
       when: inventory_hostname == groups[mon_group_name] | first
 
     - name: ensure /var/lib/ceph/bootstrap-rbd-mirror is present


### PR DESCRIPTION
3a100cfa5265b3a5327ef6a8d382a8059391b903 introduced an early check to
fail if the cluster isn't `HEALTH_OK`, this might be seen as a too aggressive
check. Passing `accept_health_warn=True` as an extra var makes it
possible to override this behavior.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>