### PR TITLE
Add higher retry/delay defaults to check the quorum status.

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -443,8 +443,8 @@ dummy:
 # for both monitors and osds.
 #
 # Monitor handler checks
-#handler_health_mon_check_retries: 5
-#handler_health_mon_check_delay: 10
+#handler_health_mon_check_retries: 10
+#handler_health_mon_check_delay: 20
 #
 # OSD handler checks
 #handler_health_osd_check_retries: 40

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -443,8 +443,8 @@ ceph_rhcs_version: 4
 # for both monitors and osds.
 #
 # Monitor handler checks
-#handler_health_mon_check_retries: 5
-#handler_health_mon_check_delay: 10
+#handler_health_mon_check_retries: 10
+#handler_health_mon_check_delay: 20
 #
 # OSD handler checks
 #handler_health_osd_check_retries: 40

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -435,8 +435,8 @@ email_address: foo@bar.com
 # for both monitors and osds.
 #
 # Monitor handler checks
-handler_health_mon_check_retries: 5
-handler_health_mon_check_delay: 10
+handler_health_mon_check_retries: 10
+handler_health_mon_check_delay: 20
 #
 # OSD handler checks
 handler_health_osd_check_retries: 40


### PR DESCRIPTION
As per [bz1718981](https://bugzilla.redhat.com/show_bug.cgi?id=1718981), this commit adds higher values to check the quorum status.
This is helpful for several OSP deployments that fail during the scale up.

Signed-off-by: fpantano <fpantano@redhat.com>