### PR TITLE
Change ansible_lsb by ansible_distribution_release

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -163,7 +163,7 @@ dummy:
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/
 # for more info read: https://github.com/ceph/ceph-ansible/issues/305
-#ceph_stable_distro_source: "{{ ansible_lsb.codename }}"
+#ceph_stable_distro_source: "{{ ansible_distribution_release }}"
 
 # This option is needed for _both_ stable and dev version, so please always fill the right version
 # # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
@@ -199,7 +199,7 @@ dummy:
 #
 #ceph_stable_repo_uca: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
 #ceph_stable_openstack_release_uca: queens
-#ceph_stable_release_uca: "{{ ansible_lsb.codename }}-updates/{{ ceph_stable_openstack_release_uca }}"
+#ceph_stable_release_uca: "{{ ansible_distribution_release }}-updates/{{ ceph_stable_openstack_release_uca }}"
 
 # REPOSITORY: openSUSE OBS
 #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -163,7 +163,7 @@ ceph_repository: rhcs
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/
 # for more info read: https://github.com/ceph/ceph-ansible/issues/305
-#ceph_stable_distro_source: "{{ ansible_lsb.codename }}"
+#ceph_stable_distro_source: "{{ ansible_distribution_release }}"
 
 # This option is needed for _both_ stable and dev version, so please always fill the right version
 # # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
@@ -199,7 +199,7 @@ ceph_rhcs_version: 4
 #
 #ceph_stable_repo_uca: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
 #ceph_stable_openstack_release_uca: queens
-#ceph_stable_release_uca: "{{ ansible_lsb.codename }}-updates/{{ ceph_stable_openstack_release_uca }}"
+#ceph_stable_release_uca: "{{ ansible_distribution_release }}-updates/{{ ceph_stable_openstack_release_uca }}"
 
 # REPOSITORY: openSUSE OBS
 #

--- a/roles/ceph-common/tasks/installs/debian_community_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_community_repository.yml
@@ -15,6 +15,6 @@
 
 - name: configure debian ceph stable community repository
   apt_repository:
-    repo: "deb {{ ceph_stable_repo }} {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
+    repo: "deb {{ ceph_stable_repo }} {{ ceph_stable_distro_source | default(ansible_distribution_release) }} main"
     state: present
     update_cache: yes

--- a/roles/ceph-common/tasks/installs/debian_custom_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_custom_repository.yml
@@ -1,7 +1,7 @@
 ---
 - name: configure debian custom repository
   apt_repository:
-    repo: "deb {{ ceph_custom_repo }} {{ ansible_lsb.codename }} main"
+    repo: "deb {{ ceph_custom_repo }} {{ ansible_distribution_release }} main"
     state: present
     update_cache: no
   notify: update apt cache if a repo was added

--- a/roles/ceph-common/tasks/installs/debian_dev_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_dev_repository.yml
@@ -1,7 +1,7 @@
 ---
 - name: fetch ceph debian development repository
   uri:
-    url: https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/{{ ansible_distribution | lower }}/{{ ansible_lsb.codename }}/repo
+    url: https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/repo
     return_content: yes
   register: ceph_dev_deb_repo
 

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install_debian.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install_debian.yml
@@ -8,7 +8,7 @@
 
 - name: enable red hat storage monitor repository for debian systems
   apt_repository:
-    repo: "deb {{ ceph_rhcs_cdn_debian_repo }}{{ ceph_rhcs_cdn_debian_repo_version }}/{{ item.repo }} {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
+    repo: "deb {{ ceph_rhcs_cdn_debian_repo }}{{ ceph_rhcs_cdn_debian_repo_version }}/{{ item.repo }} {{ ceph_stable_distro_source | default(ansible_distribution_release) }} main"
     state: present
     update_cache: yes
   with_items:

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install_debian.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_iso_install_debian.yml
@@ -51,7 +51,7 @@
 
 - name: add red hat storage repository for debian systems
   apt_repository:
-    repo: "deb file://{{ ceph_rhcs_repository_path }}/{{ item }} {{ ansible_lsb.codename }} main"
+    repo: "deb file://{{ ceph_rhcs_repository_path }}/{{ item }} {{ ansible_distribution_release }} main"
     state: present
     update_cache: yes
   with_items:

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -155,7 +155,7 @@ nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_s
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/
 # for more info read: https://github.com/ceph/ceph-ansible/issues/305
-#ceph_stable_distro_source: "{{ ansible_lsb.codename }}"
+#ceph_stable_distro_source: "{{ ansible_distribution_release }}"
 
 # This option is needed for _both_ stable and dev version, so please always fill the right version
 # # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
@@ -191,7 +191,7 @@ ceph_rhcs_cdn_debian_repo_version: "/3-release/" # for GA, later for updates use
 #
 ceph_stable_repo_uca: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
 ceph_stable_openstack_release_uca: queens
-ceph_stable_release_uca: "{{ ansible_lsb.codename }}-updates/{{ ceph_stable_openstack_release_uca }}"
+ceph_stable_release_uca: "{{ ansible_distribution_release }}-updates/{{ ceph_stable_openstack_release_uca }}"
 
 # REPOSITORY: openSUSE OBS
 #

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_debian.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_debian.yml
@@ -9,7 +9,7 @@
       block:
         - name: add nfs-ganesha stable repository
           apt_repository:
-            repo: "deb {{ nfs_ganesha_stable_deb_repo }} {{ ceph_stable_distro_source | default(ansible_lsb.codename) }} main"
+            repo: "deb {{ nfs_ganesha_stable_deb_repo }} {{ ceph_stable_distro_source | default(ansible_distribution_release) }} main"
             state: present
             update_cache: no
           register: add_ganesha_apt_repo


### PR DESCRIPTION
The ansible_lsb fact is based on the lsb package (lsb-base,
lsb-release or redhat-lsb-core).
If the package isn't installed on the remote host then the fact isn't
populated.

```
"ansible_lsb": {},
```

Switching to the ansible_distribution_release fact instead.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>