### PR TITLE
tests: add nfs-ganesha testing

### DIFF
--- a/tests/functional/all_daemons/container/hosts
+++ b/tests/functional/all_daemons/container/hosts
@@ -16,8 +16,8 @@ mds0
 [rgws]
 rgw0
 
-#[nfss]
-#nfs0
+[nfss]
+nfs0
 
 [clients]
 client0

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -20,8 +20,8 @@ rgw0
 client0
 client1
 
-#[nfss]
-#nfs0
+[nfss]
+nfs0
 
 [rbdmirrors]
 rbd-mirror0
@@ -32,5 +32,5 @@ iscsi-gw0 ceph_repository="dev"
 [all:vars]
 nfs_ganesha_stable=True
 nfs_ganesha_dev=False
-nfs_ganesha_stable_branch="V2.5-stable"
+nfs_ganesha_stable_branch="V2.7-stable"
 nfs_ganesha_flavor="ceph_master"


### PR DESCRIPTION
This was removed because of broken repositories which made the CI
failing. That doesn't make sense anymore so adding back it

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>