### PR TITLE
add-osd: fix error in validate execution role

### DIFF
--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -44,8 +44,8 @@
 
   roles:
     - ceph-defaults
-    - ceph-validate
     - ceph-facts
+    - ceph-validate
 
 - hosts: osds
   gather_facts: False


### PR DESCRIPTION
ceph-facts should be run before we play ceph-validate since it has
reference to facts that are set in ceph-facts role.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>