### PR TITLE
validate.py: Fix alphabetical order on uca

### DIFF
--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -259,9 +259,9 @@ ceph_repository_dev = (
 ceph_repository_custom = ("ceph_custom_repo", types.string)
 
 ceph_repository_uca = (
-    ("ceph_stable_repo_uca", types.string),
     ("ceph_stable_openstack_release_uca", types.string),
     ("ceph_stable_release_uca", types.string),
+    ("ceph_stable_repo_uca", types.string),
 )
 
 monitor_options = (


### PR DESCRIPTION
Alphabetized ceph_repository_uca keys due to errors validating when
using UCA/queens repository on Ubuntu 16.04

An exception occurred during task execution. To see the full
traceback, use -vvv. The error was:
SchemaError: -> ceph_stable_repo_uca  schema item is not
alphabetically ordered

Closes: #4154

Signed-off-by: Gabriel Ramirez <gabrielramirez1109@gmail.com>