### PR TITLE
ceph-osd: Add CONTAINER_IMAGE env variable

### DIFF
--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -51,6 +51,7 @@ numactl \
   {% endif -%}
   -v /run/lvm/:/run/lvm/ \
   -e CEPH_DAEMON=OSD_CEPH_VOLUME_ACTIVATE \
+  -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   -e OSD_ID="$1" \
   --name=ceph-osd-"$1" \
   {{ ceph_osd_docker_extra_env }} \


### PR DESCRIPTION
This environment variable was added in cb381b4 but was removed in
4d35e9e.
This commit reintroduces the change.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>