### PR TITLE
Add condition on dashboard installer phase

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -527,6 +527,7 @@
           installer_phase_ceph_grafana:
             status: "In Progress"
             start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+      when: dashboard_enabled | bool
 
   tasks:
     - block:
@@ -561,6 +562,7 @@
           installer_phase_ceph_grafana:
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+      when: dashboard_enabled | bool
 
 - hosts: '{{ groups["mgrs"][0] | default(groups["mons"][0]) | default(omit) }}'
   become: true
@@ -572,6 +574,7 @@
           installer_phase_ceph_dashboard:
             status: "In Progress"
             start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+      when: dashboard_enabled | bool
 
   tasks:
     - block:
@@ -590,3 +593,4 @@
           installer_phase_ceph_dashboard:
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+      when: dashboard_enabled | bool

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -491,6 +491,7 @@
           installer_phase_ceph_node_exporter:
             status: "In Progress"
             start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+      when: dashboard_enabled | bool
 
   tasks:
     - block:
@@ -514,6 +515,7 @@
           installer_phase_ceph_node_exporter:
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+      when: dashboard_enabled | bool
 
 - hosts: '{{ groups["grafana-server"][0] | default(groups["mgrs"][0]) | default(groups["mons"][0]) | default(omit) }}'
   become: true
@@ -525,6 +527,7 @@
           installer_phase_ceph_grafana:
             status: "In Progress"
             start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+      when: dashboard_enabled | bool
 
   tasks:
     - block:
@@ -555,6 +558,7 @@
           installer_phase_ceph_grafana:
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+      when: dashboard_enabled | bool
 
 - hosts: '{{ groups["mgrs"][0] | default(groups["mons"][0]) | default(omit) }}'
   become: true
@@ -566,6 +570,7 @@
           installer_phase_ceph_dashboard:
             status: "In Progress"
             start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+      when: dashboard_enabled | bool
 
   tasks:
     - block:
@@ -584,3 +589,4 @@
           installer_phase_ceph_dashboard:
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+      when: dashboard_enabled | bool


### PR DESCRIPTION
Even if dashboard feature is disabled then the installer status will
still report dashboard, grafana and node-exporter roles timing.
```console
INSTALLER STATUS **********************************
Install Ceph Monitor           : Complete (0:01:21)
Install Ceph Manager           : Complete (0:00:49)
Install Ceph Dashboard         : Complete (0:00:00)
Install Ceph Grafana           : Complete (0:00:02)
```
When need to set the dashboard_enabled condition on those installer
phase pre/post tasks.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>