### PR TITLE
tests: wait 30sec before running testinfra

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -432,6 +432,7 @@ commands=
   all_daemons: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/reboot.yml
 
   # wait 30sec for services to be ready
+  sleep 30
   # retest to ensure cluster came back up correctly after rebooting
   all_daemons: py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 


### PR DESCRIPTION
adding back a sleep 30s after nodes have rebooted before running
testinfra.
This was removed accidentally by d5be83e

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>