### PR TITLE
add tag on ceph-grafana-dashboards package.

### DIFF
--- a/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -8,6 +8,7 @@
   when:
     - not containerized_deployment
     - ansible_os_family in ['RedHat', 'Suse']
+  tags: package-install
 
 - name: make sure grafana is down
   service:


### PR DESCRIPTION
According to the OSP pattern, we need the package-install tag
to control what is installed on the host. This commit just add
the missing tag to meet the TripleO requirements.

See: /issues/4197 for details

Fixes: #4197

Signed-off-by: fmount <fpantano@redhat.com>