### PR TITLE
ceph-handler: Fix radosgw_address default value

### DIFF
--- a/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
@@ -28,7 +28,7 @@ RGW_IP={{ hostvars[inventory_hostname]['radosgw_address'] }} \
     {% elif ip_version == 'ipv6' %}
 RGW_IP=[{{ hostvars[inventory_hostname]['radosgw_address'] }}] \
     {% endif %}
-{% elif radosgw_address is defined and radosgw_address != 'address' -%}
+{% elif radosgw_address is defined and radosgw_address != '0.0.0.0' -%}
     {% if ip_version == 'ipv4' %}
 RGW_IP={{ radosgw_address }} \
     {% elif ip_version == 'ipv6' %}


### PR DESCRIPTION
The rgw restart script set the RGW_IP variable depending on ansible
variables:
  - radosgw_address
  - radosgw_address_block
  - radosgw_interface

Those variables have default values defined in ceph-defaults role:

radosgw_interface: interface
radosgw_address: 0.0.0.0
radosgw_address_block: subnet

But in the rgw restart script we always use the radosgw_address value
instead of the radosgw_interface when defined because we aren't testing
the right default value.
As a consequence, the RGW_IP variable will be set to 0.0.0.0 even if
the ip address associated to the radosgw_interface variable is set
correctly. This causes the check_rest function to fail.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>