### PR TITLE
ceph-iscsi-gw: Update log directories bind mount

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/container/containerized.yml
+++ b/roles/ceph-iscsi-gw/tasks/container/containerized.yml
@@ -1,4 +1,12 @@
 ---
+- name: create rbd target log directories
+  file:
+    path: '/var/log/{{ item }}'
+    state: directory
+  with_items:
+    - rbd-target-api
+    - rbd-target-gw
+
 - name: generate systemd unit files for tcmu-runner, rbd-target-api and rbd-target-gw
   template:
     src: "{{ role_path }}/templates/{{ item }}.service.j2"

--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -25,7 +25,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   -v /dev/log:/dev/log \
   -v /lib/modules:/lib/modules \
   -v /etc/ceph:/etc/ceph \
-  -v /var/log/ceph:/var/log/ceph:z \
+  -v /var/log/rbd-target-api:/var/log/rbd-target-api:z \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=RBD_TARGET_API \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -25,7 +25,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   -v /dev/log:/dev/log \
   -v /lib/modules:/lib/modules \
   -v /etc/ceph:/etc/ceph \
-  -v /var/log/ceph:/var/log/ceph:z \
+  -v /var/log/rbd-target-gw:/var/log/rbd-target-gw:z \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=RBD_TARGET_GW \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \


### PR DESCRIPTION
On containerized deployment we need to bind mount the ceph-iscsi
directory to avoid writing the logs in the container.
The /var/log/ceph directory isn't use by rbd-targe-api/gw services
because they have their own log directories.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>