### PR TITLE
ceph-dashboard: remove bool filter for rgw vars

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -135,25 +135,25 @@
   command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-host {{ dashboard_rgw_api_host }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  when: dashboard_rgw_api_host | bool
+  when: dashboard_rgw_api_host != ''
 
 - name: set the rgw port
   command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-port {{ dashboard_rgw_api_port }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  when: dashboard_rgw_api_port | bool
+  when: dashboard_rgw_api_port != ''
 
 - name: set the rgw scheme
   command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-scheme {{ dashboard_rgw_api_scheme }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  when: dashboard_rgw_api_scheme | bool
+  when: dashboard_rgw_api_scheme != ''
 
 - name: set the rgw admin resource
   command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-admin-resource {{ dashboard_rgw_api_admin_resource }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  when: dashboard_rgw_api_admin_resource | bool
+  when: dashboard_rgw_api_admin_resource != ''
 
 - name: disable ssl verification for rgw
   command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-ssl-verify False"


### PR DESCRIPTION
Some dashboard_rgw_api_* variables are using the bool filter but those
variables are strings with an empty string as default value.
So we should test the variable against an empty string instead of a
bool.
```yaml
dashboard_rgw_api_host: ''
dashboard_rgw_api_port: ''
dashboard_rgw_api_scheme: ''
dashboard_rgw_api_admin_resource: ''
```
Resolves: #4179

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>