### PR TITLE
mon: create crush rule from osd class

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -43,14 +43,16 @@ dummy:
 
 #crush_rule_hdd:
 #  name: HDD
-#  root: HDD
+#  root: default
 #  type: host
+#  class: hdd
 #  default: false
 
 #crush_rule_ssd:
 #  name: SSD
-#  root: SSD
+#  root: default
 #  type: host
+#  class: ssd
 #  default: false
 
 #crush_rules:

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -35,14 +35,16 @@ crush_rule_config: false
 
 crush_rule_hdd:
   name: HDD
-  root: HDD
+  root: default
   type: host
+  class: hdd
   default: false
 
 crush_rule_ssd:
   name: SSD
-  root: SSD
+  root: default
   type: host
+  class: ssd
   default: false
 
 crush_rules:

--- a/roles/ceph-mon/tasks/crush_rules.yml
+++ b/roles/ceph-mon/tasks/crush_rules.yml
@@ -12,7 +12,7 @@
     - hostvars[item]['osd_crush_location'] is defined
 
 - name: create configured crush rules
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-simple {{ item.name }} {{ item.root }} {{ item.type }}"
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-replicated {{ item.name }} {{ item.root }} {{ item.type }} {{ item.class | default('') }}"
   with_items: "{{ crush_rules | unique }}"
   changed_when: false
   when: inventory_hostname == groups.get(mon_group_name) | last


### PR DESCRIPTION
osd class can distinguwish ssd from hdd now so that we can leverage the features. 

Resolves: #4400
Signed-off-by: Ning Yao <yaoning@unitedstack.com>