### PR TITLE
shrink-osd: (ceph-disk only) ease ceph-volume migration

### DIFF
--- a/infrastructure-playbooks/shrink-osd-ceph-disk.yml
+++ b/infrastructure-playbooks/shrink-osd-ceph-disk.yml
@@ -106,16 +106,14 @@
     # NOTE(leseb): using '>' is the only way I could have the command working
     - name: find osd device based on the id
       shell: >
-        docker run --privileged=true -v /dev:/dev --entrypoint /usr/sbin/ceph-disk
-        {{ ceph_docker_registry}}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+        {{ 'docker run --privileged=true -v /dev:/dev --entrypoint' if containerized_deployment else '' }} /usr/sbin/ceph-disk
+        {{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else '' }}
         list | awk  -v pattern=osd.{{ item.0 }} '$0 ~ pattern {print $1}'
       with_together:
         - "{{ osd_to_kill.split(',') }}"
         - "{{ osd_hosts }}"
       register: osd_to_kill_disks
       delegate_to: "{{ item.1 }}"
-      when:
-        - containerized_deployment
 
     - name: find osd dedicated devices - container
       shell: >
@@ -161,8 +159,6 @@
       with_together:
         - "{{ osd_to_kill_disks.results }}"
         - "{{ osd_hosts }}"
-      when:
-        - containerized_deployment
 
     - name: zap ceph osd disks
       shell: |
@@ -172,7 +168,8 @@
         -v /dev/:/dev/ \
         -e OSD_DEVICE=/dev/{{ item.0.stdout }} \
         {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
-        zap_device
+        zap_device;
+        parted -s /dev/{{ item.0.stdout }} mklabel msdos
       delegate_to: "{{ item.1 }}"
       with_together:
         - "{{ resolved_parent_device.results }}"
@@ -225,6 +222,13 @@
       delegate_to: "{{ item.1 }}"
       when:
         - not containerized_deployment
+
+    - name: remove gpt header on device
+      command: parted -s /dev/"{{ item.0.stdout }}" mklabel msdos
+      delegate_to: "{{ item.1 }}"
+      with_together:
+        - "{{ resolved_parent_device.results }}"
+        - "{{ osd_hosts }}"
 
     - name: remove osd(s) from crush_map when ceph-disk destroy fail
       command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} osd crush remove osd.{{ item }}"

--- a/infrastructure-playbooks/shrink-osd-ceph-disk.yml
+++ b/infrastructure-playbooks/shrink-osd-ceph-disk.yml
@@ -177,6 +177,15 @@
       when:
         - containerized_deployment
 
+    - name: remove prepare container
+      command: docker rm ceph-osd-prepare-"{{ hostvars[item.1]['ansible_hostname'] }}"-"{{ item.0.stdout }}"
+      delegate_to: "{{ item.1 }}"
+      with_together:
+        - "{{ resolved_parent_device.results }}"
+        - "{{ osd_hosts }}"
+      when:
+        - containerized_deployment
+
     - name: zap ceph osd partitions from dedicated devices
       shell: |
         for osd in {{ ' '.join(item.1.stdout_lines) }}


### PR DESCRIPTION
- shrink-osd should remove the prepare container to avoid a leftover preventing from redeploying an OSD after it has been removed.
- remove the gpt header on devices so if osds are redeployed with ceph-volume it will no complain because of this.

NOTE: this hasn't been backported from master because ceph-disk doesn't exist anymore as of stable-4.0

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1613735