### PR TITLE
osd: remove add-osd.yml infra playbook

### DIFF
--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -121,3 +121,10 @@
       delegate_to: "{{ groups['mons'][0] }}"
       run_once: True
       changed_when: False
+
+    - name: warn user about deprecation
+      debug:
+        msg: |
+          Playbook has complete.
+          However, note that it will be deprecated in a future release.
+          You can achieve the same goal using the main playbook with --limit

--- a/roles/ceph-handler/tasks/handler_osds.yml
+++ b/roles/ceph-handler/tasks/handler_osds.yml
@@ -3,6 +3,11 @@
   set_fact:
     _osd_handler_called: True
 
+- name: unset noup flag
+  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd unset noup"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  changed_when: False
+
 # This does not just restart OSDs but everything else too. Unfortunately
 # at this time the ansible role does not have an OSD id list to use
 # for restarting them specifically.

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -54,6 +54,14 @@
 - name: include_tasks start_osds.yml
   include_tasks: start_osds.yml
 
+- name: unset noup flag
+  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd unset noup"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  changed_when: False
+  when:
+    - not rolling_update | default(False) | bool
+    - inventory_hostname == ansible_play_hosts_all | last
+
 - name: wait for all osd to be up
   command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json"
   register: wait_for_all_osds_up
@@ -61,10 +69,11 @@
   delay: "{{ delay_wait_osd_up }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  run_once: true
   until:
     - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] | int > 0
     - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_up_osds"]
+  when:
+    - inventory_hostname == ansible_play_hosts_all | last
 
 - name: include crush_rules.yml
   include_tasks: crush_rules.yml
@@ -87,18 +96,11 @@
     - not add_osd | bool
     - openstack_keys_tmp is defined
 
-- name: unset noup flag
-  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd unset noup"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  changed_when: False
-  when:
-    - not rolling_update | default(False) | bool
-    - inventory_hostname == ansible_play_hosts_all | last
-
 # Create the pools listed in openstack_pools
 - name: include openstack_config.yml
   include_tasks: openstack_config.yml
   when:
     - not add_osd | bool
+    - not rolling_update | default(False) | bool
     - openstack_config | bool
     - inventory_hostname == groups[osd_group_name] | last

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: set_fact add_osd
+  set_fact:
+    add_osd: "{{ groups[osd_group_name] | length != ansible_play_hosts_all | length }}"
+
 - name: include_tasks system_tuning.yml
   include_tasks: system_tuning.yml
 
@@ -24,6 +28,13 @@
 
 - name: include_tasks common.yml
   include_tasks: common.yml
+
+- name: set noup flag
+  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd set noup"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: True
+  changed_when: False
+  when: not rolling_update | default(False) | bool
 
 - name: include container_options_facts.yml
   include_tasks: container_options_facts.yml
@@ -64,7 +75,7 @@
     openstack_keys_tmp: "{{ openstack_keys_tmp|default([]) + [ { 'key': item.key, 'name': item.name, 'caps': { 'mon': item.mon_cap, 'osd': item.osd_cap|default(''), 'mds': item.mds_cap|default(''), 'mgr': item.mgr_cap|default('') } , 'mode': item.mode } ] }}"
   with_items: "{{ openstack_keys }}"
   when:
-    - not add_osd|default(False) | bool
+    - not add_osd | bool
     - openstack_config | bool
     - item.get('mon_cap', None)
     # it's enough to assume we are running an old-fashionned syntax simply by checking the presence of mon_cap since every key needs this cap
@@ -73,13 +84,21 @@
   set_fact:
     openstack_keys: "{{ openstack_keys_tmp }}"
   when:
-    - not add_osd|default(False) | bool
+    - not add_osd | bool
     - openstack_keys_tmp is defined
+
+- name: unset noup flag
+  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd unset noup"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  changed_when: False
+  when:
+    - not rolling_update | default(False) | bool
+    - inventory_hostname == ansible_play_hosts_all | last
 
 # Create the pools listed in openstack_pools
 - name: include openstack_config.yml
   include_tasks: openstack_config.yml
   when:
-    - not add_osd|default(False) | bool
+    - not add_osd | bool
     - openstack_config | bool
     - inventory_hostname == groups[osd_group_name] | last

--- a/tox.ini
+++ b/tox.ini
@@ -261,7 +261,7 @@ commands=
 commands=
   ansible-playbook -vv -i {changedir}/hosts-2 --limit osd1 {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i {changedir}/hosts-2 --limit osd1 {toxinidir}/tests/functional/lvm_setup.yml
-  ansible-playbook -vv -i {changedir}/hosts-2 --limit osd1 {toxinidir}/infrastructure-playbooks/add-osd.yml --extra-vars "\
+  ansible-playbook -vv -i {changedir}/hosts-2 --limit osd1 {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_stable_release={env:CEPH_STABLE_RELEASE:nautilus} \


### PR DESCRIPTION
This commit removes the add-osd.yml infrastructure playbook, same
operation can be achieved by running main playbook with --limit option.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>