### PR TITLE
dashboard: Use upstream default port

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -704,7 +704,7 @@ dummy:
 # Choose http or https
 # For https, you should set dashboard.crt/key and grafana.crt/key
 #dashboard_protocol: http
-#dashboard_port: 8234
+#dashboard_port: 8443
 #dashboard_admin_user: admin
 #dashboard_admin_password: admin
 # We only need this for SSL (https) connections

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -704,7 +704,7 @@ ceph_docker_registry: "registry.access.redhat.com"
 # Choose http or https
 # For https, you should set dashboard.crt/key and grafana.crt/key
 #dashboard_protocol: http
-#dashboard_port: 8234
+#dashboard_port: 8443
 #dashboard_admin_user: admin
 #dashboard_admin_password: admin
 # We only need this for SSL (https) connections

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -696,7 +696,7 @@ dashboard_enabled: False
 # Choose http or https
 # For https, you should set dashboard.crt/key and grafana.crt/key
 dashboard_protocol: http
-dashboard_port: 8234
+dashboard_port: 8443
 dashboard_admin_user: admin
 dashboard_admin_password: admin
 # We only need this for SSL (https) connections


### PR DESCRIPTION
We are currently using incorrect dashboard default port. The upstream
uses 8443 instead of 8234 by default. This should get us closer to the
upstream project.

Signed-off-by: Boris Ranto <branto@redhat.com>