### PR TITLE
tests: fix purge scenarios names

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -180,8 +180,8 @@ changedir=
   cluster: {toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
   filestore_osds: {toxinidir}/tests/functional/fs-osds{env:CONTAINER_DIR:}
   bluestore_osds: {toxinidir}/tests/functional/bs-osds{env:CONTAINER_DIR:}
-  purge_filestore_osds: {toxinidir}/tests/functional/fs-osds{env:CONTAINER_DIR:}
-  purge_bluestore_osds: {toxinidir}/tests/functional/bs-osds{env:CONTAINER_DIR:}
+  purge_filestore: {toxinidir}/tests/functional/fs-osds{env:CONTAINER_DIR:}
+  purge_bluestore: {toxinidir}/tests/functional/bs-osds{env:CONTAINER_DIR:}
   shrink_mon: {toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
   shrink_osd: {toxinidir}/tests/functional/shrink_osd{env:CONTAINER_DIR:}
   collocation: {toxinidir}/tests/functional/collocation{env:CONTAINER_DIR:}


### PR DESCRIPTION
This commit fixes the purge_* scenario names in stable-3.1

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>