### PR TITLE
ceph-infra: update handler with daemon variable

### DIFF
--- a/roles/ceph-infra/handlers/main.yml
+++ b/roles/ceph-infra/handlers/main.yml
@@ -2,14 +2,14 @@
 - name: disable ntpd
   failed_when: false
   service:
-    name: ntpd
+    name: '{{ ntp_service_name }}'
     state: stopped
     enabled: no
 
 - name: disable chronyd
   failed_when: false
   service:
-    name: chronyd
+    name: '{{ chrony_daemon_name }}'
     enabled: no
     state: stopped
 


### PR DESCRIPTION
Both ntp and chrony daemon use variable for the service name because it
could be different depending on the GNU/Linux distribution.
This has been update in 9d88d3199 for chrony but only for the start part
not for the handler.
The commit fixes this for both ntp and chrony.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>