### PR TITLE
ceph-infra: Open prometheus port

### DIFF
--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -194,9 +194,9 @@
           immediate: true
           state: enabled
 
-      - name: open dashboard port
+      - name: open prometheus port
         firewalld:
-          port: "{{ dashboard_port }}/tcp"
+          port: "9090/tcp"
           zone: "{{ ceph_dashboard_firewall_zone }}"
           permanent: true
           immediate: true


### PR DESCRIPTION
The Prometheus porrt 9090 isn't open in the firewall configuration.
Also the dashboard task on the grafana node was not required because
it's already present on the mgr node.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>