### PR TITLE
tests/dashboard: use the dedicated grafana node

### DIFF
--- a/tests/functional/dashboard/container/hosts
+++ b/tests/functional/dashboard/container/hosts
@@ -9,4 +9,4 @@ osd0
 osd1
 
 [grafana-server]
-mon0
+grafana0

--- a/tests/functional/dashboard/container/hosts-ubuntu
+++ b/tests/functional/dashboard/container/hosts-ubuntu
@@ -9,7 +9,7 @@ osd0
 osd1
 
 [grafana-server]
-mon0
+grafana0
 
 [all:vars]
 debian_ceph_packages=['ceph', 'ceph-common', 'ceph-fuse']

--- a/tests/functional/dashboard/hosts
+++ b/tests/functional/dashboard/hosts
@@ -9,4 +9,4 @@ osd0
 osd1
 
 [grafana-server]
-mon0
+grafana0

--- a/tests/functional/dashboard/hosts-ubuntu
+++ b/tests/functional/dashboard/hosts-ubuntu
@@ -9,7 +9,7 @@ osd0
 osd1
 
 [grafana-server]
-mon0
+grafana0
 
 [all:vars]
 debian_ceph_packages=['ceph', 'ceph-common', 'ceph-fuse']


### PR DESCRIPTION
The Vagrant dashboard scenario creates a dedicated grafana node but
was not use in the ansible inventory.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>