### PR TITLE
validate: fail if gpt header found on unprepared devices

### DIFF
--- a/roles/ceph-validate/tasks/check_devices.yml
+++ b/roles/ceph-validate/tasks/check_devices.yml
@@ -2,6 +2,21 @@
 - name: devices validation
   when: devices is defined
   block:
+    - name: read information about the devices
+      parted:
+        device: "{{ item }}"
+        unit: MiB
+      register: parted_results
+      with_items: "{{ devices }}"
+
+    - name: fail when gpt header found on osd devices
+      fail:
+        msg: "{{ item.disk.dev }} has gpt header, please remove it."
+      with_items: "{{ parted_results.results }}"
+      when:
+        - item.disk.table == 'gpt'
+        - item.partitions | length == 0
+
     - name: get devices information
       parted:
         device: "{{ item }}"


### PR DESCRIPTION
ceph-volume will complain if gpt headers are found on devices.
This commit checks whether a gpt header is present on devices passed in
`devices` variable and fail early.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1730541

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>