### PR TITLE
handler: fix bug in osd handlers

### DIFF
--- a/roles/ceph-handler/templates/restart_osd_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_osd_daemon.sh.j2
@@ -45,7 +45,7 @@ get_container_id_from_dev_name() {
   local count
   count=10
   while [ $count -ne 0 ]; do
-    id=$({{ container_binary }} ps -q -f "name=${1}$")
+    id=$({{ container_binary }} ps | grep -E "${1}$" | cut -d' ' -f1)
     test "$id" != "" && break
     sleep $DELAY
     let count=count-1


### PR DESCRIPTION
fbf4ed42aee8fa5fd18c4c289cbb80ffeda8f72e introduced a bug when
container binary is podman.
podman doesn't support ps -f using regular expression, the container id
is never set in the restart script causing the handler to fail.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1721536

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>