### PR TITLE
Fix handler logic if radosgw user https.

### DIFF
--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -414,6 +414,7 @@ radosgw_thread_pool_size: 512
 radosgw_interface: interface
 radosgw_address: 0.0.0.0
 radosgw_address_block: subnet
+# radosgw_fqdn: host fqdn # active this if you use https
 radosgw_keystone_ssl: false # activate this when using keystone PKI keys
 radosgw_num_instances: 1
 # Rados Gateway options

--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -22,6 +22,12 @@
     - radosgw_address is defined
     - radosgw_address != '0.0.0.0'
 
+- name: set_fact _radosgw_fqdn to radosgw_fqdn
+  set_fact:
+    _radosgw_fqdn: "{{ radosgw_fqdn }}"
+  when:
+    - radosgw_fqdn is defined
+
 - name: tasks for radosgw interface
   when:
     - radosgw_address_block == 'subnet'

--- a/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
@@ -8,8 +8,10 @@ RGW_BASE_PORT={{ radosgw_frontend_port }}
 RGW_FRONTEND_SSL_CERT={{ radosgw_frontend_ssl_certificate }}
 if [ -n "$RGW_FRONTEND_SSL_CERT" ]; then
     RGW_PROTOCOL=https
+    RGW_IP={{ hostvars[inventory_hostname]['_radosgw_fqdn'] }}
 else
     RGW_PROTOCOL=http
+    RGW_IP={{ hostvars[inventory_hostname]['_radosgw_address'] }}
 fi
 declare -a DOCKER_EXECS
 for ((i=0; i<${RGW_NUMS}; i++)); do
@@ -20,7 +22,6 @@ for ((i=0; i<${RGW_NUMS}; i++)); do
 {% endif %}
 done
 declare -a SOCKETS
-RGW_IP={{ hostvars[inventory_hostname]['_radosgw_address'] }}
 SOCKET_PREFIX="/var/run/ceph/{{ cluster }}-client.rgw.${HOST_NAME}.rgw"
 
 check_socket() {


### PR DESCRIPTION
If use https you catch error with restart daemon handler: 

curl https://10.3.3.104
curl: (51) Unable to communicate securely with peer: requested domain name does not match the server's certificate.

Signed-off-by: Mluchkin <6980570@gmail.com>