### PR TITLE
Fix backward compat with old cephfs_pools format

### DIFF
--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -26,7 +26,7 @@
             {{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
             osd pool create {{ item.name }}
             {{ item.pg_num | default(osd_pool_default_pg_num) }}
-            {{ item.pgp_num | default(item.pg_num) }}
+            {{ item.pgp_num | default(item.pg_num) | default(osd_pool_default_pg_num) }}
             {{ 'replicated_rule' if not item.rule_name | default('replicated_rule') else item.rule_name | default('replicated_rule') }}
             {{ 1 if item.type|default(1) == 'replicated' else 3 if item.type|default(1) == 'erasure' else item.type|default(1) }}
             {%- if (item.type | default("1") == '3' or item.type | default("1") == 'erasure') and item.erasure_profile != '' %}


### PR DESCRIPTION
Previously cephfs_pools items used to have a pgs: key but not
pgp_num: nor pg_num: