### PR TITLE
mon: add device_class , create_type rule in crush rules management

### DIFF
--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -33,16 +33,25 @@ client_admin_ceph_authtool_cap:
 ###############
 crush_rule_config: false
 
+
+# Caution: 
+# You can use variable root/type/device_class if u create_type = create-replicated or create-simple
+# You can define device_class hdd/ssd/nvme if in u OSD exist this device type
+# create_type mode : create-replicated / create-simple / create-erasure
 crush_rule_hdd:
   name: HDD
-  root: HDD
-  type: host
+  root: HDD 
+  type: host 
+  device_class: '' 
+  create_type: create-simple 
   default: false
 
 crush_rule_ssd:
   name: SSD
-  root: SSD
-  type: host
+  root: SSD 
+  type: host 
+  device_class: '' 
+  create_type: create-simple 
   default: false
 
 crush_rules:

--- a/roles/ceph-mon/tasks/crush_rules.yml
+++ b/roles/ceph-mon/tasks/crush_rules.yml
@@ -12,7 +12,7 @@
     - hostvars[item]['osd_crush_location'] is defined
 
 - name: create configured crush rules
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-simple {{ item.name }} {{ item.root }} {{ item.type }}"
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule {{ item.create_type }} {{ item.name }} {{ item.root }} {{ item.type }} {{ item.device_class }}"
   with_items: "{{ crush_rules | unique }}"
   changed_when: false
   when: inventory_hostname == groups.get(mon_group_name) | last


### PR DESCRIPTION
and default variables for this

With this commit u can define method for create crush rule and define device_class 

Signed-off-by: Mluchkin <6980570@gmail.com>