### PR TITLE
tests: bump nfs-ganesha version

### DIFF
--- a/tests/functional/all_daemons/group_vars/nfss
+++ b/tests/functional/all_daemons/group_vars/nfss
@@ -8,4 +8,4 @@ ganesha_conf_overrides: |
 nfs_ganesha_stable: true
 nfs_ganesha_dev: false
 nfs_ganesha_flavor: "ceph_master"
-nfs_ganesha_stable_branch: "V2.7-stable"
+nfs_ganesha_stable_branch: "V2.8-stable"


### PR DESCRIPTION
in stable-4.0, nfs-ganesha 2.8 should be used.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>