### PR TITLE
Enable dashboard deployment in all the related hostgroup nodes

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -517,7 +517,7 @@
       run_once: true
       when: not ceph_status.failed
 
-- hosts: '{{ groups["grafana-server"][0] | default(groups["mgrs"][0]) | default(groups["mons"][0]) | default(omit) }}'
+- hosts: "{{ grafana_server_group_name }}"
   become: true
   pre_tasks:
     - name: set ceph grafana install 'In Progress'

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -517,7 +517,7 @@
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
       when: dashboard_enabled | bool
 
-- hosts: '{{ groups["grafana-server"][0] | default(groups["mgrs"][0]) | default(groups["mons"][0]) | default(omit) }}'
+- hosts: "{{ grafana_server_group_name }}"
   become: true
   pre_tasks:
     - name: set ceph grafana install 'In Progress'

--- a/tests/functional/all_daemons/container/vagrant_variables.yml
+++ b/tests/functional/all_daemons/container/vagrant_variables.yml
@@ -9,7 +9,7 @@ osd_vms: 2
 mds_vms: 1
 rgw_vms: 1
 nfs_vms: 1
-grafana_server_vms: 0
+grafana_server_vms: 1
 rbd_mirror_vms: 1
 client_vms: 2
 iscsi_gw_vms: 1

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -9,7 +9,7 @@ osd_vms: 2
 mds_vms: 1
 rgw_vms: 1
 nfs_vms: 1
-grafana_server_vms: 0
+grafana_server_vms: 1
 rbd_mirror_vms: 1
 client_vms: 2
 iscsi_gw_vms: 1


### PR DESCRIPTION
Since we want to cover the HA scenario, from OSP perspective
it's better to have the new dashboard stack (grafana/prometheus
/alertmanager) deployed in all the nodes defined in the
"grafana-server" group.

Signed-off-by: fmount <fpantano@redhat.com>