### PR TITLE
infra-playbooks: rewite a condition for better readability

### DIFF
--- a/infrastructure-playbooks/shrink-mgr.yml
+++ b/infrastructure-playbooks/shrink-mgr.yml
@@ -43,8 +43,7 @@
     - name: exit playbook, if can not connect to the cluster
       command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} health"
       register: ceph_health
-      until: ceph_health.rc
-      failed_when: ceph_health.rc != 0
+      until: ceph_health is succeeded
       delegate_to: "{{ groups[mon_group_name][0] }}"
       retries: 5
       delay: 2

--- a/infrastructure-playbooks/shrink-rbdmirror.yml
+++ b/infrastructure-playbooks/shrink-rbdmirror.yml
@@ -68,8 +68,7 @@
     - name: exit playbook, if can not connect to the cluster
       command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} -s -f json"
       register: ceph_health
-      until: ceph_health.rc
-      failed_when: ceph_health.rc != 0
+      until: ceph_health is succeeded
       delegate_to: "{{ groups[mon_group_name][0] }}"
       retries: 5
       delay: 2


### PR DESCRIPTION
Use facility built-in in Ansible to check whether a command was executed
successfully rather looking at its return value.