### PR TITLE
only fail on openSUSE Leap 42.x, not on openSUSE Leap 15.x (that have a lower version number, but are actually newer)

### DIFF
--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -46,12 +46,12 @@
     - ceph_repository == 'uca'
     - ansible_distribution != 'Ubuntu'
 
-- name: fail on unsupported openSUSE distribution
+- name: fail on unsupported openSUSE distribution (42.x)
   fail:
     msg: "Distribution not supported: {{ ansible_distribution }}"
   when:
     - ansible_distribution == 'openSUSE Leap'
-    - ansible_distribution_version is version_compare('42.3', '<')
+    - ansible_distribution_version is '42.1' or ansible_distribution_version is '42.2'  ansible_distribution_version is '42.3' 
 
 - name: fail on unsupported ansible version (1.X)
   fail:


### PR DESCRIPTION
Current behaviour will fail on openSUSE Leap 15.0 and 15.1, that are way newer than openSUSE Leap 42.x, as unfortunately openSUSE switched from 42.x to 15.x to match SLES15 development.