### PR TITLE
openSUSE: support newer Leap releases

### DIFF
--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -46,12 +46,12 @@
     - ceph_repository == 'uca'
     - ansible_distribution != 'Ubuntu'
 
-- name: fail on unsupported openSUSE distribution
+- name: "fail on unsupported openSUSE distribution (only 15.x supported)"
   fail:
     msg: "Distribution not supported: {{ ansible_distribution }}"
   when:
     - ansible_distribution == 'openSUSE Leap'
-    - ansible_distribution_version is version_compare('42.3', '<')
+    - ansible_distribution_major_version != '15'
 
 - name: fail on unsupported ansible version (1.X)
   fail:


### PR DESCRIPTION
Current behaviour will fail on openSUSE Leap 15.0 and 15.1, that are way newer than openSUSE Leap 42.x, as unfortunately openSUSE switched from 42.x to 15.x to match SLES15 development.

Successfully tested on Leap 15.1 using this `group_vars/all.yml`:
```
---
ceph_origin: distro
ceph_stable_release: nautilus

#
public_network: 0.0.0.0/0
monitor_address_block: 10.11.12.0/24
cluster_network: 10.11.13.0/24

```