### PR TITLE
tests: Update ooo-collocation scenario

### DIFF
--- a/tests/functional/ooo-collocation/hosts
+++ b/tests/functional/ooo-collocation/hosts
@@ -10,7 +10,7 @@ all:
     ceph_mgr_docker_extra_env: '-e MGR_DASHBOARD=0'
     cluster: mycluster
     ceph_docker_image: ceph/daemon
-    ceph_docker_image_tag: v3.0.3-stable-3.0-luminous-centos-7-x86_64
+    ceph_docker_image_tag: v3.2.5-stable-3.2-luminous-centos-7
     ceph_docker_registry: docker.io
     ceph_origin: repository
     ceph_repository: community

--- a/tests/functional/tests/osd/test_osds.py
+++ b/tests/functional/tests/osd/test_osds.py
@@ -7,25 +7,9 @@ class TestOSDs(object):
 
     def _get_osds_id(self, node, host):
         osds = []
-        if node['rolling_update'] and node['docker']:
-            cmd = host.run('sudo docker exec {osd_id} ceph-disk list --format json'.format(osd_id=self._get_docker_exec_cmd(host)))
-            ceph_disk_list = json.loads(cmd.stdout)
-            for device in ceph_disk_list:
-                if 'partitions' in device.keys():
-                    for partition in device['partitions']:
-                        if 'type' in partition.keys() and partition['type'] == 'data':
-                            osds.append(device['path'].split('/')[-1])
-        else:
-            cmd = host.run('sudo ls /var/lib/ceph/osd/ | sed "s/.*-//"')
-            if cmd.rc == 0:
-                osd_ids = cmd.stdout.rstrip("\n").split("\n")
-                osds = osd_ids
-                if node['docker'] and node['fsid'] == "6e008d48-1661-11e8-8546-008c3214218a":
-                    osds = []
-                    for device in node['devices']:
-                        real_dev = host.run("sudo readlink -f %s" % device)
-                        real_dev_split = real_dev.stdout.split("/")[-1]
-                        osds.append(real_dev_split)
+        cmd = host.run('sudo ls /var/lib/ceph/osd/ | sed "s/.*-//"')
+        if cmd.rc == 0:
+            osds = cmd.stdout.rstrip("\n").split("\n")
         return osds
 
     def _get_docker_exec_cmd(self, host):

--- a/tox.ini
+++ b/tox.ini
@@ -205,7 +205,7 @@ setenv=
   rhcs: CEPH_STABLE_RELEASE = luminous
   lvm_osds: CEPH_STABLE_RELEASE = luminous
   rhcs: CEPH_STABLE_RELEASE = luminous
-  ooo_collocation: CEPH_DOCKER_IMAGE_TAG = v3.0.3-stable-3.0-luminous-centos-7-x86_64
+  ooo_collocation: CEPH_DOCKER_IMAGE_TAG = v3.2.5-stable-3.2-luminous-centos-7
 
 deps= -r{toxinidir}/tests/requirements.txt
 changedir=


### PR DESCRIPTION
The ooo-collocation scenario was still using an old container image and
doesn't match the requirement on latest stable-3.2 code. We need to use
at least the container image v3.2.5.
Also updating the OSD tests to reflect the changes introduced by the
commit bedc0ab because we don't have the OSD systemd unit script using
device name anymore.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>