### PR TITLE
dashboard: fix timeout usage on rgw user creation command

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -104,7 +104,7 @@
   when: groups.get(rgw_group_name, []) | length > 0
   block:
     - name: create radosgw system user
-      shell: "timeout 20 {{ container_exec_cmd }} radosgw-admin user create --uid={{ dashboard_rgw_api_user_id }} --display-name='Ceph dashboard' --system"
+      command: "timeout --foreground -s KILL 20 {{ container_exec_cmd }} radosgw-admin user create --uid={{ dashboard_rgw_api_user_id }} --display-name='Ceph dashboard' --system"
       register: rgw_user_output
       until: rgw_user_output.rc == 0
       retries: 3

--- a/tests/functional/podman/hosts
+++ b/tests/functional/podman/hosts
@@ -27,7 +27,9 @@ rbd-mirror0
 iscsi-gw0
 
 [grafana-server]
-mgr0
+mon0
+mon1
+mon2
 
 #[all:vars]
 #ansible_python_interpreter=/usr/bin/python3

--- a/tests/functional/podman/vagrant_variables.yml
+++ b/tests/functional/podman/vagrant_variables.yml
@@ -13,7 +13,7 @@ grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2
 iscsi_gw_vms: 1
-mgr_vms: 1
+mgr_vms: 0
 
 # SUBNETS TO USE FOR THE VMS
 public_subnet: 192.168.30

--- a/tests/functional/podman/vagrant_variables.yml
+++ b/tests/functional/podman/vagrant_variables.yml
@@ -21,7 +21,7 @@ cluster_subnet: 192.168.31
 
 # MEMORY
 # set 1024 for CentOS
-memory: 1024
+memory: 2048
 
 vagrant_box: centos/atomic-host
 # The sync directory changes based on vagrant box


### PR DESCRIPTION
For some reason, this is making the playbook failing like following:
    
 ```
 TASK [ceph-dashboard : create radosgw system user] ************************************************************************************************************************************************************************************************************************************************************************
************************************************************************************************************
    task path: /home/guits/ceph-ansible/roles/ceph-dashboard/tasks/configure_dashboard.yml:106
    Tuesday 30 July 2019  10:04:54 +0200 (0:00:01.910)       0:11:22.319 **********
    FAILED - RETRYING: create radosgw system user (3 retries left).
    FAILED - RETRYING: create radosgw system user (2 retries left).
    FAILED - RETRYING: create radosgw system user (1 retries left).
    fatal: [mgr0 -> mon0]: FAILED! => changed=true
      attempts: 3
      cmd: timeout 20 podman exec ceph-mon-mon0 radosgw-admin user create --uid=ceph-dashboard --display-name='Ceph dashboard' --system
      delta: '0:00:20.021973'
      end: '2019-07-30 08:06:32.656066'
      msg: non-zero return code
      rc: 124
      start: '2019-07-30 08:06:12.634093'
      stderr: 'exec failed: container_linux.go:336: starting container process caused "process_linux.go:82: copying bootstrap data to pipe caused \"write init-p: broken pipe\""'
      stderr_lines: <omitted>
      stdout: ''
      stdout_lines: <omitted>
 ```
    
using `timeout -f -s KILL` fixes this issue.
    
Also, there is no need to use `shell` module here, let's switch to `command`.
    
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>