### PR TITLE
rgw: add beast frontend

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -386,17 +386,18 @@ dummy:
 
 ## Rados Gateway options
 #
-#radosgw_frontend_type: civetweb # For additionnal frontends see: http://docs.ceph.com/docs/mimic/radosgw/frontends/
+#radosgw_frontend_type: civetweb # For additional frontends see: http://docs.ceph.com/docs/mimic/radosgw/frontends/
 
 #radosgw_civetweb_port: 8080
-#radosgw_civetweb_num_threads: 100
+#radosgw_civetweb_num_threads: 512
 #radosgw_civetweb_options: "num_threads={{ radosgw_civetweb_num_threads }}"
 # For additional civetweb configuration options available such as SSL, logging,
 # keepalive, and timeout settings, please see the civetweb docs at
 # https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md
 
 #radosgw_frontend_port: "{{ radosgw_civetweb_port if radosgw_frontend_type == 'civetweb' else '8080' }}"
-#radosgw_frontend_options: "{{ radosgw_civetweb_options if radosgw_frontend_type == 'civetweb' }}"
+#radosgw_frontend_options: "{{ radosgw_civetweb_options if radosgw_frontend_type == 'civetweb' else '' }}"
+#radosgw_thread_pool_size: 512
 
 
 # You must define either radosgw_interface, radosgw_address.

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -386,17 +386,18 @@ ceph_rhcs_version: 3
 
 ## Rados Gateway options
 #
-#radosgw_frontend_type: civetweb # For additionnal frontends see: http://docs.ceph.com/docs/mimic/radosgw/frontends/
+#radosgw_frontend_type: civetweb # For additional frontends see: http://docs.ceph.com/docs/mimic/radosgw/frontends/
 
 #radosgw_civetweb_port: 8080
-#radosgw_civetweb_num_threads: 100
+#radosgw_civetweb_num_threads: 512
 #radosgw_civetweb_options: "num_threads={{ radosgw_civetweb_num_threads }}"
 # For additional civetweb configuration options available such as SSL, logging,
 # keepalive, and timeout settings, please see the civetweb docs at
 # https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md
 
 #radosgw_frontend_port: "{{ radosgw_civetweb_port if radosgw_frontend_type == 'civetweb' else '8080' }}"
-#radosgw_frontend_options: "{{ radosgw_civetweb_options if radosgw_frontend_type == 'civetweb' }}"
+#radosgw_frontend_options: "{{ radosgw_civetweb_options if radosgw_frontend_type == 'civetweb' else '' }}"
+#radosgw_thread_pool_size: 512
 
 
 # You must define either radosgw_interface, radosgw_address.

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -173,6 +173,9 @@ osd memory target = {{ _osd_memory_target | default(osd_memory_target) }}
 host = {{ _rgw_hostname }}
 keyring = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ _rgw_hostname }}/keyring
 log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[host]['ansible_hostname'] }}.log
+{% if 'num_threads' not in radosgw_frontend_options %}
+rgw thread pool size = {{ radosgw_thread_pool_size }}
+{% endif %}
 {% if hostvars[host]['radosgw_address_block'] is defined and hostvars[host]['radosgw_address_block'] != 'subnet' %}
     {% if ip_version == 'ipv4' %}
 rgw frontends = {{ radosgw_frontend_type }} {{ 'port' if radosgw_frontend_type == 'civetweb' else 'endpoint' }}={{ hostvars[host]['ansible_all_' + ip_version + '_addresses'] | ipaddr(radosgw_address_block) | first }}:{{ radosgw_frontend_port }} {{ radosgw_frontend_options }}

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -378,17 +378,18 @@ mds_max_mds: 1
 
 ## Rados Gateway options
 #
-radosgw_frontend_type: civetweb # For additionnal frontends see: http://docs.ceph.com/docs/mimic/radosgw/frontends/
+radosgw_frontend_type: civetweb # For additional frontends see: http://docs.ceph.com/docs/mimic/radosgw/frontends/
 
 radosgw_civetweb_port: 8080
-radosgw_civetweb_num_threads: 100
+radosgw_civetweb_num_threads: 512
 radosgw_civetweb_options: "num_threads={{ radosgw_civetweb_num_threads }}"
 # For additional civetweb configuration options available such as SSL, logging,
 # keepalive, and timeout settings, please see the civetweb docs at
 # https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md
 
 radosgw_frontend_port: "{{ radosgw_civetweb_port if radosgw_frontend_type == 'civetweb' else '8080' }}"
-radosgw_frontend_options: "{{ radosgw_civetweb_options if radosgw_frontend_type == 'civetweb' }}"
+radosgw_frontend_options: "{{ radosgw_civetweb_options if radosgw_frontend_type == 'civetweb' else '' }}"
+radosgw_thread_pool_size: 512
 
 
 # You must define either radosgw_interface, radosgw_address.

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -95,3 +95,10 @@
   include_tasks: check_iscsi.yml
   when:
     - iscsi_gw_group_name in group_names
+
+- name: warn about radosgw_civetweb_num_threads option deprecation
+  debug:
+    msg: "WARNING: radosgw_civetweb_num_threads variable is deprecated. Please use radosgw_thread_pool_size instead"
+  when:
+    - radosgw_frontend_type == 'civetweb'
+    - radosgw_civetweb_num_threads is defined


### PR DESCRIPTION
Allow to configure the rgw beast frontend in addition to civetweb
(default value).
Add rgw_thread_pool_size variable with 512 as default value and keep
backward compatibility with num_threads option when using civetweb.
Update radosgw_civetweb_num_threads to reflect rgw_thread_pool_size
change.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1733406

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit d17b1b48b6d4259f88445a0752e1c13b4522ced0)