### PR TITLE
ceph-grafana: Add grafana addr to wait_for task

### DIFF
--- a/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -17,6 +17,7 @@
 
 - name: wait for grafana to be stopped
   wait_for:
+    host: '{{ grafana_server_addr }}'
     port: '{{ grafana_port }}'
     state: stopped
 
@@ -93,4 +94,5 @@
 
 - name: wait for grafana to start
   wait_for:
+    host: '{{ grafana_server_addr }}'
     port: '{{ grafana_port }}'


### PR DESCRIPTION
The ansible wait_for task is checking the grafana port (3000) against
the 127.0.0.1 host, which is the default value of the module.
Instead we should use the grafana address because the process is
binding on a specific address.

Resolves: #4288

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>