### PR TITLE
dashboard: do not deploy on Debian based OS/non-containerized

### DIFF
--- a/site.yml.sample
+++ b/site.yml.sample
@@ -485,3 +485,4 @@
   when:
     - dashboard_enabled | bool
     - groups.get(grafana_server_group_name, []) | length > 0
+    - ansible_os_family in ['RedHat', 'Suse']


### PR DESCRIPTION
in non-containerized deployment, we can't deploy dashboard on Debian
based distribution since the package `ceph-grafana-dashboards` isn't
available.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>