### PR TITLE
ceph-infra: Apply firewall rules with container

### DIFF
--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -8,7 +8,6 @@
   check_mode: no
   changed_when: false
   tags: firewall
-  when: not containerized_deployment | bool
 
 - when: (firewalld_pkg_query.get('rc', 1) == 0
       or is_atomic | bool)


### PR DESCRIPTION
We don't have a reason to not apply firewall rules on the host when
using a containerized deployment.
The TripleO environments already manage the ceph firewall rules outside
ceph-ansible and set the configure_firewall variable to false.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1733251

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>