### PR TITLE
tests/shrink_rgw: Disable dashboard

### DIFF
--- a/tests/functional/shrink_rgw/container/group_vars/all
+++ b/tests/functional/shrink_rgw/container/group_vars/all
@@ -14,3 +14,4 @@ ceph_conf_overrides:
   global:
     osd_pool_default_size: 1
 openstack_config: False
+dashboard_enabled: False

--- a/tests/functional/shrink_rgw/group_vars/all
+++ b/tests/functional/shrink_rgw/group_vars/all
@@ -11,3 +11,4 @@ copy_admin_key: true
 ceph_conf_overrides:
   global:
     osd_pool_default_size: 1
+dashboard_enabled: False


### PR DESCRIPTION
The shrink_rgw scenario has been merge just after the PR about enable
ceph dashboard by default.
So right now the shrink_rgw scenrio doesn't have nodes in the grafana
group and fails.
We just need to set dashboard_enabled to false.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>