### PR TITLE
various fixes and improvements

### DIFF
--- a/infrastructure-playbooks/shrink-mon.yml
+++ b/infrastructure-playbooks/shrink-mon.yml
@@ -116,7 +116,7 @@
     # 'sleep 5' is not that bad and should be sufficient
     - name: verify the monitor is out of the cluster
       shell: |
-        {{ container_exec_cmd }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["quorum_names"])'
+        {{ container_exec_cmd }} ceph --cluster {{ cluster }} -s -f json | {{ discovered_interpreter_python }} -c 'import sys, json; print(json.load(sys.stdin)["quorum_names"])'
       delegate_to: "{{ mon_host }}"
       failed_when: false
       register: result

--- a/infrastructure-playbooks/shrink-mon.yml
+++ b/infrastructure-playbooks/shrink-mon.yml
@@ -110,17 +110,12 @@
       delegate_to: "{{ mon_host }}"
 
   post_tasks:
-    # NOTE (leseb): sorry for the 'sleep' command
-    # but it will take a couple of seconds for other monitors
-    # to notice that one member has left.
-    # 'sleep 5' is not that bad and should be sufficient
     - name: verify the monitor is out of the cluster
-      shell: |
-        {{ container_exec_cmd }} ceph --cluster {{ cluster }} -s -f json | {{ discovered_interpreter_python }} -c 'import sys, json; print(json.load(sys.stdin)["quorum_names"])'
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} -s -f json"
       delegate_to: "{{ mon_host }}"
       failed_when: false
       register: result
-      until: mon_to_kill_hostname not in result.stdout
+      until: mon_to_kill_hostname not in (result.stdout | from_json)['quorum_names']
       retries: 2
       delay: 10
 

--- a/raw_install_python.yml
+++ b/raw_install_python.yml
@@ -1,27 +1,57 @@
 ---
 - name: check for python
   stat:
-    path: /usr/bin/python
-  ignore_errors: yes
+    path: "{{ item }}"
+  changed_when: false
+  failed_when: false
   register: systempython
+  with_items:
+    - /usr/bin/python
+    - /usr/bin/python3
 
-- name: install python for debian based systems
-  raw: apt-get -y install python-simplejson
-  ignore_errors: yes
-  register: result
-  when: systempython.stat is undefined or not systempython.stat.exists
-  until: result is succeeded
+- block:
+    - name: check for dnf-3 package manager (RedHat/Fedora/CentOS)
+      raw: stat /bin/dnf-3
+      changed_when: false
+      failed_when: false
+      register: stat_dnf3
 
-- name: install python for fedora
-  raw: dnf -y install python3; ln -sf /usr/bin/python3 /usr/bin/python creates=/usr/bin/python
-  ignore_errors: yes
-  register: result
-  when: systempython.stat is undefined or not systempython.stat.exists
-  until: (result is succeeded) and ('Failed' not in result.stdout)
+    - name: check for yum package manager (RedHat/Fedora/CentOS)
+      raw: stat /bin/yum
+      changed_when: false
+      failed_when: false
+      register: stat_yum
 
-- name: install python for opensuse
-  raw: zypper -n install python-base creates=/usr/bin/python2.7
-  ignore_errors: yes
-  register: result
-  when: systempython.stat is undefined or not systempython.stat.exists
-  until: result is succeeded
+    - name: check for apt package manager (Debian/Ubuntu)
+      raw: stat /usr/bin/apt-get
+      changed_when: false
+      failed_when: false
+      register: stat_apt
+
+    - name: check for zypper package manager (OpenSUSE)
+      raw: stat /usr/bin/zypper
+      changed_when: false
+      failed_when: false
+      register: stat_zypper
+
+    - name: install python for RedHat based OS - dnf
+      raw: >
+        {{ 'dnf' if stat_dnf3.rc == 0 else 'yum' }} -y install python3;
+        ln -sf /usr/bin/python3 /usr/bin/python
+        creates=/usr/bin/python
+      register: result
+      until: (result is succeeded) and ('Failed' not in result.stdout)
+      when: stat_dnf3.rc == 0 or stat_yum.rc == 0
+
+    - name: install python for debian based OS
+      raw: apt-get -y install python-simplejson
+      register: result
+      until: result is succeeded
+      when: stat_apt.rc == 0
+
+    - name: install python for opensuse
+      raw: zypper -n install python-base
+      register: result
+      until: result is succeeded
+      when: stat_zypper.rc == 0
+  when: not True in (systempython.results | selectattr('stat', 'defined') | map(attribute='stat.exists') | list | unique)

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -106,7 +106,7 @@
     - not rolling_update | bool
   block:
   - name: generate cluster fsid
-    shell: "{{ discovered_interpreter_python }} -c 'import uuid; print(str(uuid.uuid4()))'"
+    command: "{{ discovered_interpreter_python }} -c 'import uuid; print(str(uuid.uuid4()))'"
     register: cluster_uuid
     delegate_to: "{{ groups[mon_group_name][0] }}"
     run_once: true

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -106,7 +106,7 @@
     - not rolling_update | bool
   block:
   - name: generate cluster fsid
-    shell: python -c 'import uuid; print(str(uuid.uuid4()))'
+    shell: "{{ discovered_interpreter_python }} -c 'import uuid; print(str(uuid.uuid4()))'"
     register: cluster_uuid
     delegate_to: "{{ groups[mon_group_name][0] }}"
     run_once: true

--- a/roles/ceph-handler/templates/restart_mon_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_mon_daemon.sh.j2
@@ -19,7 +19,7 @@ $DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-mon.{{ ansible_hostname }}.asok
 
 check_quorum() {
 while [ $RETRIES -ne 0 ]; do
-  $DOCKER_EXEC ceph --cluster {{ cluster }} -s --format json | python -c 'import sys, json; exit(0) if "{{ monitor_name }}" in json.load(sys.stdin)["quorum_names"] else exit(1)' && exit 0
+  $DOCKER_EXEC ceph --cluster {{ cluster }} -s --format json | "{{ discovered_interpreter_python }}" -c 'import sys, json; exit(0) if "{{ monitor_name }}" in json.load(sys.stdin)["quorum_names"] else exit(1)' && exit 0
   sleep $DELAY
   let RETRIES=RETRIES-1
 done

--- a/roles/ceph-handler/templates/restart_osd_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_osd_daemon.sh.j2
@@ -4,12 +4,12 @@ DELAY="{{ handler_health_osd_check_delay }}"
 CEPH_CLI="--name client.bootstrap-osd --keyring /var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring --cluster {{ cluster }}"
 
 check_pgs() {
-  num_pgs=$($container_exec ceph $CEPH_CLI -s -f json|python -c 'import sys, json; print(json.load(sys.stdin)["pgmap"]["num_pgs"])')
+  num_pgs=$($container_exec ceph $CEPH_CLI -s -f json | "{{ discovered_interpreter_python }}" -c 'import sys, json; print(json.load(sys.stdin)["pgmap"]["num_pgs"])')
   if [[ "$num_pgs" == "0" ]]; then
     return 0
   fi
   while [ $RETRIES -ne 0 ]; do
-    test "$($container_exec ceph $CEPH_CLI -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["pgmap"]["num_pgs"])')" -eq "$($container_exec ceph $CEPH_CLI -s -f json | python -c 'import sys, json; print(sum ( [ i["count"] for i in json.load(sys.stdin)["pgmap"]["pgs_by_state"] if "active+clean" in i["state_name"]]))')"
+    test "$($container_exec ceph $CEPH_CLI -s -f json | "{{ discovered_interpreter_python }}" -c 'import sys, json; print(json.load(sys.stdin)["pgmap"]["num_pgs"])')" -eq "$($container_exec ceph $CEPH_CLI -s -f json | "{{ discovered_interpreter_python }}" -c 'import sys, json; print(sum ( [ i["count"] for i in json.load(sys.stdin)["pgmap"]["pgs_by_state"] if "active+clean" in i["state_name"]]))')"
     RET=$?
     test $RET -eq 0 && return 0
     sleep $DELAY

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -11,7 +11,7 @@
 
 - name: generate monitor initial keyring
   shell: >
-    python -c "import os ; import struct ;
+    {{ discovered_interpreter_python }} -c "import os ; import struct ;
     import time; import base64 ; key = os.urandom(16) ;
     header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ;
     print(base64.b64encode(header + key).decode())"

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -10,7 +10,7 @@
   when: ceph_current_status.fsid is defined
 
 - name: generate monitor initial keyring
-  shell: >
+  command: >
     {{ discovered_interpreter_python }} -c "import os ; import struct ;
     import time; import base64 ; key = os.urandom(16) ;
     header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ;

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -1,15 +1,14 @@
 ---
 - name: wait for all osd to be up
-  shell: >
-    test "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | {{ discovered_interpreter_python }} -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_osds"])')" -gt 0 &&
-    test "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | {{ discovered_interpreter_python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_osds"])')" =
-    "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | {{ discovered_interpreter_python }} -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_up_osds"])')"
+  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json"
   register: wait_for_all_osds_up
   retries: "{{ nb_retry_wait_osd_up }}"
   delay: "{{ delay_wait_osd_up }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  until: wait_for_all_osds_up.rc == 0
+  until:
+    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] | int > 0
+    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_up_osds"]
 
 - name: pool related tasks
   block:

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -1,9 +1,9 @@
 ---
 - name: wait for all osd to be up
   shell: >
-    test "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["osdmap"]["num_osds"])')" -gt 0 &&
-    test "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["osdmap"]["num_osds"])')" =
-    "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["osdmap"]["num_up_osds"])')"
+    test "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_osds"])')" -gt 0 &&
+    test "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_osds"])')" =
+    "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_up_osds"])')"
   register: wait_for_all_osds_up
   retries: "{{ nb_retry_wait_osd_up }}"
   delay: "{{ delay_wait_osd_up }}"

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -1,9 +1,9 @@
 ---
 - name: wait for all osd to be up
   shell: >
-    test "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_osds"])')" -gt 0 &&
-    test "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_osds"])')" =
-    "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_up_osds"])')"
+    test "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | {{ discovered_interpreter_python }} -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_osds"])')" -gt 0 &&
+    test "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | {{ discovered_interpreter_python -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_osds"])')" =
+    "$({{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | {{ discovered_interpreter_python }} -c 'import sys, json; print(json.load(sys.stdin)["osdmap"]["num_up_osds"])')"
   register: wait_for_all_osds_up
   retries: "{{ nb_retry_wait_osd_up }}"
   delay: "{{ delay_wait_osd_up }}"

--- a/tests/functional/tests/mgr/test_mgr.py
+++ b/tests/functional/tests/mgr/test_mgr.py
@@ -36,9 +36,5 @@ class TestMGRs(object):
         )
         output_raw = host.check_output(cmd)
         output_json = json.loads(output_raw)
-        daemons = output_json['mgrmap']['active_name']
-        standbys = [i['name'] for i in output_json['mgrmap']['standbys']]
-        result = hostname in daemons
-        if not result:
-            result = hostname in standbys
-        assert result
+
+        assert output_json['mgrmap']['available']

--- a/tox.ini
+++ b/tox.ini
@@ -411,8 +411,8 @@ setenv=
   dev: UPDATE_CEPH_DEV_SHA1 = latest
   dev: CEPH_STABLE_RELEASE = nautilus
 
-  switch_to_containers: CEPH_STABLE_RELEASE = nautilus
-  switch_to_containers: CEPH_DOCKER_IMAGE_TAG = latest-nautilus
+  switch_to_containers: CEPH_STABLE_RELEASE = octopus
+  switch_to_containers: CEPH_DOCKER_IMAGE_TAG = latest-master
 
   ooo_collocation: CEPH_DOCKER_IMAGE_TAG = v3.0.3-stable-3.0-luminous-centos-7-x86_64
 deps= -r{toxinidir}/tests/requirements.txt
@@ -445,7 +445,7 @@ changedir=
 
 commands=
   rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
-  !switch_to_containers: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
+  ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
 
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}


### PR DESCRIPTION
This PR gathers various fixes and improvements:
- refacts the raw installation of python,
- replaces some `shell` module with `command`
- get rid of complex tests using a combination of bash commands redirected in python in order to parse json data where we can use the `from_json` filter,
- update some functional tests given the json data structure returned by `ceph -s` has changed in octopus.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>