### PR TITLE
ceph-dashboard: Add run_once on delegate tasks

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -704,7 +704,6 @@ dummy:
 # Choose http or https
 # For https, you should set dashboard.crt/key and grafana.crt/key
 #dashboard_protocol: http
-#dashboard_url: "{{ ansible_hostname }}"
 #dashboard_port: 8443
 #dashboard_admin_user: admin
 #dashboard_admin_password: admin

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -704,7 +704,6 @@ ceph_docker_registry: "registry.access.redhat.com"
 # Choose http or https
 # For https, you should set dashboard.crt/key and grafana.crt/key
 #dashboard_protocol: http
-#dashboard_url: "{{ ansible_hostname }}"
 #dashboard_port: 8443
 #dashboard_admin_user: admin
 #dashboard_admin_password: admin

--- a/infrastructure-playbooks/dashboard.yml
+++ b/infrastructure-playbooks/dashboard.yml
@@ -67,7 +67,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: "{{ grafana_server_group_name }}"
+- hosts: "{{ groups[mgr_group_name] | default(groups[mon_group_name]) }}"
   become: true
   pre_tasks:
     - name: set ceph dashboard install 'In Progress'

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -97,13 +97,13 @@
   until: ac_result.rc == 0
 
 - name: set grafana url
-  command: "{{ container_exec_cmd }} ceph dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ dashboard_url }}:{{ grafana_port }}/"
+  command: "{{ container_exec_cmd }} ceph dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ grafana_server_addr }}:{{ grafana_port }}/"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   changed_when: false
 
 - name: set alertmanager host
-  command: "{{ container_exec_cmd }} ceph dashboard set-alertmanager-api-host {{ dashboard_protocol }}://{{ dashboard_url }}:{{ alertmanager_port }}/"
+  command: "{{ container_exec_cmd }} ceph dashboard set-alertmanager-api-host {{ dashboard_protocol }}://{{ grafana_server_addr }}:{{ alertmanager_port }}/"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   changed_when: false

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -7,11 +7,13 @@
 - name: disable SSL for dashboard
   command: "{{ container_exec_cmd }} ceph config set mgr mgr/dashboard/ssl false"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
   when: dashboard_protocol == "http"
 
 - name: enable SSL for dashboard
   command: "{{ container_exec_cmd }} ceph config set mgr mgr/dashboard/ssl true"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
   when: dashboard_protocol == "https"
 
 - name: copy dashboard SSL certificate file
@@ -48,33 +50,36 @@
   command: "{{ container_exec_cmd }} ceph config-key set mgr/dashboard/crt -i /etc/ceph/ceph-dashboard.crt"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
   when: dashboard_protocol == "https"
 
 - name: import dashboard certificate key
   command: "{{ container_exec_cmd }} ceph config-key set mgr/dashboard/key -i /etc/ceph/ceph-dashboard.key"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
   when: dashboard_protocol == "https"
 
 - name: "set the dashboard port ({{ dashboard_port }})"
-  shell: |
-    {{ container_exec_cmd }} ceph config set mgr mgr/dashboard/server_port {{ dashboard_port }} || \
-    {{ container_exec_cmd }} ceph config-key set mgr/dashboard/server_port {{ dashboard_port }}
+  command: "{{ container_exec_cmd }} ceph config set mgr mgr/dashboard/server_port {{ dashboard_port }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
 
 - name: "set the dashboard SSL port ({{ dashboard_port }})"
-  command: "{{ container_exec_cmd }} ceph config set mgr mgr/dashboard/ssl_server_port {{ dashboard_port }}" # Do not use the old fashioned config-key way ssl_server_port, it was not supported when this option was introduced
+  command: "{{ container_exec_cmd }} ceph config set mgr mgr/dashboard/ssl_server_port {{ dashboard_port }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  failed_when: false # Do not fail if the option does not exist, it only exists post-14.2.0
+  run_once: true
 
 - name: disable mgr dashboard module (restart)
   command: "{{ container_exec_cmd }} ceph mgr module disable dashboard"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
   changed_when: false
 
 - name: enable mgr dashboard module (restart)
   command: "{{ container_exec_cmd }} ceph mgr module enable dashboard"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
   changed_when: false
 
 - name: set or update dashboard admin username and password
@@ -88,16 +93,19 @@
   delay: 5
   register: ac_result
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
   until: ac_result.rc == 0
 
 - name: set grafana url
   command: "{{ container_exec_cmd }} ceph dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ dashboard_url }}:{{ grafana_port }}/"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
   changed_when: false
 
 - name: set alertmanager host
   command: "{{ container_exec_cmd }} ceph dashboard set-alertmanager-api-host {{ dashboard_protocol }}://{{ dashboard_url }}:{{ alertmanager_port }}/"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
   changed_when: false
 
 - name: dashboard object gateway management frontend
@@ -109,6 +117,7 @@
       until: rgw_user_output.rc == 0
       retries: 3
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
 
     - name: get the rgw access and secret keys
       set_fact:
@@ -118,54 +127,64 @@
     - name: set the rgw user
       command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-user-id {{ dashboard_rgw_api_user_id }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
       changed_when: false
 
     - name: set the rgw access key
       command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-access-key {{ rgw_access_key }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
       changed_when: false
 
     - name: set the rgw secret key
       command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-secret-key {{ rgw_secret_key }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
       changed_when: false
 
     - name: set the rgw host
       command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-host {{ dashboard_rgw_api_host }}"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
       when: dashboard_rgw_api_host != ''
 
     - name: set the rgw port
       command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-port {{ dashboard_rgw_api_port }}"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
       when: dashboard_rgw_api_port != ''
 
     - name: set the rgw scheme
       command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-scheme {{ dashboard_rgw_api_scheme }}"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
       when: dashboard_rgw_api_scheme != ''
 
     - name: set the rgw admin resource
       command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-admin-resource {{ dashboard_rgw_api_admin_resource }}"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
       when: dashboard_rgw_api_admin_resource != ''
 
     - name: disable ssl verification for rgw
       command: "{{ container_exec_cmd }} ceph dashboard set-rgw-api-ssl-verify False"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
       when: dashboard_rgw_api_no_ssl_verify | bool
 
 - name: disable mgr dashboard module (restart)
   command: "{{ container_exec_cmd }} ceph mgr module disable dashboard"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
 
 - name: enable mgr dashboard module (restart)
   command: "{{ container_exec_cmd }} ceph mgr module enable dashboard"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -696,7 +696,6 @@ dashboard_enabled: True
 # Choose http or https
 # For https, you should set dashboard.crt/key and grafana.crt/key
 dashboard_protocol: http
-dashboard_url: "{{ ansible_hostname }}"
 dashboard_port: 8443
 dashboard_admin_user: admin
 dashboard_admin_password: admin


### PR DESCRIPTION
Because we need to execute commands from a monitor node (the first one 
in the mons list) we are using delegate_to option.
If there's multiple nodes running the ceph-dashboard role then the 
delegated task will be executed multiple times.
Also remove a mgr config-key option not present for nautilus+ releases.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>