### PR TITLE
Revert "tests: disable nfs-ganesha deployment"

### DIFF
--- a/tests/functional/all_daemons/container/hosts
+++ b/tests/functional/all_daemons/container/hosts
@@ -16,8 +16,8 @@ mds0
 [rgws]
 rgw0
 
-#[nfss]
-#nfs0
+[nfss]
+nfs0
 
 [clients]
 client0

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -20,8 +20,8 @@ rgw0
 client0
 client1
 
-#[nfss]
-#nfs0
+[nfss]
+nfs0
 
 [rbdmirrors]
 rbd-mirror0

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -56,7 +56,7 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {envdir}/tmp/ceph-ansible/tests/functional/lvm_setup.yml --extra-vars "osd_scenario=lvm"
 
   # deploy the cluster
-  ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/{env:INVENTORY} {envdir}/tmp/ceph-ansible/{env:PLAYBOOK:site.yml.sample} --limit 'all:!nfs0' --extra-vars "\
+  ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/{env:INVENTORY} {envdir}/tmp/ceph-ansible/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_stable_release={env:CEPH_STABLE_RELEASE:mimic} \


### PR DESCRIPTION
This reverts commit 83940e624bc4faf6bc7bb1a7637711556d6b3e8c.

Because nfs-ganesha@master (2.9-dev) build has been fixed by [1] then
we can test nfs-ganesha in the CI for master/octopus.

[1] https://github.com/ceph/ceph-build/pull/1346

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>