### PR TITLE
Execute common roles once on all nodes

### DIFF
--- a/infrastructure-playbooks/dashboard.yml
+++ b/infrastructure-playbooks/dashboard.yml
@@ -50,8 +50,6 @@
         name: ceph-facts
       tags: ['ceph_update_config']
     - import_role:
-        name: ceph-container-engine
-    - import_role:
         name: ceph-prometheus
     - import_role:
         name: ceph-grafana

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -104,10 +104,6 @@
         name: ceph-handler
       tags: ['ceph_update_config']
     - import_role:
-        name: ceph-container-engine
-    - import_role:
-        name: ceph-container-common
-    - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
     - import_role:
@@ -151,10 +147,6 @@
         name: ceph-handler
       tags: ['ceph_update_config']
     - import_role:
-        name: ceph-container-engine
-    - import_role:
-        name: ceph-container-common
-    - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
     - import_role:
@@ -192,10 +184,6 @@
     - import_role:
         name: ceph-handler
       tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-container-engine
-    - import_role:
-        name: ceph-container-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -235,10 +223,6 @@
         name: ceph-handler
       tags: ['ceph_update_config']
     - import_role:
-        name: ceph-container-engine
-    - import_role:
-        name: ceph-container-common
-    - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
     - import_role:
@@ -276,10 +260,6 @@
     - import_role:
         name: ceph-handler
       tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-container-engine
-    - import_role:
-        name: ceph-container-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -319,10 +299,6 @@
         name: ceph-handler
       tags: ['ceph_update_config']
     - import_role:
-        name: ceph-container-engine
-    - import_role:
-        name: ceph-container-common
-    - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
     - import_role:
@@ -361,10 +337,6 @@
         name: ceph-handler
       tags: ['ceph_update_config']
     - import_role:
-        name: ceph-container-engine
-    - import_role:
-        name: ceph-container-common
-    - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
     - import_role:
@@ -402,12 +374,6 @@
     - import_role:
         name: ceph-handler
       tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-container-engine
-      when: inventory_hostname == groups.get('clients', ['']) | first
-    - import_role:
-        name: ceph-container-common
-      when: inventory_hostname == groups.get('clients', ['']) | first
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -448,10 +414,6 @@
     - import_role:
         name: ceph-handler
       tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-container-engine
-    - import_role:
-        name: ceph-container-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -63,6 +63,8 @@
         name: ceph-validate
     - import_role:
         name: ceph-infra
+    - import_role:
+        name: ceph-common
 
 - hosts: mons
   gather_facts: false
@@ -87,8 +89,6 @@
     - import_role:
         name: ceph-handler
       tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -131,8 +131,6 @@
         name: ceph-handler
       tags: ['ceph_update_config']
     - import_role:
-        name: ceph-common
-    - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
     - import_role:
@@ -170,8 +168,6 @@
     - import_role:
         name: ceph-handler
       tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -211,8 +207,6 @@
         name: ceph-handler
       tags: ['ceph_update_config']
     - import_role:
-        name: ceph-common
-    - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
     - import_role:
@@ -250,8 +244,6 @@
     - import_role:
         name: ceph-handler
       tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -291,8 +283,6 @@
         name: ceph-handler
       tags: ['ceph_update_config']
     - import_role:
-        name: ceph-common
-    - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
     - import_role:
@@ -331,8 +321,6 @@
         name: ceph-handler
       tags: ['ceph_update_config']
     - import_role:
-        name: ceph-common
-    - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
     - import_role:
@@ -370,8 +358,6 @@
     - import_role:
         name: ceph-handler
       tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']
@@ -412,8 +398,6 @@
     - import_role:
         name: ceph-handler
       tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-common
     - import_role:
         name: ceph-config
       tags: ['ceph_update_config']


### PR DESCRIPTION
The common roles don't need to be executed again on each group plays
(like mons, osds, etc..).
We only need to execute them during the first play. That wat, we will
apply the changes on all nodes in parallel instead of doing it once per
group.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>