### PR TITLE
infrastructure-playbooks: playbooks for creating LVs for bluestore-lv…

### DIFF
--- a/infrastructure-playbooks/bluestore-lv-create.yml
+++ b/infrastructure-playbooks/bluestore-lv-create.yml
@@ -1,0 +1,125 @@
+- name: creates logical volumes for osd and bluestore databases.
+  become: true
+  hosts: osds
+
+  tasks:
+
+    - name: include vars of bluestore_lv_vars.yaml
+      include_vars:
+        file: bluestore_lv_vars.yaml
+      failed_when: false
+
+    # ensure bluestore_ssd_devices_device is set
+    - name: fail if bleustore_ssd_devices is not undefined
+      fail:
+        msg: "bluestore_ssd_devices has not been set by the user"
+      when: bluestore_ssd_devices is undefined or bluestore_ssd_devices == 'dummy'
+
+    # ensure bluestore_hdd_devices is set
+
+    - name: fail if bluestore_hdd_devices is not undefined
+      fail:
+        msg: "bluestore_hdd_devices has not been set by the user"
+      when: bluestore_hdd_devices is undefined or bluestore_hdd_devices == 'dummy'
+
+
+    # get number of HDD and SSD devices from config
+
+    - set_fact:
+        ssd_count: "{{ bluestore_ssd_devices | length }}"
+        hdd_count: "{{ bluestore_hdd_devices | length }}"
+
+    # get number of new lv for each step
+
+    - set_fact:
+        first_step_lv_num: "{{ hdd_count| int // ssd_count | int * ssd_count | int }}"
+        second_step_lv_num: "{{ hdd_count| int % ssd_count | int }}"
+
+    # need to check if lvm2 is installed
+    - name: install lvm2
+      package:
+        name: lvm2
+        state: present
+      register: result
+      until: result is succeeded
+
+    # create VG for each SSD device
+
+    - name: add ssd device as lvm pv
+      lvg:
+        force: yes
+        pvs: "{{ item }}"
+        pesize: 4
+        state: present
+        vg: "ceph-block-dbs-{{ item.split('/')[-1] }}"
+      loop:
+        "{{ bluestore_ssd_devices }}"
+
+    - name: generate uuids for lvs
+      shell: uuidgen
+      with_sequence: "count={{ first_step_lv_num| int }}"
+      register: uuid_lvm_list_1
+
+    - name: generate uuids for lvs
+      shell: uuidgen
+      with_sequence: "count={{ second_step_lv_num| int }}"
+      register: uuid_lvm_list_2
+
+    - name: create lvs for bock.db and wal journals on the SSD device (step 1)
+      lvol:
+        lv: "osd-block-db-{{ item.2.stdout }}"
+        vg: "ceph-block-dbs-{{ bluestore_ssd_devices[item.0|int % ssd_count|int ].split('/')[-1] }}"
+        size: "{{ blocks_db_size }}"
+      loop: "{{ range(0, first_step_lv_num| int, 1)|list| zip(bluestore_hdd_devices, uuid_lvm_list_1.results)| list }}"
+      register: created_lvs_1
+
+    - name: create lvs for bock.db and wal journals on the SSD device (step 2)
+      lvol:
+        lv: "osd-block-db-{{ item.2.stdout }}"
+        vg: "ceph-block-dbs-{{ item.1.split('/')[-1] }}"
+        size: "{{ blocks_db_size }}"
+      loop: "{{ range(0, second_step_lv_num| int, 1)| list| zip(bluestore_ssd_devices, uuid_lvm_list_2.results)| list }}"
+      register: created_lvs_2
+
+    # Make sure all hdd devices have a unique volume group
+    - name: create vgs for all hdd devices
+      lvg:
+        force: yes
+        pvs: "{{ item }}"
+        pesize: 4
+        state: present
+        vg: "{{ bluestore_hdd_vg_prefix }}-{{ item.split('/')[-1] }}"
+      with_items: "{{ bluestore_hdd_devices }}"
+
+    - name: create lvs for the data portion on hdd devices
+      lvol:
+        lv: "{{ bluestore_hdd_lv_prefix }}-{{ item.split('/')[-1] }}"
+        vg: "{{ bluestore_hdd_vg_prefix }}-{{ item.split('/')[-1] }}"
+        size: "{{ hdd_lv_size }}"
+        pvs: "{{ item }}"
+      with_items: "{{ bluestore_hdd_devices }}"
+
+    - debug:
+        msg: "{{ item }}"
+      loop: "{{ range(0, first_step_lv_num| int, 1)| list| zip(bluestore_ssd_devices, uuid_lvm_list_1.results)| list }}"
+
+    - set_fact:
+        bluestore_logfile: |
+          # Suggested cut and paste under "lvm_volumes:" in "group_vars/osds.yml"
+          # -----------------------------------------------------------------------------------------------------------
+
+
+          {% for lv_info in bluestore_hdd_devices| zip( created_lvs_1.results + created_lvs_2.results )| list  %}
+            - data: {{ bluestore_hdd_lv_prefix }}-{{ lv_info[0].split('/')[-1] }}
+              data_vg: {{ bluestore_hdd_vg_prefix }}-{{ lv_info[0].split('/')[-1] }}
+              db: {{ lv_info[1].invocation.module_args.lv}}
+              db_vg: {{ lv_info[1].invocation.module_args.vg }}
+
+          {% endfor %}
+
+    - name: "write output for osds.yml to {{ bluestore_logfile_path }}"
+      become: false
+      copy:
+        content: "{{ bluestore_logfile }}"
+        dest: "{{ bluestore_logfile_path }}"
+      delegate_to: localhost

--- a/infrastructure-playbooks/bluestore-lv-teardown.yml
+++ b/infrastructure-playbooks/bluestore-lv-teardown.yml
@@ -1,0 +1,88 @@
+- name: tear down existing osd filesystems then logical volumes, volume groups, and physical volumes
+  become: true
+  hosts: osds
+
+  vars_prompt:
+    - name: ireallymeanit
+      prompt: Are you sure you want to tear down the logical volumes?
+      default: 'no'
+      private: no
+
+  tasks:
+    - name: exit playbook, if user did not mean to tear down logical volumes
+      fail:
+        msg: >
+          "Exiting lv-teardown playbook, logical volumes were NOT torn down.
+           To tear down the logical volumes, either say 'yes' on the prompt or
+           or use `-e ireallymeanit=yes` on the command line when
+           invoking the playbook"
+      when: ireallymeanit != 'yes'
+
+    - name: include vars of bluestore_lv_vars.yaml
+      include_vars:
+        file: bluestore_lv_vars.yaml
+      failed_when: false
+
+    # need to check if lvm2 is installed
+    - name: install lvm2
+      package:
+        name: lvm2
+        state: present
+      register: result
+      until: result is succeeded
+
+  # BEGIN TEARDOWN
+    - name: find any existing osd filesystems
+      shell: "grep /var/lib/ceph/osd /proc/mounts | awk '{print $2}'"
+      register: old_osd_filesystems
+
+    - name: tear down any existing osd filesystems
+      command: "umount -v {{ item }}"
+      with_items: "{{ old_osd_filesystems.stdout_lines }}"
+
+    - name: kill all lvm commands that may have been hung
+      command: "killall -q lvcreate pvcreate vgcreate lvconvert || echo -n"
+      failed_when: false
+
+
+    # tear down vgs
+    - name: tear down existing lv
+      lvol:
+        lv: "ceph-hdd-lv-{{ item.split('/')[-1] }}"
+        vg: "ceph-hdd-{{ item.split('/')[-1] }}"
+        state: absent
+        force: yes
+      with_items: "{{ bluestore_hdd_devices }}"
+
+    - name: remove vg for each hdd device
+      lvg:
+        vg: "ceph-hdd-vg-{{ item.split('/')[-1] }}"
+        state: absent
+        force: yes
+      with_items: "{{ bluestore_hdd_devices }}"
+
+    - name: tear down pv for each hdd device
+      command: "pvremove --force --yes {{ item }}"
+      with_items: "{{ bluestore_hdd_devices }}"
+
+    - name: get all vgs
+      command: "vgs -a -o name"
+      register: all_vgs
+
+    - name: Tear down ceph vgs
+      lvg:
+        vg: "{{ item }}"
+        state: absent
+        force: yes
+      with_items: "{{ all_vgs.stdout.split('\n') | map('trim')| list }}"
+      when:
+        - "'ceph' in item"
+
+    ## Physical Vols
+    - name: tear down pv for nvme device
+      command: "pvremove --force --yes {{ item }}"
+      with_items: "{{ bluestore_hdd_devices }}"
+
+    - name: tear down pv for each hdd device
+      command: "pvremove --force --yes {{ item }}"
+      with_items: "{{ bluestore_ssd_devices }}"

--- a/infrastructure-playbooks/vars/bluestore_lv_vars.yaml.sample
+++ b/infrastructure-playbooks/vars/bluestore_lv_vars.yaml.sample
@@ -1,0 +1,43 @@
+# This file configures logical volume creation for BlueStore Database on NVMe, a NVMe based bucket index, and HDD based OSDs.
+# This playbook configures one NVMe device at a time. If your OSD systems contain multiple NVMe devices, you will need to edit the key variables ("nvme_device", "hdd_devices") for each run.
+# It is meant to be used when osd_objectstore=filestore and it outputs the necessary input for group_vars/osds.yml.
+# The LVs for BlueStore databases are created first then the LVs for data. Each LVs for BlueStore db correspond to a LV for data.
+#
+## CHANGE THESE VARS ##
+#
+# The NVMe device and the HDD devices must be raw and not have any GPT, FS, or RAID signatures.
+# GPT, FS, & RAID signatures should be removed from a device prior to running the lv-create.yml playbook.
+#
+# Having leftover signatures can result in ansible errors that say "device $device_name excluded by a filter" after running the lv-create.yml playbook.
+# This can be done by running `wipefs -a $device_name`.
+
+# Path of nvme devices primed for LV creation for BlueStore database and journal.
+bluestore_ssd_devices:
+  - /dev/sdc
+# Path of hdd devices designated for LV creation.
+bluestore_hdd_devices:
+  - /dev/sdb
+
+# Per the lvol module documentation, "size" is the size of the logical volume, according to lvcreate(8) --size.
+# This is by default in megabytes or optionally with one of [bBsSkKmMgGtTpPeE] units; or according to lvcreate(8) --extents as a percentage of [VG|PVS|FREE]; Float values must begin with a digit.
+# For further reading and examples see: https://docs.ansible.com/ansible/2.6/modules/lvol_module.html
+
+# Suggested BlueStore db size is 30GB
+blocks_db_size: 256
+
+## TYPICAL USERS WILL NOT NEED TO CHANGE VARS FROM HERE DOWN ##
+
+# the path to where to save the logfile for bs-lv-create.log
+bluestore_logfile_path: ../bs-lv-create.log
+
+# all hdd's have to be the same size and the LVs on them are dedicated for OSD data
+hdd_lv_size: 100%FREE
+
+# Since this playbook can be run multiple times across different devices, {{ var.split('/')[-1] }} is used quite frequently in this play-book.
+
+bluestore_hdd_vg_prefix: "ceph-hdd-vg"
+bluestore_hdd_lv_prefix: "ceph-hdd-lv"
+
+
+# BlueStore DBs are created on NVMe devices
+

--- a/tests/functional/bluestore_infra_lv_create/Vagrantfile
+++ b/tests/functional/bluestore_infra_lv_create/Vagrantfile
@@ -1,0 +1,1 @@
+../../../Vagrantfile

--- a/tests/functional/bluestore_infra_lv_create/group_vars/all
+++ b/tests/functional/bluestore_infra_lv_create/group_vars/all
@@ -1,0 +1,45 @@
+---
+
+# This file configures logical volume creation for BlueStore Database on NVMe, a NVMe based bucket index, and HDD based OSDs.
+# This playbook configures one NVMe device at a time. If your OSD systems contain multiple NVMe devices, you will need to edit the key variables ("nvme_device", "hdd_devices") for each run.
+# It is meant to be used when osd_objectstore=filestore and it outputs the necessary input for group_vars/osds.yml.
+# The LVs for BlueStore databases are created first then the LVs for data. Each LVs for BlueStore db correspond to a LV for data.
+#
+## CHANGE THESE VARS ##
+#
+# The NVMe device and the HDD devices must be raw and not have any GPT, FS, or RAID signatures.
+# GPT, FS, & RAID signatures should be removed from a device prior to running the lv-create.yml playbook.
+#
+# Having leftover signatures can result in ansible errors that say "device $device_name excluded by a filter" after running the lv-create.yml playbook.
+# This can be done by running `wipefs -a $device_name`.
+
+# Path of nvme devices primed for LV creation for BlueStore database and journal.
+bluestore_ssd_devices:
+  - /dev/sdc
+# Path of hdd devices designated for LV creation.
+bluestore_hdd_devices:
+  - /dev/sdb
+
+# Per the lvol module documentation, "size" is the size of the logical volume, according to lvcreate(8) --size.
+# This is by default in megabytes or optionally with one of [bBsSkKmMgGtTpPeE] units; or according to lvcreate(8) --extents as a percentage of [VG|PVS|FREE]; Float values must begin with a digit.
+# For further reading and examples see: https://docs.ansible.com/ansible/2.6/modules/lvol_module.html
+
+# Suggested BlueStore db size is 30GB
+blocks_db_size: 256
+
+## TYPICAL USERS WILL NOT NEED TO CHANGE VARS FROM HERE DOWN ##
+
+# the path to where to save the logfile for bs-lv-create.log
+bluestore_logfile_path: ../bs-lv-create.log
+
+# all hdd's have to be the same size and the LVs on them are dedicated for OSD data
+hdd_lv_size: 100%FREE
+
+# Since this playbook can be run multiple times across different devices, {{ var.split('/')[-1] }} is used quite frequently in this play-book.
+
+bluestore_hdd_vg_prefix: "ceph-hdd-vg"
+bluestore_hdd_lv_prefix: "ceph-hdd-lv"
+
+
+# BlueStore DBs are created on NVMe devices
+

--- a/tests/functional/bluestore_infra_lv_create/hosts
+++ b/tests/functional/bluestore_infra_lv_create/hosts
@@ -1,0 +1,4 @@
+[osds]
+osd0
+#osd1
+#osd2

--- a/tests/functional/bluestore_infra_lv_create/vagrant_variables.yml
+++ b/tests/functional/bluestore_infra_lv_create/vagrant_variables.yml
@@ -1,0 +1,71 @@
+---
+
+# DEPLOY CONTAINERIZED DAEMONS
+docker: false
+
+# DEFINE THE NUMBER OF VMS TO RUN
+mon_vms: 0
+osd_vms: 1
+mds_vms: 0
+rgw_vms: 0
+nfs_vms: 0
+grafana_server_vms: 0
+rbd_mirror_vms: 0
+client_vms: 0
+iscsi_gw_vms: 0
+mgr_vms: 0
+
+# INSTALL SOURCE OF CEPH
+# valid values are 'stable' and 'dev'
+ceph_install_source: stable
+
+# SUBNETS TO USE FOR THE VMS
+public_subnet: 192.168.39
+cluster_subnet: 192.168.40
+
+# MEMORY
+# set 1024 for CentOS
+memory: 1024
+
+# Ethernet interface name
+# use eth1 for libvirt and ubuntu precise, enp0s8 for CentOS and ubuntu xenial
+eth: 'eth1'
+
+# Disks
+# For libvirt use disks: "[ '/dev/vdb', '/dev/vdc' ]"
+# For CentOS7 use disks: "[ '/dev/sda', '/dev/sdb' ]"
+disks: "[ '/dev/sdb', '/dev/sdc']"
+
+# VAGRANT BOX
+# Ceph boxes are *strongly* suggested. They are under better control and will
+# not get updated frequently unless required for build systems. These are (for
+# now):
+#
+# * ceph/ubuntu-xenial
+#
+# Ubuntu: ceph/ubuntu-xenial bento/ubuntu-16.04 or ubuntu/trusty64 or ubuntu/wily64
+# CentOS: bento/centos-7.1 or puppetlabs/centos-7.0-64-puppet
+# libvirt CentOS: centos/7
+# parallels Ubuntu: parallels/ubuntu-14.04
+# Debian: deb/jessie-amd64 - be careful the storage controller is named 'SATA Controller'
+# For more boxes have a look at:
+#   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
+#   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
+vagrant_box: centos/7
+#ssh_private_key_path: "~/.ssh/id_rsa"
+# The sync directory changes based on vagrant box
+# Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
+#vagrant_sync_dir: /home/vagrant/sync
+vagrant_sync_dir: /vagrant
+# Disables synced folder creation. Not needed for testing, will skip mounting
+# the vagrant directory on the remote box regardless of the provider.
+vagrant_disable_synced_folder: true
+# VAGRANT URL
+# This is a URL to download an image from an alternate location.  vagrant_box
+# above should be set to the filename of the image.
+# Fedora virtualbox: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
+# Fedora libvirt: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-libvirt.box
+# vagrant_box_url: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box
+
+os_tuning_params:
+  - { name: fs.file-max, value: 26234859 }

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = {dev,rhcs}-{centos,ubuntu}-{container,non_container}-{all_daemons,collocation,lvm_osds,shrink_mon,shrink_osd,shrink_mgr,shrink_mds,shrink_rbdmirror,shrink_rgw,lvm_batch,add_mons,add_osds,add_mgrs,add_mdss,add_rbdmirrors,add_rgws,rgw_multisite,purge,storage_inventory,lvm_auto_discovery}
   {dev,rhcs}-{centos,ubuntu}-container-{ooo_collocation}
   {dev,rhcs}-{centos,ubuntu}-non_container-{switch_to_containers}
-  infra_lv_create
+  infra_lv_create, bluestore_infra_lv_create
   migrate_ceph_disk_to_ceph_volume
 
 skipsdist = True
@@ -111,6 +111,41 @@ commands=
 # that purge the cluster and then set it up again to
 # ensure that a purge can clear nodes well enough that they
 # can be redployed to.
+
+[testenv:bluestore_infra_lv_create]
+whitelist_externals =
+    vagrant
+    bash
+    mkdir
+    cat
+passenv=*
+setenv=
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
+  ANSIBLE_CONFIG = -F {toxinidir}/ansible.cfg
+  ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
+  ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/plugins/callback
+  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  # only available for ansible >= 2.5
+  ANSIBLE_STDOUT_CALLBACK = yaml
+deps= -r{toxinidir}/tests/requirements.txt
+changedir={toxinidir}/tests/functional/centos/7/bluestore_infra_lv_create
+commands=
+  vagrant up --no-provision {posargs:--provider=virtualbox}
+  bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
+
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/infrastructure-playbooks/bluestore-lv-create.yml
+
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/infrastructure-playbooks/bluestore-lv-teardown.yml --extra-vars "ireallymeanit=yes"
+
+  cat {toxinidir}/bs-lv-create.log
+
+  vagrant destroy --force
+
+# extra commands for purging clusters
+# that purge the cluster and then set it up again to
+# ensure that a purge can clear nodes well enough that they
+# can be redployed to.
+
 [purge]
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\


### PR DESCRIPTION
…m configuration

This playbook is analog of lv_create and intended for use for create partitions for bluestore-lvm configuration (#3691)
It creates a separate VG for each PV (#4306)

Signed-off-by: Bogomolov Igor <igor95n@gmail.com>