### PR TITLE
mergify: disable automatic merging on master

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,16 +1,4 @@
 pull_request_rules:
-  - name: automatic merge
-    conditions:
-      - label!=DNM
-      - '#approved-reviews-by>=1'
-      - 'status-success=Testing: ceph-ansible PR Pipeline'
-    actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-      dismiss_reviews: {}
-      delete_head_branch: {}
   - name: automatic merge on skip ci
     conditions:
       - label!=DNM


### PR DESCRIPTION
automatic merging by mergify is failing for a while now.
Until we can figure out what's wrong, let's disable it on master so we don't merge "failing" PRs although they passed all scenarios.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>