### PR TITLE
[skip ci] tests: fix wrong paths for lv-create in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ setenv=
   # only available for ansible >= 2.5
   ANSIBLE_STDOUT_CALLBACK = yaml
 deps= -r{toxinidir}/tests/requirements.txt
-changedir={toxinidir}/tests/functional/centos/7/infra_lv_create
+changedir={toxinidir}/tests/functional/infra_lv_create
 commands=
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
@@ -103,7 +103,7 @@ commands=
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/infrastructure-playbooks/lv-teardown.yml --extra-vars "ireallymeanit=yes"
 
-  cat {toxinidir}/lv-create.log
+  cat {toxinidir}/infrastructure-playbooks/lv-create.log
 
   vagrant destroy --force
 


### PR DESCRIPTION
Fix bad paths for infra_lv_create
(issue: #4311)
command` tox -e infra_lv_create` fails
solution: change paths inside tox.ini file
Signed-off-by: Bogomolov Igor <igor95n@gmail.com>