### PR TITLE
Fix debian custom repo

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -235,6 +235,7 @@ dummy:
 # a URL to the .repo file to be installed on the targets.  For deb,
 # ceph_custom_repo should be the URL to the repo base.
 #
+#ceph_custom_key: https://server.domain.com/ceph-custom-repo-key.asc
 #ceph_custom_repo: https://server.domain.com/ceph-custom-repo
 
 

--- a/group_vars/clients.yml.sample
+++ b/group_vars/clients.yml.sample
@@ -58,3 +58,4 @@ dummy:
 #  - { name: client.test2, caps: { mon: "allow r", osd: "allow class-read object_prefix rbd_children, allow rwx pool=test2, osd blacklist" },  mode: "{{ ceph_keyring_permissions }}" }
 
 #ceph_nfs_ceph_user: { name: client.rgw.nfs0, key: 'SECRET==', caps: { mon: "allow rw", osd: "allow rwx" }, mode: "{{ ceph_keyring_permissions }}" }
+

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -163,3 +163,4 @@ dummy:
 
 #nb_retry_wait_osd_up: 60
 #delay_wait_osd_up: 10
+

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -235,6 +235,7 @@ ceph_rhcs_version: 4
 # a URL to the .repo file to be installed on the targets.  For deb,
 # ceph_custom_repo should be the URL to the repo base.
 #
+#ceph_custom_key: https://server.domain.com/ceph-custom-repo-key.asc
 #ceph_custom_repo: https://server.domain.com/ceph-custom-repo
 
 

--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -266,7 +266,10 @@ ceph_repository_obs = (
     ("ceph_obs_repo", types.string),
 )
 
-ceph_repository_custom = ("ceph_custom_repo", types.string)
+ceph_repository_custom = (
+    ("ceph_custom_key", types.string),
+    ("ceph_custom_repo", types.string),
+)
 
 ceph_repository_uca = (
     ("ceph_stable_openstack_release_uca", types.string),

--- a/roles/ceph-common/tasks/installs/debian_custom_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_custom_repository.yml
@@ -1,7 +1,14 @@
 ---
+- name: configure debian custom apt key
+  apt_key:
+    url: "{{ ceph_custom_key }}"
+    state: present
+  register: result
+  until: result is succeeded
+  when: ceph_custom_key is defined
+
 - name: configure debian custom repository
   apt_repository:
     repo: "deb {{ ceph_custom_repo }} {{ ansible_distribution_release }} main"
     state: present
-    update_cache: no
-  notify: update apt cache if a repo was added
+    update_cache: yes

--- a/roles/ceph-common/tasks/installs/redhat_custom_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_custom_repository.yml
@@ -1,4 +1,12 @@
 ---
+- name: configure red hat custom rpm key
+  rpm_key:
+    key: "{{ ceph_custom_key }}"
+    state: present
+  register: result
+  until: result is succeeded
+  when: ceph_custom_key is defined
+
 - name: configure red hat custom repository
   get_url:
     url: "{{ ceph_custom_repo }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -227,6 +227,7 @@ ceph_iscsi_config_dev: true # special repo for deploying iSCSI gateways
 # a URL to the .repo file to be installed on the targets.  For deb,
 # ceph_custom_repo should be the URL to the repo base.
 #
+ceph_custom_key: https://server.domain.com/ceph-custom-repo-key.asc
 ceph_custom_repo: https://server.domain.com/ceph-custom-repo
 
 


### PR DESCRIPTION
Currently custom repo doesn't have apt or rpm key defined,
so apt update gonna be failed.

This PR should fix that.