### PR TITLE
Added "rgw dns name" option to ceph.conf

### DIFF
--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -32,6 +32,10 @@ dummy:
 # limit will require admin intervention.
 #rgw_bucket_default_quota_max_objects: 1638400 # i.e., 100K * 16
 
+# The DNS name of the served domain. This is required if RGW is
+# deployed using S3-style subdomains (e.g., bucket.domain.com)
+#rgw_dns_name: server.domain.com
+
 # This dictionary will create pools with the given number of pgs.
 # This is important because they would be created with the default
 # of 8.

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -68,6 +68,9 @@ rgw override bucket index max shards = {{ rgw_override_bucket_index_max_shards }
 {% if rgw_bucket_default_quota_max_objects is defined %}
 rgw bucket default quota max objects = {{ rgw_bucket_default_quota_max_objects }}
 {% endif %}
+{% if rgw_dns_name is defined %}
+rgw dns name = {{ rgw_dns_name }}
+{% endif %}
 
 {% if inventory_hostname in groups.get(client_group_name, []) %}
 [client.libvirt]

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -24,6 +24,10 @@ copy_admin_key: false
 # limit will require admin intervention.
 #rgw_bucket_default_quota_max_objects: 1638400 # i.e., 100K * 16
 
+# The DNS name of the served domain. This is required if RGW is
+# deployed using S3-style subdomains (e.g., bucket.domain.com)
+#rgw_dns_name: server.domain.com
+
 # This dictionary will create pools with the given number of pgs.
 # This is important because they would be created with the default
 # of 8.


### PR DESCRIPTION
"rgw dns name" is the DNS name of the served domain. This is required if RGW is deployed using S3-style subdomains (e.g., bucket.domain.com)

Signed-off-by: Kevin Coakley <kcoakley@sdsc.edu>