### PR TITLE
Set proper ownership command performance improvement

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -90,14 +90,12 @@
          ceph_uid: 167
       when: ceph_docker_image is search("rhceph")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
     - name: check for existing old leveldb file extension (ldb)
       shell: stat /var/lib/ceph/mon/*/store.db/*.ldb
@@ -183,14 +181,12 @@
         ceph_uid: 167
       when: ceph_docker_image_tag | string is search("centos") or ceph_docker_image is search("rhceph") or ceph_docker_image_tag | string is search("fedora")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
   tasks:
     - import_role:
@@ -267,14 +263,12 @@
          ceph_uid: 167
       when: ceph_docker_image is search("rhceph")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown --verbose -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
     - name: check for existing old leveldb file extension (ldb)
       shell: stat /var/lib/ceph/osd/*/current/omap/*.ldb
@@ -383,14 +377,12 @@
         ceph_uid: 167
       when: ceph_docker_image_tag | string is search("centos") or ceph_docker_image is search("rhceph") or ceph_docker_image_tag | string is search("fedora")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
   tasks:
     - import_role:
@@ -431,14 +423,12 @@
         ceph_uid: 167
       when: ceph_docker_image_tag | string is search("centos") or ceph_docker_image is search("rhceph") or ceph_docker_image_tag | string is search("fedora")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
   tasks:
     - import_role:
@@ -505,14 +495,12 @@
         ceph_uid: 167
       when: ceph_docker_image_tag | string is search("centos") or ceph_docker_image is search("rhceph") or ceph_docker_image_tag | string is search("fedora")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
   tasks:
     - import_role:
@@ -564,14 +552,12 @@
         ceph_uid: 167
       when: ceph_docker_image_tag | string is search("centos") or ceph_docker_image is search("rhceph") or ceph_docker_image_tag | string is search("fedora")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
   tasks:
     - import_role:


### PR DESCRIPTION
By changing the set ownership command from using the file module in combination with a with_items loop to a raw chown command, we can achieve a 98% performance increase here.

On a ceph cluster with a significant amount of directories and files in /var/lib/ceph, the file module has to run checks on ownership of all those directories and files to determine whether a change is needed.

In this case, we just want to explicitly set the ownership of all these directories and files to the ceph_uid

Signed-off-by: Kevin Jones kevinjones@redhat.com