### PR TITLE
Only install python-xml on SUSE/openSUSE if python2 is being used

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_suse.yml
+++ b/roles/ceph-common/tasks/installs/install_on_suse.yml
@@ -19,6 +19,7 @@
   with_items: "{{ suse_package_dependencies }}"
   register: result
   until: result is succeeded
+  when: ansible_python_version is version( '3', '<')
 
 - name: include install_suse_packages.yml
   include_tasks: install_suse_packages.yml

--- a/roles/ceph-common/tasks/installs/install_suse_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_suse_packages.yml
@@ -5,6 +5,7 @@
     state: present
   register: result
   until: result is succeeded
+  when: ansible_python_version is version( '3', '<')
 
 - name: install suse ceph packages
   package:


### PR DESCRIPTION
On SUSE/openSUSE 15 or newer, the default python is python3, which does not need `python-xml` to be installed. 

Especially as this is a python2 package, that pulls in python2 and confuses ansible (unless you set the ansible_python_interpreter parameter to point to python3).

**Todo**:
- [X] ~~Check if installing python via [raw_install_python.yml](https://github.com/ceph/ceph-ansible/blob/master/raw_install_python.yml) can be safeguarded in the same way.~~ This has been fixed in master in the meantime.