### PR TITLE
raw_install_python.yml: also check for /usr/bin/python3

### DIFF
--- a/raw_install_python.yml
+++ b/raw_install_python.yml
@@ -5,6 +5,12 @@
   ignore_errors: yes
   register: systempython
 
+- name: check for python3
+  stat:
+    path: /usr/bin/python3
+  ignore_errors: yes
+  register: systempython3
+
 - name: install python for debian based systems
   raw: apt-get -y install python-simplejson
   ignore_errors: yes
@@ -23,5 +29,5 @@
   raw: zypper -n install python-base creates=/usr/bin/python2.7
   ignore_errors: yes
   register: result
-  when: systempython.stat is undefined or not systempython.stat.exists
+  when: (systempython.stat is undefined or not systempython.stat.exists) and (systempython3.stat is undefined or not systempython3.stat.exists)
   until: result is succeeded


### PR DESCRIPTION
openSUSE Leap 15.x do no longer have python2 installed, and the
installed python3 does not provide `/usr/bin/python`.

The new logic will only install python2 if python3 has not been found, either.

Signed-off-by: Johannes Kastl <kastl@b1-systems.de>