### PR TITLE
osd: copy systemd-device-to-id.sh on all osd nodes before running it

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -104,7 +104,7 @@
   when:
     - containerized_deployment
 
-- name: device to ID migration
+- name: device to id migration
   when:
     - containerized_deployment | bool
     - osd_scenario != 'lvm'
@@ -123,14 +123,17 @@
         owner: root
         group: root
         mode: 0750
-      when: ceph_osd_device_name.stdout|int != 0
-
-    - name: run the systemd-device-to-id.sh script
-      command: /usr/bin/env bash /tmp/systemd-device-to-id.sh
-      when: ceph_osd_device_name.stdout|int != 0
       with_items: "{{ groups[osd_group_name] }}"
       delegate_to: "{{ item }}"
       run_once: true
+      when: ceph_osd_device_name.stdout | int != 0
+
+    - name: run the systemd-device-to-id.sh script
+      command: /usr/bin/env bash /tmp/systemd-device-to-id.sh
+      with_items: "{{ inventory_hostname if rolling_update else groups[osd_group_name] }}"
+      delegate_to: "{{ item }}"
+      run_once: true
+      when: ceph_osd_device_name.stdout | int != 0
 
 - name: systemd start osd
   systemd:


### PR DESCRIPTION
Otherwise it will fail when running rolling_update.yml playbook because
of `serial: 1` usage.
The task which copies the script is run against the current node being
played only whereas the task which runs the script is run against all
nodes in a loop, it ends up with the typical error:

```
2019-08-08 17:47:05,115 p=14905 u=ubuntu |  failed: [magna023 -> magna030] (item=magna030) => {
    "changed": true,
    "cmd": [
        "/usr/bin/env",
        "bash",
        "/tmp/systemd-device-to-id.sh"
    ],
    "delta": "0:00:00.004339",
    "end": "2019-08-08 17:46:59.059670",
    "invocation": {
        "module_args": {
            "_raw_params": "/usr/bin/env bash /tmp/systemd-device-to-id.sh",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "warn": true
        }
    },
    "item": "magna030",
    "msg": "non-zero return code",
    "rc": 127,
    "start": "2019-08-08 17:46:59.055331",
    "stderr": "bash: /tmp/systemd-device-to-id.sh: No such file or directory",
    "stderr_lines": [
        "bash: /tmp/systemd-device-to-id.sh: No such file or directory"
    ],
    "stdout": "",
    "stdout_lines": []
}
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1739209

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>