### PR TITLE
validate: do not validate devices/lvm_volumes in osd_auto_discovery case

### DIFF
--- a/plugins/actions/validate.py
+++ b/plugins/actions/validate.py
@@ -96,16 +96,16 @@ class ActionModule(ActionBase):
             if host_vars["osd_group_name"] in host_vars["group_names"]:
                 notario.validate(host_vars, osd_options, defined_keys=True)
                 notario_store['osd_objectstore'] = host_vars["osd_objectstore"]
-
-                if host_vars.get("devices"):
-                    notario.validate(
-                        host_vars, lvm_batch_scenario, defined_keys=True)
-                elif notario_store['osd_objectstore'] == 'filestore':
-                    notario.validate(
-                        host_vars, lvm_filestore_scenario, defined_keys=True)  # noqa E501
-                elif notario_store['osd_objectstore'] == 'bluestore':
-                    notario.validate(
-                        host_vars, lvm_bluestore_scenario, defined_keys=True)  # noqa E501
+                if not host_vars.get('osd_auto_discovery'):
+                    if host_vars.get("devices"):
+                        notario.validate(
+                            host_vars, lvm_batch_scenario, defined_keys=True)
+                    elif notario_store['osd_objectstore'] == 'filestore':
+                        notario.validate(
+                            host_vars, lvm_filestore_scenario, defined_keys=True)  # noqa E501
+                    elif notario_store['osd_objectstore'] == 'bluestore':
+                        notario.validate(
+                            host_vars, lvm_bluestore_scenario, defined_keys=True)  # noqa E501
 
         except Invalid as error:
             display.vvvv("Notario Failure: %s" % str(error))


### PR DESCRIPTION
we shouldn't validate these two variables when `osd_auto_discovery` is
set.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1644623

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>