### PR TITLE
doc: update backport section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,9 @@ This will prevent the engine merging your pull request.
 
 ### Backports (maintainers only)
 
-If you wish to see your work from 'master' being backported to a stable branch you can apply a label on the PR that points to the desired stable branch.
-Labels for backports are name: `backport-stable-<branch version>`, eg: `backport-stable-3.2`.
-Once the PR from master is merged, a backport PR will be created by mergify, if there is a cherry-pick conflict you must resolv it by pulling the branch.
+If you wish to see your work from 'master' being backported to a stable branch you can ping a maintainer
+so he will set the backport label on your PR. Once the PR from master is merged, a backport PR will be created by mergify,
+if there is a cherry-pick conflict you must resolv it by pulling the branch.
 
 **NEVER** push directly into a stable branch, **unless** the code from master has diverged so much that the files don't exist in the stable branch.
 If that happens, inform the maintainers of the reasons why you pushed directly into a stable branch, if the reason is invalid, maintainers will immediatly close your pull request.


### PR DESCRIPTION
Only maintainers can set labels on PRs, so let's clarify that point in
the doc which says something confusing at the moment.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>