### PR TITLE
validate: fail on openSUSE Leap using distro packages

### DIFF
--- a/roles/ceph-validate/tasks/check_nfs.yml
+++ b/roles/ceph-validate/tasks/check_nfs.yml
@@ -6,3 +6,10 @@
     - nfs_obj_gw
     - groups.get(mon_group_name, []) | length == 0
     - (ceph_nfs_rgw_access_key is undefined or ceph_nfs_rgw_secret_key is undefined)
+
+- name: fail on openSUSE Leap 15.x using distro packages
+  fail:
+    msg: "ceph-nfs packages are not available from openSUSE Leap 15.x repositories (ceph_origin = 'distro')"
+  when:
+    - ceph_origin == 'distro'
+    - ansible_distribution == 'openSUSE Leap'


### PR DESCRIPTION
`roles/ceph-nfs/tasks/pre_requisite_non_container.yml`: fail on openSUSE Leap using `ceph_origin = distro`, as the ganesha packages are not available from the distribution repositories

Fixes #4342  in that that is desired behaviour.