### PR TITLE
osd: remove useless condition

### DIFF
--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -48,7 +48,7 @@
       with_items: "{{ openstack_pools | unique }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
-      when: item.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
+      when: item.size | default(osd_pool_default_size)
 
     - name: customize pool min_size
       command: >


### PR DESCRIPTION
just like `ceph_osd_pool_default_size`, a pool size might change after initial deployment.
Having this condition prevents from customizing the pool in that case.
This is not needed so let's remove it.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>