### PR TITLE
infrastructure-playbooks: add filestore-to-bluestore.yml

### DIFF
--- a/group_vars/iscsigws.yml.sample
+++ b/group_vars/iscsigws.yml.sample
@@ -19,6 +19,8 @@ dummy:
 #iscsi_pool_name: rbd
 #iscsi_pool_size: "{{ osd_pool_default_size }}"
 
+#copy_admin_key: True
+
 ##################
 # RBD-TARGET-API #
 ##################

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -44,10 +44,18 @@ dummy:
 # Declare devices to be used as block.db devices
 
 #dedicated_devices:
-#  - /dev/sda
-#  - /dev/sdb
+#  - /dev/sdx
+#  - /dev/sdy
 
 #dedicated_devices: []
+
+# Declare devices to be used as block.wal devices
+
+#bluestore_wal_devices:
+#  - /dev/nvme0n1
+#  - /dev/nvme0n2
+
+#bluestore_wal_devices: []
 
 #'osd_auto_discovery'  mode prevents you from filling out the 'devices' variable above.
 # Device discovery is based on the Ansible fact 'ansible_devices'

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -31,7 +31,7 @@ dummy:
 
 # Declare devices to be used as OSDs
 # All scenario(except 3rd) inherit from the following device declaration
-# Note: This scenario uses the ceph-disk tool to provision OSDs
+# Note: This scenario uses the ceph-volume lvm batch method to provision OSDs
 
 #devices:
 #  - /dev/sdb
@@ -51,9 +51,9 @@ dummy:
 
 #'osd_auto_discovery'  mode prevents you from filling out the 'devices' variable above.
 # Device discovery is based on the Ansible fact 'ansible_devices'
-# which reports all the devices on a system. If chosen all the disks
-# found will be passed to ceph-disk. You should not be worried on using
-# this option since ceph-disk has a built-in check which looks for empty devices.
+# which reports all the devices on a system. If chosen, all the disks
+# found will be passed to ceph-volume lvm batch. You should not be worried on using
+# this option since ceph-volume has a built-in check which looks for empty devices.
 # Thus devices with existing partition tables will not be used.
 #
 #osd_auto_discovery: false

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -41,6 +41,13 @@ dummy:
 
 #devices: []
 
+# Declare devices to be used as block.db devices
+
+#dedicated_devices:
+#  - /dev/sda
+#  - /dev/sdb
+
+#dedicated_devices: []
 
 #'osd_auto_discovery'  mode prevents you from filling out the 'devices' variable above.
 # Device discovery is based on the Ansible fact 'ansible_devices'

--- a/group_vars/rbdmirrors.yml.sample
+++ b/group_vars/rbdmirrors.yml.sample
@@ -11,8 +11,6 @@ dummy:
 # SETUP #
 #########
 
-#fetch_directory: fetch/
-
 # Even though rbd-mirror nodes should not have the admin key
 # at their disposal, some people might want to have it
 # distributed on rbd-mirror nodes. Setting 'copy_admin_key' to 'true'

--- a/infrastructure-playbooks/filestore-to-bluestore.yml
+++ b/infrastructure-playbooks/filestore-to-bluestore.yml
@@ -1,0 +1,245 @@
+# This playbook migrates an OSD from filestore to bluestore backend.
+#
+# Use it like this:
+# ansible-playbook infrastructure-playbooks/filestore-to-bluestore.yml --limit <osd-node-to-migrate>
+# *ALL* osds on nodes will be shrinked and redeployed using bluestore backend with ceph-volume
+
+- hosts: "{{ osd_group_name }}"
+  become: true
+  serial: 1
+  vars:
+    delegate_facts_host: true
+  tasks:
+    - name: gather and delegate facts
+      setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: True
+      with_items: "{{ groups[mon_group_name] }}"
+      run_once: true
+      when: delegate_facts_host | bool
+
+    - import_role:
+        name: ceph-defaults
+
+    - import_role:
+        name: ceph-facts
+
+    - name: get ceph osd tree data
+      command: "{{ container_exec_cmd }} ceph osd tree -f json"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      register: osd_tree
+      run_once: true
+
+    - name: get ceph-volume lvm inventory data
+      command: >
+        {{ container_binary }} run --rm --privileged=true
+        --ulimit nofile=1024:4096 --net=host --pid=host --ipc=host
+        -v /dev:/dev -v /etc/ceph:/ceph/ceph
+        -v /var/lib/ceph:/var/lib/ceph
+        -v /var/run:/var/run
+        --entrypoint=ceph-volume
+        {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+        inventory --format json
+      register: ceph_volume_inventory
+
+    - name: set_fact inventory
+      set_fact:
+        inventory: "{{ ceph_volume_inventory.stdout | from_json }}"
+
+    - name: set_fact ceph_disk_osds
+      set_fact:
+        ceph_disk_osds_devices: "{{ ceph_disk_osds_devices | default([]) + [item.path] }}"
+      with_items: "{{ inventory }}"
+      when:
+        - not item.available | bool
+        - "'Used by ceph-disk' in item.rejected_reasons"
+
+    - name: ceph-disk prepared OSDs related tasks
+      when: ceph_disk_osds_devices | default([]) | length > 0
+      block:
+        - name: get partlabel
+          command: blkid "{{ item + 'p' if item is match('/dev/(cciss/c[0-9]d[0-9]|nvme[0-9]n[0-9]){1,2}$') else item }}"1 -s PARTLABEL -o value
+          register: partlabel
+          with_items: "{{ ceph_disk_osds_devices | default([]) }}"
+
+        - name: get simple scan data
+          command: >
+            {{ container_binary }} run --rm --privileged=true
+            --ulimit nofile=1024:4096 --net=host --pid=host --ipc=host
+            -v /dev:/dev -v /etc/ceph:/etc/ceph
+            -v /var/lib/ceph:/var/lib/ceph
+            -v /var/run:/var/run
+            --entrypoint=ceph-volume
+            {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+            simple scan {{ item.item + 'p1' if item.item is match('/dev/(cciss/c[0-9]d[0-9]|nvme[0-9]n[0-9]){1,2}$') else item.item + '1' }} --stdout
+          register: simple_scan
+          with_items: "{{ partlabel.results | default([]) }}"
+          when: item.stdout == 'ceph data'
+          ignore_errors: true
+
+        - name: mark out osds
+          command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd out {{ (item.0.stdout | from_json).whoami }}"
+          with_together:
+            - "{{ simple_scan.results }}"
+            - "{{ partlabel.results }}"
+          delegate_to: "{{ groups[mon_group_name][0] }}"
+          run_once: true
+          when: item.1.stdout == 'ceph data'
+
+        - name: stop and disable old osd services
+          service:
+            name: "ceph-osd@{{ (item.0.stdout | from_json).whoami }}"
+            state: stopped
+            enabled: no
+          with_together:
+            - "{{ simple_scan.results }}"
+            - "{{ partlabel.results }}"
+          when: item.1.stdout == 'ceph data'
+
+        - name: ensure dmcrypt for data device is closed
+          command: cryptsetup close "{{ (item.0.stdout | from_json).data.uuid }}"
+          with_together:
+            - "{{ simple_scan.results }}"
+            - "{{ partlabel.results }}"
+          failed_when: false
+          changed_when: false
+          when:
+            - (item.0.stdout | from_json).encrypted | default(False)
+            -
+            - item.1.stdout == 'ceph data'
+
+        - name: ensure dmcrypt for journal device is closed
+          command: cryptsetup close "{{ (item.0.stdout | from_json).journal.uuid }}"
+          with_together:
+            - "{{ simple_scan.results }}"
+            - "{{ partlabel.results }}"
+          failed_when: false
+          changed_when: false
+          when:
+            - (item.0.stdout | from_json).encrypted | default(False)
+            - item.1.stdout == 'ceph data'
+
+        - name: zap data devices
+          command: >
+            {{ container_binary }} run --rm --privileged=true
+            --ulimit nofile=1024:4096 --net=host --pid=host --ipc=host
+            -v /dev:/dev -v /etc/ceph:/etc/ceph
+            -v /var/lib/ceph:/var/lib/ceph
+            -v /var/run:/var/run
+            --entrypoint=ceph-volume
+            {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+            lvm zap --destroy {{ (item.0.stdout | from_json).data.path }}
+          with_together:
+            - "{{ simple_scan.results }}"
+            - "{{ partlabel.results }}"
+          when: item.1.stdout == 'ceph data'
+
+        - name: zap journal devices
+          command: >
+            {{ container_binary }} run --rm --privileged=true
+            --ulimit nofile=1024:4096 --net=host --pid=host --ipc=host
+            -v /dev:/dev -v /etc/ceph:/etc/ceph
+            -v /var/lib/ceph:/var/lib/ceph
+            -v /var/run:/var/run
+            --entrypoint=ceph-volume
+            {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+            lvm zap --destroy {{ (item.0.stdout | from_json).journal.path }}
+          with_together:
+            - "{{ simple_scan.results }}"
+            - "{{ partlabel.results }}"
+          when:
+            - item.1.stdout == 'ceph data'
+            - (item.0.stdout | from_json).journal.path is defined
+
+    - name: get ceph-volume lvm list data
+      command: >
+        {{ container_binary }} run --rm --privileged=true
+        --ulimit nofile=1024:4096 --net=host --pid=host --ipc=host
+        -v /dev:/dev -v /etc/ceph:/ceph/ceph
+        -v /var/lib/ceph:/var/lib/ceph
+        -v /var/run:/var/run
+        --entrypoint=ceph-volume
+        {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+        lvm list --format json
+      register: ceph_volume_lvm_list
+
+    - name: set_fact _lvm_list
+      set_fact:
+        _lvm_list: "{{ _lvm_list | default([]) + item.value }}"
+      with_dict: "{{ (ceph_volume_lvm_list.stdout | from_json) }}"
+
+    - name: ceph-volume prepared OSDs related tasks
+      block:
+        - name: mark out osds
+          command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd out {{ item }}"
+          with_items: "{{ (ceph_volume_lvm_list.stdout | from_json).keys() | list }}"
+          delegate_to: "{{ groups[mon_group_name][0] }}"
+          run_once: true
+
+        - name: stop and disable old osd services
+          service:
+            name: "ceph-osd@{{ item }}"
+            state: stopped
+            enabled: no
+          with_items: "{{ (ceph_volume_lvm_list.stdout | from_json).keys() | list }}"
+
+        - name: ensure all dmcrypt for data and journal are closed
+          command: cryptsetup close "{{ item['lv_uuid'] }}"
+          with_items: "{{ _lvm_list }}"
+          changed_when: false
+          failed_when: false
+          when: item['tags']['ceph.encrypted'] | int == 1
+
+        - name: set_fact osd_fsid_list
+          set_fact:
+            osd_fsid_list: "{{ osd_fsid_list | default([]) + [item.tags['ceph.osd_fsid']] }}"
+          with_items: "{{ _lvm_list }}"
+          when: item.type == 'data'
+
+        - name: zap ceph-volume prepared OSDs
+          ceph_volume:
+            action: "zap"
+            osd_fsid: "{{ item }}"
+          environment:
+            CEPH_VOLUME_DEBUG: 1
+            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+          loop: "{{ osd_fsid_list }}"
+      when: _lvm_list is defined
+
+    - name: set_fact osd_ids
+      set_fact:
+        osd_ids: "{{ osd_ids | default([]) + [item] }}"
+      with_items:
+        - "{{ ((osd_tree.stdout | from_json).nodes | selectattr('name', 'match', inventory_hostname) | map(attribute='children') | list) }}"
+
+
+    - name: purge osd(s) from the cluster
+      command: >
+        {{ container_exec_cmd }} ceph --cluster {{ cluster }} osd purge {{ item }} --yes-i-really-mean-it
+      run_once: true
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      with_items: "{{ osd_ids }}"
+
+    - name: purge /var/lib/ceph/osd directories
+      file:
+        path: "/var/lib/ceph/osd/{{ cluster }}-{{ item }}"
+        state: absent
+      with_items: "{{ osd_ids }}"
+
+    - name: remove gpt header
+      command: parted -s "{{ item }}" mklabel msdos
+      with_items: "{{ devices + dedicated_devices | default([]) }}"
+
+    - import_role:
+        name: ceph-facts
+    - import_role:
+        name: ceph-defaults
+    - import_role:
+        name: ceph-handler
+    - import_role:
+        name: ceph-container-common
+    - import_role:
+        name: ceph-osd
+      vars:
+        osd_objectstore: bluestore

--- a/infrastructure-playbooks/lv-create.yml
+++ b/infrastructure-playbooks/lv-create.yml
@@ -27,7 +27,7 @@
     failed_when: false
 
   # ensure nvme_device is set
-  - name: fail if nvme_device is not undefined
+  - name: fail if nvme_device is not defined
     fail:
       msg: "nvme_device has not been set by the user"
     when: nvme_device is undefined or nvme_device == 'dummy'

--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -280,6 +280,7 @@ def batch(module, container_image):
     journal_size = module.params.get('journal_size', None)
     block_db_size = module.params.get('block_db_size', None)
     block_db_devices = module.params.get('block_db_devices', None)
+    wal_devices = module.params.get('wal_devices', None)
     dmcrypt = module.params.get('dmcrypt', None)
     osds_per_device = module.params.get('osds_per_device', 1)
 
@@ -320,6 +321,9 @@ def batch(module, container_image):
 
     if block_db_devices:
         cmd.extend(['--db-devices', ' '.join(block_db_devices)])
+
+    if wal_devices:
+        cmd.extend(['--wal-devices', ' '.join(wal_devices)])
 
     return cmd
 
@@ -508,6 +512,7 @@ def run_module():
         journal_size=dict(type='str', required=False, default='5120'),
         block_db_size=dict(type='str', required=False, default='-1'),
         block_db_devices=dict(type='list', required=False, default=[]),
+        wal_devices=dict(type='list', required=False, default=[]),
         report=dict(type='bool', required=False, default=False),
         containerized=dict(type='str', required=False, default=False),
         osd_fsid=dict(type='str', required=False),

--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -279,6 +279,7 @@ def batch(module, container_image):
     crush_device_class = module.params.get('crush_device_class', None)
     journal_size = module.params.get('journal_size', None)
     block_db_size = module.params.get('block_db_size', None)
+    block_db_devices = module.params.get('block_db_devices', None)
     dmcrypt = module.params.get('dmcrypt', None)
     osds_per_device = module.params.get('osds_per_device', 1)
 
@@ -316,6 +317,9 @@ def batch(module, container_image):
         cmd.extend(['--block-db-size', block_db_size])
 
     cmd.extend(batch_devices)
+
+    if block_db_devices:
+        cmd.extend(['--db-devices', ' '.join(block_db_devices)])
 
     return cmd
 
@@ -503,6 +507,7 @@ def run_module():
         osds_per_device=dict(type='int', required=False, default=1),
         journal_size=dict(type='str', required=False, default='5120'),
         block_db_size=dict(type='str', required=False, default='-1'),
+        block_db_devices=dict(type='list', required=False, default=[]),
         report=dict(type='bool', required=False, default=False),
         containerized=dict(type='str', required=False, default=False),
         osd_fsid=dict(type='str', required=False),

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -1,11 +1,24 @@
 ---
 - name: copy ceph admin keyring
-  copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.client.admin.keyring"
-    dest: "/etc/ceph/"
-    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "{{ ceph_keyring_permissions }}"
-  when:
-    - cephx | bool
-    - copy_admin_key | bool
+  block:
+    - name: get keys from monitors
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      register: _client_keys
+      with_items:
+        - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+      delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+      when:
+        - cephx | bool
+        - item.copy_key | bool
+
+    - name: copy ceph key(s) if needed
+      copy:
+        dest: "{{ item.item.path }}"
+        content: "{{ item.stdout + '\n' }}"
+        owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        mode: "{{ ceph_keyring_permissions }}"
+      with_items: "{{ _client_keys.results }}"
+      when:
+        - item.item.copy_key | bool
+  when: cephx | bool

--- a/roles/ceph-iscsi-gw/defaults/main.yml
+++ b/roles/ceph-iscsi-gw/defaults/main.yml
@@ -11,6 +11,8 @@ iscsi_conf_overrides: {}
 iscsi_pool_name: rbd
 iscsi_pool_size: "{{ osd_pool_default_size }}"
 
+copy_admin_key: True
+
 ##################
 # RBD-TARGET-API #
 ##################

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -1,12 +1,25 @@
 ---
-- name: copy admin key
+- name: get keys from monitors
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  register: _iscsi_keys
+  with_items:
+    - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+  when:
+    - cephx | bool
+    - item.copy_key | bool
+
+- name: copy ceph key(s) if needed
   copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.client.admin.keyring"
-    dest: "/etc/ceph/{{ cluster }}.client.admin.keyring"
-    owner: "root"
-    group: "root"
+    dest: "{{ item.item.path }}"
+    content: "{{ item.stdout + '\n' }}"
+    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: "{{ ceph_keyring_permissions }}"
-  when: cephx | bool
+  with_items: "{{ _iscsi_keys.results }}"
+  when:
+    - cephx | bool
+    - item.item.copy_key | bool
 
 - name: deploy gateway settings, used by the ceph_iscsi_config modules
   config_template:

--- a/roles/ceph-iscsi-gw/tasks/deploy_ssl_keys.yml
+++ b/roles/ceph-iscsi-gw/tasks/deploy_ssl_keys.yml
@@ -1,4 +1,11 @@
 ---
+- name: create a temporary directory
+  tempfile:
+    state: directory
+  register: iscsi_ssl_tmp_dir
+  delegate_to: localhost
+  run_once: true
+
 - name: set_fact crt_files
   set_fact:
     crt_files:
@@ -7,54 +14,75 @@
       - "iscsi-gateway.pem"
       - "iscsi-gateway-pub.key"
 
-- name: stat for crt file(s)
-  stat:
-    path: "{{ fetch_directory }}/{{ fsid }}/{{ item }}"
-  delegate_to: localhost
+- name: check for existing crt file(s) in monitor key/value store
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} config get iscsi/ssl/{{ item }}"
   with_items: "{{ crt_files }}"
   changed_when: false
   failed_when: false
-  check_mode: no
+  run_once: true
+  delegate_to: "{{ groups.get(mon_group_name)[0] }}"
   register: crt_files_exist
 
-- name: create ssl crt/key files
-  command: >
-    openssl req -newkey rsa:2048 -nodes -keyout {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.key
-     -x509 -days 365 -out {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.crt
-     -subj "/C=US/ST=./L=./O=RedHat/OU=Linux/CN={{ ansible_hostname }}"
-  delegate_to: localhost
-  become: False
-  run_once: True
-  with_items: "{{ crt_files_exist.results }}"
-  when: not item.stat.exists
+- name: set_fact crt_files_missing
+  set_fact:
+    crt_files_missing: "{{ crt_files_exist.results | selectattr('rc', 'equalto', 0) | map(attribute='rc') | list | length != crt_files | length }}"
 
-- name: create pem
-  shell: >
-    cat {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.crt
-    {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.key > {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.pem
-  delegate_to: localhost
-  become: False
-  run_once: True
-  register: pem
-  with_items: "{{ crt_files_exist.results }}"
-  when: not item.stat.exists
+- name: generate ssl crt/key files
+  block:
+    - name: create ssl crt/key files
+      command: >
+        openssl req -newkey rsa:2048 -nodes -keyout {{ iscsi_ssl_tmp_dir.path }}/iscsi-gateway.key
+         -x509 -days 365 -out {{ iscsi_ssl_tmp_dir.path }}/iscsi-gateway.crt
+         -subj "/C=US/ST=./L=./O=RedHat/OU=Linux/CN={{ ansible_hostname }}"
+      delegate_to: localhost
+      run_once: True
+      with_items: "{{ crt_files_exist.results }}"
 
-- name: create public key from pem
-  shell: >
-    openssl x509 -inform pem -in {{ fetch_directory }}/{{ fsid }}/iscsi-gateway.pem
-    -pubkey -noout > {{ fetch_directory }}/{{ fsid }}/iscsi-gateway-pub.key
-  delegate_to: localhost
-  become: False
-  run_once: True
-  when: pem.changed
-  tags: skip_ansible_lint
+    - name: create pem
+      shell: >
+        cat {{ iscsi_ssl_tmp_dir.path }}/iscsi-gateway.crt
+        {{ iscsi_ssl_tmp_dir.path }}/iscsi-gateway.key > {{ iscsi_ssl_tmp_dir.path }}/iscsi-gateway.pem
+      delegate_to: localhost
+      run_once: True
+      register: pem
+      with_items: "{{ crt_files_exist.results }}"
+
+    - name: create public key from pem
+      shell: >
+        openssl x509 -inform pem -in {{ iscsi_ssl_tmp_dir.path }}/iscsi-gateway.pem
+        -pubkey -noout > {{ iscsi_ssl_tmp_dir.path }}/iscsi-gateway-pub.key
+      delegate_to: localhost
+      run_once: True
+      when: pem.changed
+      tags: skip_ansible_lint
+
+    - name: slurp ssl crt/key files
+      slurp:
+        src: "{{ iscsi_ssl_tmp_dir.path }}/{{ item }}"
+      register: iscsi_ssl_files_content
+      with_items: "{{ crt_files }}"
+      run_once: true
+      delegate_to: localhost
+
+    - name: store ssl crt/key files
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} config-key put iscsi/ssl/{{ item.item }} {{ item.content }}"
+      run_once: true
+      delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+      with_items: "{{ iscsi_ssl_files_content.results }}"
+  when: crt_files_missing
 
 - name: copy crt file(s) to gateway nodes
   copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/{{ item }}"
-    dest: "/etc/ceph/{{ item }}"
+    content: "{{ item.stdout | b64decode }}"
+    dest: "/etc/ceph/{{ item.item }}"
     owner: root
     group: root
     mode: 0400
   changed_when: false
-  with_items: "{{ crt_files }}"
+  with_items: "{{ crt_files_exist.results if not crt_files_missing else iscsi_ssl_files_content.results }}"
+  when: not crt_files_missing
+
+- name: clean temporary directory
+  file:
+    path: "{{ iscsi_ssl_tmp_dir.path }}"
+    state: absent

--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -63,7 +63,9 @@
         state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
       register: result
       until: result is succeeded
-      with_items: "{{ ceph_iscsi_pkgs }}"
+      with_items:
+        - "{{ ceph_iscsi_pkgs }}"
+        - python-requests
 
 - name: check the status of the target.service override
   stat:

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -10,16 +10,25 @@
     - /var/lib/ceph/bootstrap-mds/
     - /var/lib/ceph/mds/{{ cluster }}-{{ mds_name }}
 
-- name: copy ceph keyring(s) if needed
+- name: get keys from monitors
+  command: "{{ hostvars[groups.get(mon_group_name)[0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  register: _mds_keys
+  with_items:
+    - { name: "client.bootstrap-mds", path: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring", copy_key: true }
+    - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+  when:
+    - cephx | bool
+    - item.copy_key | bool
+
+- name: copy ceph key(s) if needed
   copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/{{ item.name }}"
-    dest: "{{ item.name }}"
+    dest: "{{ item.item.path }}"
+    content: "{{ item.stdout + '\n' }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: "{{ ceph_keyring_permissions }}"
-  with_items:
-    - { name: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring", copy_key: true }
-    - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  with_items: "{{ _mds_keys.results }}"
   when:
-    - cephx
-    - item.copy_key|bool
+    - cephx | bool
+    - item.item.copy_key | bool

--- a/roles/ceph-mds/tasks/containerized.yml
+++ b/roles/ceph-mds/tasks/containerized.yml
@@ -3,46 +3,6 @@
   set_fact:
     container_exec_cmd: "{{ container_binary }} exec ceph-mds-{{ ansible_hostname }}"
 
-- name: set_fact admin_keyring
-  set_fact:
-    admin_keyring:
-      - "/etc/ceph/{{ cluster }}.client.admin.keyring"
-  when: copy_admin_key
-
-- name: set_fact ceph_config_keys
-  set_fact:
-    ceph_config_keys:
-      - /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring
-
-- name: merge ceph_config_keys and admin_keyring
-  set_fact:
-    ceph_config_keys: "{{ ceph_config_keys + admin_keyring }}"
-  when: copy_admin_key
-
-- name: stat for ceph config and keys
-  stat:
-    path: "{{ fetch_directory }}/{{ fsid }}/{{ item }}"
-  delegate_to: localhost
-  with_items: "{{ ceph_config_keys }}"
-  changed_when: false
-  become: false
-  failed_when: false
-  check_mode: no
-  register: statconfig
-
-- name: try to fetch ceph config and keys
-  copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/{{ item.0 }}"
-    dest: "{{ item.0 }}"
-    owner: root
-    group: root
-    mode: 0644
-  changed_when: false
-  with_together:
-    - "{{ ceph_config_keys }}"
-    - "{{ statconfig.results }}"
-  when: item.1.stat.exists
-
 - name: generate systemd unit file
   become: true
   template:

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -49,34 +49,33 @@
       run_once: True
       delegate_to: "{{ groups[mon_group_name][0] }}"
 
-    - name: copy ceph mgr key(s) from mon node to the ansible server
-      fetch:
-        src: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
-        dest: "{{ fetch_directory }}/{{ fsid }}/{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
-        flat: yes
+    - name: set_fact _mgr_keys
+      set_fact:
+        _mgr_keys: "{{ _mgr_keys | default([{ 'name': 'client.admin', 'path': '/etc/ceph/' + cluster + '.client.admin.keyring', 'copy_key': copy_admin_key, 'hostname': hostvars[item]['ansible_hostname'] }]) + [{ 'name': 'mgr.' + hostvars[item]['ansible_hostname'], 'path': '/var/lib/ceph/mgr/' + cluster + '-' + hostvars[item]['ansible_hostname'] + '/keyring', 'copy_key': true, 'hostname': hostvars[item]['ansible_hostname'] }] }}"
       with_items: "{{ groups.get(mgr_group_name, []) }}"
-      delegate_to: "{{ groups[mon_group_name][0] }}"
 
-    - name: copy ceph keyring(s) to mgr node
+    - name: get keys from monitors
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      register: _mgr_keys
+      with_items: "{{ _mgr_keys }}"
+      delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+      when:
+        - cephx | bool
+        - item.copy_key | bool
+
+    - name: copy ceph key(s) if needed
       copy:
-        src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.mgr.{{ ansible_hostname }}.keyring"
-        dest: "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring"
+        dest: "{{ item.item.path }}"
+        content: "{{ item.stdout + '\n' }}"
         owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         mode: "{{ ceph_keyring_permissions }}"
-      when: cephx | bool
-
-- name: copy ceph keyring(s) if needed
-  copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.client.admin.keyring"
-    dest: "/etc/ceph/{{ cluster }}.client.admin.keyring"
-    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "{{ ceph_keyring_permissions }}"
-  when:
-    - cephx | bool
-    - groups.get(mgr_group_name, []) | length > 0
-    - copy_admin_key | bool
+      with_items: "{{ _mgr_keys.results }}"
+      delegate_to: "{{ item.item.hostname }}"
+      run_once: true
+      when:
+        - cephx | bool
+        - item.item.copy_key | bool
 
 - name: set mgr key permissions
   file:

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -16,31 +16,16 @@
   delay: "{{ handler_health_mon_check_delay }}"
   changed_when: false
 
-- name: tasks for MONs when cephx is enabled
-  when: cephx | bool
-  block:
-  - name: fetch ceph initial keys
-    ceph_key:
-      state: fetch_initial_keys
-      cluster: "{{ cluster }}"
-      owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-      group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-      mode: "0400"
-    environment:
-      CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-      CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-      CEPH_ROLLING_UPDATE: "{{ rolling_update }}"
-
-  - name: copy keys to the ansible server
-    fetch:
-      src: "{{ item }}"
-      dest: "{{ fetch_directory }}/{{ fsid }}/{{ item }}"
-      flat: yes
-    with_items:
-      - /var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring
-      - /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring
-      - /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring
-      - /var/lib/ceph/bootstrap-rbd/{{ cluster }}.keyring
-      - /var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring
-      - /etc/ceph/{{ cluster }}.client.admin.keyring
-    when: inventory_hostname == groups[mon_group_name] | last
+- name: fetch ceph initial keys
+  ceph_key:
+    state: fetch_initial_keys
+    cluster: "{{ cluster }}"
+    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    mode: "0400"
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+    CEPH_ROLLING_UPDATE: "{{ rolling_update }}"
+  when:
+    - cephx | bool

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -1,45 +1,28 @@
 ---
 - name: keyring related tasks
   block:
-    - name: set_fact admin_keyring
-      set_fact:
-        admin_keyring:
-          - "/etc/ceph/{{ cluster }}.client.admin.keyring"
-      when: copy_admin_key | bool
+    - name: get keys from monitors
+      command: "{{ hostvars[groups.get(mon_group_name)[0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      register: _rgw_keys
+      with_items:
+        - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
+        - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+      delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+      when:
+        - cephx | bool
+        - item.copy_key | bool
 
-    - name: set_fact ceph_config_keys
-      set_fact:
-        ceph_config_keys:
-          - /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring
-
-    - name: merge ceph_config_keys and admin_keyring
-      set_fact:
-        ceph_config_keys: "{{ ceph_config_keys + admin_keyring }}"
-      when: copy_admin_key | bool
-
-    - name: stat for config and keys
-      stat:
-        path: "{{ fetch_directory }}/{{ fsid }}/{{ item }}"
-      delegate_to: localhost
-      with_items: "{{ ceph_config_keys }}"
-      changed_when: false
-      become: false
-      failed_when: false
-      check_mode: no
-      register: statconfig
-
-    - name: try to fetch config and keys
+    - name: copy ceph key(s) if needed
       copy:
-        src: "{{ fetch_directory }}/{{ fsid }}/{{ item.0 }}"
-        dest: "{{ item.0 }}"
-        owner: "64045"
-        group: "64045"
-        mode: 0644
-      changed_when: false
-      with_together:
-        - "{{ ceph_config_keys }}"
-        - "{{ statconfig.results }}"
-      when: item.1.stat.exists
+        dest: "{{ item.item.path }}"
+        content: "{{ item.stdout + '\n' }}"
+        owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        mode: "{{ ceph_keyring_permissions }}"
+      with_items: "{{ _rgw_keys.results }}"
+      when:
+        - cephx | bool
+        - item.item.copy_key | bool
   when: groups.get(mon_group_name, []) | length > 0
 
 - name: dbus related tasks

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -46,17 +46,28 @@
     - cephx | bool
     - groups.get(mon_group_name, []) | length > 0
   block:
-    - name: copy bootstrap cephx keys
-      copy:
-        src: "{{ fetch_directory }}/{{ fsid }}/{{ item.name }}"
-        dest: "{{ item.name }}"
-        owner: "ceph"
-        group: "ceph"
-        mode: "0600"
+    - name: get keys from monitors
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      register: _rgw_keys
       with_items:
-        - { name: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: "{{ nfs_obj_gw }}" }
-        - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
-      when: item.copy_key | bool
+        - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
+        - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+      delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+      when:
+        - cephx | bool
+        - item.copy_key | bool
+
+    - name: copy ceph key(s) if needed
+      copy:
+        dest: "{{ item.item.path }}"
+        content: "{{ item.stdout + '\n' }}"
+        owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        mode: "{{ ceph_keyring_permissions }}"
+      with_items: "{{ _rgw_keys.results }}"
+      when:
+        - cephx | bool
+        - item.item.copy_key | bool
 
     - name: nfs object gateway related tasks
       when: nfs_obj_gw | bool

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -33,6 +33,13 @@ copy_admin_key: false
 
 devices: []
 
+# Declare devices to be used as block.db devices
+
+#dedicated_devices:
+#  - /dev/sda
+#  - /dev/sdb
+
+dedicated_devices: []
 
 #'osd_auto_discovery'  mode prevents you from filling out the 'devices' variable above.
 # Device discovery is based on the Ansible fact 'ansible_devices'

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -23,7 +23,7 @@ copy_admin_key: false
 
 # Declare devices to be used as OSDs
 # All scenario(except 3rd) inherit from the following device declaration
-# Note: This scenario uses the ceph-disk tool to provision OSDs
+# Note: This scenario uses the ceph-volume lvm batch method to provision OSDs
 
 #devices:
 #  - /dev/sdb
@@ -43,9 +43,9 @@ dedicated_devices: []
 
 #'osd_auto_discovery'  mode prevents you from filling out the 'devices' variable above.
 # Device discovery is based on the Ansible fact 'ansible_devices'
-# which reports all the devices on a system. If chosen all the disks
-# found will be passed to ceph-disk. You should not be worried on using
-# this option since ceph-disk has a built-in check which looks for empty devices.
+# which reports all the devices on a system. If chosen, all the disks
+# found will be passed to ceph-volume lvm batch. You should not be worried on using
+# this option since ceph-volume has a built-in check which looks for empty devices.
 # Thus devices with existing partition tables will not be used.
 #
 osd_auto_discovery: false

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -36,10 +36,18 @@ devices: []
 # Declare devices to be used as block.db devices
 
 #dedicated_devices:
-#  - /dev/sda
-#  - /dev/sdb
+#  - /dev/sdx
+#  - /dev/sdy
 
 dedicated_devices: []
+
+# Declare devices to be used as block.wal devices
+
+#bluestore_wal_devices:
+#  - /dev/nvme0n1
+#  - /dev/nvme0n2
+
+bluestore_wal_devices: []
 
 #'osd_auto_discovery'  mode prevents you from filling out the 'devices' variable above.
 # Device discovery is based on the Ansible fact 'ansible_devices'

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -11,16 +11,25 @@
     - /var/lib/ceph/bootstrap-osd/
     - /var/lib/ceph/osd/
 
-- name: copy ceph key(s) if needed
-  copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/{{ item.name }}"
-    dest: "{{ item.name }}"
-    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "{{ ceph_keyring_permissions }}"
+- name: get keys from monitors
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  register: _osd_keys
   with_items:
-    - { name: "/var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring", copy_key: true }
-    - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+    - { name: "client.bootstrap-osd", path: "/var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring", copy_key: true }
+    - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  delegate_to: "{{ groups.get(mon_group_name)[0] }}"
   when:
     - cephx | bool
     - item.copy_key | bool
+
+- name: copy ceph key(s) if needed
+  copy:
+    dest: "{{ item.item.path }}"
+    content: "{{ item.stdout + '\n' }}"
+    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    mode: "{{ ceph_keyring_permissions }}"
+  with_items: "{{ _osd_keys.results }}"
+  when:
+    - cephx | bool
+    - item.item.copy_key | bool

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -67,40 +67,38 @@
       when: item.application is defined
 
 - name: create openstack cephx key(s)
-  ceph_key:
-    state: present
-    name: "{{ item.name }}"
-    caps: "{{ item.caps }}"
-    secret: "{{ item.key | default('') }}"
-    cluster: "{{ cluster }}"
-    mode: "{{ item.mode|default(omit) }}"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-  with_items: "{{ openstack_keys }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  when: cephx | bool
+  block:
+    - name: generate keys
+      ceph_key:
+        state: present
+        name: "{{ item.name }}"
+        caps: "{{ item.caps }}"
+        secret: "{{ item.key | default('') }}"
+        cluster: "{{ cluster }}"
+        mode: "{{ item.mode|default(omit) }}"
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+      with_items: "{{ openstack_keys }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
 
-- name: fetch openstack cephx key(s)
-  fetch:
-    src: "/etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
-    dest: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.{{ item.name }}.keyring"
-    flat: yes
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  with_items: "{{ openstack_keys }}"
+    - name: get keys from monitors
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      register: _osp_keys
+      with_items: "{{ openstack_keys }}"
+      delegate_to: "{{ groups.get(mon_group_name)[0] }}"
 
-- name: copy to other mons the openstack cephx key(s)
-  copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.{{ item.1.name }}.keyring"
-    dest: "/etc/ceph/{{ cluster }}.{{ item.1.name }}.keyring"
-    owner: "{{ ceph_uid }}"
-    group: "{{ ceph_uid }}"
-    mode: "{{ item.1.mode|default(omit) }}"
-  with_nested:
-    - "{{ groups[mon_group_name] }}"
-    - "{{ openstack_keys }}"
-  delegate_to: "{{ item.0 }}"
+    - name: copy ceph key(s) if needed
+      copy:
+        dest: "/etc/ceph/{{ cluster }}.{{ item.0.item.name }}.keyring"
+        content: "{{ item.0.stdout + '\n' }}"
+        owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+        mode: "{{ item.0.item.mode }}"
+      with_nested:
+        - "{{ _osp_keys.results }}"
+        - "{{ groups[mon_group_name] }}"
+      delegate_to: "{{ item.1 }}"
   when:
     - cephx | bool
     - openstack_config | bool
-    - item.0 != groups[mon_group_name]

--- a/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
@@ -11,6 +11,7 @@
     journal_size: "{{ journal_size }}"
     block_db_size: "{{ block_db_size }}"
     block_db_devices: "{{ dedicated_devices | unique if dedicated_devices | length > 0 else omit }}"
+    wal_devices: "{{ bluestore_wal_devices | unique if bluestore_wal_devices | length > 0 else omit }}"
     action: "batch"
   environment:
     CEPH_VOLUME_DEBUG: 1

--- a/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
@@ -10,6 +10,7 @@
     osds_per_device: "{{ osds_per_device }}"
     journal_size: "{{ journal_size }}"
     block_db_size: "{{ block_db_size }}"
+    block_db_devices: "{{ dedicated_devices | unique if dedicated_devices | length > 0 else omit }}"
     action: "batch"
   environment:
     CEPH_VOLUME_DEBUG: 1

--- a/roles/ceph-rbd-mirror/defaults/main.yml
+++ b/roles/ceph-rbd-mirror/defaults/main.yml
@@ -3,8 +3,6 @@
 # SETUP #
 #########
 
-fetch_directory: fetch/
-
 # Even though rbd-mirror nodes should not have the admin key
 # at their disposal, some people might want to have it
 # distributed on rbd-mirror nodes. Setting 'copy_admin_key' to 'true'

--- a/roles/ceph-rbd-mirror/tasks/common.yml
+++ b/roles/ceph-rbd-mirror/tasks/common.yml
@@ -1,20 +1,26 @@
 ---
-- name: copy rbd-mirror bootstrap key
-  copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring"
-    dest: "/var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring"
-    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "{{ ceph_keyring_permissions }}"
+- name: get keys from monitors
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  register: _rbd_mirror_keys
+  with_items:
+    - { name: "client.bootstrap-rbd-mirror", path: "/var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring", copy_key: true }
+    - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+  when:
+    - cephx | bool
+    - item.copy_key | bool
 
-- name: copy ceph admin keyring if needed
+- name: copy ceph key(s) if needed
   copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.client.admin.keyring"
-    dest: "/etc/ceph/{{ cluster }}.client.admin.keyring"
+    dest: "{{ item.item.path }}"
+    content: "{{ item.stdout + '\n' }}"
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: "{{ ceph_keyring_permissions }}"
-  when: copy_admin_key | bool
+  with_items: "{{ _rbd_mirror_keys.results }}"
+  when:
+    - cephx | bool
+    - item.item.copy_key | bool
 
 - name: create rbd-mirror keyring
   command: >

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -18,16 +18,25 @@
   with_items: "{{ rgw_instances }}"
   when: rgw_instances is defined
 
-- name: copy ceph keyring(s) if needed
-  copy:
-    src: "{{ fetch_directory }}/{{ fsid }}/{{ item.name }}"
-    dest: "{{ item.name }}"
-    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "{{ ceph_keyring_permissions }}"
+- name: get keys from monitors
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  register: _rgw_keys
   with_items:
-    - { name: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
-    - { name: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+    - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
+    - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  delegate_to: "{{ groups.get(mon_group_name)[0] }}"
   when:
     - cephx | bool
     - item.copy_key | bool
+
+- name: copy ceph key(s) if needed
+  copy:
+    dest: "{{ item.item.path }}"
+    content: "{{ item.stdout + '\n' }}"
+    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    mode: "{{ ceph_keyring_permissions }}"
+  with_items: "{{ _rgw_keys.results }}"
+  when:
+    - cephx | bool
+    - item.item.copy_key | bool

--- a/tests/functional/shrink_mds/container/group_vars/all
+++ b/tests/functional/shrink_mds/container/group_vars/all
@@ -14,3 +14,4 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False
+copy_admin_key: True

--- a/tests/functional/shrink_osd/container/group_vars/all
+++ b/tests/functional/shrink_osd/container/group_vars/all
@@ -14,3 +14,4 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False
+copy_admin_key: True

--- a/tests/functional/shrink_osd/group_vars/all
+++ b/tests/functional/shrink_osd/group_vars/all
@@ -8,3 +8,4 @@ ceph_conf_overrides:
     osd_pool_default_size: 3
 openstack_config: False
 dashboard_enabled: False
+copy_admin_key: True

--- a/tests/functional/shrink_rbdmirror/container/group_vars/all
+++ b/tests/functional/shrink_rbdmirror/container/group_vars/all
@@ -13,3 +13,4 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False
+copy_admin_key: True

--- a/tests/functional/shrink_rgw/container/group_vars/all
+++ b/tests/functional/shrink_rgw/container/group_vars/all
@@ -15,3 +15,4 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False
+copy_admin_key: True

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,6 +5,7 @@ pytest-xdist==1.28.0
 pytest>=4.4,<4.5
 notario>=0.0.13
 ansible>=2.8,<2.9
+Jinja2>=2.10
 netaddr
 mock
 jmespath

--- a/tox-podman.ini
+++ b/tox-podman.ini
@@ -51,7 +51,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      copy_admin_key={env:COPY_ADMIN_KEY:False} \
       container_binary=podman \
       container_package_name=podman \
       container_service_name=podman \

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -63,7 +63,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-mimic} \
-      copy_admin_key={env:COPY_ADMIN_KEY:False} \
   "'
 
   pip install -r {toxinidir}/tests/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      copy_admin_key={env:COPY_ADMIN_KEY:False} \
   "
 
   # wait 30sec for services to be ready
@@ -391,14 +390,9 @@ setenv=
   container: CONTAINER_DIR = /container
   container: PLAYBOOK = site-docker.yml.sample
   container: PURGE_PLAYBOOK = purge-docker-cluster.yml
-  storage_inventory: COPY_ADMIN_KEY = True
   non_container: PLAYBOOK = site.yml.sample
   shrink_mon: MON_TO_KILL = mon2
-  shrink_osd: COPY_ADMIN_KEY = True
   shrink_mgr: MGR_TO_KILL = mgr1
-  shrink_mds: COPY_ADMIN_KEY = True
-  shrink_rbdmirror: COPY_ADMIN_KEY = True
-  shrink_rgw: COPY_ADMIN_KEY = True
 
   rhcs: CEPH_STABLE_RELEASE = luminous
   lvm_osds: CEPH_STABLE_RELEASE = luminous
@@ -466,7 +460,6 @@ commands=
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
-      copy_admin_key={env:COPY_ADMIN_KEY:False} \
   "
 
   # wait 30sec for services to be ready
@@ -483,7 +476,7 @@ commands=
   all_daemons: py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 
   # handlers/idempotency test
-  all_daemons: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "delegate_facts_host={env:DELEGATE_FACTS_HOST:True} fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} ceph_stable_release={env:CEPH_STABLE_RELEASE:nautilus} ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-bis-master} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} copy_admin_key={env:COPY_ADMIN_KEY:False}" --extra-vars @ceph-override.json
+  all_daemons: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "delegate_facts_host={env:DELEGATE_FACTS_HOST:True} fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} ceph_stable_release={env:CEPH_STABLE_RELEASE:nautilus} ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-bis-master} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --extra-vars @ceph-override.json
 
   purge: {[purge]commands}
   switch_to_containers: {[switch-to-containers]commands}


### PR DESCRIPTION
This playbook helps to migrate all osds on a node from filestore to
bluestore backend.
Note that *ALL* osd on the specified osd nodes will be shrinked and
redeployed.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1729267

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>

- [x] add ceph-disk prepared  OSDs support
- [x] add dmcrypt support
- [x] add ceph-volume prepared OSDs support
- [x] remove fetch_directory dependency