### PR TITLE
common: remove duplicate task installing suse dependencies

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_suse.yml
+++ b/roles/ceph-common/tasks/installs/install_on_suse.yml
@@ -11,14 +11,5 @@
   include_tasks: configure_suse_repository_installation.yml
   when: ceph_origin == 'repository'
 
-- name: install dependencies
-  zypper:
-    name: "{{ item }}"
-    state: present
-    update_cache: yes
-  with_items: "{{ suse_package_dependencies }}"
-  register: result
-  until: result is succeeded
-
 - name: include install_suse_packages.yml
   include_tasks: install_suse_packages.yml


### PR DESCRIPTION
roles/ceph-common/tasks/installs/install_on_suse.yml: remove the task that
installs the dependencies, as this is done later in install_suse_packages.yml

See the original discussion [here](https://github.com/ceph/ceph-ansible/pull/4324#discussion_r315541367).