### PR TITLE
move python-xml to raw_install_python.yml

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -89,8 +89,7 @@ dummy:
 
 #redhat_package_dependencies: []
 
-#suse_package_dependencies:
-#  - python-xml
+#suse_package_dependencies: []
 
 # Whether or not to install the ceph-test package.
 #ceph_test: false

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -89,8 +89,7 @@ fetch_directory: ~/ceph-ansible-keys
 
 #redhat_package_dependencies: []
 
-#suse_package_dependencies:
-#  - python-xml
+#suse_package_dependencies: []
 
 # Whether or not to install the ceph-test package.
 #ceph_test: false

--- a/raw_install_python.yml
+++ b/raw_install_python.yml
@@ -56,3 +56,14 @@
       until: result is succeeded
       when: stat_zypper.rc == 0
   when: not True in (systempython.results | selectattr('stat', 'defined') | map(attribute='stat.exists') | list | unique)
+
+- name: install python-xml for opensuse only if python2 is installed already
+  raw: zypper -n install python-xml
+  register: result
+  until: result is succeeded
+  with_items: "{{ systempython.results }}"
+  when:
+    - stat_zypper.rc is defined
+    - stat_zypper.rc == 0
+    - item.stat.exists | bool
+    - item.stat.path == '/usr/bin/python'

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -81,8 +81,7 @@ centos_package_dependencies:
 
 redhat_package_dependencies: []
 
-suse_package_dependencies:
-  - python-xml
+suse_package_dependencies: []
 
 # Whether or not to install the ceph-test package.
 ceph_test: false


### PR DESCRIPTION
The package python-xml is needed for ansible's zypper module to interact with
the zypper package management tool.

roles/ceph-defaults/defaults/main.yml:
Remove python-xml from variable suse_package_dependencies to only
install python-xml on SUSE/openSUSE if python is not found.
raw_install_python.yml already contains all the logic needed to check
if there is a valid python installation, so this is better suited there.

openSUSE Leap 15.x / SLES 15.x do no longer have /usr/bin/python,
only /usr/bin/python3, which already contains the xml module, so
nothing needs to be installed in that case.
