### PR TITLE
fix SUSE/openSUSE naming

### DIFF
--- a/raw_install_python.yml
+++ b/raw_install_python.yml
@@ -28,7 +28,7 @@
       failed_when: false
       register: stat_apt
 
-    - name: check for zypper package manager (OpenSUSE)
+    - name: check for zypper package manager (SUSE/OpenSUSE)
       raw: stat /usr/bin/zypper
       changed_when: false
       failed_when: false
@@ -49,7 +49,7 @@
       until: result is succeeded
       when: stat_apt.rc == 0
 
-    - name: install python for opensuse
+    - name: install python for SUSE/OpenSUSE
       raw: zypper -n install python-base
       register: result
       until: result is succeeded

--- a/roles/ceph-common/tasks/installs/install_on_suse.yml
+++ b/roles/ceph-common/tasks/installs/install_on_suse.yml
@@ -1,8 +1,8 @@
 ---
-# SUSE only supports the following:
+# SUSE/openSUSE only supports the following:
 # - ceph_origin == 'distro'
 # - ceph_origin == 'repository' and ceph_repository == 'obs'
-- name: Check for supported installation method on suse
+- name: Check for supported installation method on SUSE/openSUSE
   fail:
     msg: "Unsupported installation method origin:{{ ceph_origin }} repo:{{ ceph_repository }}'"
   when: ceph_origin != 'distro' or (ceph_origin == 'repository' and ceph_repository != 'obs')

--- a/roles/ceph-common/tasks/installs/install_suse_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_suse_packages.yml
@@ -1,12 +1,12 @@
 ---
-- name: install suse dependencies
+- name: install SUSE/openSUSE dependencies
   package:
     name: "{{ suse_package_dependencies }}"
     state: present
   register: result
   until: result is succeeded
 
-- name: install suse ceph packages
+- name: install SUSE/openSUSE ceph packages
   package:
     name: "{{ suse_ceph_pkgs | unique }}"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"

--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -1,5 +1,5 @@
 ---
-- name: check firewalld installation on redhat or suse
+- name: check firewalld installation on redhat or SUSE/openSUSE
   command: rpm -q firewalld
   args:
     warn: no

--- a/roles/ceph-mds/tasks/non_containerized.yml
+++ b/roles/ceph-mds/tasks/non_containerized.yml
@@ -10,7 +10,7 @@
   register: result
   until: result is succeeded
 
-- name: install ceph-mds package on redhat or suse
+- name: install ceph-mds package on redhat or SUSE/openSUSE
   package:
     name: "ceph-mds"
     state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -7,7 +7,7 @@
   include_tasks: pre_requisite_non_container_debian.yml
   when: ansible_os_family == 'Debian'
 
-- name: install nfs rgw/cephfs gateway - suse
+- name: install nfs rgw/cephfs gateway - SUSE/openSUSE
   zypper:
     name: "{{ item.name }}"
     disable_gpg_check: yes


### PR DESCRIPTION
As SUSE 15.x and openSUSE Leap 15.x share the same base, make it clear that both are targeted by the respective tasks