### PR TITLE
fix when-syntax in roles/ceph-common/tasks/installs/install_on_suse.yml

### DIFF
--- a/roles/ceph-common/tasks/installs/install_on_suse.yml
+++ b/roles/ceph-common/tasks/installs/install_on_suse.yml
@@ -1,12 +1,4 @@
 ---
-# SUSE/openSUSE only supports the following:
-# - ceph_origin == 'distro'
-# - ceph_origin == 'repository' and ceph_repository == 'obs'
-- name: Check for supported installation method on SUSE/openSUSE
-  fail:
-    msg: "Unsupported installation method origin:{{ ceph_origin }} repo:{{ ceph_repository }}'"
-  when: ceph_origin != 'distro' or (ceph_origin == 'repository' and ceph_repository != 'obs')
-
 - name: include configure_suse_repository_installation.yml
   include_tasks: configure_suse_repository_installation.yml
   when: ceph_origin == 'repository'

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -27,6 +27,25 @@
         - ceph_rhcs_cdn_debian_repo == 'https://customername:customerpasswd@rhcs.download.redhat.com'
         - ceph_repository not in ['rhcs', 'dev', 'obs']
 
+# SUSE/openSUSE Leap only supports the following:
+# - ceph_origin == 'distro'
+# - ceph_origin == 'repository' and ceph_repository == 'obs'
+- name: SUSE/openSUSE Leap based system tasks
+  when: ansible_os_family == 'Suse'
+  block:
+    - name: Check ceph_origin definition on SUSE/openSUSE Leap
+      fail:
+        msg: "Unsupported installation method origin:{{ ceph_origin }}"
+      when: ceph_origin not in ['distro', 'repository']
+
+    - name: Check ceph_repository definition on SUSE/openSUSE Leap
+      fail:
+        msg: "Unsupported installation method origin:{{ ceph_origin }} repo:{{ ceph_repository }}'
+                  only valid combination is ceph_origin == 'repository' and ceph_repository == 'obs'"
+      when:
+        - ceph_origin == 'repository'
+        - ceph_repository != 'obs'
+
 - name: validate ntp daemon type
   fail:
     msg: "ntp_daemon_type must be one of chronyd, ntpd, or timesyncd"


### PR DESCRIPTION
Fixes: #4362

There are two valid combinations of `ceph_origin` and `ceph_repository` on
SUSE/openSUSE:
- ceph_origin == 'distro'
- ceph_origin == 'repository' and ceph_repository == 'obs'

The current when condition would fail even in the valid second combination,
as ceph_origin != distro would be true then

Signed-off-by: Johannes Kastl <kastl@b1-systems.de>