### PR TITLE
roles/ceph-validate/tasks/check_system.yml: fail on unsupported SUSE versions

### DIFF
--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -46,11 +46,11 @@
     - ceph_repository == 'uca'
     - ansible_distribution != 'Ubuntu'
 
-- name: "fail on unsupported openSUSE distribution (only 15.x supported)"
+- name: "fail on unsupported SUSE/openSUSE distribution (only 15.x supported)"
   fail:
-    msg: "Distribution not supported: {{ ansible_distribution }}"
+    msg: "Distribution not supported: {{ ansible_distribution }} {{ ansible_distribution_major_version }}"
   when:
-    - ansible_distribution == 'openSUSE Leap'
+    - ansible_distribution == 'openSUSE Leap' or ansible_distribution == 'SUSE'
     - ansible_distribution_major_version != '15'
 
 - name: fail on unsupported ansible version (1.X)


### PR DESCRIPTION
Fail if SUSE distributions other than 15.x are found, similar to what we have for openSUSE