### PR TITLE
openSUSE OBS repository using ceph_stable_release

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -209,7 +209,7 @@ dummy:
 # usually has newer Ceph releases than the normal distro repository.
 #
 #
-#ceph_obs_repo: "https://download.opensuse.org/repositories/filesystems:/ceph:/luminous/openSUSE_Leap_{{ ansible_distribution_version }}/"
+#ceph_obs_repo: "https://download.opensuse.org/repositories/filesystems:/ceph:/{{ ceph_stable_release }}/openSUSE_Leap_{{ ansible_distribution_version }}/"
 
 # REPOSITORY: DEV
 #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -209,7 +209,7 @@ ceph_rhcs_version: 4
 # usually has newer Ceph releases than the normal distro repository.
 #
 #
-#ceph_obs_repo: "https://download.opensuse.org/repositories/filesystems:/ceph:/luminous/openSUSE_Leap_{{ ansible_distribution_version }}/"
+#ceph_obs_repo: "https://download.opensuse.org/repositories/filesystems:/ceph:/{{ ceph_stable_release }}/openSUSE_Leap_{{ ansible_distribution_version }}/"
 
 # REPOSITORY: DEV
 #

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -201,7 +201,7 @@ ceph_stable_release_uca: "{{ ansible_distribution_release }}-updates/{{ ceph_sta
 # usually has newer Ceph releases than the normal distro repository.
 #
 #
-#ceph_obs_repo: "https://download.opensuse.org/repositories/filesystems:/ceph:/luminous/openSUSE_Leap_{{ ansible_distribution_version }}/"
+ceph_obs_repo: "https://download.opensuse.org/repositories/filesystems:/ceph:/{{ ceph_stable_release }}/openSUSE_Leap_{{ ansible_distribution_version }}/"
 
 # REPOSITORY: DEV
 #


### PR DESCRIPTION
Instead of hardcoding `luminous`, use the `ceph_stable_release` variable to point to the correct repository.

Uncomment this in `roles/ceph-defaults/defaults/main.yml` to be avaible, as it is only used if `ceph_repository` is set to `obs`.

Could not be tested due to #4361.

