### PR TITLE
mgr: add a check task for all mgr to be up

### DIFF
--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -16,32 +16,44 @@
   include_tasks: docker/main.yml
   when: containerized_deployment
 
-- name: get enabled modules from ceph-mgr
-  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} --format json mgr module ls"
-  register: _ceph_mgr_modules
-  delegate_to: "{{ groups[mon_group_name][0] }}"
+- block:
+    - name: wait for all mgr to be up
+      command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr dump -f json"
+      register: mgr_dump
+      retries: 30
+      delay: 5
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      until:
+        - mgr_dump.rc == 0
+        - (mgr_dump.stdout | from_json).available | bool
 
-- name: set _ceph_mgr_modules fact (convert _ceph_mgr_modules.stdout to a dict)
-  set_fact:
-    _ceph_mgr_modules: "{{ _ceph_mgr_modules.get('stdout', '{}') | from_json }}"
+    - name: get enabled modules from ceph-mgr
+      command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} --format json mgr module ls"
+      register: _ceph_mgr_modules
+      delegate_to: "{{ groups[mon_group_name][0] }}"
 
-- name: set _disabled_ceph_mgr_modules fact
-  set_fact:
-    _disabled_ceph_mgr_modules: "{% if _ceph_mgr_modules.disabled_modules | length == 0 %}[]{% elif _ceph_mgr_modules.disabled_modules[0] | type_debug != 'dict' %}{{ _ceph_mgr_modules['disabled_modules'] }}{% else %}{{ _ceph_mgr_modules['disabled_modules'] | map(attribute='name') | list }}{% endif %}"
+    - name: set _ceph_mgr_modules fact (convert _ceph_mgr_modules.stdout to a dict)
+      set_fact:
+        _ceph_mgr_modules: "{{ _ceph_mgr_modules.get('stdout', '{}') | from_json }}"
 
-- name: disable ceph mgr enabled modules
-  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module disable {{ item }}"
-  # When ceph release is jewel, ceph-mgr role is skipped. It means, the enabled_ceph_mgr_modules doesn't contain 'stdout' attribute.
-  # Therefore, we need to get a default value which can be used up by from_json filter.
-  with_items: "{{ _ceph_mgr_modules.get('enabled_modules', []) }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  when:
-    - item not in ceph_mgr_modules
-    - not _ceph_mgr_modules.get('skipped')
+    - name: set _disabled_ceph_mgr_modules fact
+      set_fact:
+        _disabled_ceph_mgr_modules: "{% if _ceph_mgr_modules.disabled_modules | length == 0 %}[]{% elif _ceph_mgr_modules.disabled_modules[0] | type_debug != 'dict' %}{{ _ceph_mgr_modules['disabled_modules'] }}{% else %}{{ _ceph_mgr_modules['disabled_modules'] | map(attribute='name') | list }}{% endif %}"
 
-- name: add modules to ceph-mgr
-  command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module enable {{ item }}"
-  with_items: "{{ ceph_mgr_modules }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  when:
-    - (item in _disabled_ceph_mgr_modules or _disabled_ceph_mgr_modules == [])
+    - name: disable ceph mgr enabled modules
+      command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module disable {{ item }}"
+      # When ceph release is jewel, ceph-mgr role is skipped. It means, the enabled_ceph_mgr_modules doesn't contain 'stdout' attribute.
+      # Therefore, we need to get a default value which can be used up by from_json filter.
+      with_items: "{{ _ceph_mgr_modules.get('enabled_modules', []) }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      when:
+        - item not in ceph_mgr_modules
+        - not _ceph_mgr_modules.get('skipped')
+
+    - name: add modules to ceph-mgr
+      command: "{{ docker_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module enable {{ item }}"
+      with_items: "{{ ceph_mgr_modules }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      when:
+        - (item in _disabled_ceph_mgr_modules or _disabled_ceph_mgr_modules == [])
+  when: inventory_hostname == groups.get(mgr_group_name, []) | last


### PR DESCRIPTION
This can't be backported from master since there was too many
modifications meantime.

When mgr aren't all ready, sometimes the following error can show up:

```
stderr: 'Error ENOENT: all mgr daemons do not support module ''status'', pass --force to force enablement'
```

This commit adds a check so all mgr are available when we try to enable
modules.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>