### PR TITLE
generating cluster fsid failed if ansible_python_interpreter is set

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -21,6 +21,14 @@
   set_fact:
     container_binary: "{{ 'podman' if (podman_binary.stat.exists and ansible_distribution == 'Fedora') or (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'docker' }}"
 
+# In case ansible_python_interpreter is set by the user,
+# ansible will not discover python and discovered_python_interpreter
+# will not be set
+- name: set_fact discovered_python_interpreter
+  set_fact:
+    discovered_python_interpreter: ansible_python_interpreter
+  when: ansible_python_interpreter is defined
+
 # Set ceph_release to ceph_stable by default
 - name: set_fact ceph_release ceph_stable_release
   set_fact:


### PR DESCRIPTION
If the user has set the `ansible_python_interpreter`, ansible will not try to discover python, so `discovered_python_interpreter` will not be set.

Solution: Use `ansible_python_interpreter` as fallback, if `discovered_python_interpreter` is unset.