### PR TITLE
fix openSUSE OBS repo creation

### DIFF
--- a/roles/ceph-common/tasks/installs/suse_obs_repository.yml
+++ b/roles/ceph-common/tasks/installs/suse_obs_repository.yml
@@ -1,8 +1,8 @@
 ---
 - name: configure openSUSE ceph OBS repository
   zypper_repository:
-    name: "OBS:filesystems:ceph"
+    name: "OBS:filesystems:ceph:{{ ceph_release }}"
     state: present
-    uri: "{{ ceph_obs_repo }}"
+    repo: "{{ ceph_obs_repo }}"
     auto_import_keys: yes
     autorefresh: yes


### PR DESCRIPTION
roles/ceph-common/tasks/installs/suse_obs_repository.yml:
ansible's zypper_repository module does not know a parameter 'uri', this is called 'repo' instead