### PR TITLE
[skip ci] tests: change container image tag for switch_to_containers

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -412,7 +412,7 @@ setenv=
   dev: CEPH_STABLE_RELEASE = nautilus
 
   switch_to_containers: CEPH_STABLE_RELEASE = octopus
-  switch_to_containers: CEPH_DOCKER_IMAGE_TAG = latest-master
+  switch_to_containers: CEPH_DOCKER_IMAGE_TAG = latest-devel
 
   ooo_collocation: CEPH_DOCKER_IMAGE_TAG = v3.0.3-stable-3.0-luminous-centos-7-x86_64
 deps= -r{toxinidir}/tests/requirements.txt


### PR DESCRIPTION
test switch_to_containers job against the latest ceph@master
ceph-container image tag available.
In order to be sure the ceph release deployed in the first step (non
containerized deployment) isn't newer than the tag used for the
containerized migration (which would mean we try to downgrade the
version).

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>