### PR TITLE
Add http_addr option to grafana config

### DIFF
--- a/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -17,6 +17,7 @@
 
 - name: wait for grafana to be stopped
   wait_for:
+    host: '{{ grafana_server_addr }}'
     port: '{{ grafana_port }}'
     state: stopped
 
@@ -97,4 +98,5 @@
 
 - name: wait for grafana to start
   wait_for:
+    host: '{{ grafana_server_addr }}'
     port: '{{ grafana_port }}'

--- a/roles/ceph-grafana/templates/datasources-ceph-dashboard.yml.j2
+++ b/roles/ceph-grafana/templates/datasources-ceph-dashboard.yml.j2
@@ -17,7 +17,7 @@ datasources:
   # <int> org id. will default to orgId 1 if not specified
   orgId: 1
   # <string> url
-  url: 'http://{{ grafana_server_addr | default(_current_monitor_address) }}:{{ prometheus_port }}'
+  url: 'http://{{ grafana_server_addr }}:{{ prometheus_port }}'
   # <bool> enable/disable basic auth
   basicAuth: false
   # <bool> mark as default datasource. Max one per org

--- a/roles/ceph-grafana/templates/grafana.ini.j2
+++ b/roles/ceph-grafana/templates/grafana.ini.j2
@@ -21,6 +21,7 @@ cert_key = /etc/grafana/ceph-dashboard.key
 domain = {{ ansible_fqdn }}
 protocol = {{ dashboard_protocol }}
 http_port = {{ grafana_port }}
+http_addr = {{ grafana_server_addr }}
 
 [security]
 admin_user = {{ grafana_admin_user }}

--- a/roles/ceph-prometheus/templates/prometheus.yml.j2
+++ b/roles/ceph-prometheus/templates/prometheus.yml.j2
@@ -52,4 +52,4 @@ alerting:
   alertmanagers:
   - scheme: http
     static_configs:
-    - targets: ['{{ grafana_server_addr | default(_current_monitor_address) }}:{{ alertmanager_port }}']
+    - targets: ['{{ grafana_server_addr }}:{{ alertmanager_port }}']


### PR DESCRIPTION
We have no reason to make grafana container
listen on *, so this change adds the
http_addr option to the grafana config file
and adds the related option on the wait_for
tasks.

Signed-off-by: fmount <fpantano@redhat.com>