### PR TITLE
ceph-mon: Bind mount the ca-trust directory

### DIFF
--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -22,6 +22,9 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
   -v /var/run/ceph:/var/run/ceph:z \
   -v /etc/localtime:/etc/localtime:ro \
   -v /var/log/ceph:/var/log/ceph:z \
+{% if ansible_distribution == 'RedHat' -%}
+  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:z \
+{% endif -%}
 {% if mon_docker_privileged -%}
   --privileged \
 {% endif -%}


### PR DESCRIPTION
On containerized deployment, the mon container sometimes needs to
access to the radosgw endpoint (via the radosgw-admin command). When
using TLS on the radosgw with self-signed certificates then we need to
access to the CA certification from the mon container.
The CA certificate needs to be added on the host and then the directory
will be bind mount on the container.

Resolves: #4358

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>