### PR TITLE
tests: update container tag for ooo_collocation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,12 +60,6 @@ def setup(host):
         if cmd.rc == 0:
             osd_ids = cmd.stdout.rstrip("\n").split("\n")
             osds = osd_ids
-            if docker and fsid == "6e008d48-1661-11e8-8546-008c3214218a":
-                osds = []
-                for device in ansible_vars.get("devices", []):
-                    real_dev = host.run("sudo readlink -f %s" % device)
-                    real_dev_split = real_dev.stdout.split("/")[-1]
-                    osds.append(real_dev_split)
 
     address = host.interface(public_interface).addresses[0]
 

--- a/tests/functional/ooo-collocation/hosts
+++ b/tests/functional/ooo-collocation/hosts
@@ -46,7 +46,7 @@ all:
     ireallymeanit: 'yes'
     keys:
       - {key: AQAN0RdbAAAAABAA3CpSKRVDrENjkOSunEFZ0A==, mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow r', name: client.openstack, osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=backups, allow rwx pool=vms, allow rwx pool=images, allow rwx pool=metrics"}
-      - {key: AQAN0RdbAAAAABAAtV5Dq28z4H6XxwhaNEaFZg==, mds_cap: 'allow *', mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow r, allow command \"auth del\", allow command \"auth caps\", allow command \"auth get\", allow command \"auth get-or-create\"', name: client.manila, osd_cap: 'allow rw'}
+      - {key: AQAN0RdbAAAAABAAtV5Dq28z4H6XxwhaNEaFZg==, mds_cap: 'allow *', mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow r, allow command "auth del", allow command "auth caps", allow command "auth get", allow command "auth get-or-create"', name: client.manila, osd_cap: 'allow rw'}
       - {key: AQAN0RdbAAAAABAAH5D3WgMN9Rxw3M8jkpMIfg==, mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow rw', name: client.radosgw, osd_cap: 'allow rwx'}
     monitor_address_block: 192.168.95.0/24
     monitor_secret: AQBSV4xaAAAAABAALqm4vRHcITs4/041TwluMg==
@@ -54,7 +54,7 @@ all:
     openstack_config: true
     openstack_keys:
       - {key: AQAN0RdbAAAAABAA3CpSKRVDrENjkOSunEFZ0A==, mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow r', name: client.openstack, osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=backups, allow rwx pool=vms, allow rwx pool=images, allow rwx pool=metrics"}
-      - {key: AQAN0RdbAAAAABAAtV5Dq28z4H6XxwhaNEaFZg==, mds_cap: 'allow *', mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow r, allow command \"auth del\", allow command \"auth caps\", allow command \"auth get\", allow command \"auth get-or-create\"', name: client.manila, osd_cap: 'allow rw'}
+      - {key: AQAN0RdbAAAAABAAtV5Dq28z4H6XxwhaNEaFZg==, mds_cap: 'allow *', mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow r, allow command "auth del", allow command "auth caps", allow command "auth get", allow command "auth get-or-create"', name: client.manila, osd_cap: 'allow rw'}
       - {key: AQAN0RdbAAAAABAAH5D3WgMN9Rxw3M8jkpMIfg==, mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow rw', name: client.radosgw, osd_cap: 'allow rwx'}
     openstack_pools:
     - {name: images, pg_num: 8, rule_name: ''}

--- a/tests/functional/ooo-collocation/hosts
+++ b/tests/functional/ooo-collocation/hosts
@@ -11,10 +11,6 @@ all:
     ceph_docker_image: ceph/daemon
     ceph_docker_image_tag: latest-master
     ceph_docker_registry: docker.io
-    ceph_origin: repository
-    ceph_repository: community
-    ceph_release: luminous
-    ceph_stable: true
     cephfs_data_pool:
       name: 'manila_data'
       pg_num: "{{ osd_pool_default_pg_num }}"
@@ -48,7 +44,6 @@ all:
     generate_fsid: false
     ip_version: ipv4
     ireallymeanit: 'yes'
-    journal_size: 512
     keys:
       - {key: AQAN0RdbAAAAABAA3CpSKRVDrENjkOSunEFZ0A==, mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow r', name: client.openstack, osd_cap: "allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=backups, allow rwx pool=vms, allow rwx pool=images, allow rwx pool=metrics"}
       - {key: AQAN0RdbAAAAABAAtV5Dq28z4H6XxwhaNEaFZg==, mds_cap: 'allow *', mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow r, allow command \"auth del\", allow command \"auth caps\", allow command \"auth get\", allow command \"auth get-or-create\"', name: client.manila, osd_cap: 'allow rw'}
@@ -67,7 +62,6 @@ all:
     - {name: backups, pg_num: 8, rule_name: ''}
     - {name: vms, pg_num: 8, rule_name: ''}
     - {name: volumes, pg_num: 8, rule_name: ''}
-    osd_objectstore: filestore
     ceph_osd_docker_run_script_path: /opt
     pools: []
     public_network: 192.168.95.0/24
@@ -75,6 +69,7 @@ all:
     radosgw_civetweb_port: '8080'
     radosgw_keystone_ssl: false
     user_config: true
+    dashboard_enabled: false
 clients:
   hosts:
     client0: {}

--- a/tox.ini
+++ b/tox.ini
@@ -405,7 +405,7 @@ setenv=
   switch_to_containers: CEPH_STABLE_RELEASE = octopus
   switch_to_containers: CEPH_DOCKER_IMAGE_TAG = latest-master-devel
 
-  ooo_collocation: CEPH_DOCKER_IMAGE_TAG = v3.0.3-stable-3.0-luminous-centos-7-x86_64
+  ooo_collocation: CEPH_DOCKER_IMAGE_TAG = latest-master
 deps= -r{toxinidir}/tests/requirements.txt
 changedir=
   all_daemons: {toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
@@ -442,7 +442,7 @@ commands=
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   # configure lvm
-  !lvm_batch-!lvm_auto_discovery: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml
+  !lvm_batch-!lvm_auto_discovery-!ooo_collocation: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml
 
   rhcs: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
 


### PR DESCRIPTION
It doesn't make sense to test the old 3.0.x container images with
nautilus+ ceph releases.
Also disable the dashboard deployment.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>