### PR TITLE
tests: use a single grafana node on podman

### DIFF
--- a/tests/functional/podman/hosts
+++ b/tests/functional/podman/hosts
@@ -28,8 +28,6 @@ iscsi-gw0
 
 [grafana-server]
 mon0
-mon1
-mon2
 
 #[all:vars]
 #ansible_python_interpreter=/usr/bin/python3


### PR DESCRIPTION
We don't use multiple grafana nodes for the moment on the others
scenarios and I don't think this is supposed to be working.
We can often see failure on grafana on that scenario.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>