### PR TITLE
tests: update dedidated mgr node all_daemons

### DIFF
--- a/tests/functional/all_daemons/container/hosts-ubuntu
+++ b/tests/functional/all_daemons/container/hosts-ubuntu
@@ -4,7 +4,7 @@ mon1
 mon2
 
 [mgrs]
-mon0
+mgr0
 
 [osds]
 osd0 osd_crush_location="{ 'root': 'HDD', 'rack': 'mon-rackkkk', 'pod': 'monpod', 'host': 'osd0' }"

--- a/tests/functional/all_daemons/hosts-switch-to-containers
+++ b/tests/functional/all_daemons/hosts-switch-to-containers
@@ -7,7 +7,7 @@ mon1 monitor_interface=eth1
 mon2 monitor_address=192.168.1.12
 
 [mgrs]
-mon0
+mgr0
 
 [osds]
 osd0

--- a/tests/functional/all_daemons/hosts-ubuntu
+++ b/tests/functional/all_daemons/hosts-ubuntu
@@ -4,7 +4,7 @@ mon1 monitor_interface=eth1
 mon2 monitor_address=192.168.1.12
 
 [mgrs]
-mon0
+mgr0
 
 [osds]
 osd0 osd_crush_location="{ 'root': 'HDD', 'rack': 'mon-rackkkk', 'pod': 'monpod', 'host': 'osd0' }"


### PR DESCRIPTION
5b29144 change the mgr node to a dedicated node instead of the first
monitor node.
But the change didn't update the switch-to-containers inventory which
cause this playbook to fail.
Also update the ubuntu inventory to have the same configuration.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>