### PR TITLE
ceph-common: install only necesarry ceph-* packages on debian

### DIFF
--- a/roles/ceph-common/vars/main.yml
+++ b/roles/ceph-common/vars/main.yml
@@ -2,13 +2,13 @@
 # ceph-common is always installed, if a package isn't to be installed we replace
 # it with 'ceph-common' and run the install with the | unique filter.
 debian_ceph_pkgs:
-  - "{{ (ceph_repository != 'rhcs') | ternary('ceph', 'ceph-common') }}"
+  - "{{ (ceph_repository != 'rhcs') | ternary('ceph-base', 'ceph-common') }}"
   - "ceph-common"
-  - "{{ ((ceph_repository == 'rhcs') and (mon_group_name in group_names)) | ternary('ceph-mon', 'ceph-common') }}"
-  - "{{ ((ceph_repository == 'rhcs') and (osd_group_name in group_names)) | ternary('ceph-osd', 'ceph-common') }}"
+  - "{{ (mon_group_name in group_names) | ternary('ceph-mon', 'ceph-common') }}"
+  - "{{ (osd_group_name in group_names) | ternary('ceph-osd', 'ceph-common') }}"
   - "{{ (ceph_test) | ternary('ceph-test', 'ceph-common') }}"
   - "{{ (rgw_group_name in group_names) | ternary('radosgw', 'ceph-common') }}"
-  - "{{ ((ceph_repository == 'rhcs') and (client_group_name in group_names)) | ternary('ceph-fuse', 'ceph-common') }}"
+  - "{{ (client_group_name in group_names) | ternary('ceph-fuse', 'ceph-common') }}"
 
 redhat_ceph_pkgs:
   - "{{ (ceph_test) | ternary('ceph-test', 'ceph-common') }}"


### PR DESCRIPTION
Currently, ceph package only an meta-package that do not contain
actual software, but simply depend on other packages. It's been few
release since debian stretch (official), ubuntu bionic (official),
ubuntu uca repository and upstream debian-jewel.
As we only support nautilus and higher release for master branch,
I propose to drop ceph package and use ceph-base instead for repository
model other than rhcs so debian ceph install will be more minimalis.

Signed-off-by: Anthony Rusdi <33247310+antrusd@users.noreply.github.com>