### PR TITLE
Fix discovered_interpreter_python variable

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -22,11 +22,11 @@
     container_binary: "{{ 'podman' if (podman_binary.stat.exists and ansible_distribution == 'Fedora') or (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'docker' }}"
 
 # In case ansible_python_interpreter is set by the user,
-# ansible will not discover python and discovered_python_interpreter
+# ansible will not discover python and discovered_interpreter_python
 # will not be set
-- name: set_fact discovered_python_interpreter
+- name: set_fact discovered_interpreter_python
   set_fact:
-    discovered_python_interpreter: ansible_python_interpreter
+    discovered_interpreter_python: "{{ ansible_python_interpreter }}"
   when: ansible_python_interpreter is defined
 
 # Set ceph_release to ceph_stable by default


### PR DESCRIPTION
This change fixes the discovered_interpreter_python variable
name that was "discovered_python_interpreter" and caused a
failure in OSP deployments.

Signed-off-by: fmount <fpantano@redhat.com>