### PR TITLE
rbd-mirror: configure pool and peer

### DIFF
--- a/group_vars/rbdmirrors.yml.sample
+++ b/group_vars/rbdmirrors.yml.sample
@@ -30,6 +30,7 @@ dummy:
 
 #ceph_rbd_mirror_configure: false
 #ceph_rbd_mirror_pool: ""
+#ceph_rbd_mirror_mode: pool
 
 # NOTE (leseb): the following variable needs the name of the remote cluster.
 # The name of this cluster must be different than your local cluster simply

--- a/roles/ceph-rbd-mirror/defaults/main.yml
+++ b/roles/ceph-rbd-mirror/defaults/main.yml
@@ -22,6 +22,7 @@ ceph_rbd_mirror_local_user: "admin"
 
 ceph_rbd_mirror_configure: false
 ceph_rbd_mirror_pool: ""
+ceph_rbd_mirror_mode: pool
 
 # NOTE (leseb): the following variable needs the name of the remote cluster.
 # The name of this cluster must be different than your local cluster simply

--- a/roles/ceph-rbd-mirror/tasks/configure_mirroring.yml
+++ b/roles/ceph-rbd-mirror/tasks/configure_mirroring.yml
@@ -1,4 +1,9 @@
 ---
-- name: add a peer
-  command: "rbd mirror pool peer add {{ ceph_rbd_mirror_pool }} {{ ceph_rbd_mirror_remote_user }}@{{ ceph_rbd_mirror_remote_cluster }}"
+- name: enable mirroring on the pool
+  command: "{{ container_exec_cmd | default('') }} rbd --cluster {{ cluster }} mirror pool enable {{ ceph_rbd_mirror_pool }} {{ ceph_rbd_mirror_mode }}"
   changed_when: false
+
+- name: add a mirroring peer
+  command: "{{ container_exec_cmd | default('') }} rbd --cluster {{ cluster }} mirror pool peer add {{ ceph_rbd_mirror_pool }} {{ ceph_rbd_mirror_remote_user }}@{{ ceph_rbd_mirror_remote_cluster }}"
+  changed_when: false
+  failed_when: false

--- a/roles/ceph-rbd-mirror/tasks/main.yml
+++ b/roles/ceph-rbd-mirror/tasks/main.yml
@@ -8,14 +8,8 @@
   when: cephx | bool
 
 - name: tasks for non-containerized deployment
+  include_tasks: start_rbd_mirror.yml
   when: not containerized_deployment | bool
-  block:
-    - name: include start_rbd_mirror.yml
-      include_tasks: start_rbd_mirror.yml
-
-    - name: include configure_mirroring.yml
-      include_tasks: configure_mirroring.yml
-      when: ceph_rbd_mirror_configure | bool
 
 - name: tasks for containerized deployment
   when: containerized_deployment | bool
@@ -26,3 +20,7 @@
 
     - name: include container/main.yml
       include_tasks: container/main.yml
+
+- name: include configure_mirroring.yml
+  include_tasks: configure_mirroring.yml
+  when: ceph_rbd_mirror_configure | bool


### PR DESCRIPTION
The rbd mirror configuration was only available for non containerized
deployment and was also imcomplete.
We now enable the mirroring on the pool and add the remote peer in both
scenarios.

The default mirroring mode is set to 'pool' but can be configured via
the ceph_rbd_mirror_mode variable.

This commit also fixes an issue on the rbd mirror command if the ceph
cluster name isn't using the default value (ceph) due to a missing
--cluster parameter to the command.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1665877

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>