### PR TITLE
rhcs: Pin downstream containers

### DIFF
--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -718,14 +718,14 @@ ceph_docker_registry: "registry.access.redhat.com"
 #dashboard_rgw_api_scheme: ''
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
-#node_exporter_container_image: prom/node-exporter:latest
+node_exporter_container_image: registry.access.redhat.com/openshift4/ose-prometheus-node-exporter:v4.1
 #node_exporter_port: 9100
 #grafana_admin_user: admin
 #grafana_admin_password: admin
 # We only need this for SSL (https) connections
 #grafana_crt: ''
 #grafana_key: ''
-#grafana_container_image: "grafana/grafana:latest"
+grafana_container_image: registry.access.redhat.com/openshift4/ose-grafana:v4.1
 #grafana_container_cpu_period: 100000
 #grafana_container_cpu_cores: 2
 # container_memory is in GB
@@ -738,7 +738,7 @@ ceph_docker_registry: "registry.access.redhat.com"
 #  - grafana-piechart-panel
 #grafana_allow_embedding: True
 #grafana_port: 3000
-#prometheus_container_image: prom/prometheus:latest
+prometheus_container_image: registry.access.redhat.com/openshift4/ose-prometheus:v4.1
 #prometheus_container_cpu_period: 100000
 #prometheus_container_cpu_cores: 2
 # container_memory is in GB
@@ -747,7 +747,7 @@ ceph_docker_registry: "registry.access.redhat.com"
 #prometheus_conf_dir: /etc/prometheus
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 #prometheus_port: 9090
-#alertmanager_container_image: prom/alertmanager:latest
+alertmanager_container_image: registry.access.redhat.com/openshift4/ose-prometheus-alertmanager:v4.1
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2
 # container_memory is in GB

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -5,4 +5,8 @@ ceph_rhcs_version: 4
 ceph_docker_image: "rhceph/rhceph-4-rhel8"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.access.redhat.com"
+node_exporter_container_image: registry.access.redhat.com/openshift4/ose-prometheus-node-exporter:v4.1
+grafana_container_image: registry.access.redhat.com/openshift4/ose-grafana:v4.1
+prometheus_container_image: registry.access.redhat.com/openshift4/ose-prometheus:v4.1
+alertmanager_container_image: registry.access.redhat.com/openshift4/ose-prometheus-alertmanager:v4.1
 # END OF FILE, DO NOT TOUCH ME!


### PR DESCRIPTION
We should pin down the versions of downstream container for dashboard
instead of using upstream containers.

Signed-off-by: Boris Ranto <branto@redhat.com>

Please let me know if there is a better/any other way of overriding the downstream versions of these containers.