### PR TITLE
Support comma-delimited subnets in firewall

### DIFF
--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -20,15 +20,16 @@
 
   - name: open monitor and manager ports
     firewalld:
-      service: "{{ item.service }}"
-      zone: "{{ item.zone }}"
-      source: "{{ public_network }}"
+      service: "{{ item[1].service }}"
+      zone: "{{ item[1].zone }}"
+      source: "{{ item[0] }}"
       permanent: true
       immediate: true
       state: enabled
-    with_items:
-      - { 'service': 'ceph-mon', 'zone': "{{ ceph_mon_firewall_zone }}" }
-      - { 'service': 'ceph', 'zone': "{{ ceph_mgr_firewall_zone }}" }
+    with_nested:
+      - "{{ public_network.split(',') }}"
+      - - { 'service': 'ceph-mon', 'zone': "{{ ceph_mon_firewall_zone }}" }
+        - { 'service': 'ceph', 'zone': "{{ ceph_mgr_firewall_zone }}" }
     when:
       - mon_group_name is defined
       - mon_group_name in group_names
@@ -38,10 +39,11 @@
     firewalld:
       service: ceph
       zone: "{{ ceph_mgr_firewall_zone }}"
-      source: "{{ public_network }}"
+      source: "{{ item }}"
       permanent: true
       immediate: true
       state: enabled
+    with_items: "{{ public_network.split(',') }}"
     when:
       - mgr_group_name is defined
       - mgr_group_name in group_names
@@ -55,9 +57,7 @@
       permanent: true
       immediate: true
       state: enabled
-    with_items:
-      - "{{ public_network }}"
-      - "{{ cluster_network }}"
+    with_items: "{{ public_network.split(',') | union(cluster_network.split(',')) }}"
     when:
       - osd_group_name is defined
       - osd_group_name in group_names
@@ -67,10 +67,11 @@
     firewalld:
       port: "{{ radosgw_frontend_port }}/tcp"
       zone: "{{ ceph_rgw_firewall_zone }}"
-      source: "{{ public_network }}"
+      source: "{{ item }}"
       permanent: true
       immediate: true
       state: enabled
+    with_items: "{{ public_network.split(',') }}"
     when:
       - rgw_group_name is defined
       - rgw_group_name in group_names
@@ -80,10 +81,11 @@
     firewalld:
       service: ceph
       zone: "{{ ceph_mds_firewall_zone }}"
-      source: "{{ public_network }}"
+      source: "{{ item }}"
       permanent: true
       immediate: true
       state: enabled
+    with_items: "{{ public_network.split(',') }}"
     when:
       - mds_group_name is defined
       - mds_group_name in group_names
@@ -93,10 +95,11 @@
     firewalld:
       service: nfs
       zone: "{{ ceph_nfs_firewall_zone }}"
-      source: "{{ public_network }}"
+      source: "{{ item }}"
       permanent: true
       immediate: true
       state: enabled
+    with_items: "{{ public_network.split(',') }}"
     when:
       - nfs_group_name is defined
       - nfs_group_name in group_names
@@ -106,10 +109,11 @@
     firewalld:
       port: "111/tcp"
       zone: "{{ ceph_nfs_firewall_zone }}"
-      source: "{{ public_network }}"
+      source: "{{ item }}"
       permanent: true
       immediate: true
       state: enabled
+    with_items: "{{ public_network.split(',') }}"
     when:
       - nfs_group_name is defined
       - nfs_group_name in group_names
@@ -119,10 +123,11 @@
     firewalld:
       service: ceph
       zone: "{{ ceph_rbdmirror_firewall_zone }}"
-      source: "{{ public_network }}"
+      source: "{{ item }}"
       permanent: true
       immediate: true
       state: enabled
+    with_items: "{{ public_network.split(',') }}"
     when:
       - rbdmirror_group_name is defined
       - rbdmirror_group_name in group_names
@@ -132,10 +137,11 @@
     firewalld:
       port: "3260/tcp"
       zone: "{{ ceph_iscsi_firewall_zone }}"
-      source: "{{ public_network }}"
+      source: "{{ item }}"
       permanent: true
       immediate: true
       state: enabled
+    with_items: "{{ public_network.split(',') }}"
     when:
       - iscsi_gw_group_name is defined
       - iscsi_gw_group_name in group_names
@@ -145,10 +151,11 @@
     firewalld:
       port: "{{ api_port | default(5000) }}/tcp"
       zone: "{{ ceph_iscsi_firewall_zone }}"
-      source: "{{ public_network }}"
+      source: "{{ item }}"
       permanent: true
       immediate: true
       state: enabled
+    with_items: "{{ public_network.split(',') }}"
     when:
       - iscsi_gw_group_name is defined
       - iscsi_gw_group_name in group_names
@@ -228,10 +235,11 @@
     firewalld:
       port: "{{ haproxy_frontend_port | default(80) }}/tcp"
       zone: "{{ ceph_rgwloadbalancer_firewall_zone }}"
-      source: "{{ public_network }}"
+      source: "{{ item }}"
       permanent: true
       immediate: true
       state: enabled
+    with_items: "{{ public_network.split(',') }}"
     when:
       - rgwloadbalancer_group_name is defined
       - rgwloadbalancer_group_name in group_names


### PR DESCRIPTION
ceph.conf supports a comma separated list of
subnet CIDR's for the public_network and the
cluster network. ceph-ansible should support
setting up the firewall for this configuration.

Closes: #4425
Related: #4333
https://docs.ceph.com/docs/nautilus/rados/configuration/network-config-ref/#network-config-settings

Signed-off-by: Harald Jensås <hjensas@redhat.com>