### PR TITLE
tox: Fix incorrect ANSIBLE_CONFIG value

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ whitelist_externals =
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
-  ANSIBLE_CONFIG = -F {toxinidir}/ansible.cfg
+  ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
   ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/plugins/callback
   ANSIBLE_CALLBACK_WHITELIST = profile_tasks
@@ -87,7 +87,7 @@ whitelist_externals =
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
-  ANSIBLE_CONFIG = -F {toxinidir}/ansible.cfg
+  ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/plugins/actions
   ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/plugins/callback
   ANSIBLE_CALLBACK_WHITELIST = profile_tasks


### PR DESCRIPTION
The ANSIBLE_CONFIG value wasn't set correctly for two scenarios. This
environment variable doesn't use '-F'.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>