### PR TITLE
ceph-handler: Fix osd restart condition

### DIFF
--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -104,7 +104,6 @@
         # except when a crush location is specified. ceph-disk will start the osds before the osd crush location is specified
         - osd_group_name in group_names
         - containerized_deployment | bool
-        - inventory_hostname == groups.get(osd_group_name) | last
         - ceph_osd_container_stat.get('rc') == 0
         - ceph_osd_container_stat.get('stdout_lines', [])|length != 0
         - handler_health_osd_check | bool


### PR DESCRIPTION
In containerized deployment, the restart OSD handler couldn't be
triggered in most ansible execution.
This is due to the usage of run_once + a condition on the inventory
hostname and the last filter.
The run_once is triggered first so ansible will pick a node in the
osd group to execute the restart task. But if this node isn't the
last one in the osd group then the task is ignored. There's more
probability that the task will be ignored than executed.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>