### PR TITLE
Look for additional names when checking ceph-nfs container status

### DIFF
--- a/roles/ceph-handler/tasks/check_running_containers.yml
+++ b/roles/ceph-handler/tasks/check_running_containers.yml
@@ -48,7 +48,7 @@
   when: inventory_hostname in groups.get(rbdmirror_group_name, [])
 
 - name: check for a nfs container
-  command: "{{ container_binary }} ps -q --filter='name=ceph-nfs-{{ ansible_hostname }}'"
+  command: "{{ container_binary }} ps -q --filter='name=ceph-nfs-{{ ceph_nfs_service_suffix | default(ansible_hostname) }}'"
   register: ceph_nfs_container_stat
   changed_when: false
   failed_when: false

--- a/roles/ceph-handler/templates/restart_nfs_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_nfs_daemon.sh.j2
@@ -5,7 +5,7 @@ DELAY="{{ handler_health_nfs_check_delay }}"
 NFS_NAME="ceph-nfs@{{ ceph_nfs_service_suffix | default(ansible_hostname) }}"
 PID=/var/run/ganesha.pid
 {% if containerized_deployment %}
-DOCKER_EXEC="{{ container_binary }} exec ceph-nfs-{{ ansible_hostname }}"
+DOCKER_EXEC="{{ container_binary }} exec ceph-nfs-{{ ceph_nfs_service_suffix | default(ansible_hostname) }}"
 {% endif %}
 
 # First, restart the daemon

--- a/roles/ceph-nfs/tasks/main.yml
+++ b/roles/ceph-nfs/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: set_fact container_exec_cmd
   set_fact:
-    container_exec_cmd: "{{ container_binary }} exec ceph-nfs-{{ ansible_hostname }}"
+    container_exec_cmd: "{{ container_binary }} exec ceph-nfs-{{ ceph_nfs_service_suffix | default(ansible_hostname) }}"
   when: containerized_deployment | bool
 
 - name: include pre_requisite_non_container.yml


### PR DESCRIPTION
Ganesha cannot be operated active/active, in those deployments
where it is managed by pacemaker the container name can be
different than the default.

This change uses "ceph_nfs_service_suffix" where previously
missing to ensure tasks will work with customized names.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1750005
Signed-off-by: Giulio Fidente <gfidente@redhat.com>