### PR TITLE
Inject ceph grafana dashboard layouts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -184,7 +184,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       grf.vm.hostname = "#{LABEL_PREFIX}grafana#{i}"
       if ASSIGN_STATIC_IP
         grf.vm.network :private_network,
-          ip: "#{PUBLIC_SUBNET}.3#{i}"
+          ip: "#{PUBLIC_SUBNET}.2#{i}"
       end
       # Virtualbox
       grf.vm.provider :virtualbox do |vb|

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -192,3 +192,10 @@
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
+
+- name: inject grafana dashboard layouts
+  command: "{{ container_exec_cmd }} ceph dashboard grafana dashboards update"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  changed_when: false
+  when: containerized_deployment | bool

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -318,6 +318,7 @@
     - groups.get(grafana_server_group_name, []) | length > 0
     - ip_version == 'ipv4'
     - dashboard_enabled | bool
+    - inventory_hostname in groups[grafana_server_group_name]
 
 - name: set grafana_server_addr fact - ipv6
   set_fact:
@@ -326,6 +327,25 @@
     - groups.get(grafana_server_group_name, []) | length > 0
     - ip_version == 'ipv6'
     - dashboard_enabled | bool
+    - inventory_hostname in groups[grafana_server_group_name]
+
+- name: set grafana_server_addr fact - ipv4 - (external instance)
+  set_fact:
+    grafana_server_addr: "{{ hostvars[groups.get(grafana_server_group_name, []) | first]['ansible_all_ipv4_addresses'] | ipaddr(public_network) | first }}"
+  when:
+    - groups.get(grafana_server_group_name, []) | length > 0
+    - ip_version == 'ipv4'
+    - dashboard_enabled | bool
+    - inventory_hostname not in groups[grafana_server_group_name]
+
+- name: set grafana_server_addr fact - ipv6 - (external instance)
+  set_fact:
+    grafana_server_addr: "{{ hostvars[groups.get(grafana_server_group_name, []) | first]['ansible_all_ipv6_addresses'] | ipaddr(public_network) | last | ipwrap }}"
+  when:
+    - groups.get(grafana_server_group_name, []) | length > 0
+    - ip_version == 'ipv6'
+    - dashboard_enabled | bool
+    - inventory_hostname not in groups[grafana_server_group_name]
 
 - name: set_fact use_new_ceph_iscsi package or old ceph-iscsi-config/cli
   set_fact:


### PR DESCRIPTION
This change just adds the task to inject from the
ceph dashboard mgr module the required layouts
to show all the cluster metrics on the grafana
instance.

Signed-off-by: fmount <fpantano@redhat.com>