### PR TITLE
container: Allow to use registry authentication

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -573,6 +573,7 @@ dummy:
 #ceph_docker_image: "ceph/daemon"
 #ceph_docker_image_tag: latest
 #ceph_docker_registry: docker.io
+#ceph_docker_registry_auth: false
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -572,7 +572,8 @@ ceph_rhcs_version: 4
 #docker: false
 ceph_docker_image: "rhceph/rhceph-4-rhel8"
 ceph_docker_image_tag: "latest"
-ceph_docker_registry: "registry.access.redhat.com"
+ceph_docker_registry: "registry.redhat.io"
+ceph_docker_registry_auth: true
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
@@ -718,14 +719,14 @@ ceph_docker_registry: "registry.access.redhat.com"
 #dashboard_rgw_api_scheme: ''
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
-node_exporter_container_image: registry.access.redhat.com/openshift4/ose-prometheus-node-exporter:v4.1
+node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1
 #node_exporter_port: 9100
 #grafana_admin_user: admin
 #grafana_admin_password: admin
 # We only need this for SSL (https) connections
 #grafana_crt: ''
 #grafana_key: ''
-grafana_container_image: registry.access.redhat.com/openshift4/ose-grafana:v4.1
+grafana_container_image: registry.redhat.io/openshift4/ose-grafana:v4.1
 #grafana_container_cpu_period: 100000
 #grafana_container_cpu_cores: 2
 # container_memory is in GB
@@ -738,7 +739,7 @@ grafana_container_image: registry.access.redhat.com/openshift4/ose-grafana:v4.1
 #  - grafana-piechart-panel
 #grafana_allow_embedding: True
 #grafana_port: 3000
-prometheus_container_image: registry.access.redhat.com/openshift4/ose-prometheus:v4.1
+prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.1
 #prometheus_container_cpu_period: 100000
 #prometheus_container_cpu_cores: 2
 # container_memory is in GB
@@ -747,7 +748,7 @@ prometheus_container_image: registry.access.redhat.com/openshift4/ose-prometheus
 #prometheus_conf_dir: /etc/prometheus
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 #prometheus_port: 9090
-alertmanager_container_image: registry.access.redhat.com/openshift4/ose-prometheus-alertmanager:v4.1
+alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.1
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2
 # container_memory is in GB

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -4,9 +4,10 @@ fetch_directory: ~/ceph-ansible-keys
 ceph_rhcs_version: 4
 ceph_docker_image: "rhceph/rhceph-4-rhel8"
 ceph_docker_image_tag: "latest"
-ceph_docker_registry: "registry.access.redhat.com"
-node_exporter_container_image: registry.access.redhat.com/openshift4/ose-prometheus-node-exporter:v4.1
-grafana_container_image: registry.access.redhat.com/openshift4/ose-grafana:v4.1
-prometheus_container_image: registry.access.redhat.com/openshift4/ose-prometheus:v4.1
-alertmanager_container_image: registry.access.redhat.com/openshift4/ose-prometheus-alertmanager:v4.1
+ceph_docker_registry: "registry.redhat.io"
+ceph_docker_registry_auth: true
+node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1
+grafana_container_image: registry.redhat.io/openshift4/ose-grafana:v4.1
+prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.1
+alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.1
 # END OF FILE, DO NOT TOUCH ME!

--- a/roles/ceph-container-common/tasks/main.yml
+++ b/roles/ceph-container-common/tasks/main.yml
@@ -15,6 +15,12 @@
         ceph_docker_version: "{{ ceph_docker_version.stdout.split(' ')[2] }}"
   when: container_binary == 'docker'
 
+- name: container registry authentication
+  command: '{{ container_binary }} login -u {{ ceph_docker_registry_username }} -p {{ ceph_docker_registry_password }} {{ ceph_docker_registry }}'
+  changed_when: false
+  no_log: true
+  when: ceph_docker_registry_auth | bool
+
 - name: include fetch_image.yml
   include_tasks: fetch_image.yml
   tags: fetch_container_image

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -565,6 +565,7 @@ docker: false
 ceph_docker_image: "ceph/daemon"
 ceph_docker_image_tag: latest
 ceph_docker_registry: docker.io
+ceph_docker_registry_auth: false
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 ceph_client_docker_image: "{{ ceph_docker_image }}"
 ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -142,4 +142,5 @@
     msg: 'ceph_docker_registry_username and/or ceph_docker_registry_password variables need to be set'
   when:
     - ceph_docker_registry_auth | bool
-    - ceph_docker_registry_username is not defined or ceph_docker_registry_password is not defined
+    - (ceph_docker_registry_username is not defined or ceph_docker_registry_password is not defined)
+    - (ceph_docker_registry_username | length == 0 or ceph_docker_registry_password | length == 0)

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -136,3 +136,10 @@
         msg: "you must add at least one node in the [grafana-server] hosts group"
       when: groups[grafana_server_group_name] | length < 1
   when: dashboard_enabled | bool
+
+- name: validate container registry credentials
+  fail:
+    msg: 'ceph_docker_registry_username and/or ceph_docker_registry_password variables need to be set'
+  when:
+    - ceph_docker_registry_auth | bool
+    - ceph_docker_registry_username is not defined or ceph_docker_registry_password is not defined


### PR DESCRIPTION
The registry.redhat.io regsitry requires authentication so before pulling
the RHCS 4 container images from the registry we need to do the login
step.
This is done via the new ceph_docker_registry_auth variable. The
default value is false but true for RHCS setup.
When set to true, you need to provide the username and password
for the registry via the associated variables.
This patch also updates the ceph_docker_registry value for RHCS setup.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1748911

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>