### PR TITLE
rhel8: add default python bin path

### DIFF
--- a/raw_install_python.yml
+++ b/raw_install_python.yml
@@ -8,6 +8,7 @@
   with_items:
     - /usr/bin/python
     - /usr/bin/python3
+    - /usr/libexec/platform-python
 
 - block:
     - name: check for dnf-3 package manager (RedHat/Fedora/CentOS)


### PR DESCRIPTION
On RHEL 8 system we should check the /usr/libexec/platform-python path
instead of installing python36 package.

[DEPRECATION WARNING]: Distribution redhat 8.0 on host xxxxx should use
/usr/libexec/platform-python, but is using /usr/bin/python for backward
compatibility with prior Ansible releases. A future Ansible release will
default to using the discovered platform python for this host.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>