### PR TITLE
shrink-mon: search mon in the quorum_names list

### DIFF
--- a/infrastructure-playbooks/shrink-mon.yml
+++ b/infrastructure-playbooks/shrink-mon.yml
@@ -124,13 +124,13 @@
           msg: "The monitor has been successfully removed from the cluster.
           Please remove the monitor entry from the rest of your ceph configuration files, cluster wide."
       run_once: true
-      when: mon_to_kill_hostname not in result.stdout
+      when: mon_to_kill_hostname not in (result.stdout | from_json)['quorum_names']
 
     - name: fail if monitor is still part of the cluster
       fail:
           msg: "Monitor appears to still be part of the cluster, please check what happened."
       run_once: true
-      when: mon_to_kill_hostname in result.stdout
+      when: mon_to_kill_hostname in (result.stdout | from_json)['quorum_names']
 
     - name: show ceph health
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} -s"


### PR DESCRIPTION
If we're looking at the mon hostname in the ceph status output then
there's some scenarios where this could be true.
If we collocate some services (mons, mgrs, etc..) then the hostname of
the monitor to shrink will still be present in the ceph status (like
in mgrs or other).
Instead we should check the hostame only in the mon part of the output.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>