### PR TITLE
rolling_update.yml: force ceph-volume scan on osds

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -420,7 +420,7 @@
       when: containerized_deployment | bool
 
     - name: scan ceph-disk osds with ceph-volume if deploying nautilus
-      command: "ceph-volume --cluster={{ cluster }} simple scan"
+      command: "ceph-volume --cluster={{ cluster }} simple scan --force"
       environment:
         CEPH_VOLUME_DEBUG: 1
       when:


### PR DESCRIPTION
The rolling_update.yml playbook fails when scanning ceph-disk osds while
deploying nautilus. The --force flag is required to scan existing osds
and rewrite their json metadata.

Signed-off-by: Sam Choraria <sam.choraria@bbc.co.uk>