### PR TITLE
tests: do not rely on pg_num to validate rgw_tuning_pools

### DIFF
--- a/tests/functional/tests/rgw/test_rgw_tuning.py
+++ b/tests/functional/tests/rgw/test_rgw_tuning.py
@@ -24,32 +24,30 @@ class TestRGWs(object):
 
     @pytest.mark.no_docker
     def test_rgw_tuning_pools_are_set(self, node, host, setup):
-        cmd = "sudo ceph --cluster={cluster} --connect-timeout 5 -n client.rgw.{hostname}.rgw0 --keyring /var/lib/ceph/radosgw/{cluster}-rgw.{hostname}.rgw0/keyring osd dump".format(  # noqa E501
-            hostname=node["vars"]["inventory_hostname"],
-            cluster=setup['cluster_name']
-        )
-        output = host.check_output(cmd)
         pools = node["vars"]["rgw_create_pools"]
-        for pool_name, pg_num in pools.items():
-            assert pool_name in output
-            pg_num_str = "pg_num {pg_num}".format(pg_num=pg_num["pg_num"])
-            assert pg_num_str in output
+        if pools is None:
+            pytest.skip('rgw_create_pools not defined, nothing to test')
+        for pool_name in pools.keys():
+            cmd = host.run("sudo ceph --cluster={cluster} --connect-timeout 5 -n client.rgw.{hostname}.rgw0 --keyring /var/lib/ceph/radosgw/{cluster}-rgw.{hostname}.rgw0/keyring osd pool get {pool_name} size".format(  # noqa E501
+                hostname=node["vars"]["inventory_hostname"],
+                cluster=setup['cluster_name'],
+                pool_name=pool_name
+            ))
+            assert cmd.rc == 0
 
     @pytest.mark.docker
     def test_docker_rgw_tuning_pools_are_set(self, node, host, setup):
         hostname = node["vars"]["inventory_hostname"]
         cluster = setup['cluster_name']
         container_binary = setup["container_binary"]
-        cmd = "sudo {container_binary} exec ceph-rgw-{hostname}-rgw0 ceph --cluster={cluster} -n client.rgw.{hostname}.rgw0 --connect-timeout 5 --keyring /var/lib/ceph/radosgw/{cluster}-rgw.{hostname}.rgw0/keyring  osd dump".format(  # noqa E501
-            hostname=hostname,
-            cluster=cluster,
-            container_binary=container_binary
-        )
-        output = host.check_output(cmd)
         pools = node["vars"].get("rgw_create_pools")
         if pools is None:
             pytest.skip('rgw_create_pools not defined, nothing to test')
-        for pool_name, pg_num in pools.items():
-            assert pool_name in output
-            pg_num_str = "pg_num {pg_num}".format(pg_num=pg_num["pg_num"])
-            assert pg_num_str in output
+        for pool_name in pools.keys():
+            cmd = host.run("sudo {container_binary} exec ceph-rgw-{hostname}-rgw0 ceph --cluster={cluster} -n client.rgw.{hostname}.rgw0 --connect-timeout 5 --keyring /var/lib/ceph/radosgw/{cluster}-rgw.{hostname}.rgw0/keyring osd pool get {pool_name} size".format(  # noqa E501
+                hostname=hostname,
+                cluster=cluster,
+                pool_name=pool_name,
+                container_binary=container_binary
+            ))
+            assert cmd.rc == 0


### PR DESCRIPTION
Since the pg_autoscaler has been enabled recently in ceph, this check
should stick to validate the requested pools are well created only.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>