### PR TITLE
shrink-rgw.yml: fix confirmation play's name

### DIFF
--- a/infrastructure-playbooks/shrink-rgw.yml
+++ b/infrastructure-playbooks/shrink-rgw.yml
@@ -20,7 +20,7 @@
     - debug:
         msg: gather facts on MONS and RGWs
 
-- name: confirm whether user really meant to remove monitor from the ceph cluster
+- name: confirm whether user really meant to remove rgw from the ceph cluster
   hosts: localhost
   become: true
   vars_prompt:


### PR DESCRIPTION
the confirmation play's name should confirm removing rgw instead of
monitor

signed-off-by: Mehdy Khoshnoody <mehdy.khoshnoody@gmail.com>