### PR TITLE
ceph-osd: handle loop devices with containers

### DIFF
--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -17,7 +17,7 @@ function id_to_device () {
   docker run --rm --net=host --ulimit nofile=1024:4096 --ipc=host --pid=host --privileged=true -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph/:/var/lib/ceph/:z -v /dev:/dev -v /etc/localtime:/etc/localtime:ro -e DEBUG=verbose -e CLUSTER={{ cluster }} {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} osd_ceph_disk_dmcrypt_data_map
 {% endif %}
   DATA_PART=$(docker run --rm --ulimit nofile=1024:4096 --privileged=true -v /dev/:/dev/ -v /etc/ceph:/etc/ceph:z --entrypoint ceph-disk {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} list | grep ", osd\.${1}," | awk '{ print $1 }')
-  if [[ "${DATA_PART}" =~ ^/dev/(cciss|nvme) ]]; then
+  if [[ "${DATA_PART}" =~ ^/dev/(cciss|nvme|loop) ]]; then
     OSD_DEVICE=${DATA_PART:0:-2}
   else
     OSD_DEVICE=${DATA_PART:0:-1}


### PR DESCRIPTION
Since we change the way to run the OSD containers with the ID instead
of the device name, we lost the ability to use loop devices.
Loop devices are like nvme or cciss devices because the partitions are
referenced with an extra 'p' before the partition number.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1749097

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>