### PR TITLE
mon: use ceph_key module for containerized mgr keyring creation

### DIFF
--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -94,27 +94,33 @@
     - not containerized_deployment_with_kv
 
 - block:
-  - name: create ceph mgr keyring(s) when mon is containerized
-    command: "{{ docker_exec_cmd }} ceph --cluster {{ cluster }} auth get-or-create mgr.{{ hostvars[item]['ansible_hostname'] }} mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o /etc/ceph/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
-    args:
-      creates: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
-    changed_when: false
-    when:
-      - cephx
-      - containerized_deployment
-      - "{{ groups.get(mgr_group_name, []) | length > 0 }}"
-      - not containerized_deployment_with_kv
-    with_items: "{{ groups.get(mgr_group_name, []) }}"
+    - name: create ceph mgr keyring(s) when mon is containerized
+      ceph_key:
+        state: present
+        name: "mgr.{{ hostvars[item]['ansible_hostname'] }}"
+        caps:
+          mon: 'allow profile mgr'
+          osd: 'allow *'
+          mds: 'allow *'
+        containerized: "{{ docker_exec_cmd }}"
+        cluster: "{{ cluster }}"
+        mode: "{{ ceph_keyring_permissions }}"
+      with_items: "{{ groups.get(mgr_group_name) }}"
+      when:
+        - cephx
+        - containerized_deployment
+        - "{{ groups.get(mgr_group_name, []) | length > 0 }}"
+        - not containerized_deployment_with_kv
 
-  - name: fetch ceph mgr key(s)
-    fetch:
-      src: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
-      dest: "{{ fetch_directory }}/{{ fsid }}/{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
-      flat: yes
-    with_items:
-      - "{{ groups.get(mgr_group_name, []) }}"
-    when:
-      - "{{ groups.get(mgr_group_name, []) | length > 0 }}"
+    - name: fetch ceph mgr key(s)
+      fetch:
+        src: "{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
+        dest: "{{ fetch_directory }}/{{ fsid }}/{{ ceph_conf_key_directory }}/{{ cluster }}.mgr.{{ hostvars[item]['ansible_hostname'] }}.keyring"
+        flat: yes
+      with_items:
+        - "{{ groups.get(mgr_group_name, []) }}"
+      when:
+        - "{{ groups.get(mgr_group_name, []) | length > 0 }}"
 
   when:
     - not rolling_update


### PR DESCRIPTION
This commit replaces a `command` task with `ceph_key` in order to create
mgr keyrings.

This allows us to use `mode` parameter to set the right mode on
generated keys.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1734513

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>