### PR TITLE
ceph-nfs: Allow to configure SecType value

### DIFF
--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -79,6 +79,7 @@ dummy:
 #ceph_nfs_ceph_access_type: "RW"
 #ceph_nfs_ceph_user: "admin"
 #ceph_nfs_ceph_squash: "Root_Squash"
+#ceph_nfs_ceph_sectype: "sys,krb5,krb5i,krb5p"
 
 ###################
 # FSAL RGW Config #
@@ -89,6 +90,7 @@ dummy:
 #ceph_nfs_rgw_access_type: "RW"
 #ceph_nfs_rgw_user: "cephnfs"
 #ceph_nfs_rgw_squash: "Root_Squash"
+#ceph_nfs_rgw_sectype: "sys,krb5,krb5i,krb5p"
 # Note: keys are optional and can be generated, but not on containerized, where
 # they must be configered.
 #ceph_nfs_rgw_access_key: "QFAMEDSJP5DEKJO0DDXY"

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -71,6 +71,7 @@ ceph_nfs_ceph_protocols: "3,4"
 ceph_nfs_ceph_access_type: "RW"
 ceph_nfs_ceph_user: "admin"
 ceph_nfs_ceph_squash: "Root_Squash"
+ceph_nfs_ceph_sectype: "sys,krb5,krb5i,krb5p"
 
 ###################
 # FSAL RGW Config #
@@ -81,6 +82,7 @@ ceph_nfs_rgw_protocols: "3,4"
 ceph_nfs_rgw_access_type: "RW"
 ceph_nfs_rgw_user: "cephnfs"
 ceph_nfs_rgw_squash: "Root_Squash"
+ceph_nfs_rgw_sectype: "sys,krb5,krb5i,krb5p"
 # Note: keys are optional and can be generated, but not on containerized, where
 # they must be configered.
 #ceph_nfs_rgw_access_key: "QFAMEDSJP5DEKJO0DDXY"

--- a/roles/ceph-nfs/templates/ganesha.conf.j2
+++ b/roles/ceph-nfs/templates/ganesha.conf.j2
@@ -57,7 +57,7 @@ EXPORT
 
 	Transports = TCP;
 
-	SecType = sys,krb5,krb5i,krb5p;
+	SecType = {{ ceph_nfs_ceph_sectype }};
 
 	Squash = {{ ceph_nfs_ceph_squash }};
 
@@ -86,7 +86,7 @@ EXPORT
 
 	Transports = TCP;
 
-	SecType = sys,krb5,krb5i,krb5p;
+	SecType = {{ ceph_nfs_rgw_sectype }};
 
 	Squash = {{ ceph_nfs_rgw_squash }};
 


### PR DESCRIPTION
Depending on the infrastruture (w/o kerberos auth) then the SecType
value could be different.
Currently this value is hardcoded in the NFS Ganesha template. Instead
we can use a variable.
The default value is still the same to avoid breaking the backward
compatibility.

Closes: #4459

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>