### PR TITLE
dashboard: fix downstream deployment of the dashboard

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -759,7 +759,7 @@ dummy:
 #prometheus_data_dir: /var/lib/prometheus
 #prometheus_conf_dir: /etc/prometheus
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
-#prometheus_port: 9090
+#prometheus_port: 9092
 #alertmanager_container_image: prom/alertmanager:latest
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -759,7 +759,7 @@ prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
 #prometheus_data_dir: /var/lib/prometheus
 #prometheus_conf_dir: /etc/prometheus
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
-#prometheus_port: 9090
+#prometheus_port: 9092
 alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:4.1
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -725,7 +725,7 @@ node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node
 # We only need this for SSL (https) connections
 #grafana_crt: ''
 #grafana_key: ''
-grafana_container_image: registry.redhat.io/openshift4/ose-grafana:v4.1
+grafana_container_image: registry.redhat.io/rhceph/rhceph-3-dashboard-rhel7:3
 #grafana_container_cpu_period: 100000
 #grafana_container_cpu_cores: 2
 # container_memory is in GB
@@ -751,7 +751,7 @@ grafana_container_image: registry.redhat.io/openshift4/ose-grafana:v4.1
 #  - grafana-piechart-panel
 #grafana_allow_embedding: True
 #grafana_port: 3000
-prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.1
+prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
 #prometheus_container_cpu_period: 100000
 #prometheus_container_cpu_cores: 2
 # container_memory is in GB
@@ -760,7 +760,7 @@ prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.1
 #prometheus_conf_dir: /etc/prometheus
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 #prometheus_port: 9090
-alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.1
+alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:4.1
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2
 # container_memory is in GB

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -7,7 +7,7 @@ ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"
 ceph_docker_registry_auth: true
 node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1
-grafana_container_image: registry.redhat.io/openshift4/ose-grafana:v4.1
-prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.1
-alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.1
+grafana_container_image: registry.redhat.io/rhceph/rhceph-3-dashboard-rhel7:3
+prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
+alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:4.1
 # END OF FILE, DO NOT TOUCH ME!

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -751,7 +751,7 @@ prometheus_container_memory: 4
 prometheus_data_dir: /var/lib/prometheus
 prometheus_conf_dir: /etc/prometheus
 prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
-prometheus_port: 9090
+prometheus_port: 9092
 alertmanager_container_image: prom/alertmanager:latest
 alertmanager_container_cpu_period: 100000
 alertmanager_container_cpu_cores: 2


### PR DESCRIPTION
We are hitting several issues when deploying downstream (and with downstream images). We need to change the floating tags for the ose containers since these changed when we switched from unauthenticated registry to registry.redhat.io.

The downstream grafana container is also a lot less user-friendly and you need to handle all the options and plugin installation manually instead. We also need to make sure the container is run with uid 472 and that all the configurations paths are correct.