### PR TITLE
Revert "ceph-common: install only necesarry ceph-* packages on debian"

### DIFF
--- a/roles/ceph-common/vars/main.yml
+++ b/roles/ceph-common/vars/main.yml
@@ -2,13 +2,13 @@
 # ceph-common is always installed, if a package isn't to be installed we replace
 # it with 'ceph-common' and run the install with the | unique filter.
 debian_ceph_pkgs:
-  - "{{ (ceph_repository != 'rhcs') | ternary('ceph-base', 'ceph-common') }}"
+  - "{{ (ceph_repository != 'rhcs') | ternary('ceph', 'ceph-common') }}"
   - "ceph-common"
-  - "{{ (mon_group_name in group_names) | ternary('ceph-mon', 'ceph-common') }}"
-  - "{{ (osd_group_name in group_names) | ternary('ceph-osd', 'ceph-common') }}"
+  - "{{ ((ceph_repository == 'rhcs') and (mon_group_name in group_names)) | ternary('ceph-mon', 'ceph-common') }}"
+  - "{{ ((ceph_repository == 'rhcs') and (osd_group_name in group_names)) | ternary('ceph-osd', 'ceph-common') }}"
   - "{{ (ceph_test) | ternary('ceph-test', 'ceph-common') }}"
   - "{{ (rgw_group_name in group_names) | ternary('radosgw', 'ceph-common') }}"
-  - "{{ (client_group_name in group_names) | ternary('ceph-fuse', 'ceph-common') }}"
+  - "{{ ((ceph_repository == 'rhcs') and (client_group_name in group_names)) | ternary('ceph-fuse', 'ceph-common') }}"
 
 redhat_ceph_pkgs:
   - "{{ (ceph_test) | ternary('ceph-test', 'ceph-common') }}"


### PR DESCRIPTION
This reverts commit 58b27ef0b3bbd64d8a66da24d702f3ff761fe6ec.
This is breaking debian based OS deployments.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>