### PR TITLE
tests: remove debug log verbosity

### DIFF
--- a/tests/functional/all_daemons/ceph-override.json
+++ b/tests/functional/all_daemons/ceph-override.json
@@ -3,11 +3,6 @@
     "global": {
       "osd_pool_default_pg_num": 12,
       "osd_pool_default_size": 1,
-      "debug_ms": 20
-    },
-    "osd": {
-      "debug_bluefs": 20,
-      "debug_bluestore": 20
     }
   },
   "cephfs_pools": [


### PR DESCRIPTION
This was added for debugging purpose.
It's generating very large log output, let's remove this now.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>