### PR TITLE
ceph-config: do not always assume containers when calculating num_osds

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -30,7 +30,7 @@
     register: lvm_batch_report
     environment:
       CEPH_VOLUME_DEBUG: 1
-      CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+      CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
       CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     when:
       - devices | default([]) | length > 0
@@ -50,7 +50,7 @@
     register: lvm_list
     environment:
       CEPH_VOLUME_DEBUG: 1
-      CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+      CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
       CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     when:
       - devices | default([]) | length > 0


### PR DESCRIPTION
CEPH_CONTAINER_IMAGE should be None if containerized_deployment
is False.

Resolves: #4498

Signed-off-by: Andrew Schoen <aschoen@redhat.com>
(cherry picked from commit 70a4368bc5a58f198b23751f8478f2d79bc5e9f4)