### PR TITLE
ceph-config: don't notify all handlers

### DIFF
--- a/roles/ceph-common/tasks/configure_memory_allocator.yml
+++ b/roles/ceph-common/tasks/configure_memory_allocator.yml
@@ -9,7 +9,7 @@
   when:
     - ansible_os_family == 'Debian'
     - etc_default_ceph.stat.exists
-  notify: restart ceph osds
+  notify: "restart ceph {{ osd_group_name }}"
 
 - name: configure TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES for redhat
   lineinfile:
@@ -19,4 +19,4 @@
     regexp: "^TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES="
     line: "TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }}"
   when: ansible_os_family == 'RedHat'
-  notify: restart ceph osds
+  notify: "restart ceph {{ osd_group_name }}"

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -62,6 +62,14 @@
       - devices | default([]) | length > 0
       - not (lvm_batch_report.stdout | from_json).changed
 
+- name: generate the ceph notify list
+  set_fact:
+    ceph_notify: "{{ (ceph_notify | default([]) + ['restart ceph ' + item]) | unique }}"
+  with_items: "{{ group_names }}"
+  when:
+    - not rolling_update | bool
+    - item not in [client_group_name, grafana_server_group_name, rgwloadbalancer_group_name]
+
 # ceph-common
 - name: config file operation for non-containerized scenarios
   when: not containerized_deployment | bool
@@ -84,14 +92,7 @@
       mode: "0644"
       config_overrides: "{{ ceph_conf_overrides }}"
       config_type: ini
-    notify:
-      - restart ceph mons
-      - restart ceph osds
-      - restart ceph mdss
-      - restart ceph rgws
-      - restart ceph mgrs
-      - restart ceph rbdmirrors
-      - restart ceph rbd-target-api-gw
+    notify: "{{ ceph_notify | default(omit) }}"
 
   - name: "ensure fetch directory exists"
     run_once: true
@@ -143,11 +144,4 @@
       mode: "0644"
       config_overrides: "{{ ceph_conf_overrides }}"
       config_type: ini
-    notify:
-      - restart ceph mons
-      - restart ceph osds
-      - restart ceph mdss
-      - restart ceph rgws
-      - restart ceph mgrs
-      - restart ceph rbdmirrors
-      - restart ceph rbd-target-api-gw
+    notify: "{{ ceph_notify | default(omit) }}"

--- a/roles/ceph-container-common/tasks/fetch_image.yml
+++ b/roles/ceph-container-common/tasks/fetch_image.yml
@@ -200,7 +200,7 @@
   set_fact:
     ceph_mon_image_updated: "{{ ceph_mon_image_repodigest_before_pulling != image_repodigest_after_pulling }}"
   changed_when: true
-  notify: restart ceph mons
+  notify: "restart ceph {{ mon_group_name }}"
   when:
     - mon_group_name in group_names
     - ceph_mon_container_inspect_before_pull.get('rc') == 0
@@ -210,7 +210,7 @@
   set_fact:
     ceph_osd_image_updated: "{{ ceph_osd_image_repodigest_before_pulling != image_repodigest_after_pulling }}"
   changed_when: true
-  notify: restart ceph osds
+  notify: "restart ceph {{ osd_group_name }}"
   when:
     - osd_group_name in group_names
     - ceph_osd_container_inspect_before_pull.get('rc') == 0
@@ -220,7 +220,7 @@
   set_fact:
     ceph_mds_image_updated: "{{ ceph_mds_image_repodigest_before_pulling != image_repodigest_after_pulling }}"
   changed_when: true
-  notify: restart ceph mdss
+  notify: "restart ceph {{ mds_group_name }}"
   when:
     - mds_group_name in group_names
     - ceph_mds_container_inspect_before_pull.get('rc') == 0
@@ -230,7 +230,7 @@
   set_fact:
     ceph_rgw_image_updated: "{{ ceph_rgw_image_repodigest_before_pulling != image_repodigest_after_pulling }}"
   changed_when: true
-  notify: restart ceph rgws
+  notify: "restart ceph {{ rgw_group_name }}"
   when:
     - rgw_group_name in group_names
     - ceph_rgw_container_inspect_before_pull.get('rc') == 0
@@ -240,7 +240,7 @@
   set_fact:
     ceph_mgr_image_updated: "{{ ceph_mgr_image_repodigest_before_pulling != image_repodigest_after_pulling }}"
   changed_when: true
-  notify: restart ceph mgrs
+  notify: "restart ceph {{ mgr_group_name }}"
   when:
     - mgr_group_name in group_names
     - ceph_mgr_container_inspect_before_pull.get('rc') == 0
@@ -250,7 +250,7 @@
   set_fact:
     ceph_rbd_mirror_image_updated: "{{ ceph_rbd_mirror_image_repodigest_before_pulling != image_repodigest_after_pulling }}"
   changed_when: true
-  notify: restart ceph rbdmirrors
+  notify: "restart ceph {{ rbdmirror_group_name }}"
   when:
     - rbdmirror_group_name in group_names
     - ceph_rbd_mirror_container_inspect_before_pull.get('rc') == 0
@@ -260,7 +260,7 @@
   set_fact:
     ceph_nfs_image_updated: "{{ ceph_nfs_image_repodigest_before_pulling != image_repodigest_after_pulling }}"
   changed_when: true
-  notify: restart ceph nfss
+  notify: "restart ceph {{ nfs_group_name }}"
   when:
     - nfs_group_name in group_names
     - ceph_nfs_container_inspect_before_pull.get('rc') == 0

--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -9,47 +9,38 @@
       register: result
       until: result is succeeded
 
-    - name: mons handler
+    - name: "restart ceph {{ mon_group_name }}"
       include_tasks: handler_mons.yml
       when: mon_group_name in group_names
-      listen: "restart ceph mons"
 
-    - name: osds handler
+    - name: "restart ceph {{ osd_group_name }}"
       include_tasks: handler_osds.yml
       when: osd_group_name in group_names
-      listen: "restart ceph osds"
 
-    - name: mdss handler
+    - name: "restart ceph {{ mds_group_name }}"
       include_tasks: handler_mdss.yml
       when: mds_group_name in group_names
-      listen: "restart ceph mdss"
 
-    - name: rgws handler
+    - name: "restart ceph {{ rgw_group_name }}"
       include_tasks: handler_rgws.yml
       when: rgw_group_name in group_names
-      listen: "restart ceph rgws"
 
-    - name: nfss handler
+    - name: "restart ceph {{ nfs_group_name }}"
       include_tasks: handler_nfss.yml
       when: nfs_group_name in group_names
-      listen: "restart ceph nfss"
 
-    - name: rbdmirrors handler
+    - name: "restart ceph {{ rbdmirror_group_name }}"
       include_tasks: handler_rbdmirrors.yml
       when: rbdmirror_group_name in group_names
-      listen: "restart ceph rbdmirrors"
 
-    - name: mgrs handler
+    - name: "restart ceph {{ mgr_group_name }}"
       include_tasks: handler_mgrs.yml
       when: mgr_group_name in group_names
-      listen: "restart ceph mgrs"
 
-    - name: tcmu-runner handler
+    - name: "restart ceph tcmu-runner"
       include_tasks: handler_tcmu_runner.yml
       when: iscsi_gw_group_name in group_names
-      listen: "restart ceph tcmu-runner"
 
-    - name: rbd-target-api and rbd-target-gw handler
+    - name: "restart ceph {{ iscsi_gw_group_name }}"
       include_tasks: handler_rbd_target_api_gw.yml
       when: iscsi_gw_group_name in group_names
-      listen: "restart ceph rbd-target-api-gw"

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -34,7 +34,7 @@
     dest: /etc/ceph/iscsi-gateway.cfg
     config_type: ini
     config_overrides: '{{ iscsi_conf_overrides }}'
-  notify: restart ceph rbd-target-api-gw
+  notify: 'restart ceph {{ iscsi_gw_group_name }}'
 
 - name: set_fact container_exec_cmd
   set_fact:

--- a/roles/ceph-iscsi-gw/tasks/systemd.yml
+++ b/roles/ceph-iscsi-gw/tasks/systemd.yml
@@ -13,4 +13,4 @@
     - rbd-target-api
   notify:
     - restart ceph tcmu-runner
-    - restart ceph rbd-target-api-gw
+    - "restart ceph {{ iscsi_gw_group_name }}"

--- a/roles/ceph-mds/tasks/systemd.yml
+++ b/roles/ceph-mds/tasks/systemd.yml
@@ -7,4 +7,4 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  notify: restart ceph mdss
+  notify: "restart ceph {{ mds_group_name }}"

--- a/roles/ceph-mgr/tasks/systemd.yml
+++ b/roles/ceph-mgr/tasks/systemd.yml
@@ -7,4 +7,4 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  notify: restart ceph mgrs
+  notify: "restart ceph {{ mgr_group_name }}"

--- a/roles/ceph-mon/tasks/systemd.yml
+++ b/roles/ceph-mon/tasks/systemd.yml
@@ -7,4 +7,4 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  notify: restart ceph mons
+  notify: "restart ceph {{ mon_group_name }}"

--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -39,7 +39,7 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  notify: restart ceph nfss
+  notify: "restart ceph {{ nfs_group_name }}"
 
 - name: create exports directory
   file:

--- a/roles/ceph-nfs/tasks/systemd.yml
+++ b/roles/ceph-nfs/tasks/systemd.yml
@@ -7,4 +7,4 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  notify: restart ceph nfss
+  notify: "restart ceph {{ nfs_group_name }}"

--- a/roles/ceph-osd/tasks/systemd.yml
+++ b/roles/ceph-osd/tasks/systemd.yml
@@ -8,7 +8,7 @@
     group: "root"
     mode: "0744"
     setype: "bin_t"
-  notify: restart ceph osds
+  notify: "restart ceph {{ osd_group_name }}"
 
 - name: generate systemd unit file
   become: true
@@ -18,4 +18,4 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  notify: restart ceph osds
+  notify: "restart ceph {{ osd_group_name }}"

--- a/roles/ceph-rbd-mirror/tasks/systemd.yml
+++ b/roles/ceph-rbd-mirror/tasks/systemd.yml
@@ -7,4 +7,4 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  notify: restart ceph rbdmirrors
+  notify: "restart ceph {{ rbdmirror_group_name }}"

--- a/roles/ceph-rgw/tasks/systemd.yml
+++ b/roles/ceph-rgw/tasks/systemd.yml
@@ -7,4 +7,4 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  notify: restart ceph rgws
+  notify: "restart ceph {{ rgw_group_name }}"


### PR DESCRIPTION
Because ceph-config role is used to by multiple plays (mons, osds,
etc...) we need to notify the handlers when the ceph configuration
change.
Currently we are notifying all handlers : mons, osds, mdss rgws, rgws,
mgrs and rbdmirrors. The handler code isn't executed because we're
using some condition on the group_name but the ansible handler
notification process could be slow when evaluation the tasks.
To avoid this we could notify only the handler related to the ansible
group name (like mons).

Before:
```console
NOTIFIED HANDLER ceph-handler : mons handler for osd-45
NOTIFIED HANDLER ceph-handler : osds handler for osd-45
NOTIFIED HANDLER ceph-handler : mdss handler for osd-45
NOTIFIED HANDLER ceph-handler : rgws handler for osd-45
NOTIFIED HANDLER ceph-handler : mgrs handler for osd-45
NOTIFIED HANDLER ceph-handler : rbdmirrors handler for osd-45
NOTIFIED HANDLER ceph-handler : rbd-target-api and rbd-target-gw handler for osd-45
```

After:
```console
NOTIFIED HANDLER ceph-handler : restart ceph osds for osd-45
```
If multiple daemons are collocated on the same host then we will notify
each handler
```console
NOTIFIED HANDLER ceph-handler : restart ceph mgrs for mon-2
NOTIFIED HANDLER ceph-handler : restart ceph mons for mon-2
```
This patch removes the handler listen because we now have only one task
to notify and because the listen doens't support variables we can 
fallback to the task name which does.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>