### PR TITLE
[skip ci] validate: fix gpt header check

### DIFF
--- a/roles/ceph-validate/tasks/check_devices.yml
+++ b/roles/ceph-validate/tasks/check_devices.yml
@@ -1,22 +1,27 @@
 ---
-- name: devices validation
-  when: devices is defined
+- name: check no gpt header is present when osd scenario is lvm/lvm-batch
   block:
     - name: read information about the devices
       parted:
-        device: "{{ item }}"
+        device: "{{ item.data if item.data_vg is undefined and lvm_volumes is defined else item if devices is defined else omit }}"
         unit: MiB
       register: parted_results
-      with_items: "{{ devices }}"
+      with_items: "{{ lvm_volumes | default(devices) }}"
+      when:
+        - inventory_hostname in groups.get(osd_group_name, [])
+        - (item.data is defined and item.data_vg is undefined) or devices is defined
 
     - name: fail when gpt header found on osd devices
       fail:
         msg: "{{ item.disk.dev }} has gpt header, please remove it."
       with_items: "{{ parted_results.results }}"
       when:
+        - item.skipped is undefined
         - item.disk.table == 'gpt'
         - item.partitions | length == 0
 
+- name: check devices are block devices
+  block:
     - name: get devices information
       parted:
         device: "{{ item }}"


### PR DESCRIPTION
Check for gpt header when osd scenario is lvm or lvm batch.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>