### PR TITLE
Set proper ownership command performance improvement

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -92,14 +92,12 @@
          ceph_uid: 167
       when: ceph_docker_image is search("rhceph")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
     - name: check for existing old leveldb file extension (ldb)
       shell: stat /var/lib/ceph/mon/*/store.db/*.ldb
@@ -170,14 +168,12 @@
         ceph_uid: 167
       when: ceph_docker_image_tag | string is search("centos") or ceph_docker_image is search("rhceph") or ceph_docker_image_tag | string is search("fedora")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
   roles:
     - ceph-defaults
@@ -242,14 +238,12 @@
          ceph_uid: 167
       when: ceph_docker_image is search("rhceph")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown --verbose -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
     - name: check for existing old leveldb file extension (ldb)
       shell: stat /var/lib/ceph/osd/*/current/omap/*.ldb
@@ -341,14 +335,12 @@
         ceph_uid: 167
       when: ceph_docker_image_tag | string is search("centos") or ceph_docker_image is search("rhceph") or ceph_docker_image_tag | string is search("fedora")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
   roles:
     - ceph-defaults
@@ -385,14 +377,12 @@
         ceph_uid: 167
       when: ceph_docker_image_tag | string is search("centos") or ceph_docker_image is search("rhceph") or ceph_docker_image_tag | string is search("fedora")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
   roles:
     - ceph-defaults
@@ -429,14 +419,12 @@
         ceph_uid: 167
       when: ceph_docker_image_tag | string is search("centos") or ceph_docker_image is search("rhceph") or ceph_docker_image_tag | string is search("fedora")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
   roles:
     - ceph-defaults
@@ -477,14 +465,12 @@
         ceph_uid: 167
       when: ceph_docker_image_tag | string is search("centos") or ceph_docker_image is search("rhceph") or ceph_docker_image_tag | string is search("fedora")
 
+    # NOTE: changed from file module to raw chown command for performance reasons
+    # The file module has to run checks on current ownership of all directories and files. This is unnecessary
+    # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      file:
-        path: "{{ item }}"
-        owner: "{{ ceph_uid }}"
-        recurse: yes
-      with_items:
-        - /var/lib/ceph
-        - /etc/ceph
+      command: "chown -R {{ ceph_uid }} /var/lib/ceph /etc/ceph"
+      changed_when: false
 
   roles:
     - ceph-defaults


### PR DESCRIPTION
By changing the set ownership command from using the file module in combination with a with_items loop to a raw chown command, we can achieve a 98% performance increase here.

On a ceph cluster with a significant amount of directories and files in /var/lib/ceph, the file module has to run checks on ownership of all those directories and files to determine whether a change is needed.

In this case, we just want to explicitly set the ownership of all these directories and files to the ceph_uid

Added context note to all set proper ownership tasks

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1757400

Signed-off-by: Kevin Jones <kevinjones@redhat.com>
(cherry picked from commit 47bf47c9d87fe057bc1402f7a1aa0a84d13b5fd0)