### PR TITLE
common: improve keyrings generation

### DIFF
--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -7,6 +7,7 @@
       with_items:
         - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+      run_once: true
       when:
         - cephx | bool
         - item.copy_key | bool

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -5,6 +5,7 @@
   with_items:
     - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
   delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+  run_once: true
   when:
     - cephx | bool
     - item.copy_key | bool

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -17,6 +17,7 @@
     - { name: "client.bootstrap-mds", path: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring", copy_key: true }
     - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
   delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+  run_once: true
   when:
     - cephx | bool
     - item.copy_key | bool

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -59,6 +59,7 @@
       register: _mgr_keys
       with_items: "{{ _mgr_keys }}"
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+      run_once: true
       when:
         - cephx | bool
         - item.copy_key | bool

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -8,6 +8,7 @@
         - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
         - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+      run_once: true
       when:
         - cephx | bool
         - item.copy_key | bool

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -53,6 +53,7 @@
         - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
         - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+      run_once: true
       when:
         - cephx | bool
         - item.copy_key | bool

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -18,6 +18,7 @@
     - { name: "client.bootstrap-osd", path: "/var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring", copy_key: true }
     - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
   delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+  run_once: true
   when:
     - cephx | bool
     - item.copy_key | bool

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -86,6 +86,7 @@
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
       register: _osp_keys
       with_items: "{{ openstack_keys }}"
+      run_once: true
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
 
     - name: copy ceph key(s) if needed

--- a/roles/ceph-rbd-mirror/tasks/common.yml
+++ b/roles/ceph-rbd-mirror/tasks/common.yml
@@ -6,6 +6,7 @@
     - { name: "client.bootstrap-rbd-mirror", path: "/var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring", copy_key: true }
     - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
   delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+  run_once: true
   when:
     - cephx | bool
     - item.copy_key | bool

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -25,6 +25,7 @@
     - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
     - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
   delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+  run_once: true
   when:
     - cephx | bool
     - item.copy_key | bool


### PR DESCRIPTION
There is no need to get n * number of nodes the different keyrings.
Adding a `run_once: true` here avoid running a ceph command too many
times which could be impacting large cluster deployment.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>