### PR TITLE
main: exclude client nodes from facts gathering

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -28,13 +28,15 @@
     # pre-tasks for following import -
     - name: gather facts
       setup:
-      when: not delegate_facts_host | bool
+      when:
+        - not delegate_facts_host | bool
+        - not inventory_hostname in groups.get('clients', [])
 
     - name: gather and delegate facts
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items: "{{ groups['all'] }}"
+      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
       run_once: true
       when: delegate_facts_host | bool
 

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -32,13 +32,15 @@
 
     - name: gather facts
       setup:
-      when: not delegate_facts_host | bool
+      when:
+        - not delegate_facts_host | bool
+        - not inventory_hostname in groups.get('clients', [])
 
     - name: gather and delegate facts
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items: "{{ groups['all'] }}"
+      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
       run_once: true
       when: delegate_facts_host | bool
 


### PR DESCRIPTION
This commit excludes client nodes from facts gathering, they are not
needed and can speed up this task.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>