### PR TITLE
main: exclude client nodes from facts gathering

### DIFF
--- a/infrastructure-playbooks/add-mon.yml
+++ b/infrastructure-playbooks/add-mon.yml
@@ -13,9 +13,10 @@
   pre_tasks:
     - name: gather facts
       setup:
-      when: not delegate_facts_host | bool
+      when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
     - import_role:
         name: ceph-defaults
+
     - name: gather and delegate facts
       setup:
       delegate_to: "{{ item }}"

--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -24,13 +24,13 @@
     # pre-tasks for following import -
     - name: gather facts
       setup:
-      when: not delegate_facts_host | bool
+      when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
 
     - name: gather and delegate facts
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items: "{{ groups['all'] }}"
+      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
       run_once: true
       when: delegate_facts_host | bool
 

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -59,13 +59,13 @@
 
     - name: gather facts
       setup:
-      when: not delegate_facts_host | bool
+      when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
 
     - name: gather and delegate facts
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items: "{{ groups['all'] }}"
+      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
       run_once: true
       when: delegate_facts_host | bool
 

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -57,6 +57,9 @@
   tasks:
     - debug: msg="gather facts on all Ceph hosts for following reference"
 
+    - import_role:
+        name: ceph-defaults
+
     - name: gather facts
       setup:
       when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -28,13 +28,14 @@
     # pre-tasks for following import -
     - name: gather facts
       setup:
-      when: not delegate_facts_host | bool
+      when:
+        - not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
 
     - name: gather and delegate facts
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items: "{{ groups['all'] }}"
+      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
       run_once: true
       when: delegate_facts_host | bool
 

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -43,14 +43,6 @@
       run_once: true
       when: delegate_facts_host | bool
 
-    - name: install required packages for fedora > 23
-      raw: sudo dnf -y install python2-dnf libselinux-python ntp
-      register: result
-      when:
-        - ansible_distribution == 'Fedora'
-        - ansible_distribution_major_version|int >= 23
-      until: result is succeeded
-
     - name: check if it is atomic host
       stat:
         path: /run/ostree-booted

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -32,13 +32,14 @@
 
     - name: gather facts
       setup:
-      when: not delegate_facts_host | bool
+      when:
+        - not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
 
     - name: gather and delegate facts
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items: "{{ groups['all'] }}"
+      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
       run_once: true
       when: delegate_facts_host | bool
 


### PR DESCRIPTION
This commit excludes client nodes from facts gathering, they are not
needed and can speed up this task.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>