### PR TITLE
dashboard: remove rgw api host,port,scheme

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -713,9 +713,6 @@ dummy:
 #dashboard_crt: ''
 #dashboard_key: ''
 #dashboard_rgw_api_user_id: ceph-dashboard
-#dashboard_rgw_api_host: ''
-#dashboard_rgw_api_port: ''
-#dashboard_rgw_api_scheme: ''
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
 #node_exporter_container_image: prom/node-exporter:latest

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -713,9 +713,6 @@ ceph_docker_registry_auth: true
 #dashboard_crt: ''
 #dashboard_key: ''
 #dashboard_rgw_api_user_id: ceph-dashboard
-#dashboard_rgw_api_host: ''
-#dashboard_rgw_api_port: ''
-#dashboard_rgw_api_scheme: ''
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
 node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -153,25 +153,22 @@
       changed_when: false
 
     - name: set the rgw host
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-host {{ dashboard_rgw_api_host }}"
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-host {{ hostvars[groups[rgw_group_name][0]]['rgw_instances'][0]['radosgw_address'] }}"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
-      when: dashboard_rgw_api_host != ''
 
     - name: set the rgw port
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-port {{ dashboard_rgw_api_port }}"
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-port {{ hostvars[groups[rgw_group_name][0]]['rgw_instances'][0]['radosgw_frontend_port'] }}"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
-      when: dashboard_rgw_api_port != ''
 
     - name: set the rgw scheme
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-scheme {{ dashboard_rgw_api_scheme }}"
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-scheme {{ 'https' if radosgw_frontend_ssl_certificate else 'http' }}"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
-      when: dashboard_rgw_api_scheme != ''
 
     - name: set the rgw admin resource
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-admin-resource {{ dashboard_rgw_api_admin_resource }}"
@@ -185,7 +182,9 @@
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
-      when: dashboard_rgw_api_no_ssl_verify | bool
+      when:
+        - dashboard_rgw_api_no_ssl_verify | bool
+        - radosgw_frontend_ssl_certificate | length > 0
 
 - name: disable mgr dashboard module (restart)
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} mgr module disable dashboard"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -705,9 +705,6 @@ dashboard_admin_password: admin
 dashboard_crt: ''
 dashboard_key: ''
 dashboard_rgw_api_user_id: ceph-dashboard
-dashboard_rgw_api_host: ''
-dashboard_rgw_api_port: ''
-dashboard_rgw_api_scheme: ''
 dashboard_rgw_api_admin_resource: ''
 dashboard_rgw_api_no_ssl_verify: False
 node_exporter_container_image: prom/node-exporter:latest


### PR DESCRIPTION
We don't need to have dedicated variables for the RGW integration into
the Ceph Dashboard and need to be manually filled.
Instead we can use the current values from the RGW nodes by using the
IP and port from the first RGW instance of the first RGW node via the
radosgw_address and radosgw_frontend_port variables.
We don't need to specify all RGW nodes, this will be done automatically
with one node.
The RGW api scheme is using the radosgw_frontend_ssl_certificate variable
to determine if the value is http or https. This variable is also reuse
as a condition for the ssl verify task.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>