### PR TITLE
ceph-handler: don't restart all OSDs with limit

### DIFF
--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -92,7 +92,7 @@
         - ceph_current_status.fsid is defined
         - handler_health_osd_check | bool
         - hostvars[item]['_osd_handler_called'] | default(False) | bool
-      with_items: "{{ groups[osd_group_name] }}"
+      with_items: "{{ groups[osd_group_name] | intersect(ansible_play_batch) }}"
       delegate_to: "{{ item }}"
       run_once: True
 
@@ -108,7 +108,7 @@
         - ceph_osd_container_stat.get('stdout_lines', [])|length != 0
         - handler_health_osd_check | bool
         - hostvars[item]['_osd_handler_called'] | default(False)
-      with_items: "{{ groups[osd_group_name] }}"
+      with_items: "{{ groups[osd_group_name] | intersect(ansible_play_batch) }}"
       delegate_to: "{{ item }}"
       run_once: True
 


### PR DESCRIPTION
When using the ansible --limit option on one or few OSD nodes and if the
handler is triggered then we will restart the OSD service on all OSDs
nodes instead of the hosts limited by the limit value.
Even if the play is limited by the --limit value we are using all OSD
nodes from the OSD group.

```yaml
  with_items: '{{ groups[osd_group_name] }}'
```

Instead we should iterate only on the nodes present in both OSD group and
limit list.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>