### PR TITLE
dashboard: remove useless block section

### DIFF
--- a/infrastructure-playbooks/dashboard.yml
+++ b/infrastructure-playbooks/dashboard.yml
@@ -11,17 +11,16 @@
             start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
   tasks:
-    - block:
-        - import_role:
-            name: ceph-defaults
-          tags: ['ceph_update_config']
-        - import_role:
-            name: ceph-facts
-          tags: ['ceph_update_config']
-        - import_role:
-            name: ceph-container-engine
-        - import_role:
-            name: ceph-node-exporter
+    - import_role:
+        name: ceph-defaults
+      tags: ['ceph_update_config']
+    - import_role:
+        name: ceph-facts
+      tags: ['ceph_update_config']
+    - import_role:
+        name: ceph-container-engine
+    - import_role:
+        name: ceph-node-exporter
 
   post_tasks:
     - name: set ceph node exporter install 'Complete'
@@ -44,19 +43,18 @@
             start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
   tasks:
-    - block:
-        - import_role:
-            name: ceph-defaults
-          tags: ['ceph_update_config']
-        - import_role:
-            name: ceph-facts
-          tags: ['ceph_update_config']
-        - import_role:
-            name: ceph-container-engine
-        - import_role:
-            name: ceph-prometheus
-        - import_role:
-            name: ceph-grafana
+    - import_role:
+        name: ceph-defaults
+      tags: ['ceph_update_config']
+    - import_role:
+        name: ceph-facts
+      tags: ['ceph_update_config']
+    - import_role:
+        name: ceph-container-engine
+    - import_role:
+        name: ceph-prometheus
+    - import_role:
+        name: ceph-grafana
 
   post_tasks:
     - name: set ceph grafana install 'Complete'
@@ -79,15 +77,14 @@
             start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
   tasks:
-    - block:
-        - import_role:
-            name: ceph-defaults
-          tags: ['ceph_update_config']
-        - import_role:
-            name: ceph-facts
-          tags: ['ceph_update_config']
-        - import_role:
-            name: ceph-dashboard
+    - import_role:
+        name: ceph-defaults
+      tags: ['ceph_update_config']
+    - import_role:
+        name: ceph-facts
+      tags: ['ceph_update_config']
+    - import_role:
+        name: ceph-dashboard
 
   post_tasks:
     - name: set ceph dashboard install 'Complete'


### PR DESCRIPTION
The block section were used with the dashboard_enabled condition when
the code was included in the main playbooks.
Because this condition isn't present in the dashboard playbook anymore
we can remove the block section.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>