### PR TITLE
rgw multisite secondary endpoint checks

### DIFF
--- a/roles/ceph-rgw/tasks/multisite/secondary.yml
+++ b/roles/ceph-rgw/tasks/multisite/secondary.yml
@@ -1,4 +1,8 @@
 ---
+- name: ensure connection to primary cluster
+  uri:
+    url: "{{ rgw_pull_proto }}://{{ rgw_pullhost }}:{{ rgw_pull_port }}"
+
 - name: fetch the realm
   command: "{{ container_exec_cmd }} radosgw-admin realm pull --url={{ rgw_pull_proto }}://{{ rgw_pullhost }}:{{ rgw_pull_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -6,10 +10,15 @@
   when: "'No such file or directory' in realmcheck.stderr"
 
 - name: fetch the period
-  command: "{{ container_exec_cmd }} radosgw-admin period pull --url={{ rgw_pull_proto }}://{{ rgw_pullhost }}:{{ rgw_pull_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}"
+  command: "{{ container_exec_cmd }} radosgw-admin period get --url={{ rgw_pull_proto }}://{{ rgw_pullhost }}:{{ rgw_pull_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
+  register: period_get
   when: "'No such file or directory' in realmcheck.stderr"
+
+- name: include_tasks secondary_connection_checks.yml
+  include_tasks: secondary_connection_checks.yml
+  when: period_get is defined
 
 - name: set default realm
   command: "{{ container_exec_cmd }} radosgw-admin realm default --rgw-realm={{ rgw_realm }}"

--- a/roles/ceph-rgw/tasks/multisite/secondary_connection_checks.yml
+++ b/roles/ceph-rgw/tasks/multisite/secondary_connection_checks.yml
@@ -1,0 +1,30 @@
+- name: get zonegroups list from period_get
+  set_fact:
+    zonegroups: "{{ (period_get.stdout | from_json)['period_map']['zonegroups'] }}"
+
+- name: get zones from zonegroups list
+  set_fact:
+    zonegroups_endpoints: "{{ zonegroups_endpoints | default([]) }} + {{ item.endpoints }}"
+  with_items: "{{ zonegroups }}"
+
+- name: get zones from zonegroups list
+  set_fact:
+    zones: "{{ zones | default([]) }} + {{ item.zones }}"
+  with_items: "{{ zonegroups }}"
+  when: item.name == rgw_zonegroup
+
+- name: get endpoints from zones list
+  set_fact:
+    zone_endpoints: "{{ zone_endpoints | default([]) }} + {{ item.endpoints }}"
+  with_items: "{{ zones }}"
+  when: item.name != rgw_zone
+
+- name: ensure connection to zonegroups endpoints
+  uri:
+    url: "{{ item }}"
+  with_items: "{{ zonegroups_endpoints }}"
+
+- name: ensure connection to zones endpoints
+  uri:
+    url: "{{ item }}"
+  with_items: "{{ zone_endpoints }}"


### PR DESCRIPTION
Add two checks in secondary.yml:

1) a check that ensures a connection to the
endpoint the realm is being fetched from.

2) a check that ensures connections from the
host rgw to all the rgws endpoints in a zone and
all the rgw endpoints for all the zonegroups
in a realm.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1731158

Signed-off-by: Ali Maredia <amaredia@redhat.com>