### PR TITLE
validate: prevent from installing osd on already used device

### DIFF
--- a/roles/ceph-validate/tasks/check_devices.yml
+++ b/roles/ceph-validate/tasks/check_devices.yml
@@ -1,4 +1,16 @@
 ---
+- name: get device name using readlink -f
+  command: "readlink -f {{ item.data if item.data_vg is undefined and lvm_volumes is defined else item }}"
+  with_items: "{{ lvm_volumes | default(devices) }}"
+  changed_when: false
+  register: readlink_devices
+
+- name: fail if one device is already used
+  fail:
+    msg: "device {{ item.stdout }} is already used!"
+  with_items: "{{ readlink_devices.results }}"
+  when: ansible_devices[item.stdout.split('/')[-1]].partitions | length != 0
+
 - name: check no gpt header is present when osd scenario is lvm/lvm-batch
   block:
     - name: read information about the devices


### PR DESCRIPTION
This commit adds a validation task in order to prevent from installing
an OSD on a device which is already used.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1623580

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>