### PR TITLE
Fixes 'ssh: host unreachable' error in Copy ceph key task in ceph-mgr role

### DIFF
--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -72,7 +72,7 @@
         group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         mode: "{{ ceph_keyring_permissions }}"
       with_items: "{{ _mgr_keys.results }}"
-      delegate_to: "{{ item.item.hostname }}"
+      delegate_to: "{{ item.item.hostname | regex_replace('^ip-([0-9]+)-([0-9]+)-([0-9]+)-([0-9]+)$', '\\1.\\2.\\3.\\4' ) }}"
       run_once: true
       when:
         - cephx | bool


### PR DESCRIPTION
## Context

In 'Copy ceph key(s) task, if 'mgr' instance was given an IP in host inventory,
ceph ansible was passing it as `ip-10-20-30-40` to `delegate_to` field in the task which results
in 'ssh: host unreachable' error. This is one of the possible fixes!