### PR TITLE
playbook: add missing tags

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -101,6 +101,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-container-engine
     - import_role:
@@ -147,6 +148,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-container-engine
     - import_role:
@@ -188,6 +190,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-container-engine
     - import_role:
@@ -229,6 +232,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-container-engine
     - import_role:
@@ -270,6 +274,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-container-engine
     - import_role:
@@ -311,6 +316,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-container-engine
     - import_role:
@@ -352,6 +358,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-container-engine
     - import_role:
@@ -393,6 +400,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-container-engine
       when: inventory_hostname == groups.get('clients', ['']) | first
@@ -438,6 +446,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-container-engine
     - import_role:

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -93,6 +93,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-common
     - import_role:
@@ -135,6 +136,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-common
     - import_role:
@@ -174,6 +176,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-common
     - import_role:
@@ -213,6 +216,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-common
     - import_role:
@@ -252,6 +256,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-common
     - import_role:
@@ -291,6 +296,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-common
     - import_role:
@@ -330,6 +336,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-common
     - import_role:
@@ -369,6 +376,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-common
     - import_role:
@@ -410,6 +418,7 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-handler
+      tags: ['ceph_update_config']
     - import_role:
         name: ceph-common
     - import_role:


### PR DESCRIPTION
Add missing tag on ceph-handler role call.
Otherwise, we can't use `--tags='ceph_update_config'` for updating the
ceph configuration file.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1754432

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>