### PR TITLE
tests: fix rgw multisite vagrant variables

### DIFF
--- a/tests/functional/rgw-multisite/container/hosts
+++ b/tests/functional/rgw-multisite/container/hosts
@@ -5,4 +5,4 @@ mon0
 osd0
 
 [rgws]
-osd0 rgw_multisite_proto=http rgw_multisite_endpoint_addr=192.168.105.100
+osd0 rgw_multisite_proto=http rgw_multisite_endpoint_addr=192.168.105.11

--- a/tests/functional/rgw-multisite/container/secondary/hosts
+++ b/tests/functional/rgw-multisite/container/secondary/hosts
@@ -5,4 +5,4 @@ mon0
 osd0
 
 [rgws]
-osd0 copy_admin_key=True rgw_multisite=True rgw_zone=mars rgw_zonemaster=False rgw_zonesecondary=True rgw_zonegroup=solarsystem rgw_zone_user=zone.user rgw_realm=milkyway rgw_multisite_proto=http rgw_multisite_endpoint_addr=192.168.107.100 system_access_key=6kWkikvapSnHyE22P7nO system_secret_key=MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt rgw_pull_proto=http rgw_pull_port=8080 rgw_pullhost=192.168.105.100
+osd0 copy_admin_key=True rgw_multisite=True rgw_zone=mars rgw_zonemaster=False rgw_zonesecondary=True rgw_zonegroup=solarsystem rgw_zone_user=zone.user rgw_realm=milkyway rgw_multisite_proto=http rgw_multisite_endpoint_addr=192.168.107.11 system_access_key=6kWkikvapSnHyE22P7nO system_secret_key=MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt rgw_pull_proto=http rgw_pull_port=8080 rgw_pullhost=192.168.105.11

--- a/tests/functional/rgw-multisite/container/secondary/vagrant_variables.yml
+++ b/tests/functional/rgw-multisite/container/secondary/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tests/functional/rgw-multisite/hosts
+++ b/tests/functional/rgw-multisite/hosts
@@ -5,4 +5,4 @@ mon0
 osd0
 
 [rgws]
-osd0 rgw_multisite_proto=http rgw_multisite_endpoint_addr=192.168.101.100
+osd0 rgw_multisite_proto=http rgw_multisite_endpoint_addr=192.168.101.11

--- a/tests/functional/rgw-multisite/secondary/hosts
+++ b/tests/functional/rgw-multisite/secondary/hosts
@@ -5,4 +5,4 @@ mon0
 osd0
 
 [rgws]
-osd0 rgw_multisite=True rgw_zone=mars rgw_zonemaster=False rgw_zonesecondary=True rgw_zonegroup=solarsystem rgw_zone_user=zone.user rgw_realm=milkyway rgw_multisite_proto=http rgw_multisite_endpoint_addr=192.168.103.100 system_access_key=6kWkikvapSnHyE22P7nO system_secret_key=MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt rgw_pull_proto=http rgw_pull_port=8080 rgw_pullhost=192.168.101.100
+osd0 rgw_multisite=True rgw_zone=mars rgw_zonemaster=False rgw_zonesecondary=True rgw_zonegroup=solarsystem rgw_zone_user=zone.user rgw_realm=milkyway rgw_multisite_proto=http rgw_multisite_endpoint_addr=192.168.103.11 system_access_key=6kWkikvapSnHyE22P7nO system_secret_key=MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt rgw_pull_proto=http rgw_pull_port=8080 rgw_pullhost=192.168.101.11

--- a/tests/functional/rgw-multisite/secondary/vagrant_variables.yml
+++ b/tests/functional/rgw-multisite/secondary/vagrant_variables.yml
@@ -9,6 +9,7 @@ osd_vms: 1
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0
+grafana_server_vms: 0
 rbd_mirror_vms: 0
 client_vms: 0
 iscsi_gw_vms: 0

--- a/tox.ini
+++ b/tox.ini
@@ -331,13 +331,13 @@ commands=
 commands=
   bash -c "cd {changedir}/secondary && vagrant up --no-provision {posargs:--provider=virtualbox}"
   bash -c "cd {changedir}/secondary && bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}/secondary"
-  ansible-playbook --ssh-extra-args='-F {changedir}/secondary/vagrant_ssh_config' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/setup.yml
+  ansible-playbook --ssh-common-args='-F {changedir}/secondary/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir}/secondary ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
-  ansible-playbook --ssh-extra-args='-F {changedir}/secondary/vagrant_ssh_config' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/lvm_setup.yml
+  ansible-playbook --ssh-common-args='-F {changedir}/secondary/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/lvm_setup.yml
   # ensure the rule isn't already present
   ansible -i localhost, all -c local -b -m iptables -a 'chain=FORWARD protocol=tcp source=192.168.0.0/16 destination=192.168.0.0/16 jump=ACCEPT action=insert rule_num=1 state=absent'
   ansible -i localhost, all -c local -b -m iptables -a 'chain=FORWARD protocol=tcp source=192.168.0.0/16 destination=192.168.0.0/16 jump=ACCEPT action=insert rule_num=1 state=present'
-  ansible-playbook --ssh-extra-args='-F {changedir}/secondary/vagrant_ssh_config' -vv -i {changedir}/secondary/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
+  ansible-playbook --ssh-common-args='-F {changedir}/secondary/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey' -vv -i {changedir}/secondary/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/secondary/fetch} \
       ceph_stable_release={env:CEPH_STABLE_RELEASE:nautilus} \
@@ -348,7 +348,7 @@ commands=
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       "
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/rgw_multisite.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest}"
-  ansible-playbook -vv --ssh-extra-args='-F {changedir}/secondary/vagrant_ssh_config' -i {changedir}/secondary/hosts {toxinidir}/tests/functional/rgw_multisite.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest}"
+  ansible-playbook --ssh-common-args='-F {changedir}/secondary/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/rgw_multisite.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest}"
   bash -c "cd {changedir}/secondary && vagrant destroy --force"
   # clean rule after the scenario is complete
   ansible -i localhost, all -c local -b -m iptables -a 'chain=FORWARD protocol=tcp source=192.168.0.0/16 destination=192.168.0.0/16 jump=ACCEPT action=insert rule_num=1 state=absent'


### PR DESCRIPTION
The secondary vagrant variables didn't have the grafana vm variable
set which create an vagrant error.

```console
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
an invalid or undefined variable.
```

This patch also changes the ssh-extra-args parameter to ssh-common-args
to get the same values for ssh/sftp/scp. Otherwise we can see warnings
from ansible and some tasks are failing.

```console
[WARNING]: sftp transfer mechanism failed on [mon0]. Use ANSIBLE_DEBUG=1
to see detailed information
```

It also updates the ssh-common-args value for the rgw-multisite scenario
to reflect the ANSIBLE_SSH_ARGS environment variable value.

Finally changing the IP addresses due to the Vagrant refact done in the
commit 778c51a

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>