### PR TITLE
ceph-rgw: add cluster parameter to multisite tasks

### DIFF
--- a/roles/ceph-rgw/tasks/multisite/checks.yml
+++ b/roles/ceph-rgw/tasks/multisite/checks.yml
@@ -1,6 +1,6 @@
 ---
 - name: check if the realm already exists
-  command: "{{ container_exec_cmd }} radosgw-admin realm get --rgw-realm={{ rgw_realm }}"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} realm get --rgw-realm={{ rgw_realm }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   register: realmcheck
   failed_when: False
@@ -8,7 +8,7 @@
   check_mode: no
 
 - name: check if the zonegroup already exists
-  command: "{{ container_exec_cmd }} radosgw-admin zonegroup get --rgw-zonegroup={{ rgw_zonegroup }}"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} zonegroup get --rgw-zonegroup={{ rgw_zonegroup }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   register: zonegroupcheck
   failed_when: False
@@ -16,7 +16,7 @@
   check_mode: no
 
 - name: check if the zone already exists
-  command: "{{ container_exec_cmd }} radosgw-admin zone get --rgw-zone={{ rgw_zone }}"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} zone get --rgw-zone={{ rgw_zone }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   register: zonecheck
   failed_when: False
@@ -24,7 +24,7 @@
   check_mode: no
 
 - name: check if the system user already exists
-  command: "{{ container_exec_cmd }} radosgw-admin user info --uid={{ rgw_zone_user }}"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} user info --uid={{ rgw_zone_user }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   register: usercheck
   failed_when: False

--- a/roles/ceph-rgw/tasks/multisite/destroy.yml
+++ b/roles/ceph-rgw/tasks/multisite/destroy.yml
@@ -1,13 +1,13 @@
 ---
 - name: delete the zone user
-  command: radosgw-admin user rm --uid=zone.user
+  command: radosgw-admin --cluster {{ cluster }} user rm --uid=zone.user
   run_once: true
   failed_when: false
   register: rgw_delete_the_zone_user
   changed_when: rgw_delete_the_zone_user.rc == 0
 
 - name: remove zone from zonegroup
-  command: radosgw-admin zonegroup remove --rgw-zonegroup={{ rgw_zonegroup }} --rgw-zone={{ rgw_zone }}
+  command: radosgw-admin --cluster {{ cluster }} zonegroup remove --rgw-zonegroup={{ rgw_zonegroup }} --rgw-zone={{ rgw_zone }}
   run_once: true
   failed_when: false
   register: rgw_remove_zone_from_zonegroup
@@ -15,21 +15,21 @@
   notify: update period
 
 - name: delete the zone
-  command: radosgw-admin zone delete --rgw-zonegroup={{ rgw_zonegroup }} --rgw-zone={{ rgw_zone }}
+  command: radosgw-admin --cluster {{ cluster }} zone delete --rgw-zonegroup={{ rgw_zonegroup }} --rgw-zone={{ rgw_zone }}
   run_once: true
   failed_when: false
   register: rgw_delete_the_zone
   changed_when: rgw_delete_the_zone.rc == 0
 
 - name: delete the zonegroup
-  command: radosgw-admin zonegroup delete --rgw-zonegroup={{ rgw_zonegroup }}
+  command: radosgw-admin --cluster {{ cluster }} zonegroup delete --rgw-zonegroup={{ rgw_zonegroup }}
   run_once: true
   failed_when: false
   register: rgw_delete_the_zonegroup
   changed_when: rgw_delete_the_zonegroup.rc == 0
 
 - name: delete the realm
-  command: radosgw-admin realm delete --rgw-realm={{ rgw_realm }}
+  command: radosgw-admin --cluster {{ cluster }} realm delete --rgw-realm={{ rgw_realm }}
   run_once: true
   failed_when: false
   register: rgw_delete_the_realm

--- a/roles/ceph-rgw/tasks/multisite/master.yml
+++ b/roles/ceph-rgw/tasks/multisite/master.yml
@@ -1,31 +1,31 @@
 ---
 - name: create the realm
-  command: "{{ container_exec_cmd }} radosgw-admin realm create --rgw-realm={{ rgw_realm }} --default"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} realm create --rgw-realm={{ rgw_realm }} --default"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   when: "'No such file or directory' in realmcheck.stderr"
 
 - name: create the zonegroup
-  command: "{{ container_exec_cmd }} radosgw-admin zonegroup create --rgw-zonegroup={{ rgw_zonegroup }} --endpoints={{ rgw_multisite_proto }}://{{ rgw_multisite_endpoint_addr }}:{{ radosgw_frontend_port }} --master --default"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} zonegroup create --rgw-zonegroup={{ rgw_zonegroup }} --endpoints={{ rgw_multisite_proto }}://{{ rgw_multisite_endpoint_addr }}:{{ radosgw_frontend_port }} --master --default"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   when: "'No such file or directory' in zonegroupcheck.stderr"
 
 - name: create the zone
-  command: "{{ container_exec_cmd }} radosgw-admin zone create --rgw-zonegroup={{ rgw_zonegroup }} --rgw-zone={{ rgw_zone }} --endpoints={{ rgw_multisite_proto }}://{{ rgw_multisite_endpoint_addr }}:{{ radosgw_frontend_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }} --default --master"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} zone create --rgw-zonegroup={{ rgw_zonegroup }} --rgw-zone={{ rgw_zone }} --endpoints={{ rgw_multisite_proto }}://{{ rgw_multisite_endpoint_addr }}:{{ radosgw_frontend_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }} --default --master"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   when: "'No such file or directory' in zonecheck.stderr"
 
 - name: create the zone user
-  command: "{{ container_exec_cmd }} radosgw-admin user create --uid={{ rgw_zone_user }} --display-name=\"Zone User\" --access-key={{ system_access_key }} --secret={{ system_secret_key }} --system"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} user create --uid={{ rgw_zone_user }} --display-name=\"Zone User\" --access-key={{ system_access_key }} --secret={{ system_secret_key }} --system"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   when: "'could not fetch user info: no user info saved' in usercheck.stderr"
   notify: update period
 
 - name: add other endpoints to the zone
-  command: "{{ container_exec_cmd }} radosgw-admin zone modify --rgw-zone={{ rgw_zone }} --endpoints {{ rgw_multisite_endpoints_list }}"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} zone modify --rgw-zone={{ rgw_zone }} --endpoints {{ rgw_multisite_endpoints_list }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   when: rgw_multisite_endpoints_list is defined

--- a/roles/ceph-rgw/tasks/multisite/secondary.yml
+++ b/roles/ceph-rgw/tasks/multisite/secondary.yml
@@ -1,37 +1,37 @@
 ---
 - name: fetch the realm
-  command: "{{ container_exec_cmd }} radosgw-admin realm pull --url={{ rgw_pull_proto }}://{{ rgw_pullhost }}:{{ rgw_pull_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} realm pull --url={{ rgw_pull_proto }}://{{ rgw_pullhost }}:{{ rgw_pull_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   when: "'No such file or directory' in realmcheck.stderr"
 
 - name: fetch the period
-  command: "{{ container_exec_cmd }} radosgw-admin period pull --url={{ rgw_pull_proto }}://{{ rgw_pullhost }}:{{ rgw_pull_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} period pull --url={{ rgw_pull_proto }}://{{ rgw_pullhost }}:{{ rgw_pull_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   when: "'No such file or directory' in realmcheck.stderr"
 
 - name: set default realm
-  command: "{{ container_exec_cmd }} radosgw-admin realm default --rgw-realm={{ rgw_realm }}"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} realm default --rgw-realm={{ rgw_realm }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
 
 - name: set default zonegroup
-  command: "{{ container_exec_cmd }} radosgw-admin zonegroup default --rgw-zonegroup={{ rgw_zonegroup }}"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} zonegroup default --rgw-zonegroup={{ rgw_zonegroup }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
 
 - name: create the zone
-  command: "{{ container_exec_cmd }} radosgw-admin zone create --rgw-zonegroup={{ rgw_zonegroup }} --rgw-zone={{ rgw_zone }} --endpoints={{ rgw_multisite_proto }}://{{ rgw_multisite_endpoint_addr }}:{{ radosgw_frontend_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }} --default"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} zone create --rgw-zonegroup={{ rgw_zonegroup }} --rgw-zone={{ rgw_zone }} --endpoints={{ rgw_multisite_proto }}://{{ rgw_multisite_endpoint_addr }}:{{ radosgw_frontend_port }} --access-key={{ system_access_key }} --secret={{ system_secret_key }} --default"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   when: "'No such file or directory' in zonecheck.stderr"
   notify: update period
 
 - name: add other endpoints to the zone
-  command: "{{ container_exec_cmd }} radosgw-admin zone modify --rgw-zone={{ rgw_zone }} --endpoints {{ rgw_multisite_endpoints_list }}"
+  command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} zone modify --rgw-zone={{ rgw_zone }} --endpoints {{ rgw_multisite_endpoints_list }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   when: rgw_multisite_endpoints_list is defined


### PR DESCRIPTION
The rgw multisite tasks didn't use the cluster option so the
radosgw-admin commands would fail if the cluster name isn't the default
value.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>