### PR TITLE
nfs: stop nfs server service

### DIFF
--- a/roles/ceph-nfs/tasks/main.yml
+++ b/roles/ceph-nfs/tasks/main.yml
@@ -4,6 +4,14 @@
     container_exec_cmd: "{{ container_binary }} exec ceph-nfs-{{ ceph_nfs_service_suffix | default(ansible_hostname) }}"
   when: containerized_deployment | bool
 
+# global/common requirement
+- name: stop nfs server service
+  systemd:
+    name: "{{ 'nfs-server' if ansible_os_family == 'RedHat' else 'nfsserver' if ansible_os_family == 'Suse' else 'nfs-kernel-server' if ansible_os_family == 'Debian' }}"
+    state: stopped
+    enabled: no
+  failed_when: false
+
 - name: include pre_requisite_non_container.yml
   include_tasks: pre_requisite_non_container.yml
   when: not containerized_deployment | bool

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -92,10 +92,3 @@
     owner: "root"
     group: "root"
     mode: "0755"
-
-- name: stop nfs server service
-  systemd:
-    name: "{{ 'nfs-server' if ansible_os_family == 'RedHat' else 'nfsserver' if ansible_os_family == 'Suse' else 'nfs-kernel-server' if ansible_os_family == 'Debian' }}"
-    state: stopped
-    enabled: no
-  failed_when: false


### PR DESCRIPTION
stop nfs server service for containerized AND non containerized deployments.

(this is also needed for containerized deployment, there's a requirement where we must stop nfs service service on the node hosting the containers as well)

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1508506