### PR TITLE
ceph-mgr: fix ceph_key module with container

### DIFF
--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -21,9 +21,7 @@
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: "0400"
     dest: "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+    containerized: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] if containerized_deployment | bool else omit }}"
   when: groups.get(mgr_group_name, []) | length == 0 # the key is present already since one of the mons created it in "create ceph mgr keyring(s)"
 
 - name: create and copy keyrings
@@ -42,9 +40,7 @@
         owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         mode: "0400"
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+        containerized: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] if containerized_deployment | bool else omit }}"
       with_items: "{{ groups.get(mgr_group_name, []) }}"
       run_once: True
       delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
556052b changed the way the mgr keyring are created but the ceph_key
module need the containerized parameter when the deployment is using
containers.
This module doesn't support CEPH_CONTAINER_[BINARY|IMAGE] environment
variables.

Closes: #4547

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>