### PR TITLE
switch_to_containers: umount osd lockbox partition

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -257,13 +257,13 @@
 
     - name: get osd directories
       command: >
-        ls -1 /var/lib/ceph/osd
+        find /var/lib/ceph/osd {% if dmcrypt | bool %}/var/lib/ceph/osd-lockbox{% endif %} -maxdepth 1 -mindepth 1 -type d
       register: osd_dirs
       changed_when: false
 
     - name: unmount all the osd directories
       command: >
-        umount /var/lib/ceph/osd/{{ item }}
+        umount {{ item }}
       changed_when: false
       failed_when: false
       with_items: "{{ osd_dirs.stdout_lines }}"


### PR DESCRIPTION
When switching from a baremetal deployment to a containerized deployment
we only umount the OSD data partition.
If the OSD is encrypted (dmcrypt: true) then there's an additional
partition (part number 5) used for the lockbox and mount in the
/var/lib/ceph/osd-lockbox/ directory.
Because this partition isn't umount then the containerized OSD aren't
able to start. The partition is still mount by the system and can't be
remount from the container.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1616159

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>