### PR TITLE
ceph-config: remove container_binary variable

### DIFF
--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -105,7 +105,6 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       delegate_to: "{{ item.0 }}"
       loop: "{{ osd_hosts }}"
 

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -31,7 +31,6 @@
     environment:
       CEPH_VOLUME_DEBUG: 1
       CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-      CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     when:
       - devices | default([]) | length > 0
       - osd_scenario == 'lvm'
@@ -51,7 +50,6 @@
     environment:
       CEPH_VOLUME_DEBUG: 1
       CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-      CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     when:
       - devices | default([]) | length > 0
       - osd_scenario == 'lvm'


### PR DESCRIPTION
9e7972a introduced a regression via the container_binary variable
which is undefined.
The CEPH_CONTAINER_BINARY environment variable isn't used at all.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>