### PR TITLE
validate: prevent from installing OSD on same disk as the OS

### DIFF
--- a/roles/ceph-validate/tasks/check_devices.yml
+++ b/roles/ceph-validate/tasks/check_devices.yml
@@ -1,4 +1,59 @@
 ---
+- name: find device used for operating system
+  command: findmnt -v -n -T / -o SOURCE
+  changed_when: false
+  register: root_device
+
+- name: resolve root_device
+  command: "readlink -f {{ root_device.stdout }}"
+  changed_when: false
+  register: _root_device
+
+- name: set_fact root_device
+  set_fact:
+    root_device: "{{ _root_device.stdout }}"
+
+- name: lvm_volumes variable's tasks related
+  when:
+    - lvm_volumes is defined
+    - lvm_volumes | length > 0
+  block:
+    - name: resolve devices in lvm_volumes
+      command: "readlink -f {{ item.data }}"
+      changed_when: false
+      register: _lvm_volumes_data_devices
+      with_items: "{{ lvm_volumes }}"
+      when:
+        - item.data_vg is undefined
+
+    - name: set_fact lvm_volumes_data_devices
+      set_fact:
+        lvm_volumes_data_devices: "{{ lvm_volumes_data_devices | default([]) + [item.stdout] }}"
+      with_items: "{{ _lvm_volumes_data_devices.results }}"
+      when:
+        - item.skipped is undefined
+
+- name: devices variable's tasks related
+  when:
+    - devices is defined
+    - devices | length > 0
+  block:
+    - name: resolve devices in devices
+      command: "readlink -f {{ item }}"
+      changed_when: false
+      register: devices_resolved
+      with_items: "{{ devices }}"
+
+    - name: set_fact devices_resolved
+      set_fact:
+        _devices: "{{ _devices | default([]) + [item.stdout] }}"
+      with_items: "{{ devices_resolved.results }}"
+
+- name: fail if root_device is passed in lvm_volumes or devices
+  fail:
+    msg: "{{ root_device }} found in either lvm_volumes or devices variable"
+  when: root_device in lvm_volumes_data_devices | default([]) or root_device in _devices | default([])
+
 - name: check no gpt header is present when osd scenario is lvm/lvm-batch
   block:
     - name: read information about the devices


### PR DESCRIPTION
This commit adds a validation task to prevent from installing an OSD on
the same disk as the OS.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1623580

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>