### PR TITLE
tests: reduce handler mon and osd delay

### DIFF
--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -38,3 +38,5 @@ openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"
 docker_pull_timeout: 600s
+handler_health_mon_check_delay: 10
+handler_health_osd_check_delay: 10

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -31,3 +31,5 @@ openstack_cinder_pool:
 openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"
+handler_health_mon_check_delay: 10
+handler_health_osd_check_delay: 10

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -17,3 +17,5 @@ ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
     osd_pool_default_size: 1
+handler_health_mon_check_delay: 10
+handler_health_osd_check_delay: 10

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -14,3 +14,5 @@ ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
     osd_pool_default_size: 1
+handler_health_mon_check_delay: 10
+handler_health_osd_check_delay: 10

--- a/tests/functional/lvm-auto-discovery/container/group_vars/all
+++ b/tests/functional/lvm-auto-discovery/container/group_vars/all
@@ -24,3 +24,5 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False
+handler_health_mon_check_delay: 10
+handler_health_osd_check_delay: 10

--- a/tests/functional/lvm-auto-discovery/group_vars/all
+++ b/tests/functional/lvm-auto-discovery/group_vars/all
@@ -17,3 +17,5 @@ ceph_conf_overrides:
   global:
     osd_pool_default_size: 1
 dashboard_enabled: False
+handler_health_mon_check_delay: 10
+handler_health_osd_check_delay: 10

--- a/tests/functional/lvm-batch/container/group_vars/all
+++ b/tests/functional/lvm-batch/container/group_vars/all
@@ -26,3 +26,5 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False
+handler_health_mon_check_delay: 10
+handler_health_osd_check_delay: 10

--- a/tests/functional/lvm-batch/group_vars/all
+++ b/tests/functional/lvm-batch/group_vars/all
@@ -19,3 +19,5 @@ ceph_conf_overrides:
   global:
     osd_pool_default_size: 1
 dashboard_enabled: False
+handler_health_mon_check_delay: 10
+handler_health_osd_check_delay: 10

--- a/tests/functional/lvm-osds/container/group_vars/all
+++ b/tests/functional/lvm-osds/container/group_vars/all
@@ -20,3 +20,5 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False
+handler_health_mon_check_delay: 10
+handler_health_osd_check_delay: 10

--- a/tests/functional/lvm-osds/group_vars/all
+++ b/tests/functional/lvm-osds/group_vars/all
@@ -14,3 +14,5 @@ ceph_conf_overrides:
   global:
     osd_pool_default_size: 1
 dashboard_enabled: False
+handler_health_mon_check_delay: 10
+handler_health_osd_check_delay: 10

--- a/tests/functional/podman/group_vars/all
+++ b/tests/functional/podman/group_vars/all
@@ -37,3 +37,5 @@ openstack_cinder_pool:
 openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"
+handler_health_mon_check_delay: 10
+handler_health_osd_check_delay: 10


### PR DESCRIPTION
We don't need to have high handler delay in the CI so reducing to
10 seconds.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>