### PR TITLE
rgw: remove rgw_zone_endpoints list

### DIFF
--- a/README-MULTISITE.md
+++ b/README-MULTISITE.md
@@ -35,7 +35,6 @@ rgw_zonemaster: true
 rgw_zonesecondary: false
 rgw_multisite_proto: "http"
 rgw_multisite_endpoint_addr: "{{ ansible_fqdn }}"
-rgw_multisite_endpoints_list: "{{ rgw_multisite_proto }}://{{ ansible_fqdn }}:{{ radosgw_frontend_port }}"
 rgw_zonegroup: solarsystem
 rgw_zone_user: zone.user
 rgw_realm: milkyway
@@ -48,12 +47,6 @@ system_secret_key: MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt
 **Note:** replace the `system_access_key` and `system_secret_key` values with the ones you generated
 
 **Note:** `ansible_fqdn` domain name assigned to `rgw_multisite_endpoint_addr` must be resolvable from the secondary Ceph clusters mon and rgw node(s)
-
-**Note:** if there is more than 1 RGW in the cluster, `rgw_multisite_endpoints` needs to be set.<br/>
-`rgw_multisite_endpoints` is a comma seperated list, with no spaces, of the RGW endpoints in the format:<br/>
-`{{ rgw_multisite_proto }}://{{ ansible_fqdn }}:{{ radosgw_frontend_port }}`<br/>
-for example: `rgw_multisite_endpoints: http://foo.example.com:8080,http://bar.example.com:8080,http://baz.example.com:8080`
-
 
 3. Run the ceph-ansible playbook on your 1st cluster
 
@@ -70,7 +63,6 @@ rgw_zonemaster: false
 rgw_zonesecondary: true
 rgw_multisite_proto: "http"
 rgw_multisite_endpoint_addr: "{{ ansible_fqdn }}"
-rgw_multisite_endpoints_list: "{{ rgw_multisite_proto }}://{{ ansible_fqdn }}:{{ radosgw_frontend_port }}"
 rgw_zonegroup: solarsystem
 rgw_zone_user: zone.user
 rgw_realm: milkyway
@@ -88,8 +80,6 @@ rgw_pullhost: cluster0-rgw0
 **Note:** `rgw_zone_user`, `system_access_key`, and `system_secret_key` should match what you used in the Primary Cluster
 
 **Note:** `ansible_fqdn` domain name assigned to `rgw_multisite_endpoint_addr` must be resolvable from the Primary Ceph cluster's mon and rgw node(s)
-
-**Note:** if there is more than 1 RGW in the Secondary Cluster, `rgw_multisite_endpoints` needs to be set with the RGWs in the Secondary Cluster just like it was set in the Primary Cluster
 
 5. Run the ceph-ansible playbook on your 2nd cluster
 

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -495,12 +495,6 @@ dummy:
 
 # The following Multi-site related variables should be set by the user.
 #
-# If there is more than 1 RGW in a master or secondary cluster than rgw_multisite_endpoints needs to be a comma seperated list (with no spaces) of the RGW endpoints in the format:
-# {{ rgw_multisite_proto }}://{{ ansible_fqdn }}:{{ radosgw_frontend_port }}
-# ex: rgw_multisite_endpoints: http://foo.example.com:8080,http://bar.example.com:8080,http://baz.example.com:8080
-#
-# If there is only 1 RGW in the inventory, rgw_multisite_endpoints does not need to change
-#
 # rgw_zone is set to "default" to enable compression for clusters configured without rgw multi-site
 # If multisite is configured rgw_zone should not be set to "default". See README-MULTISITE.md for an example.
 #rgw_zone: default
@@ -509,7 +503,6 @@ dummy:
 #rgw_zonesecondary: false
 #rgw_multisite_proto: "http"
 #rgw_multisite_endpoint_addr: "{{ ansible_fqdn }}"
-#rgw_multisite_endpoints_list: "{{ rgw_multisite_proto }}://{{ ansible_fqdn }}:{{ radosgw_frontend_port }}"
 #rgw_zonegroup: solarsystem # should be set by the user
 #rgw_zone_user: zone.user
 #rgw_realm: milkyway # should be set by the user

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -495,12 +495,6 @@ ceph_rhcs_version: 4
 
 # The following Multi-site related variables should be set by the user.
 #
-# If there is more than 1 RGW in a master or secondary cluster than rgw_multisite_endpoints needs to be a comma seperated list (with no spaces) of the RGW endpoints in the format:
-# {{ rgw_multisite_proto }}://{{ ansible_fqdn }}:{{ radosgw_frontend_port }}
-# ex: rgw_multisite_endpoints: http://foo.example.com:8080,http://bar.example.com:8080,http://baz.example.com:8080
-#
-# If there is only 1 RGW in the inventory, rgw_multisite_endpoints does not need to change
-#
 # rgw_zone is set to "default" to enable compression for clusters configured without rgw multi-site
 # If multisite is configured rgw_zone should not be set to "default". See README-MULTISITE.md for an example.
 #rgw_zone: default
@@ -509,7 +503,6 @@ ceph_rhcs_version: 4
 #rgw_zonesecondary: false
 #rgw_multisite_proto: "http"
 #rgw_multisite_endpoint_addr: "{{ ansible_fqdn }}"
-#rgw_multisite_endpoints_list: "{{ rgw_multisite_proto }}://{{ ansible_fqdn }}:{{ radosgw_frontend_port }}"
 #rgw_zonegroup: solarsystem # should be set by the user
 #rgw_zone_user: zone.user
 #rgw_realm: milkyway # should be set by the user

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -125,6 +125,7 @@ log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[host]['ansible_hostname']
 {{ radosgw_frontend_type }} {{ 'ssl_' if radosgw_frontend_ssl_certificate else '' }}endpoint={{ _rgw_binding_socket }}{{ ' ssl_certificate='+radosgw_frontend_ssl_certificate if radosgw_frontend_ssl_certificate else '' }}
 {%- endif -%}
 {%- endmacro -%}
+rgw dns name = {{ radosgw_dns_name }}
 rgw frontends = {{ frontend_line(radosgw_frontend_type) }} {{ radosgw_frontend_options }}
 {% if 'num_threads' not in radosgw_frontend_options %}
 rgw thread pool size = {{ radosgw_thread_pool_size }}

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -487,12 +487,6 @@ rgw_multisite: false
 
 # The following Multi-site related variables should be set by the user.
 #
-# If there is more than 1 RGW in a master or secondary cluster than rgw_multisite_endpoints needs to be a comma seperated list (with no spaces) of the RGW endpoints in the format:
-# {{ rgw_multisite_proto }}://{{ ansible_fqdn }}:{{ radosgw_frontend_port }}
-# ex: rgw_multisite_endpoints: http://foo.example.com:8080,http://bar.example.com:8080,http://baz.example.com:8080
-#
-# If there is only 1 RGW in the inventory, rgw_multisite_endpoints does not need to change
-#
 # rgw_zone is set to "default" to enable compression for clusters configured without rgw multi-site
 # If multisite is configured rgw_zone should not be set to "default". See README-MULTISITE.md for an example.
 rgw_zone: default
@@ -501,7 +495,6 @@ rgw_zonemaster: true
 rgw_zonesecondary: false
 rgw_multisite_proto: "http"
 rgw_multisite_endpoint_addr: "{{ ansible_fqdn }}"
-#rgw_multisite_endpoints_list: "{{ rgw_multisite_proto }}://{{ ansible_fqdn }}:{{ radosgw_frontend_port }}"
 #rgw_zonegroup: solarsystem # should be set by the user
 #rgw_zone_user: zone.user
 #rgw_realm: milkyway # should be set by the user

--- a/roles/ceph-rgw/tasks/multisite/add_zone_endpoints.yml
+++ b/roles/ceph-rgw/tasks/multisite/add_zone_endpoints.yml
@@ -1,0 +1,34 @@
+- name: create a list of dicts with each rgw endpoint and it's zone
+  set_fact:
+    zone_endpoint_pairs: "{{ zone_endpoint_list | default([]) + [{ 'endpoint': hostvars[item]['rgw_multisite_proto'] + '://' + hostvars[item]['radosgw_address'] + ':' + hostvars[item]['radosgw_civetweb_port']|string, 'rgw_zone': hostvars[item]['rgw_zone'] }] }}"
+  with_items: "{{ groups.get('rgws', []) }}"
+  run_once: true
+
+- name: create string of all the endpoints in the same rgw_zone
+  set_fact:
+    zone_endpoints_string: "{{ zone_endpoints_string | default('') + item.endpoint + ',' }}"
+  with_items: "{{ zone_endpoint_pairs }}"
+  when: item.rgw_zone == rgw_zone
+
+- name: remove ',' after last endpoint in a endpoints string
+  set_fact:
+    zone_endpoints_string: "{{ zone_endpoints_string[:-1] }}"
+  when: endpoints_string[-1] == ','
+
+- name: create a list of zones and all their endpoints
+  set_fact:
+    zone_endpoints_list: "{{ zone_endpoints_list | default([]) + [{ 'endpoints': hostvars[item]['zone_endpoints_string'], 'rgw_zone': hostvars[item]['rgw_zone'] }] }}"
+  with_items: "{{ groups.get('rgws', []) }}"
+  run_once: true
+
+- name: make all items in zone_endpoints_list unique
+  set_fact:
+    zone_endpoints_list: "{{ zone_endpoints_list | unique }}"
+  run_once: true
+
+- name: add endpoints to their zone(s)
+  command: "{{ container_exec_cmd }} radosgw-admin zone modify --rgw-zone={{ item.rgw_zone }} --endpoints {{ item.endpoints }}"
+  with_items: "{{ zone_endpoints_list }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  notify: update period

--- a/roles/ceph-rgw/tasks/multisite/main.yml
+++ b/roles/ceph-rgw/tasks/multisite/main.yml
@@ -15,6 +15,9 @@
     - not rgw_zonemaster | bool
     - rgw_zonesecondary | bool
 
+- name: include add_zone_endpoints.yml
+  include_tasks: add_zone_endpoints.yml
+
 # Continue with common tasks
 - name: add zone to rgw stanza in ceph.conf
   ini_file:

--- a/roles/ceph-rgw/tasks/multisite/master.yml
+++ b/roles/ceph-rgw/tasks/multisite/master.yml
@@ -23,10 +23,3 @@
   run_once: true
   when: "'could not fetch user info: no user info saved' in usercheck.stderr"
   notify: update period
-
-- name: add other endpoints to the zone
-  command: "{{ container_exec_cmd }} radosgw-admin zone modify --rgw-zone={{ rgw_zone }} --endpoints {{ rgw_multisite_endpoints_list }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  run_once: true
-  when: rgw_multisite_endpoints_list is defined
-  notify: update period

--- a/roles/ceph-rgw/tasks/multisite/secondary.yml
+++ b/roles/ceph-rgw/tasks/multisite/secondary.yml
@@ -29,10 +29,3 @@
   run_once: true
   when: "'No such file or directory' in zonecheck.stderr"
   notify: update period
-
-- name: add other endpoints to the zone
-  command: "{{ container_exec_cmd }} radosgw-admin zone modify --rgw-zone={{ rgw_zone }} --endpoints {{ rgw_multisite_endpoints_list }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  run_once: true
-  when: rgw_multisite_endpoints_list is defined
-  notify: update period


### PR DESCRIPTION
remove manually added rgw_zone_endpoints var
and have ceph-ansible automatically add the
correct endpoints of all the rgws in a rgw_zone
from the information provided in that rgws hostvars.

Signed-off-by: Ali Maredia <amaredia@redhat.com>