### PR TITLE
mergify: Update condition on status success

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,7 +16,8 @@ pull_request_rules:
       - author=mergify[bot]
       - base=stable-3.0
       - label!=DNM
-      - 'status-success=Testing: ceph-ansible PR Pipeline'
+      - status-success~=^Testing:\s(centos|ubuntu)-(non_)?container-.*
+      - status-success=continuous-integration/travis-ci/pr
     actions:
       merge:
         method: rebase
@@ -29,7 +30,8 @@ pull_request_rules:
       - author=mergify[bot]
       - base=stable-3.1
       - label!=DNM
-      - 'status-success=Testing: ceph-ansible PR Pipeline'
+      - status-success~=^Testing:\s(centos|ubuntu)-(non_)?container-.*
+      - status-success=continuous-integration/travis-ci/pr
     actions:
       merge:
         method: rebase
@@ -42,7 +44,8 @@ pull_request_rules:
       - author=mergify[bot]
       - base=stable-3.2
       - label!=DNM
-      - 'status-success=Testing: ceph-ansible PR Pipeline'
+      - status-success~=^Testing:\s(centos|ubuntu)-(non_)?container-.*
+      - status-success=continuous-integration/travis-ci/pr
     actions:
       merge:
         method: rebase
@@ -55,7 +58,8 @@ pull_request_rules:
       - author=mergify[bot]
       - base=stable-4.0
       - label!=DNM
-      - 'status-success=Testing: ceph-ansible PR Pipeline'
+      - status-success~=^Testing:\s(centos|ubuntu)-(non_)?container-.*
+      - status-success=continuous-integration/travis-ci/pr
     actions:
       merge:
         method: rebase


### PR DESCRIPTION
We don't have one global pipeline anymore reporting the jenkins job
status. So we need to match the  CI scenario name.
This also add the Travis CI status as a condition.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>