### PR TITLE
dashboard: do not fail in case of external ceph cluster

### DIFF
--- a/infrastructure-playbooks/dashboard.yml
+++ b/infrastructure-playbooks/dashboard.yml
@@ -65,7 +65,9 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: "{{ groups[mgr_group_name] | default(groups[mon_group_name]) }}"
+# using groups[] here otherwise it can't fallback to the mon if there's no mgr group.
+# adding an additional | default(omit) in case where no monitors are present (external ceph cluster)
+- hosts: "{{ groups[mgr_group_name] | default(groups[mon_group_name]) | default(omit) }}"
   become: true
   pre_tasks:
     - name: set ceph dashboard install 'In Progress'


### PR DESCRIPTION
If no host is available, let's just skip these plays.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1759917

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>