### PR TITLE
ceph-dashboard: remove timeout KILL command

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -116,7 +116,7 @@
   when: groups.get(rgw_group_name, []) | length > 0
   block:
     - name: create radosgw system user
-      command: "timeout --foreground -s KILL 20 {{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} user create --uid={{ dashboard_rgw_api_user_id }} --display-name='Ceph dashboard' --system"
+      command: "{{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} user create --uid={{ dashboard_rgw_api_user_id }} --display-name='Ceph dashboard' --system"
       register: rgw_user_output
       until: rgw_user_output.rc == 0
       retries: 3


### PR DESCRIPTION
We have a lot of issues with this command and this shoudln't be
necessary.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>