### PR TITLE
lint: fix error [303,602,701,702]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
 script:
   - if [[ -n $(grep --exclude-dir=.git -P "\xa0" -r .) ]]; then echo 'NBSP characters found'; exit 1; fi
   - pytest -vvvv library/ plugins/
-  - for i in $(ls -1 roles/); do ansible-lint -x 204 -v roles/$i/ ; done
+  - for i in $(ls -1 roles/); do ANSIBLE_LOG_PATH=/dev/null ansible-lint -x 204 -v roles/$i/ ; done

--- a/roles/ceph-common/tasks/installs/configure_redhat_local_installation.yml
+++ b/roles/ceph-common/tasks/installs/configure_redhat_local_installation.yml
@@ -6,20 +6,20 @@
   when: use_installer | bool
 
 - name: use mktemp to create name for rundep
-  command: "mktemp /tmp/rundep.XXXXXXXX"
+  tempfile:
+    path: /tmp
+    prefix: rundep.
   register: rundep_location
   when: use_installer | bool
 
 - name: copy rundep
   copy:
     src: "{{ ansible_dir }}/rundep"
-    dest: "{{ item }}"
-  with_items: "{{ (rundep_location|default({})).stdout_lines|default([]) }}"
+    dest: "{{ rundep_location.path }}"
   when: use_installer | bool
 
 - name: install ceph dependencies
-  script: "{{ ansible_dir }}/rundep_installer.sh {{ item }}"
-  with_items: "{{ (rundep_location|default({})).stdout_lines|default([]) }}"
+  script: "{{ ansible_dir }}/rundep_installer.sh {{ rundep_location.path }}"
   when: use_installer | bool
 
 - name: ensure rsync is installed

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -169,7 +169,7 @@
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
-      when: dashboard_rgw_api_admin_resource != ''
+      when: dashboard_rgw_api_admin_resource | length > 0
 
     - name: disable ssl verification for rgw
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-ssl-verify False"

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -29,7 +29,7 @@
             {{ item.pgp_num | default(item.pg_num) | default(osd_pool_default_pg_num) }}
             {{ 'replicated_rule' if not item.rule_name | default('replicated_rule') else item.rule_name | default('replicated_rule') }}
             {{ 1 if item.type|default(1) == 'replicated' else 3 if item.type|default(1) == 'erasure' else item.type|default(1) }}
-            {%- if (item.type | default("1") == '3' or item.type | default("1") == 'erasure') and item.erasure_profile != '' %}
+            {%- if (item.type | default("1") == '3' or item.type | default("1") == 'erasure') and item.erasure_profile | length > 0 %}
             {{ item.erasure_profile }}
             {%- endif %}
             {{ item.expected_num_objects | default('') }}

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -11,7 +11,7 @@
   register: ceph_health_raw
   run_once: true
   until: >
-    (ceph_health_raw.stdout != "") and (ceph_health_raw.stdout | default('{}') | from_json)['state'] in ['leader', 'peon']
+    (ceph_health_raw.stdout | length > 0) and (ceph_health_raw.stdout | default('{}') | from_json)['state'] in ['leader', 'peon']
   retries: "{{ handler_health_mon_check_retries }}"
   delay: "{{ handler_health_mon_check_delay }}"
   changed_when: false

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -19,7 +19,7 @@
   until: result is succeeded
   when:
     - containerized_deployment | bool
-    - ceph_osd_numactl_opts != ""
+    - ceph_osd_numactl_opts | length > 0
   tags: with_pkg
 
 - name: install lvm2

--- a/roles/ceph-prometheus/meta/main.yml
+++ b/roles/ceph-prometheus/meta/main.yml
@@ -1,3 +1,14 @@
 ---
-dependencies:
-  - role: ceph-defaults
+galaxy_info:
+  company: Red Hat
+  author: Boris Ranto
+  description: Configures Prometheus for Ceph Dashboard
+  license: Apache
+  min_ansible_version: 2.4
+  platforms:
+    - name: EL
+      versions:
+        - 7
+  galaxy_tags:
+    - system
+dependencies: []

--- a/roles/ceph-rgw-loadbalancer/meta/main.yml
+++ b/roles/ceph-rgw-loadbalancer/meta/main.yml
@@ -8,6 +8,6 @@ galaxy_info:
     - name: EL
       versions:
         - 7
-  categories:
+  galaxy_tags:
     - system
 dependencies: []


### PR DESCRIPTION
```console
 [303] mktemp used in place of tempfile module
 [602] Don't compare to empty string
 [701] No 'galaxy_info' found
 [702] Use 'galaxy_tags' rather than 'categories'
```

This patch also changes the ansible log_path value via the
ANSIBLE_LOG_PATH environment variable in the travis configuration to
avoid warnings.

[WARNING]: log file at /home/travis/ansible/ansible.log is not writeable
and we cannot create it, aborting

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>