### PR TITLE
Set remote_user on "copy ceph key(s) if needed"

### DIFF
--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -73,6 +73,7 @@
         mode: "{{ ceph_keyring_permissions }}"
       with_items: "{{ _mgr_keys.results }}"
       delegate_to: "{{ item.item.hostname }}"
+      remote_user: "{{ ansible_user | default(omit) }}"
       run_once: true
       when:
         - cephx | bool


### PR DESCRIPTION
The ssh username is omitted from the ssh command when using copy and delegate_to with a hostname. remote_user was added to include the ssh username for users who use ansible_user in their inventory to specify the remote user.  See issue https://github.com/ceph/ceph-ansible/issues/4518 .

Signed-off-by: Kevin Coakley <kcoakley@sdsc.edu>