### PR TITLE
Fix wait_for_all_osds_up JSON in ceph_osd openstack_config

### DIFF
--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -7,8 +7,8 @@
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   until:
-    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] | int > 0
-    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_up_osds"]
+    - (wait_for_all_osds_up.stdout | from_json)['osdmap']['osdmap']['num_osds'] | int > 0
+    - (wait_for_all_osds_up.stdout | from_json)['osdmap']['osdmap']['num_osds'] == (wait_for_all_osds_up.stdout | from_json)['osdmap']['osdmap']['num_up_osds']
 
 - name: pool related tasks
   block:


### PR DESCRIPTION
`num_osd` and `num_up_osd` are nested under an additional `osdmap`.