### PR TITLE
mgr: do not copy all keyrings on all mgr

### DIFF
--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -51,15 +51,15 @@
 
     - name: set_fact _mgr_keys
       set_fact:
-        _mgr_keys: "{{ _mgr_keys | default([{ 'name': 'client.admin', 'path': '/etc/ceph/' + cluster + '.client.admin.keyring', 'copy_key': copy_admin_key }]) + [{ 'name': 'mgr.' + hostvars[item]['ansible_hostname'], 'path': '/var/lib/ceph/mgr/' + cluster + '-' + hostvars[item]['ansible_hostname'] + '/keyring', 'copy_key': true }] }}"
-      with_items: "{{ groups.get(mgr_group_name, []) }}"
+        _mgr_keys:
+          - { 'name': 'client.admin', 'path': "/etc/ceph/{{ cluster }}.client.admin.keyring", 'copy_key': copy_admin_key }
+          - { 'name': "mgr.{{ ansible_hostname }}", 'path': "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring", 'copy_key': true }
 
     - name: get keys from monitors
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
       register: _mgr_keys
       with_items: "{{ _mgr_keys }}"
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
-      run_once: true
       when:
         - cephx | bool
         - item.copy_key | bool


### PR DESCRIPTION
There is no need to loop over all mgr nodes to set this fact, it's even
breaking deployments because it tries to copy all mgr keyring on all
mgr.

Closes: #4602

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>