### PR TITLE
rbd-mirror: fail if the peer is not added

### DIFF
--- a/roles/ceph-rbd-mirror/tasks/configure_mirroring.yml
+++ b/roles/ceph-rbd-mirror/tasks/configure_mirroring.yml
@@ -3,7 +3,13 @@
   command: "{{ container_exec_cmd | default('') }} rbd --cluster {{ cluster }} --keyring /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring --name client.rbd-mirror.{{ ansible_hostname }} mirror pool enable {{ ceph_rbd_mirror_pool }} {{ ceph_rbd_mirror_mode }}"
   changed_when: false
 
+- name: list mirroring peer
+  shell: "{{ container_exec_cmd | default('') }} rbd --cluster {{ cluster }} --keyring /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring --name client.rbd-mirror.{{ ansible_hostname }} mirror pool info {{ ceph_rbd_mirror_pool }} | grep -q {{ ceph_rbd_mirror_remote_user }}"
+  changed_when: false
+  failed_when: false
+  register: mirror_peer
+
 - name: add a mirroring peer
   command: "{{ container_exec_cmd | default('') }} rbd --cluster {{ cluster }} --keyring /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring --name client.rbd-mirror.{{ ansible_hostname }} mirror pool peer add {{ ceph_rbd_mirror_pool }} {{ ceph_rbd_mirror_remote_user }}@{{ ceph_rbd_mirror_remote_cluster }}"
   changed_when: false
-  failed_when: false
+  when: mirror_peer.rc == 1


### PR DESCRIPTION
Due the 'failed_when: false' statement present in the peer task then
the playbook continues to ran even if the peer task was failing (like
incorrect remote peer format.

"stderr": "rbd: invalid spec 'admin@cluster1'"

This patch adds a task to list the peer present and add the peer only if
it's not already added. With this we don't need the failed_when statement
anymore.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1665877

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>