### PR TITLE
playbook: remove duplicate facts

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -39,26 +39,6 @@
       run_once: true
       when: delegate_facts_host | bool
 
-    - name: check if it is atomic host
-      stat:
-        path: /run/ostree-booted
-      register: stat_ostree
-      tags: always
-
-    - name: set_fact is_atomic
-      set_fact:
-        is_atomic: '{{ stat_ostree.stat.exists }}'
-      tags: always
-
-    - name: check if podman binary is present
-      stat:
-        path: /usr/bin/podman
-      register: podman_binary
-
-    - name: set_fact container_binary
-      set_fact:
-        container_binary: "{{ 'podman' if (podman_binary.stat.exists and ansible_distribution == 'Fedora') or (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'docker' }}"
-
     - import_role:
         name: ceph-defaults
       tags: [with_pkg, fetch_container_image]

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -43,17 +43,6 @@
       run_once: true
       when: delegate_facts_host | bool
 
-    - name: check if it is atomic host
-      stat:
-        path: /run/ostree-booted
-      register: stat_ostree
-      tags: always
-
-    - name: set_fact is_atomic
-      set_fact:
-        is_atomic: '{{ stat_ostree.stat.exists }}'
-      tags: always
-
   tasks:
     - import_role:
         name: ceph-defaults


### PR DESCRIPTION
The is_atomic and container_binary facts are already defined in the
ceph-facts role so we don't need to have dedicated tasks for that
before the ceph-facts role exectution.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>