### PR TITLE
iscsi-gw: Fix rtslib installation

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -7,7 +7,6 @@
         common_pkgs:
           - tcmu-runner
           - targetcli
-          - python-rtslib
         common_repos:
           - tcmu-runner
           - python-rtslib


### PR DESCRIPTION
When using python3 the name of the rtslib rpm is python3-rtslib. The
packages that use rtslib already have code that detects the python
version and distro deps, so drop it from the ceph iscsi gw task list and
let the ceph-iscsi rpm dependency handle it.

Signed-off-by: Mike Christie <mchristi@redhat.com>