### PR TITLE
nfs: remove unnecessary set_fact in main.yml

### DIFF
--- a/roles/ceph-nfs/tasks/main.yml
+++ b/roles/ceph-nfs/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: set_fact container_exec_cmd
-  set_fact:
-    container_exec_cmd: "{{ container_binary }} exec ceph-nfs-{{ ceph_nfs_service_suffix | default(ansible_hostname) }}"
-  when: containerized_deployment | bool
-
 # global/common requirement
 - name: stop nfs server service
   systemd:


### PR DESCRIPTION
this task is a leftover and no longer needed.
It even causes bug when collocating nfs with mon.

Closes: #4609

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>