### PR TITLE
upgrade: fix standby_mdss group creation

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -577,7 +577,7 @@
 
     - name: create standby_mdss group
       add_host:
-        name: "{{ standby_mdss }}"
+        name: "{{ item }}"
         groups: standby_mdss
         ansible_host: "{{ hostvars[item]['ansible_host'] | default(omit) }}"
         ansible_port: "{{ hostvars[item]['ansible_port'] | default(omit) }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -588,6 +588,15 @@
         name: ceph-mds@{{ hostvars[item]['ansible_hostname'] }}
         state: stopped
         enabled: no
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups['standby_mdss'] }}"
+      when: groups['standby_mdss'] | default([]) | length > 0
+
+    # dedicated task for masking systemd unit
+    # somehow, having a single task doesn't work in containerized context
+    - name: mask systemd units for standby ceph mds
+      systemd:
+        name: ceph-mds@{{ hostvars[item]['ansible_hostname'] }}
         masked: yes
       delegate_to: "{{ item }}"
       with_items: "{{ groups['standby_mdss'] }}"

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -40,3 +40,4 @@ openstack_pools:
 docker_pull_timeout: 600s
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
+mds_max_mds: 3

--- a/tests/functional/all_daemons/container/hosts
+++ b/tests/functional/all_daemons/container/hosts
@@ -12,6 +12,8 @@ osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"
 
 [mdss]
 mds0
+mds1
+mds2
 
 [rgws]
 rgw0

--- a/tests/functional/all_daemons/container/hosts-ubuntu
+++ b/tests/functional/all_daemons/container/hosts-ubuntu
@@ -12,6 +12,8 @@ osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"
 
 [mdss]
 mds0
+mds1
+mds2
 
 [rgws]
 rgw0

--- a/tests/functional/all_daemons/container/vagrant_variables.yml
+++ b/tests/functional/all_daemons/container/vagrant_variables.yml
@@ -6,7 +6,7 @@ docker: True
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 3
 osd_vms: 2
-mds_vms: 1
+mds_vms: 3
 rgw_vms: 1
 nfs_vms: 1
 grafana_server_vms: 0

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -33,3 +33,4 @@ openstack_pools:
   - "{{ openstack_cinder_pool }}"
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
+mds_max_mds: 3

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -12,6 +12,8 @@ osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"
 
 [mdss]
 mds0
+mds1
+mds2
 
 [rgws]
 rgw0

--- a/tests/functional/all_daemons/hosts-switch-to-containers
+++ b/tests/functional/all_daemons/hosts-switch-to-containers
@@ -14,6 +14,8 @@ osd0
 
 [mdss]
 mds0
+mds1
+mds2
 
 [rgws]
 rgw0

--- a/tests/functional/all_daemons/hosts-ubuntu
+++ b/tests/functional/all_daemons/hosts-ubuntu
@@ -12,6 +12,8 @@ osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"
 
 [mdss]
 mds0
+mds1
+mds2
 
 [rgws]
 rgw0

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -6,7 +6,7 @@ docker: false
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 3
 osd_vms: 2
-mds_vms: 1
+mds_vms: 3
 rgw_vms: 1
 nfs_vms: 1
 grafana_server_vms: 0


### PR DESCRIPTION
upgrade: fix standby_mdss group creation

This commit fixes the standby_mdss group creation by using `{{ item }}`.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>