### PR TITLE
tests: add multimds coverage

### DIFF
--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -37,3 +37,4 @@ openstack_cinder_pool:
 openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"
+mds_max_mds: 3

--- a/tests/functional/all_daemons/container/hosts
+++ b/tests/functional/all_daemons/container/hosts
@@ -12,6 +12,8 @@ osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"
 
 [mdss]
 mds0
+mds1
+mds2
 
 [rgws]
 rgw0

--- a/tests/functional/all_daemons/container/vagrant_variables.yml
+++ b/tests/functional/all_daemons/container/vagrant_variables.yml
@@ -6,7 +6,7 @@ docker: True
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 3
 osd_vms: 2
-mds_vms: 1
+mds_vms: 3
 rgw_vms: 1
 nfs_vms: 1
 rbd_mirror_vms: 1

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -31,3 +31,4 @@ openstack_cinder_pool:
 openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"
+mds_max_mds: 3

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -12,6 +12,8 @@ osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"
 
 [mdss]
 mds0
+mds1
+mds2
 
 [rgws]
 rgw0

--- a/tests/functional/all_daemons/hosts-switch-to-containers
+++ b/tests/functional/all_daemons/hosts-switch-to-containers
@@ -14,6 +14,8 @@ osd0
 
 [mdss]
 mds0
+mds1
+mds2
 
 [rgws]
 rgw0

--- a/tests/functional/all_daemons/hosts-ubuntu
+++ b/tests/functional/all_daemons/hosts-ubuntu
@@ -12,6 +12,8 @@ osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"
 
 [mdss]
 mds0
+mds1
+mds2
 
 [rgws]
 rgw0

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -6,7 +6,7 @@ docker: false
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 3
 osd_vms: 2
-mds_vms: 1
+mds_vms: 3
 rgw_vms: 1
 nfs_vms: 1
 rbd_mirror_vms: 1

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -62,6 +62,7 @@ commands=
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-jewel} \
       copy_admin_key={env:COPY_ADMIN_KEY:False} \
+      mds_max_mds=1 \
   "
 
   pip install -r {toxinidir}/tests/requirements.txt


### PR DESCRIPTION
This commit makes the all_daemons scenario deploying 3 mds in order to
cover the multimds case.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>