### PR TITLE
ceph-mgr: set custom port for prometheus plugin

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -74,6 +74,7 @@ dummy:
 #ceph_iscsi_firewall_zone: public
 #ceph_dashboard_firewall_zone: public
 #ceph_rgwloadbalancer_firewall_zone: public
+#ceph_mgr_prometheus_plugin_port: 9283
 
 # Generate local ceph.conf in fetch directory
 #ceph_conf_local: false

--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -24,6 +24,7 @@ dummy:
 # Ceph mgr modules to enable, to view the list of available mpdules see: http://docs.ceph.com/docs/CEPH_VERSION/mgr/
 # and replace CEPH_VERSION with your current Ceph version, e,g: 'mimic'
 #ceph_mgr_modules: []
+#ceph_mgr_prometheus_plugin_port: 9283
 
 ############
 # PACKAGES #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -74,6 +74,7 @@ fetch_directory: ~/ceph-ansible-keys
 #ceph_iscsi_firewall_zone: public
 #ceph_dashboard_firewall_zone: public
 #ceph_rgwloadbalancer_firewall_zone: public
+#ceph_mgr_prometheus_plugin_port: 9283
 
 # Generate local ceph.conf in fetch directory
 #ceph_conf_local: false

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -66,6 +66,7 @@ ceph_rbdmirror_firewall_zone: public
 ceph_iscsi_firewall_zone: public
 ceph_dashboard_firewall_zone: public
 ceph_rgwloadbalancer_firewall_zone: public
+ceph_mgr_prometheus_plugin_port: 9283
 
 # Generate local ceph.conf in fetch directory
 ceph_conf_local: false

--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -193,7 +193,7 @@
 
       - name: open mgr/prometheus port
         firewalld:
-          port: "9283/tcp"
+          port: "{{ ceph_mgr_prometheus_plugin_port }}/tcp"
           zone: "{{ ceph_dashboard_firewall_zone }}"
           permanent: true
           immediate: true

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -16,6 +16,7 @@ mgr_secret: 'mgr_secret'
 # Ceph mgr modules to enable, to view the list of available mpdules see: http://docs.ceph.com/docs/CEPH_VERSION/mgr/
 # and replace CEPH_VERSION with your current Ceph version, e,g: 'mimic'
 ceph_mgr_modules: []
+ceph_mgr_prometheus_plugin_port: 9283
 
 ############
 # PACKAGES #

--- a/roles/ceph-mgr/handlers/main.yml
+++ b/roles/ceph-mgr/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: restart prometheus module
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  block:
+    - name: disable prometheus module
+      command: "{{ container_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module disable prometheus"
+    - name: enable prometheus module
+      command: "{{ container_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module enable prometheus"

--- a/roles/ceph-mgr/tasks/mgr_modules.yml
+++ b/roles/ceph-mgr/tasks/mgr_modules.yml
@@ -41,3 +41,17 @@
   with_items: "{{ ceph_mgr_modules }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when: (item in _disabled_ceph_mgr_modules or _disabled_ceph_mgr_modules == [])
+
+- name: check prometheus plugin port
+  command: "{{ container_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} config get mgr. mgr/prometheus/server_port"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  register: ceph_mgr_prometheus_plugin_actual_port
+  when: "'prometheus' in ceph_mgr_modules"
+
+- name: set prometheus plugin port
+  command: "{{ container_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} config set mgr mgr/prometheus/server_port {{ ceph_mgr_prometheus_plugin_port }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  when:
+    - ceph_mgr_prometheus_plugin_actual_port.stdout|int != ceph_mgr_prometheus_plugin_port
+    - "'prometheus' in ceph_mgr_modules"
+  notify: restart prometheus module

--- a/roles/ceph-prometheus/templates/prometheus.yml.j2
+++ b/roles/ceph-prometheus/templates/prometheus.yml.j2
@@ -13,7 +13,7 @@ scrape_configs:
     honor_labels: true
     static_configs:
 {% for host in groups['mgrs'] | default(groups['mons']) %}
-      - targets: ['{{ host }}:9283']
+      - targets: ['{{ host }}:{{ ceph_mgr_prometheus_plugin_port }}']
         labels:
           instance: 'ceph_cluster'
 {% endfor %}


### PR DESCRIPTION
Feature to change prometheus plugin default port to custom with variable. 

Signed-off-by: Askar Sabyrov <askar.sabyrov@btsdigital.kz>