### PR TITLE
travis: fail on ansible-lint errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
 script:
   - if [[ -n $(grep --exclude-dir=.git -P "\xa0" -r .) ]]; then echo 'NBSP characters found'; exit 1; fi
   - pytest -vvvv library/ plugins/
-  - for i in $(ls -1 roles/); do ANSIBLE_LOG_PATH=/dev/null ansible-lint -x 204 -v roles/$i/ ; done
+  - for i in $(ls -1 roles/); do ANSIBLE_LOG_PATH=/dev/null ansible-lint -x 204 -v roles/$i/; if [ $? -ne 0 ]; then exit 1; fi; done

--- a/roles/ceph-rbd-mirror/tasks/configure_mirroring.yml
+++ b/roles/ceph-rbd-mirror/tasks/configure_mirroring.yml
@@ -4,12 +4,11 @@
   changed_when: false
 
 - name: list mirroring peer
-  shell: "{{ container_exec_cmd | default('') }} rbd --cluster {{ cluster }} --keyring /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring --name client.rbd-mirror.{{ ansible_hostname }} mirror pool info {{ ceph_rbd_mirror_pool }} | grep -q {{ ceph_rbd_mirror_remote_user }}"
+  command: "{{ container_exec_cmd | default('') }} rbd --cluster {{ cluster }} --keyring /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring --name client.rbd-mirror.{{ ansible_hostname }} mirror pool info {{ ceph_rbd_mirror_pool }}"
   changed_when: false
-  failed_when: false
   register: mirror_peer
 
 - name: add a mirroring peer
   command: "{{ container_exec_cmd | default('') }} rbd --cluster {{ cluster }} --keyring /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring --name client.rbd-mirror.{{ ansible_hostname }} mirror pool peer add {{ ceph_rbd_mirror_pool }} {{ ceph_rbd_mirror_remote_user }}@{{ ceph_rbd_mirror_remote_cluster }}"
   changed_when: false
-  when: mirror_peer.rc == 1
+  when: ceph_rbd_mirror_remote_user in mirror_peer.stdout


### PR DESCRIPTION
If ansible-lint reports an error then it's skipped. We should fail in
this case.

This patch also fixes the pipefail lint in the rbd mirror role

[306] Shells that use pipes should set the pipefail option

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>