### PR TITLE
validate: fix credentials validation

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -224,5 +224,5 @@
     msg: 'ceph_docker_registry_username and/or ceph_docker_registry_password variables need to be set'
   when:
     - ceph_docker_registry_auth | bool
-    - (ceph_docker_registry_username is not defined or ceph_docker_registry_password is not defined)
-    - (ceph_docker_registry_username | length == 0 or ceph_docker_registry_password | length == 0)
+    - (ceph_docker_registry_username is not defined or ceph_docker_registry_password is not defined) or
+      (ceph_docker_registry_username | length == 0 or ceph_docker_registry_password | length == 0)


### PR DESCRIPTION
This task is failing when `ceph_docker_registry_auth` is enabled and
`ceph_docker_registry_username` is undefined with an ansible error
instead of the expected message.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1763139

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>