### PR TITLE
Move six from tests/requirements.txt to requirements.txt

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -22,9 +22,11 @@ Requires: ansible >= 2.8
 %if 0%{?rhel} == 7
 BuildRequires: python2-devel
 Requires: python2-netaddr
+Requires: python2-six
 %else
 BuildRequires: python3-devel
 Requires: python3-netaddr
+Requires: python3-six
 %endif
 
 %description

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # These are Python requirements needed to run ceph-ansible master
 ansible>=2.8,<2.9
 netaddr
+six

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 # These are Python requirements needed to run the functional tests
-six==1.10.0
 testinfra>=3.2,<3.3
 pytest-xdist==1.28.0
 pytest>=4.6,<5.0


### PR DESCRIPTION
six is used in plugins/actions/config_template.py and
roles/ceph-common/plugins/actions/config_template.py so move it to
requirements.txt .