### PR TITLE
container/dashboard: run the registry auth task

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -21,6 +21,12 @@
     - import_role:
         name: ceph-container-engine
     - import_role:
+        name: ceph-container-common
+        tasks_from: registry
+      when:
+        - not containerized_deployment | bool
+        - ceph_docker_registry_auth | bool
+    - import_role:
         name: ceph-node-exporter
 
   post_tasks:

--- a/roles/ceph-container-common/tasks/main.yml
+++ b/roles/ceph-container-common/tasks/main.yml
@@ -15,10 +15,8 @@
         ceph_docker_version: "{{ ceph_docker_version.stdout.split(' ')[2] }}"
   when: container_binary == 'docker'
 
-- name: container registry authentication
-  command: '{{ container_binary }} login -u {{ ceph_docker_registry_username }} -p {{ ceph_docker_registry_password }} {{ ceph_docker_registry }}'
-  changed_when: false
-  no_log: true
+- name: include registry.yml
+  include_tasks: registry.yml
   when: ceph_docker_registry_auth | bool
 
 - name: include fetch_image.yml

--- a/roles/ceph-container-common/tasks/registry.yml
+++ b/roles/ceph-container-common/tasks/registry.yml
@@ -1,0 +1,5 @@
+---
+- name: container registry authentication
+  command: '{{ container_binary }} login -u {{ ceph_docker_registry_username }} -p {{ ceph_docker_registry_password }} {{ ceph_docker_registry }}'
+  changed_when: false
+  no_log: true


### PR DESCRIPTION
When deploying with packages then the ceph-container-common role isn't
executed so the registry authentication task is ignored.

Closes: #4636

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>