### PR TITLE
Allow setting dist and mock configuration in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ NAME = ceph-ansible
 #  A "git describe" value of "v2.2.0" creates an NVR
 #  "ceph-ansible-2.2.0-1.el8"
 
+DIST ?= "el8"
+MOCK_CONFIG ?= "epel-7-x86_64"
 TAG := $(shell git describe --tags --abbrev=0 --match 'v*')
 VERSION := $(shell echo $(TAG) | sed 's/^v//')
 COMMIT := $(shell git rev-parse HEAD)
@@ -46,7 +48,7 @@ ifneq (,$(shell echo $(VERSION) | grep [a-zA-Z]))
     $(error cannot translate Git tag version $(VERSION) to an RPM NVR)
 endif
 
-NVR := $(NAME)-$(VERSION)-$(RELEASE).el8
+NVR := $(NAME)-$(VERSION)-$(RELEASE).$(DIST)
 
 all: srpm
 
@@ -77,12 +79,12 @@ srpm: dist spec
 	  --define "_topdir ." \
 	  --define "_sourcedir ." \
 	  --define "_srcrpmdir ." \
-	  --define "dist .el8"
+	  --define "dist .$(DIST)"
 
 rpm: dist srpm
-	mock -r epel-7-x86_64 rebuild $(NVR).src.rpm \
+	mock -r $(MOCK_CONFIG) rebuild $(NVR).src.rpm \
 	  --resultdir=. \
-	  --define "dist .el8"
+	  --define "dist .$(DIST)"
 
 tag:
 	$(eval BRANCH := $(shell git rev-parse --abbrev-ref HEAD))


### PR DESCRIPTION
Curently, the dist and mock configurations are hardcoded in the
Makefile to be el8 and epel-7-x86_64, respectively. This commit
allows the user to override those settings using the DIST and
MOCK_CONFIG environment variables, falling back to the current
defaults if not set.

This provides additional flexibility when building the RPM directly
from the repository.