### PR TITLE
update: use right node when creating active mds group

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -613,8 +613,8 @@
           add_host:
             name: "{{ mds_active_name[0] if mds_active_name is defined else groups.get(mds_group_name)[0] }}"
             groups: active_mdss
-            ansible_host: "{{ hostvars[mds_active_name]['ansible_host'] | default(omit) }}"
-            ansible_port: "{{ hostvars[mds_active_name]['ansible_port'] | default(omit) }}"
+            ansible_host: "{{ hostvars[mds_active_name[0] if mds_active_name is defined else groups.get(mds_group_name)[0]]['ansible_host'] | default(omit) }}"
+            ansible_port: "{{ hostvars[mds_active_name[0] if mds_active_name is defined else groups.get(mds_group_name)[0]]['ansible_port'] | default(omit) }}"
 
 
 - name: upgrade active mds


### PR DESCRIPTION
This must be consistent with what is used in `name` parameter.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>