### PR TITLE
mon: call mon_status from asok

### DIFF
--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -4,8 +4,7 @@
     {{ container_exec_cmd }}
     ceph
     --cluster {{ cluster }}
-    -n mon.
-    -k /var/lib/ceph/mon/{{ cluster }}-{{ ansible_hostname }}/keyring
+    daemon mon.{{ ansible_hostname }}
     mon_status
     --format json
   register: ceph_health_raw


### PR DESCRIPTION
since c09b82a80a392ccd0da7677c7b424ce5cd3fa5d6 in ceph/ceph we must call
mon_status from asok instead.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>