### PR TITLE
add-{mon,osd}: add ceph-container-engine role

### DIFF
--- a/infrastructure-playbooks/add-mon.yml
+++ b/infrastructure-playbooks/add-mon.yml
@@ -29,6 +29,19 @@
         name: ceph-facts
     - import_role:
         name: ceph-validate
+    - import_role:
+        name: ceph-infra
+    - import_role:
+        name: ceph-handler
+    - import_role:
+        name: ceph-common
+      when: not containerized_deployment | bool
+    - import_role:
+        name: ceph-container-engine
+      when: containerized_deployment | bool
+    - import_role:
+        name: ceph-container-common
+      when: containerized_deployment | bool
 
 - hosts: mons
   gather_facts: false
@@ -41,15 +54,7 @@
     - import_role:
         name: ceph-handler
     - import_role:
-        name: ceph-common
-      when: not containerized_deployment | bool
-    - import_role:
-        name: ceph-container-common
-      when: containerized_deployment | bool
-    - import_role:
         name: ceph-config
-    - import_role:
-        name: ceph-infra
     - import_role:
         name: ceph-mon
 

--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -76,6 +76,22 @@
       run_once: True
       when: delegate_facts_host | bool
 
+    - import_role:
+        name: ceph-facts
+    - import_role:
+        name: ceph-handler
+    - import_role:
+        name: ceph-infra
+    - import_role:
+        name: ceph-container-engine
+      when: containerized_deployment | bool
+    - import_role:
+        name: ceph-container-common
+      when: containerized_deployment | bool
+    - import_role:
+        name: ceph-common
+      when: not containerized_deployment | bool
+
     # this task is needed so we can skip the openstack_config.yml include in roles/ceph-osd
     - name: set_fact add_osd
       set_fact:
@@ -90,24 +106,10 @@
   tasks:
     - import_role:
         name: ceph-facts
-
     - import_role:
         name: ceph-handler
-
-    - import_role:
-        name: ceph-infra
-
-    - import_role:
-        name: ceph-container-common
-      when: containerized_deployment | bool
-
-    - import_role:
-        name: ceph-common
-      when: not containerized_deployment | bool
-
     - import_role:
         name: ceph-config
-
     - import_role:
         name: ceph-osd
 


### PR DESCRIPTION
The ceph-container-engine role is missing from both playbooks so the
container engine (docker, podman) isn't install resulting in a failure
on the added nodes.
```console
fatal: [xxxxx]: FAILED! => changed=false
  cmd: docker --version
  msg: '[Errno 2] No such file or directory'
  rc: 2
```
Closes: #4634

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>