### PR TITLE
defaults: add user/pass auth registry variables

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -573,6 +573,8 @@ dummy:
 #ceph_docker_image_tag: latest
 #ceph_docker_registry: docker.io
 #ceph_docker_registry_auth: false
+#ceph_docker_registry_username:
+#ceph_docker_registry_password:
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -573,6 +573,8 @@ ceph_docker_image: "rhceph/rhceph-4-rhel8"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"
 ceph_docker_registry_auth: true
+#ceph_docker_registry_username:
+#ceph_docker_registry_password:
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -565,6 +565,8 @@ ceph_docker_image: "ceph/daemon"
 ceph_docker_image_tag: latest
 ceph_docker_registry: docker.io
 ceph_docker_registry_auth: false
+#ceph_docker_registry_username:
+#ceph_docker_registry_password:
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 ceph_client_docker_image: "{{ ceph_docker_image }}"
 ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"


### PR DESCRIPTION
Add ceph_docker_registry_username and ceph_docker_registry_password
variables in ceph-defaults role so they will be present in the group_vars
samples but commented.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1763139

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>