### PR TITLE
add-mon: add missing become flag

### DIFF
--- a/infrastructure-playbooks/add-mon.yml
+++ b/infrastructure-playbooks/add-mon.yml
@@ -10,6 +10,7 @@
   gather_facts: false
   vars:
     delegate_facts_host: true
+  become: true
   pre_tasks:
     - name: gather facts
       setup:


### PR DESCRIPTION
Without the become flag set to true, we can't executed the roles
successfully.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>