### PR TITLE
rolling_update: fix reset mon_host variable

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -277,7 +277,7 @@
 
     - name: reset mon_host fact
       set_fact:
-        mon_host: "{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
+        mon_host: "{{ groups[mon_group_name][0] }}"
 
 
 - name: upgrade ceph mgr nodes when implicitly collocated on monitors


### PR DESCRIPTION
mon_host should use the inventory hostname and not the node hostname.
Fix creates an issue when the inventory and node hostname are different.

Closes: #4670

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>