### PR TITLE
move library/plugins tests files under tests dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ install:
   - pip install ansible-lint pytest
 script:
   - if [[ -n $(grep --exclude-dir=.git -P "\xa0" -r .) ]]; then echo 'NBSP characters found'; exit 1; fi
-  - pytest -vvvv library/ plugins/
+  - pytest -vvvv tests/library/ tests/plugins/filter/
   - for i in $(ls -1 roles/); do ANSIBLE_LOG_PATH=/dev/null ansible-lint -x 204 -v roles/$i/; if [ $? -ne 0 ]; then exit 1; fi; done

--- a/plugins/filter/ipaddrs_in_ranges.py
+++ b/plugins/filter/ipaddrs_in_ranges.py
@@ -8,23 +8,23 @@ except ImportError:
 
 
 class FilterModule(object):
-   ''' IP addresses within IP ranges '''
+    ''' IP addresses within IP ranges '''
 
-   def ips_in_ranges(self, ip_addresses, ip_ranges):
-       ips_in_ranges = list()
-       for ip_addr in ip_addresses:
-           for ip_range in ip_ranges:
-               if netaddr.IPAddress(ip_addr) in netaddr.IPNetwork(ip_range):
-                   ips_in_ranges.append(ip_addr)
-       return ips_in_ranges
+    def ips_in_ranges(self, ip_addresses, ip_ranges):
+        ips_in_ranges = list()
+        for ip_addr in ip_addresses:
+            for ip_range in ip_ranges:
+                if netaddr.IPAddress(ip_addr) in netaddr.IPNetwork(ip_range):
+                    ips_in_ranges.append(ip_addr)
+        return ips_in_ranges
 
-   def filters(self):
-       if netaddr:
-           return {
-               'ips_in_ranges': self.ips_in_ranges
-           }
-       else:
-           # Need to install python's netaddr for these filters to work
-           raise errors.AnsibleFilterError(
-               "The ips_in_ranges filter requires python's netaddr be "
-               "installed on the ansible controller.")
+    def filters(self):
+        if netaddr:
+            return {
+                'ips_in_ranges': self.ips_in_ranges
+            }
+        else:
+            # Need to install python's netaddr for these filters to work
+            raise errors.AnsibleFilterError(
+                "The ips_in_ranges filter requires python's netaddr be "
+                "installed on the ansible controller.")

--- a/tests/library/test_ceph_crush.py
+++ b/tests/library/test_ceph_crush.py
@@ -1,4 +1,6 @@
-from . import ceph_crush
+import sys
+sys.path.append('./library')
+import ceph_crush
 import pytest
 
 

--- a/tests/library/test_ceph_key.py
+++ b/tests/library/test_ceph_key.py
@@ -1,6 +1,8 @@
 import json
 import os
-from . import ceph_key
+import sys
+sys.path.append('./library')
+import ceph_key
 import mock
 
 

--- a/tests/library/test_ceph_volume.py
+++ b/tests/library/test_ceph_volume.py
@@ -1,4 +1,6 @@
-from . import ceph_volume
+import sys
+sys.path.append('./library')
+import ceph_volume
 import mock
 import os
 

--- a/tests/plugins/filter/test_ipaddrs_in_ranges.py
+++ b/tests/plugins/filter/test_ipaddrs_in_ranges.py
@@ -1,4 +1,6 @@
-from . import ipaddrs_in_ranges
+import sys
+sys.path.append('./plugins/filter')
+import ipaddrs_in_ranges
 
 filter_plugin = ipaddrs_in_ranges.FilterModule()
 


### PR DESCRIPTION
To avoid unnecessary ansible warnings during playbook execution we can
move the library and plugins test files under a different directory.
```console
[WARNING]: Skipping plugin (plugins/filter/test_ipaddrs_in_ranges.py) as
it seems to be invalid:
cannot import name 'ipaddrs_in_ranges'
```
Closes: #4656

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>