### PR TITLE
rolling_update: fix active mds host value

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -571,8 +571,14 @@
 
             - name: set_fact mds_active_name
               set_fact:
-                mds_active_name: "{{ [(_mds_active_name.stdout | from_json)['filesystems'][0]['mdsmap']['info'][item.key]['name']] }}"
+                mds_active_name: "{{ (_mds_active_name.stdout | from_json)['filesystems'][0]['mdsmap']['info'][item.key]['name'] }}"
               with_dict: "{{ (_mds_active_name.stdout | from_json).filesystems[0]['mdsmap']['info'] }}"
+
+            - name: set_fact mds_active_host
+              set_fact:
+                mds_active_host: "{{ [hostvars[item]['inventory_hostname']] }}"
+              with_items: "{{ groups[mds_group_name] }}"
+              when: hostvars[item]['ansible_hostname'] == mds_active_name
 
             - name: create standby_mdss group
               add_host:
@@ -580,7 +586,7 @@
                 groups: standby_mdss
                 ansible_host: "{{ hostvars[item]['ansible_host'] | default(omit) }}"
                 ansible_port: "{{ hostvars[item]['ansible_port'] | default(omit) }}"
-              with_items: "{{ groups[mds_group_name] | difference(mds_active_name) }}"
+              with_items: "{{ groups[mds_group_name] | difference(mds_active_host) }}"
 
             - name: stop standby ceph mds
               systemd:
@@ -611,10 +617,10 @@
 
         - name: create active_mdss group
           add_host:
-            name: "{{ mds_active_name[0] if mds_active_name is defined else groups.get(mds_group_name)[0] }}"
+            name: "{{ mds_active_host[0] if mds_active_host is defined else groups.get(mds_group_name)[0] }}"
             groups: active_mdss
-            ansible_host: "{{ hostvars[mds_active_name[0] if mds_active_name is defined else groups.get(mds_group_name)[0]]['ansible_host'] | default(omit) }}"
-            ansible_port: "{{ hostvars[mds_active_name[0] if mds_active_name is defined else groups.get(mds_group_name)[0]]['ansible_port'] | default(omit) }}"
+            ansible_host: "{{ hostvars[mds_active_host[0] if mds_active_host is defined else groups.get(mds_group_name)[0]]['ansible_host'] | default(omit) }}"
+            ansible_port: "{{ hostvars[mds_active_host[0] if mds_active_host is defined else groups.get(mds_group_name)[0]]['ansible_port'] | default(omit) }}"
 
 
 - name: upgrade active mds

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -626,7 +626,7 @@
 - name: upgrade active mds
   vars:
     upgrade_ceph_packages: True
-  hosts: active_mdss | default([])
+  hosts: active_mdss
   become: true
   tasks:
     - import_role:
@@ -667,7 +667,7 @@
 - name: upgrade standbys ceph mdss cluster
   vars:
     upgrade_ceph_packages: True
-  hosts: standby_mdss | default([])
+  hosts: standby_mdss
   become: True
 
   tasks:


### PR DESCRIPTION
The active mds host should be based on the inventory hostname and not on
the ansible hostname.
The value returns under the mdsmap structure is based on the OS hostname
so we need to find the right node in the inventory with this value when
doing operation on inventory nodes.

Othewise we could see error like:
```console
The task includes an option with an undefined variable. The error was:
"hostvars[foobar]" is undefined
```
Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>