### PR TITLE
ceph-mon: use --admin-daemon to set default crush rule

### DIFF
--- a/roles/ceph-mon/tasks/crush_rules.yml
+++ b/roles/ceph-mon/tasks/crush_rules.yml
@@ -38,7 +38,7 @@
     - not item.get('skipped', false)
 
 - name: insert new default crush rule into daemon to prevent restart
-  command: "{{ hostvars[item]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} daemon mon.{{ hostvars[item]['monitor_name'] }} config set osd_pool_default_crush_rule {{ info_ceph_default_crush_rule_yaml.rule_id }}"
+  command: "{{ hostvars[item]['container_exec_cmd'] | default('') }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ hostvars[item]['monitor_name'] }}.asok config set osd_pool_default_crush_rule {{ info_ceph_default_crush_rule_yaml.rule_id }}"
   changed_when: false
   delegate_to: "{{ item }}"
   with_items: "{{ groups[mon_group_name] }}"


### PR DESCRIPTION
A default crush rule is inserted into the daemon via the ceph daemon config
command. This command tries to resolve the admin socket path and fails if you
have a duplicate key in the ceph configuration.

This PR uses the `--admin-daemon` option to prevent the task from failling.

This is related to #4492 (which has been fixed with #4507)

Signed-off-by: Mihai Plasoianu <m.plasoianu@vertical.de>