### PR TITLE
ceph-nfs: add nfs-ganesha-rados-grace explicitly

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
@@ -37,7 +37,7 @@
   block:
     - name: install nfs cephfs gateway
       package:
-        name: nfs-ganesha-ceph
+        name: ['nfs-ganesha-ceph', 'nfs-ganesha-rados-grace']
         state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
       register: result
       until: result is succeeded
@@ -45,7 +45,7 @@
 
     - name: install redhat nfs-ganesha-rgw and ceph-radosgw packages
       package:
-        name: ['nfs-ganesha-rgw', 'ceph-radosgw']
+        name: ['nfs-ganesha-rgw', 'nfs-ganesha-rados-grace', 'ceph-radosgw']
         state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
       register: result
       until: result is succeeded


### PR DESCRIPTION
Since nfs-ganesha V3.0-rc4 and [1] we need to explicitly install the
nfs-ganesha-rados-grace package.

[1] https://github.com/nfs-ganesha/nfs-ganesha/commit/0fea990

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>