### PR TITLE
ceph-osd: Remove ulimit nofile on container start

### DIFF
--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -17,7 +17,6 @@ numactl \
   --privileged=true \
   --pid=host \
   --ipc=host \
-  --ulimit nofile=1024:4096 \
   {% if osd_objectstore == 'filestore' -%}
   --memory={{ ceph_osd_docker_memory_limit }} \
   {% endif -%}


### PR DESCRIPTION
Even if this improves ceph-disk/ceph-volume performances then it also
impact the ceph-osd process.
The ceph-osd process shouldn't use 1024:4096 value for the max open
files.
Removing the ulimit option from the container engine and doing this kind
of change on the container side [1].

[1] https://github.com/ceph/ceph-container/pull/1497

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1702285

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>