### PR TITLE
ceph-defaults: pin grafana container tag to 5.2.4

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -724,7 +724,7 @@ dummy:
 # We only need this for SSL (https) connections
 #grafana_crt: ''
 #grafana_key: ''
-#grafana_container_image: "grafana/grafana:latest"
+#grafana_container_image: "grafana/grafana:5.2.4"
 #grafana_container_cpu_period: 100000
 #grafana_container_cpu_cores: 2
 # container_memory is in GB

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -716,7 +716,7 @@ grafana_admin_password: admin
 # We only need this for SSL (https) connections
 grafana_crt: ''
 grafana_key: ''
-grafana_container_image: "grafana/grafana:latest"
+grafana_container_image: "grafana/grafana:5.2.4"
 grafana_container_cpu_period: 100000
 grafana_container_cpu_cores: 2
 # container_memory is in GB


### PR DESCRIPTION
The latest grafana container tag is using grafana 6.x release which could
cause issue with the ceph dashboard integration.
Considering that the grafana container in RHCS 3 is based on 5.x then we
should use the same version.

$ docker run --rm rhceph/rhceph-3-dashboard-rhel7:3 -v
Version 5.2.4 (commit: unknown-dev)

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>