### PR TITLE
ceph-osd: add device class to crush rules

### DIFF
--- a/group_vars/mons.yml.sample
+++ b/group_vars/mons.yml.sample
@@ -43,14 +43,16 @@ dummy:
 
 #crush_rule_hdd:
 #  name: HDD
-#  root: HDD
+#  root: default
 #  type: host
+#  class: hdd
 #  default: false
 
 #crush_rule_ssd:
 #  name: SSD
-#  root: SSD
+#  root: default
 #  type: host
+#  class: ssd
 #  default: false
 
 #crush_rules:

--- a/roles/ceph-mon/defaults/main.yml
+++ b/roles/ceph-mon/defaults/main.yml
@@ -35,14 +35,16 @@ crush_rule_config: false
 
 crush_rule_hdd:
   name: HDD
-  root: HDD
+  root: default
   type: host
+  class: hdd
   default: false
 
 crush_rule_ssd:
   name: SSD
-  root: SSD
+  root: default
   type: host
+  class: ssd
   default: false
 
 crush_rules:

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -23,7 +23,3 @@
   when:
     - secure_cluster | bool
     - inventory_hostname == groups[mon_group_name] | first
-
-- name: crush_rules.yml
-  include_tasks: crush_rules.yml
-  when: crush_rule_config | bool

--- a/roles/ceph-osd/tasks/crush_rules.yml
+++ b/roles/ceph-osd/tasks/crush_rules.yml
@@ -11,7 +11,7 @@
     - osd_crush_location is defined
 
 - name: create configured crush rules
-  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd crush rule create-simple {{ item.name }} {{ item.root }} {{ item.type }}"
+  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd crush rule {{ 'create-replicated' if item.class is defined else 'create-simple' }} {{ item.name }} {{ item.root }} {{ item.type }} {{ item.class | default('') }}"
   changed_when: false
   with_items: "{{ hostvars[groups[mon_group_name][0]]['crush_rules'] | unique }}"
   delegate_to: '{{ groups[mon_group_name][0] }}'

--- a/roles/ceph-osd/tasks/crush_rules.yml
+++ b/roles/ceph-osd/tasks/crush_rules.yml
@@ -2,29 +2,29 @@
 - name: configure crush hierarchy
   ceph_crush:
     cluster: "{{ cluster }}"
-    location: "{{ hostvars[item]['osd_crush_location'] }}"
-    containerized: "{{ container_exec_cmd }}"
-  with_items: "{{ groups[osd_group_name] }}"
+    location: "{{ osd_crush_location }}"
+    containerized: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }}"
   register: config_crush_hierarchy
+  delegate_to: '{{ groups[mon_group_name][0] }}'
   when:
-    - inventory_hostname == groups.get(mon_group_name) | last
-    - create_crush_tree | bool
-    - hostvars[item]['osd_crush_location'] is defined
+    - hostvars[groups[mon_group_name][0]]['create_crush_tree'] | default(false) | bool
+    - osd_crush_location is defined
 
 - name: create configured crush rules
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd crush rule create-simple {{ item.name }} {{ item.root }} {{ item.type }}"
-  with_items: "{{ crush_rules | unique }}"
+  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd crush rule create-simple {{ item.name }} {{ item.root }} {{ item.type }}"
   changed_when: false
-  when: inventory_hostname == groups.get(mon_group_name) | last
+  with_items: "{{ hostvars[groups[mon_group_name][0]]['crush_rules'] | unique }}"
+  delegate_to: '{{ groups[mon_group_name][0] }}'
+  run_once: true
 
 - name: get id for new default crush rule
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd -f json crush rule dump {{ item.name }}"
+  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd -f json crush rule dump {{ item.name }}"
   register: info_ceph_default_crush_rule
   changed_when: false
-  with_items: "{{ crush_rules }}"
-  when:
-    - inventory_hostname == groups.get(mon_group_name) | last
-    - item.default
+  with_items: "{{ hostvars[groups[mon_group_name][0]]['crush_rules'] | unique }}"
+  delegate_to: '{{ groups[mon_group_name][0] }}'
+  run_once: true
+  when: item.default | bool
 
 # If multiple rules are set as default (should not be) then the last one is taken as actual default.
 # the with_items statement overrides each iteration with the new one.
@@ -33,15 +33,15 @@
   set_fact:
     info_ceph_default_crush_rule_yaml: "{{ item.stdout | from_json() }}"
   with_items: "{{ info_ceph_default_crush_rule.results }}"
-  when:
-    - inventory_hostname == groups.get(mon_group_name) | last
-    - not item.get('skipped', false)
+  run_once: true
+  when: not item.get('skipped', false)
 
 - name: insert new default crush rule into daemon to prevent restart
   command: "{{ hostvars[item]['container_exec_cmd'] | default('') }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ hostvars[item]['monitor_name'] }}.asok config set osd_pool_default_crush_rule {{ info_ceph_default_crush_rule_yaml.rule_id }}"
   changed_when: false
   delegate_to: "{{ item }}"
   with_items: "{{ groups[mon_group_name] }}"
+  run_once: true
   when:
     - not config_crush_hierarchy.get('skipped', false)
     - info_ceph_default_crush_rule_yaml | default('') | length > 0
@@ -54,6 +54,7 @@
     value: "{{ info_ceph_default_crush_rule_yaml.rule_id }}"
   delegate_to: "{{ item }}"
   with_items: "{{ groups[mon_group_name] }}"
+  run_once: true
   when:
     - not config_crush_hierarchy.get('skipped', false)
     - info_ceph_default_crush_rule_yaml | default('') | length > 0

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -51,6 +51,10 @@
 - name: include_tasks start_osds.yml
   include_tasks: start_osds.yml
 
+- name: include crush_rules.yml
+  include_tasks: crush_rules.yml
+  when: hostvars[groups[mon_group_name][0]]['crush_rule_config'] | default(false) | bool
+
 - name: set_fact openstack_keys_tmp - preserve backward compatibility after the introduction of the ceph_keys module
   set_fact:
     openstack_keys_tmp: "{{ openstack_keys_tmp|default([]) + [ { 'key': item.key, 'name': item.name, 'caps': { 'mon': item.mon_cap, 'osd': item.osd_cap|default(''), 'mds': item.mds_cap|default(''), 'mgr': item.mgr_cap|default('') } , 'mode': item.mode } ] }}"

--- a/tests/functional/all_daemons/container/group_vars/mons
+++ b/tests/functional/all_daemons/container/group_vars/mons
@@ -3,8 +3,9 @@ create_crush_tree: True
 crush_rule_config: True
 crush_rule_hdd:
   name: HDD
-  root: HDD
+  root: default
   type: host
+  class: hdd
   default: true
 crush_rules:
   - "{{ crush_rule_hdd }}"

--- a/tests/functional/all_daemons/group_vars/mons
+++ b/tests/functional/all_daemons/group_vars/mons
@@ -3,8 +3,9 @@ create_crush_tree: True
 crush_rule_config: True
 crush_rule_hdd:
   name: HDD
-  root: HDD
+  root: default
   type: host
+  class: hdd
   default: true
 crush_rules:
   - "{{ crush_rule_hdd }}"

--- a/tests/functional/podman/group_vars/mons
+++ b/tests/functional/podman/group_vars/mons
@@ -3,8 +3,9 @@ create_crush_tree: True
 crush_rule_config: True
 crush_rule_hdd:
   name: HDD
-  root: HDD
+  root: default
   type: host
+  class: hdd
   default: true
 crush_rules:
   - "{{ crush_rule_hdd }}"


### PR DESCRIPTION
This adds device class support to crush rules when using the class key
in the rule dict via the create-replicated sub command.
If the class key isn't specified then we use the create-simple sub
command for backward compatibility.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1636508

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>