### PR TITLE
tests/requirements: bump testinfra and pytest

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,12 +1,11 @@
 # These are Python requirements needed to run the functional tests
 six==1.10.0
-testinfra>=3.0,<3.1
+testinfra>=3.2,<3.3
 pytest-xdist==1.28.0
-pytest>=4.4,<4.5
+pytest>=4.6,<5.0
 ansible>=2.8,<2.9
 Jinja2>=2.10
 netaddr
 mock
 jmespath
-paramiko
 pytest-rerunfailures


### PR DESCRIPTION
The ansible ssh connections are now using the ssh backend instead of
paramiko starting testinfra 3.1 and persistent connections too.
pytest 4.6 is the latest release to be supported by python 2.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>