### PR TITLE
add-{mon,osd}: run raw install python tasks

### DIFF
--- a/infrastructure-playbooks/add-mon.yml
+++ b/infrastructure-playbooks/add-mon.yml
@@ -12,6 +12,8 @@
     delegate_facts_host: true
   become: true
   pre_tasks:
+    - import_tasks: "{{ playbook_dir }}/../raw_install_python.yml"
+
     - name: gather facts
       setup:
       when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])

--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -26,6 +26,8 @@
     delegate_facts_host: True
 
   pre_tasks:
+    - import_tasks: "{{ playbook_dir }}/../raw_install_python.yml"
+
     - name: gather facts
       setup:
       when: not delegate_facts_host | bool


### PR DESCRIPTION
If the new mon/osd node doesn't have python installed then we need to
execute the tasks from raw_install_python.yml.

Closes: #4368

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>