### PR TITLE
ceph-defaults: pin prometheus container tags

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -717,7 +717,7 @@ dummy:
 #dashboard_rgw_api_user_id: ceph-dashboard
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
-#node_exporter_container_image: prom/node-exporter:latest
+#node_exporter_container_image: "prom/node-exporter:v0.17.0"
 #node_exporter_port: 9100
 #grafana_admin_user: admin
 #grafana_admin_password: admin
@@ -750,7 +750,7 @@ dummy:
 #  - grafana-piechart-panel
 #grafana_allow_embedding: True
 #grafana_port: 3000
-#prometheus_container_image: prom/prometheus:latest
+#prometheus_container_image: "prom/prometheus:v2.7.2"
 #prometheus_container_cpu_period: 100000
 #prometheus_container_cpu_cores: 2
 # container_memory is in GB
@@ -759,7 +759,7 @@ dummy:
 #prometheus_conf_dir: /etc/prometheus
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 #prometheus_port: 9092
-#alertmanager_container_image: prom/alertmanager:latest
+#alertmanager_container_image: "prom/alertmanager:v0.16.2"
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2
 # container_memory is in GB

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -709,7 +709,7 @@ dashboard_key: ''
 dashboard_rgw_api_user_id: ceph-dashboard
 dashboard_rgw_api_admin_resource: ''
 dashboard_rgw_api_no_ssl_verify: False
-node_exporter_container_image: prom/node-exporter:latest
+node_exporter_container_image: "prom/node-exporter:v0.17.0"
 node_exporter_port: 9100
 grafana_admin_user: admin
 grafana_admin_password: admin
@@ -742,7 +742,7 @@ grafana_plugins:
   - grafana-piechart-panel
 grafana_allow_embedding: True
 grafana_port: 3000
-prometheus_container_image: prom/prometheus:latest
+prometheus_container_image: "prom/prometheus:v2.7.2"
 prometheus_container_cpu_period: 100000
 prometheus_container_cpu_cores: 2
 # container_memory is in GB
@@ -751,7 +751,7 @@ prometheus_data_dir: /var/lib/prometheus
 prometheus_conf_dir: /etc/prometheus
 prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 prometheus_port: 9092
-alertmanager_container_image: prom/alertmanager:latest
+alertmanager_container_image: "prom/alertmanager:v0.16.2"
 alertmanager_container_cpu_period: 100000
 alertmanager_container_cpu_cores: 2
 # container_memory is in GB


### PR DESCRIPTION
In addition to the grafana container tag change, we need to do the same
for the prometheus container stack based on the release present in the
OSE 4.1 container image.
```console
$ docker run --rm openshift4/ose-prometheus-node-exporter:v4.1 --version
node_exporter, version 0.17.0
  build user:       root@67fee13ed48f
  build date:       20191023-14:38:12
  go version:       go1.11.13
$ docker run --rm openshift4/ose-prometheus-alertmanager:4.1 --version
alertmanager, version 0.16.2
  build user:       root@70b79a3f29b6
  build date:       20191023-14:57:30
  go version:       go1.11.13
$ docker run --rm openshift4/ose-prometheus:4.1 --version
prometheus, version 2.7.2
  build user:       root@12da054778a3
  build date:       20191023-14:39:36
  go version:       go1.11.13
```
Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>