### PR TITLE
purge: use sysfs to unmap rbd devices

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -68,8 +68,15 @@
     - name: ensure cephfs mountpoint are unmounted
       command: umount -a -t ceph
 
-    - name: ensure rbd devices are unmapped
-      command: rbdmap unmap-all
+    - name: find mapped rbd ids
+      find:
+        paths: /sys/bus/rbd/devices
+        file_type: any
+      register: rbd_mapped_ids
+
+    - name: use sysfs to unmap rbd devices
+      shell: "echo {{ item.path | basename }} > /sys/bus/rbd/remove_single_major"
+      with_items: "{{ rbd_mapped_ids.files }}"
 
     - name: unload ceph kernel modules
       modprobe:

--- a/tests/functional/rbd_map_devices.yml
+++ b/tests/functional/rbd_map_devices.yml
@@ -1,0 +1,54 @@
+---
+- hosts: client0
+  gather_facts: false
+  become: yes
+  tasks:
+    - name: check if it is atomic host
+      stat:
+        path: /run/ostree-booted
+      register: stat_ostree
+      tags: always
+
+# all our containerized job are based on atomic os, so we can rely on is_atomic to detect
+# whether we are running a containerized job
+    - name: set_fact is_atomic
+      set_fact:
+        is_atomic: '{{ stat_ostree.stat.exists }}'
+      tags: always
+
+    - name: load rbd module
+      modprobe:
+        name: rbd
+        state: present
+      delegate_to: "{{ item }}"
+      with_items:
+        - mon0
+        - client0
+
+    - name: create an rbd image - non container
+      command: "rbd create --size=1024 test/rbd_test"
+      delegate_to: "mon0"
+      when: not is_atomic
+
+    - name: create an rbd image - container
+      command: "docker run --rm -v /etc/ceph:/etc/ceph --net=host --entrypoint=rbd {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} create --size=1024 test/rbd_test"
+      delegate_to: "mon0"
+      when: is_atomic
+
+    - name: non container
+      when: not is_atomic
+      block:
+        - name: disable features unsupported by the kernel
+          command: rbd feature disable test/rbd_test object-map fast-diff deep-flatten
+
+        - name: map a device
+          command: rbd map test/rbd_test
+
+    - name: container
+      when: is_atomic
+      block:
+        - name: disable features unsupported by the kernel
+          command: "docker run --rm -v /etc/ceph:/etc/ceph --net=host --entrypoint=rbd {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} feature disable test/rbd_test object-map fast-diff deep-flatten"
+
+        - name: map a device
+          command: "docker run --rm --privileged -v /etc/ceph:/etc/ceph -v /dev:/dev --net=host --entrypoint=rbd {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} map test/rbd_test"

--- a/tox.ini
+++ b/tox.ini
@@ -113,6 +113,12 @@ commands=
 # can be redployed to.
 [purge]
 commands=
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/rbd_map_devices.yml --extra-vars "\
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+  "
+
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
       ireallymeanit=yes \
       remove_packages=yes \


### PR DESCRIPTION
in containerized context, using the binary provided in atomic os won't
work because it's an old version provided by ceph-common based on
10.2.5.
Using a container could be an idea but for large cluster with hundreds
of client nodes, that would require to pull the image of each of them
just to unmap the rbd devices.

Let's use the sysfs method in order to avoid any issue related to ceph
version that is shipped on the host.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1766064

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>