### PR TITLE
ceph-validate: add rbdmirror validation

### DIFF
--- a/roles/ceph-validate/tasks/check_rbdmirror.yml
+++ b/roles/ceph-validate/tasks/check_rbdmirror.yml
@@ -1,0 +1,15 @@
+---
+- name: ensure ceph_rbd_mirror_pool is set
+  fail:
+    msg: "ceph_rbd_mirror_pool needs to be provided"
+  when: ceph_rbd_mirror_pool | default("") | length == 0
+
+- name: ensure ceph_rbd_mirror_remote_cluster is set
+  fail:
+    msg: "ceph_rbd_mirror_remote_cluster needs to be provided"
+  when: ceph_rbd_mirror_remote_cluster | default("") | length == 0
+
+- name: ensure ceph_rbd_mirror_remote_user is set
+  fail:
+    msg: "ceph_rbd_mirror_remote_user needs to be provided"
+  when: ceph_rbd_mirror_remote_user | default("") | length == 0

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -207,6 +207,12 @@
   include_tasks: check_nfs.yml
   when: inventory_hostname in groups.get(nfs_group_name, [])
 
+- name: include check_rbdmirror.yml
+  include_tasks: check_rbdmirror.yml
+  when:
+    - rbdmirror_group_name in group_names
+    - ceph_rbd_mirror_configure | default(false) | bool
+
 - block:
     - name: fail if [grafana-server] group doesn't exist
       fail:


### PR DESCRIPTION
When ceph_rbd_mirror_configure is set to true we need to ensure that
the required variables aren't empty.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1760553

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>