### PR TITLE
rgw: don't create user on secondary zones

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -129,16 +129,27 @@
   block:
     - name: create radosgw system user
       command: "timeout --foreground -s KILL 20 {{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} user create --uid={{ dashboard_rgw_api_user_id }} --display-name='Ceph dashboard' --system"
-      register: rgw_user_output
-      until: rgw_user_output.rc == 0
+      register: create_rgw_user
+      until: create_rgw_user.rc == 0
       retries: 3
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
+      when: not rgw_multisite | bool or rgw_zonemaster | bool
+
+    - name: get radosgw system user
+      command: "timeout --foreground -s KILL 20 {{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} user info --uid={{ dashboard_rgw_api_user_id }}"
+      register: get_rgw_user
+      until: get_rgw_user.rc == 0
+      retries: 3
+      when:
+        - rgw_multisite | bool
+        - not rgw_zonemaster | bool
+        - rgw_zonesecondary | bool
 
     - name: get the rgw access and secret keys
       set_fact:
-        rgw_access_key: "{{ (rgw_user_output.stdout | from_json)['keys'][0]['access_key'] }}"
-        rgw_secret_key: "{{ (rgw_user_output.stdout | from_json)['keys'][0]['secret_key'] }}"
+        rgw_access_key: "{{ (create_rgw_user.stdout | default(get_rgw_user.stdout) | from_json)['keys'][0]['access_key'] }}"
+        rgw_secret_key: "{{ (create_rgw_user.stdout | default(get_rgw_user.stdout) | from_json)['keys'][0]['secret_key'] }}"
 
     - name: set the rgw user
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-user-id {{ dashboard_rgw_api_user_id }}"


### PR DESCRIPTION
The rgw user creation for the Ceph dashboard integration shouldn't be
created on secondary rgw zones.

Closes: #4707
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1794351

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>