### PR TITLE
ceph-osd: fix fs.aio-max-nr sysctl condition

### DIFF
--- a/roles/ceph-osd/tasks/system_tuning.yml
+++ b/roles/ceph-osd/tasks/system_tuning.yml
@@ -56,6 +56,6 @@
     sysctl_set: yes
     ignoreerrors: yes
   with_items:
-    - { name: "fs.aio-max-nr", value: "1048576", enable: (osd_objectstore == 'bluestore') }
+    - { name: "fs.aio-max-nr", value: "1048576", enable: "{{ osd_objectstore == 'bluestore' }}" }
     - "{{ os_tuning_params }}"
   when: item.enable | default(true) | bool


### PR DESCRIPTION
[1] introduced a regression on the fs.aio-max-nr sysctl value condition.
The enable key isn't a boolean but a string because the expression isn't
evaluated.
This string output "(osd_objectstore == 'bluestore')" is always true
because item.enable condition only matches non empty string. So the
sysctl value was applyied for both filestore and bluestore backend.

[2] added the bool filter to the condition but the filter always returns
false on string and the sysctl wasn't applyed at all.

This commit fixes the enable key value by evaluating the value instead
of using the string.

[1] https://github.com/ceph/ceph-ansible/commit/08a2b58
[2] https://github.com/ceph/ceph-ansible/commit/ab54fe2

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>