### PR TITLE
site-docker: add always tag on gather fact tasks

### DIFF
--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -24,8 +24,8 @@
   pre_tasks:
     - name: gather facts
       setup:
-      when:
-        - not delegate_facts_host | bool
+      when: not delegate_facts_host | bool
+      tags: always
 
     - name: gather and delegate facts
       setup:
@@ -33,21 +33,19 @@
       delegate_facts: True
       with_items: "{{ groups['all'] }}"
       run_once: true
-      when:
-        - delegate_facts_host | bool
+      when: delegate_facts_host | bool
+      tags: always
 
     - name: check if it is atomic host
       stat:
         path: /run/ostree-booted
       register: stat_ostree
-      tags:
-        - always
+      tags: always
 
     - name: set_fact is_atomic
       set_fact:
         is_atomic: '{{ stat_ostree.stat.exists }}'
-      tags:
-        - always
+      tags: always
 
   roles:
     - role: ceph-defaults
@@ -74,6 +72,7 @@
 
 - hosts: mons
   any_errors_fatal: true
+  gather_facts: false
   tasks:
     - name: set ceph monitor install 'In Progress'
       run_once: true
@@ -102,6 +101,7 @@
 
 - hosts: mons
   any_errors_fatal: true
+  gather_facts: false
   tasks:
     - name: set ceph monitor install 'Complete'
       run_once: true


### PR DESCRIPTION
If we execute the site-docker.yml playbook with specific tags (like
ceph_update_config) then we need to be sure to gather the facts otherwise
we will see error like:

The task includes an option with an undefined variable. The error was:
'ansible_hostname' is undefined

This commit also adds missing 'gather_facts: false' to mons plays.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1754432

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>