### PR TITLE
container: add always tag on gather fact tasks

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -28,8 +28,8 @@
     # pre-tasks for following import -
     - name: gather facts
       setup:
-      when:
-        - not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
+      when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
+      tags: always
 
     - name: gather and delegate facts
       setup:
@@ -38,6 +38,7 @@
       with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
       run_once: true
       when: delegate_facts_host | bool
+      tags: always
 
     - import_role:
         name: ceph-defaults
@@ -59,6 +60,7 @@
       when: not (inventory_hostname in groups.get('clients', [])) or (inventory_hostname == groups.get('clients', [''])|first)
 
 - hosts: mons
+  gather_facts: false
   any_errors_fatal: true
   tasks:
     - name: set ceph monitor install 'In Progress'
@@ -93,6 +95,7 @@
       when: groups.get(mgr_group_name, []) | length == 0
 
 - hosts: mons
+  gather_facts: false
   any_errors_fatal: true
   tasks:
     - name: set ceph monitor install 'Complete'


### PR DESCRIPTION
If we execute the site-container.yml playbook with specific tags (like
ceph_update_config) then we need to be sure to gather the facts otherwise
we will see error like:

The task includes an option with an undefined variable. The error was:
'ansible_hostname' is undefined

This commit also adds missing 'gather_facts: false' to mons plays.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1754432

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>