### PR TITLE
Fixes failure of cephfs configuration using --limit while running purge-docker.yml 

### DIFF
--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -11,7 +11,7 @@
     - /var/lib/ceph/mds/{{ cluster }}-{{ mds_name }}
 
 - name: get keys from monitors
-  command: "{{ hostvars[groups.get(mon_group_name)[0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
   register: _mds_keys
   with_items:
     - { name: "client.bootstrap-mds", path: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -23,7 +23,7 @@
       block:
         - name: create filesystem pools
           command: >
-            {{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
+            {{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }}
             osd pool create {{ item.name }}
             {{ item.pg_num | default(osd_pool_default_pg_num) }}
             {{ item.pgp_num | default(item.pg_num) | default(osd_pool_default_pg_num) }}


### PR DESCRIPTION
Configuration of cephfs with an existing cluster using --limit used to fail
at different tasks while running with site-docker.yml
This commit addresses both of those tasks

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1773489
Signed-off-by: VasishtaShastry <vipin.indiasmg@gmail.com>