### PR TITLE
tox-podman: use centos 8 vagrant image

### DIFF
--- a/roles/ceph-container-engine/tasks/main.yml
+++ b/roles/ceph-container-engine/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: include pre_requisites/prerequisites.yml
   include_tasks: pre_requisites/prerequisites.yml
-  when: not is_atomic
+  when: not is_atomic | bool

--- a/roles/ceph-container-engine/vars/CentOS-8.yml
+++ b/roles/ceph-container-engine/vars/CentOS-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml

--- a/tox-podman.ini
+++ b/tox-podman.ini
@@ -22,12 +22,11 @@ setenv=
   # only available for ansible >= 2.5
   ANSIBLE_STDOUT_CALLBACK = yaml
   # Set the vagrant box image to use
-  CEPH_ANSIBLE_VAGRANT_BOX = centos/atomic-host
+  CEPH_ANSIBLE_VAGRANT_BOX = centos/8
 
   # Set the ansible inventory host file to be used according to which distrib we are running on
   INVENTORY = {env:_INVENTORY:hosts}
-  PLAYBOOK = site-docker.yml.sample
-  PURGE_PLAYBOOK = purge-docker-cluster.yml
+  PLAYBOOK = site-container.yml.sample
   IS_PODMAN = TRUE
   CEPH_STABLE_RELEASE = nautilus
 
@@ -49,10 +48,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      container_binary=podman \
-      container_package_name=podman \
-      container_service_name=podman \
-      container_binding_name=podman \
   "
 
   # wait 30sec for services to be ready


### PR DESCRIPTION
Switch the podman scenario from atomic centos 7 to centos 8 (not atomic)

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>