### PR TITLE
facts: avoid duplicated element in devices list

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -181,7 +181,7 @@
 
 - name: set_fact devices generate device list when osd_auto_discovery
   set_fact:
-    devices: "{{ devices | default([]) + [ item.key | regex_replace('^', '/dev/') ] }}"
+    devices: "{{ (devices | default([]) + [ item.key | regex_replace('^', '/dev/') ]) | unique }}"
   with_dict: "{{ ansible_devices }}"
   when:
     - osd_auto_discovery | default(False) | bool


### PR DESCRIPTION
When using `osd_auto_discovery`, `devices` is built multiple times due
to multiple runs of `ceph-facts` role. It end up with duplicate
instances of a same device in the list.

Using `unique` filter when building the list fixes this issue.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>