### PR TITLE
rolling_update: don't enable ceph-mon unit

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -105,7 +105,7 @@
       systemd:
         name: ceph-mon@{{ ansible_hostname }}
         state: stopped
-        enabled: yes
+        enabled: no
       ignore_errors: True
       when:
         - not containerized_deployment
@@ -114,7 +114,7 @@
       systemd:
         name: ceph-mon@{{ ansible_fqdn }}
         state: stopped
-        enabled: yes
+        enabled: no
       ignore_errors: True
       when:
         - not containerized_deployment


### PR DESCRIPTION
On non containerized deployment the ceph-mon hostname/fqdn systemd
service are stopped at the beginning of the mon upgrade.
But the parameter enabled is set to true for both task so even if we're
not using the fqdn then it will enabled the systemd unit based on it.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1649617

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>