### PR TITLE
travis: add python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
+  - "3.8"
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/
 install:


### PR DESCRIPTION
Add both python 3.7 and 3.8 in the travis matrix testing.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>