### PR TITLE
tests: revert vagrant_variable file name detection

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,13 +4,7 @@
 require 'yaml'
 VAGRANTFILE_API_VERSION = '2'
 
-if File.file?('vagrant_variables.yml') then
-  vagrant_variable_filename='vagrant_variables.yml'
-else
-  vagrant_variable_filename='vagrant_variables.yml.sample'
-end
-
-config_file=File.expand_path(File.join(File.dirname(__FILE__), vagrant_variable_filename))
+config_file=File.expand_path(File.join(File.dirname(__FILE__), 'vagrant_variables.yml'))
 
 settings=YAML.load_file(config_file)
 


### PR DESCRIPTION
This commit reverts the following change:

https://github.com/ceph/ceph-ansible/pull/4510/commits/fcf181342a70b78a355d1c985699028012326b5f#diff-23b6f443c01ea2efcb4f36eedfea9089R7-R14

this is causing CI failures so this commit is intended to unlock the CI.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>