### PR TITLE
container: add token registry authentication

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -573,8 +573,13 @@ dummy:
 #ceph_docker_image_tag: latest
 #ceph_docker_registry: docker.io
 #ceph_docker_registry_auth: false
+# The container registry authentication could be use with:
+# 1) the container registry username and password
 #ceph_docker_registry_username:
 #ceph_docker_registry_password:
+# 2) the container registry token which is basically the
+# username:password encoded in base64
+#ceph_docker_registry_token:
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -573,8 +573,13 @@ ceph_docker_image: "rhceph/rhceph-4-rhel8"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"
 ceph_docker_registry_auth: true
+# The container registry authentication could be use with:
+# 1) the container registry username and password
 #ceph_docker_registry_username:
 #ceph_docker_registry_password:
+# 2) the container registry token which is basically the
+# username:password encoded in base64
+#ceph_docker_registry_token:
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"

--- a/roles/ceph-container-common/tasks/registry.yml
+++ b/roles/ceph-container-common/tasks/registry.yml
@@ -1,4 +1,16 @@
 ---
+- name: set_fact registry credentials
+  set_fact:
+    ceph_docker_registry_username: "{{ (ceph_docker_registry_token | b64decode).split(':') | first }}"
+    ceph_docker_registry_password: "{{ (ceph_docker_registry_token | b64decode).split(':') | last }}"
+  no_log: true
+  when:
+    - ceph_docker_registry_auth | bool
+    - ceph_docker_registry_username is not defined
+    - ceph_docker_registry_password is not defined
+    - ceph_docker_registry_token is defined
+    - ceph_docker_registry_token | length > 0
+
 - name: container registry authentication
   command: '{{ container_binary }} login -u {{ ceph_docker_registry_username }} -p {{ ceph_docker_registry_password }} {{ ceph_docker_registry }}'
   changed_when: false

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -565,8 +565,13 @@ ceph_docker_image: "ceph/daemon"
 ceph_docker_image_tag: latest
 ceph_docker_registry: docker.io
 ceph_docker_registry_auth: false
+# The container registry authentication could be use with:
+# 1) the container registry username and password
 #ceph_docker_registry_username:
 #ceph_docker_registry_password:
+# 2) the container registry token which is basically the
+# username:password encoded in base64
+#ceph_docker_registry_token:
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 ceph_client_docker_image: "{{ ceph_docker_image }}"
 ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -228,8 +228,9 @@
 
 - name: validate container registry credentials
   fail:
-    msg: 'ceph_docker_registry_username and/or ceph_docker_registry_password variables need to be set'
+    msg: 'ceph_docker_registry_username/ceph_docker_registry_password or ceph_docker_registry_token variable(s) need to be set'
   when:
     - ceph_docker_registry_auth | bool
     - (ceph_docker_registry_username is not defined or ceph_docker_registry_password is not defined) or
       (ceph_docker_registry_username | length == 0 or ceph_docker_registry_password | length == 0)
+    - ceph_docker_registry_token is not defined or ceph_docker_registry_token | length == 0


### PR DESCRIPTION
Instead of storing the username and password value for the container
authentication in clear text then one can use the token authentication
system which is basically "username:password" format encoded in base64.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1768584

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>