### PR TITLE
ceph-grafana: remove ipv6 brakets on wait_for

### DIFF
--- a/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -17,7 +17,7 @@
 
 - name: wait for grafana to be stopped
   wait_for:
-    host: '{{ grafana_server_addr }}'
+    host: '{{ grafana_server_addr if ip_version == "ipv4" else grafana_server_addr[1:-1] }}'
     port: '{{ grafana_port }}'
     state: stopped
 
@@ -107,5 +107,5 @@
 
 - name: wait for grafana to start
   wait_for:
-    host: '{{ grafana_server_addr }}'
+    host: '{{ grafana_server_addr if ip_version == "ipv4" else grafana_server_addr[1:-1] }}'
     port: '{{ grafana_port }}'


### PR DESCRIPTION
The wait_for ansible module doesn't support the backets on IPv6 address
so need to remove them.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1769710

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>