### PR TITLE
dashboard: only print dashboard url of the grafana-server node

### DIFF
--- a/roles/ceph-dashboard/tasks/main.yml
+++ b/roles/ceph-dashboard/tasks/main.yml
@@ -5,3 +5,4 @@
 - name: print dashboard URL
   debug:
     msg: "The dashboard has been deployed! You can access your dashboard web UI at {{ dashboard_protocol }}://{{ ansible_fqdn }}:{{ dashboard_port }}/ as an '{{ dashboard_admin_user }}' user with '{{ dashboard_admin_password }}' password."
+  run_once: true


### PR DESCRIPTION
This commit makes the ceph-dashboard role only printing ceph-dashboard
URL of the nodes present in grafana-server group

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1762163

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>