### PR TITLE
purge/update: remove backward compatibility legacy

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -129,7 +129,6 @@
     - grafana-server
     - clients
     - iscsigws
-    - iscsi-gws # for backward compatibility only!
 
   become: true
 

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -263,15 +263,7 @@
 
   tasks:
 
-# For backward compatibility
-  - name: disable ceph rgw service (old unit name, for backward compatibility)
-    service:
-      name: "ceph-rgw@{{ ansible_hostname }}"
-      state: stopped
-      enabled: no
-    ignore_errors: true
-
-  - name: disable ceph rgw service (new unit name)
+  - name: disable ceph rgw service
     service:
       name: "ceph-radosgw@*"
       state: stopped
@@ -287,12 +279,8 @@
 
   - name: remove ceph rgw service
     file:
-      path: "{{ item }}"
+      path: /etc/systemd/system/ceph-radosgw@.service
       state: absent
-    with_items:
-# For backward compatibility
-      - /etc/systemd/system/ceph-rgw@.service
-      - /etc/systemd/system/ceph-radosgw@.service
 
   - name: remove ceph rgw image
     docker_image:
@@ -514,7 +502,6 @@
     - "{{ mgr_group_name|default('mgrs') }}"
     - grafana-server
     - iscsigws
-    - iscsi-gws # for backward compatibility only!
     - clients
 
   gather_facts: false

--- a/infrastructure-playbooks/purge-iscsi-gateways.yml
+++ b/infrastructure-playbooks/purge-iscsi-gateways.yml
@@ -22,7 +22,6 @@
 - name: stopping the gateways
   hosts:
     - iscsigws
-    - iscsi-gws # for backward compatibility only!
   become: yes
   vars:
     - igw_purge_type: "{{hostvars['localhost']['igw_purge_type']}}"
@@ -41,7 +40,6 @@
 - name: removing the gateway configuration
   hosts:
     - iscsigws
-    - iscsi-gws # for backward compatibility only!
   become: yes
   vars:
     - igw_purge_type: "{{ hostvars['localhost']['igw_purge_type'] }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -847,7 +847,6 @@
     upgrade_ceph_packages: True
   hosts:
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
-    - iscsi-gws # for backward compatibility only!
   serial: 1
   become: True
   tasks:


### PR DESCRIPTION
This was introduced in 3.1 and marked as deprecation
We can definitely drop it in stable-4.0

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>