### PR TITLE
purge: add podman support

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -542,7 +542,9 @@
         name: docker
         state: stopped
         enabled: no
-      when: not is_atomic
+      when:
+        - not is_atomic
+        - container_binary == 'docker'
       ignore_errors: true
 
     - name: remove docker on debian/ubuntu

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -103,13 +103,6 @@
       enabled: no
     ignore_errors: true
 
-  - name: remove ceph nfs container
-    docker_container:
-      image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
-      name: "ceph-nfs-{{ ansible_hostname }}"
-      state: absent
-    ignore_errors: true
-
   - name: remove ceph nfs service
     file:
       path: /etc/systemd/system/ceph-nfs@.service
@@ -124,14 +117,6 @@
       - /var/lib/nfs/ganesha
       - /var/run/ganesha
 
-  - name: remove ceph nfs image
-    docker_image:
-      state: absent
-      repository: "{{ ceph_docker_registry }}"
-      name: "{{ ceph_docker_image }}"
-      tag: "{{ ceph_docker_image_tag }}"
-      force: yes
-    tags: remove_img
 
 - name: purge ceph mds cluster
 
@@ -148,27 +133,11 @@
       enabled: no
     ignore_errors: true
 
-  - name: remove ceph mds container
-    docker_container:
-      image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
-      name: "ceph-mds-{{ ansible_hostname }}"
-      state: absent
-    ignore_errors: true
-
   - name: remove ceph mds service
     file:
       path: /etc/systemd/system/ceph-mds@.service
       state: absent
 
-  - name: remove ceph mds image
-    docker_image:
-      state: absent
-      repository: "{{ ceph_docker_registry }}"
-      name: "{{ ceph_docker_image }}"
-      tag: "{{ ceph_docker_image_tag }}"
-      force: yes
-    tags: remove_img
-    ignore_errors: true
 
 - name: purge ceph iscsigws cluster
 
@@ -189,17 +158,6 @@
       - rbd-target-gw
       - tcmu-runner
 
-  - name: remove ceph iscsigw containers
-    docker_container:
-      image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
-      name: "{{ item }}"
-      state: absent
-    ignore_errors: true
-    with_items:
-      - rbd-target-api
-      - rbd-target-gw
-      - tcmu-runner
-
   - name: remove ceph iscsigw systemd unit files
     file:
       path: /etc/systemd/system/{{ item }}.service
@@ -210,15 +168,6 @@
       - rbd-target-gw
       - tcmu-runner
 
-  - name: remove ceph iscsigw image
-    docker_image:
-      state: absent
-      repository: "{{ ceph_docker_registry }}"
-      name: "{{ ceph_docker_image }}"
-      tag: "{{ ceph_docker_image_tag }}"
-      force: yes
-    tags: remove_img
-    ignore_errors: true
 
 - name: purge ceph mgr cluster
 
@@ -233,27 +182,11 @@
       enabled: no
     ignore_errors: true
 
-  - name: remove ceph mgr container
-    docker_container:
-      image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
-      name: "ceph-mgr-{{ ansible_hostname }}"
-      state: absent
-    ignore_errors: true
-
   - name: remove ceph mgr service
     file:
       path: /etc/systemd/system/ceph-mgr@.service
       state: absent
 
-  - name: remove ceph mgr image
-    docker_image:
-      state: absent
-      repository: "{{ ceph_docker_registry }}"
-      name: "{{ ceph_docker_image }}"
-      tag: "{{ ceph_docker_image_tag }}"
-      force: yes
-    tags: remove_img
-    ignore_errors: true
 
 - name: purge ceph rgw cluster
 
@@ -270,28 +203,10 @@
       enabled: no
     ignore_errors: true
 
-  - name: remove ceph rgw container
-    docker_container:
-      image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
-      name: "ceph-rgw-{{ ansible_hostname }}-*"
-      state: absent
-    ignore_errors: true
-
   - name: remove ceph rgw service
     file:
       path: /etc/systemd/system/ceph-radosgw@.service
       state: absent
-
-  - name: remove ceph rgw image
-    docker_image:
-      state: absent
-      repository: "{{ ceph_docker_registry }}"
-      name: "{{ ceph_docker_image }}"
-      tag: "{{ ceph_docker_image_tag }}"
-      force: yes
-    tags:
-      remove_img
-    ignore_errors: true
 
 
 - name: purge ceph rbd-mirror cluster
@@ -309,26 +224,10 @@
       enabled: no
     ignore_errors: true
 
-  - name: remove ceph rbd-mirror container
-    docker_container:
-      image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
-      name: "ceph-rbd-mirror-{{ ansible_hostname }}"
-      state: absent
-    ignore_errors: true
-
   - name: remove ceph rbd-mirror service
     file:
       path: /etc/systemd/system/ceph-rbd-mirror@.service
       state: absent
-
-  - name: remove ceph rbd-mirror image
-    docker_image:
-      state: absent
-      repository: "{{ ceph_docker_registry }}"
-      name: "{{ ceph_docker_image }}"
-      tag: "{{ ceph_docker_image_tag }}"
-      force: yes
-    tags: remove_img
 
 
 - name: purge ceph osd cluster
@@ -411,16 +310,6 @@
       path: /etc/systemd/system/ceph-osd@.service
       state: absent
 
-  - name: remove ceph osd image
-    docker_image:
-      state: absent
-      repository: "{{ ceph_docker_registry }}"
-      name: "{{ ceph_docker_image }}"
-      tag: "{{ ceph_docker_image_tag }}"
-      force: yes
-    tags: remove_img
-    ignore_errors: true
-
   - name: include vars from group_vars/osds.yml
     include_vars:
       file: "{{ item }}"
@@ -461,16 +350,6 @@
       - "ceph-mgr@{{ ansible_hostname }}"
       - "ceph-mon@{{ ansible_hostname }}"
 
-  - name: remove ceph mon and mgr container
-    docker_container:
-      image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
-      name: "{{ item }}"
-      state: absent
-    ignore_errors: true
-    with_items:
-      - "ceph-mon-{{ ansible_hostname }}"
-      - "ceph-mgr-{{ ansible_hostname }}"
-
   - name: remove ceph mon and mgr service
     file:
       path: "/etc/systemd/system/ceph-{{ item }}@.service"
@@ -478,16 +357,6 @@
     with_items:
       - mon
       - mgr
-
-  - name: remove ceph mon and mgr image
-    docker_image:
-      state: absent
-      repository: "{{ ceph_docker_registry }}"
-      name: "{{ ceph_docker_image }}"
-      tag: "{{ ceph_docker_image_tag }}"
-      force: yes
-    tags: remove_img
-    ignore_errors: true
 
 
 - name: purge node-exporter
@@ -521,26 +390,15 @@
         enabled: no
       failed_when: false
 
-    - name: remove node-exporter container
-      docker_container:
-        name: node_exporter
-        state: absent
-      failed_when: false
-
     - name: remove node_exporter service file
       file:
         name: /etc/systemd/system/node_exporter.service
         state: absent
 
     - name: remove node-exporter image
-      docker_image:
-        image: "{{ ceph_docker_registry }}/prom/node-exporter"
-        state: absent
-        force: yes
+      command: "{{ container_binary }} rmi {{ node_exporter_container_image }}"
       tags:
         - remove_img
-      failed_when: false
-
 
 - name: purge ceph-grafana
 
@@ -570,13 +428,6 @@
       with_items: "{{ grafana_services }}"
       failed_when: false
 
-    - name: remove containers
-      docker_container:
-        name: "{{ item }}"
-        state: absent
-      with_items: "{{ grafana_services }}"
-      failed_when: false
-
     - name: remove service files
       file:
         name: "/etc/systemd/system/{{ item }}.service"
@@ -584,16 +435,15 @@
       with_items: "{{ grafana_services }}"
       failed_when: false
 
-    - name: remove images
-      docker_image:
-        name: "{{ item }}"
-        state: absent
-        force: yes
+    - name: remove ceph dashboard container images
+      command: "{{ container_binary }} rmi {{ item }}"
       with_items:
-        - "{{ ceph_docker_registry }}/prom/prometheus"
-        - "{{ ceph_docker_registry }}/grafana/grafana"
-        - "{{ ceph_docker_registry }}/prom/alertmanager"
+        - "{{ prometheus_container_image }}"
+        - "{{ grafana_container_image }}"
+        - "{{ alertmanager_container_image }}"
       failed_when: false
+      tags:
+        - remove_img
 
     - name: remove data
       file:
@@ -648,7 +498,8 @@
       msg: "It looks like container are still present."
     when: containers_list.stdout_lines|length > 0
 
-- name: remove installed packages
+
+- name: final cleanup
 
   hosts:
     - "{{ mon_group_name|default('mons') }}"
@@ -664,72 +515,82 @@
   tags: with_pkg
 
   tasks:
-  - name: check if it is Atomic host
-    stat: path=/run/ostree-booted
-    register: stat_ostree
+    - import_role:
+        name: ceph-defaults
+    - import_role:
+        name: ceph-facts
 
-  - name: set fact for using Atomic host
-    set_fact:
-      is_atomic: "{{ stat_ostree.stat.exists }}"
+    - name: check if it is Atomic host
+      stat: path=/run/ostree-booted
+      register: stat_ostree
 
-  - name: stop docker service
-    service:
-      name: docker
-      state: stopped
-      enabled: no
-    when: not is_atomic
-    ignore_errors: true
+    - name: set fact for using Atomic host
+      set_fact:
+        is_atomic: "{{ stat_ostree.stat.exists }}"
 
-  - name: remove docker on debian/ubuntu
-    apt:
-      name: ['docker-ce', 'docker-engine', 'docker.io', 'python-docker', 'python3-docker']
-      state: absent
-      update_cache: yes
-      autoremove: yes
-    when: ansible_os_family == 'Debian'
+    - name: remove ceph container image
+      command: "{{ container_binary }} rmi {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+      tags:
+        - remove_img
 
-  - name: red hat based systems tasks
-    block:
-      - name: yum related tasks on red hat
-        block:
-          - name: remove packages on redhat
-            yum:
-              name: ['epel-release', 'docker', 'python-docker-py']
-              state: absent
+    - name: stop docker service
+      service:
+        name: docker
+        state: stopped
+        enabled: no
+      when: not is_atomic
+      ignore_errors: true
 
-          - name: remove package dependencies on redhat
-            command: yum -y autoremove
-            args:
-              warn: no
+    - name: remove docker on debian/ubuntu
+      apt:
+        name: ['docker-ce', 'docker-engine', 'docker.io', 'python-docker', 'python3-docker']
+        state: absent
+        update_cache: yes
+        autoremove: yes
+      when: ansible_os_family == 'Debian'
 
-          - name: remove package dependencies on redhat again
-            command: yum -y autoremove
-            args:
-              warn: no
-        when:
-          ansible_pkg_mgr == "yum"
+    - name: red hat based systems tasks
+      block:
+        - name: yum related tasks on red hat
+          block:
+            - name: remove packages on redhat
+              yum:
+                name: ['epel-release', 'docker', 'python-docker-py']
+                state: absent
 
-      - name: dnf related tasks on red hat
-        block:
-          - name: remove docker on redhat
-            dnf:
-              name: ['docker', 'python3-docker']
-              state: absent
+            - name: remove package dependencies on redhat
+              command: yum -y autoremove
+              args:
+                warn: no
 
-          - name: remove package dependencies on redhat
-            command: dnf -y autoremove
-            args:
-              warn: no
+            - name: remove package dependencies on redhat again
+              command: yum -y autoremove
+              args:
+                warn: no
+          when:
+            ansible_pkg_mgr == "yum"
 
-          - name: remove package dependencies on redhat again
-            command: dnf -y autoremove
-            args:
-              warn: no
-        when:
-          ansible_pkg_mgr == "dnf"
-    when:
-      ansible_os_family == 'RedHat' and
-      not is_atomic
+        - name: dnf related tasks on red hat
+          block:
+            - name: remove docker on redhat
+              dnf:
+                name: ['docker', 'python3-docker']
+                state: absent
+
+            - name: remove package dependencies on redhat
+              command: dnf -y autoremove
+              args:
+                warn: no
+
+            - name: remove package dependencies on redhat again
+              command: dnf -y autoremove
+              args:
+                warn: no
+          when:
+            ansible_pkg_mgr == "dnf"
+      when:
+        ansible_os_family == 'RedHat' and
+        not is_atomic
 
 - name: purge ceph directories
 

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -378,10 +378,11 @@
   become: true
 
   tasks:
-    - name: set ceph_docker_registry value if not set
-      set_fact:
-        ceph_docker_registry: "docker.io"
-      when: ceph_docker_registry is not defined
+    - import_role:
+        name: ceph-defaults
+    - import_role:
+        name: ceph-facts
+        tasks_from: container_binary
 
     - name: disable node_exporter service
       service:
@@ -415,10 +416,11 @@
       - alertmanager
 
   tasks:
-    - name: set ceph_docker_registry value if not set
-      set_fact:
-        ceph_docker_registry: "docker.io"
-      when: ceph_docker_registry is not defined
+    - import_role:
+        name: ceph-defaults
+    - import_role:
+        name: ceph-facts
+        tasks_from: container_binary
 
     - name: stop services
       service:
@@ -517,8 +519,6 @@
   tasks:
     - import_role:
         name: ceph-defaults
-    - import_role:
-        name: ceph-facts
 
     - name: check if it is Atomic host
       stat: path=/run/ostree-booted
@@ -527,6 +527,10 @@
     - name: set fact for using Atomic host
       set_fact:
         is_atomic: "{{ stat_ostree.stat.exists }}"
+
+    - import_role:
+        name: ceph-facts
+        tasks_from: container_binary
 
     - name: remove ceph container image
       command: "{{ container_binary }} rmi {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"

--- a/roles/ceph-facts/tasks/container_binary.yml
+++ b/roles/ceph-facts/tasks/container_binary.yml
@@ -1,0 +1,9 @@
+---
+- name: check if podman binary is present
+  stat:
+    path: /usr/bin/podman
+  register: podman_binary
+
+- name: set_fact container_binary
+  set_fact:
+    container_binary: "{{ 'podman' if (podman_binary.stat.exists and ansible_distribution == 'Fedora') or (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'docker' }}"

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -8,18 +8,12 @@
   set_fact:
     is_atomic: "{{ stat_ostree.stat.exists }}"
 
-- name: check if podman binary is present
-  stat:
-    path: /usr/bin/podman
-  register: podman_binary
+- name: import_tasks container_binary.yml
+  import_tasks: container_binary.yml
 
 - name: set_fact is_podman
   set_fact:
     is_podman: "{{ podman_binary.stat.exists }}"
-
-- name: set_fact container_binary
-  set_fact:
-    container_binary: "{{ 'podman' if (podman_binary.stat.exists and ansible_distribution == 'Fedora') or (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8') else 'docker' }}"
 
 # In case ansible_python_interpreter is set by the user,
 # ansible will not discover python and discovered_interpreter_python

--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -11,7 +11,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f node-exporter
-ExecStart=/usr/bin/{{ container_binary }} run --name=node-exporter \
+ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
   -v /proc:/host/proc:ro -v /sys:/host/sys:ro \
   --net=host \
   {{ node_exporter_container_image }} \

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -12,7 +12,7 @@ After=network.target
 WorkingDirectory={{ alertmanager_data_dir }}
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f alertmanager
-ExecStart=/usr/bin/{{ container_binary }} run --name=alertmanager \
+ExecStart=/usr/bin/{{ container_binary }} run --rm --name=alertmanager \
   -v "{{ alertmanager_conf_dir }}:/etc/alertmanager:Z" \
   -v "{{ alertmanager_data_dir }}:/alertmanager:Z" \
   --net=host \

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -11,7 +11,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f prometheus
-ExecStart=/usr/bin/{{ container_binary }} run --name=prometheus \
+ExecStart=/usr/bin/{{ container_binary }} run --rm --name=prometheus \
   -v "{{ prometheus_conf_dir }}:/etc/prometheus:Z" \
   -v "{{ prometheus_data_dir }}:/prometheus:Z" \
   --net=host \


### PR DESCRIPTION
All containers are removed when systemd stops them.
There is no need to call this module in purge container playbook.
    
This commit also removes all docker_image task and remove all container
images in the final cleanup play.
    
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1776736
    
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>