### PR TITLE
tests: fix cluster health status

### DIFF
--- a/tests/functional/add-mdss/container/group_vars/all
+++ b/tests/functional/add-mdss/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False

--- a/tests/functional/add-mdss/group_vars/all
+++ b/tests/functional/add-mdss/group_vars/all
@@ -21,5 +21,6 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/add-mgrs/container/group_vars/all
+++ b/tests/functional/add-mgrs/container/group_vars/all
@@ -24,6 +24,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False

--- a/tests/functional/add-mgrs/group_vars/all
+++ b/tests/functional/add-mgrs/group_vars/all
@@ -22,5 +22,6 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/add-mons/container/group_vars/all
+++ b/tests/functional/add-mons/container/group_vars/all
@@ -24,6 +24,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False

--- a/tests/functional/add-mons/group_vars/all
+++ b/tests/functional/add-mons/group_vars/all
@@ -22,5 +22,6 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/add-osds/container/group_vars/all
+++ b/tests/functional/add-osds/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False

--- a/tests/functional/add-osds/group_vars/all
+++ b/tests/functional/add-osds/group_vars/all
@@ -21,5 +21,6 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/add-rbdmirrors/container/group_vars/all
+++ b/tests/functional/add-rbdmirrors/container/group_vars/all
@@ -24,6 +24,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False

--- a/tests/functional/add-rbdmirrors/group_vars/all
+++ b/tests/functional/add-rbdmirrors/group_vars/all
@@ -22,5 +22,6 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/add-rgws/container/group_vars/all
+++ b/tests/functional/add-rgws/container/group_vars/all
@@ -24,6 +24,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 rgw_override_bucket_index_max_shards: 16

--- a/tests/functional/add-rgws/group_vars/all
+++ b/tests/functional/add-rgws/group_vars/all
@@ -22,5 +22,6 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/add-rgws/group_vars/rgws
+++ b/tests/functional/add-rgws/group_vars/rgws
@@ -1,8 +1,8 @@
 copy_admin_key: true
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/all_daemons/ceph-override.json
+++ b/tests/functional/all_daemons/ceph-override.json
@@ -3,6 +3,7 @@
     "global": {
       "osd_pool_default_pg_num": 12,
       "osd_pool_default_size": 1,
+      "mon_warn_on_pool_no_redundancy": false
     }
   },
   "cephfs_pools": [

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -14,6 +14,7 @@ rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: True
 openstack_glance_pool:

--- a/tests/functional/all_daemons/container/group_vars/rgws
+++ b/tests/functional/all_daemons/container/group_vars/rgws
@@ -2,6 +2,6 @@
 copy_admin_key: True
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -6,6 +6,7 @@ cluster_network: "192.168.2.0/24"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: True
 openstack_glance_pool:

--- a/tests/functional/all_daemons/group_vars/rgws
+++ b/tests/functional/all_daemons/group_vars/rgws
@@ -1,8 +1,8 @@
 copy_admin_key: true
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -16,6 +16,7 @@ rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10

--- a/tests/functional/collocation/container/group_vars/rgws
+++ b/tests/functional/collocation/container/group_vars/rgws
@@ -1,6 +1,6 @@
 ---
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -13,6 +13,7 @@ rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10

--- a/tests/functional/collocation/group_vars/rgws
+++ b/tests/functional/collocation/group_vars/rgws
@@ -1,6 +1,6 @@
 ---
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16

--- a/tests/functional/lvm-auto-discovery/container/group_vars/all
+++ b/tests/functional/lvm-auto-discovery/container/group_vars/all
@@ -21,6 +21,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False

--- a/tests/functional/lvm-auto-discovery/group_vars/all
+++ b/tests/functional/lvm-auto-discovery/group_vars/all
@@ -15,6 +15,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False
 handler_health_mon_check_delay: 10

--- a/tests/functional/lvm-batch/container/group_vars/all
+++ b/tests/functional/lvm-batch/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False

--- a/tests/functional/lvm-batch/group_vars/all
+++ b/tests/functional/lvm-batch/group_vars/all
@@ -17,6 +17,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False
 handler_health_mon_check_delay: 10

--- a/tests/functional/lvm-osds/container/group_vars/all
+++ b/tests/functional/lvm-osds/container/group_vars/all
@@ -17,6 +17,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False

--- a/tests/functional/lvm-osds/group_vars/all
+++ b/tests/functional/lvm-osds/group_vars/all
@@ -12,6 +12,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False
 handler_health_mon_check_delay: 10

--- a/tests/functional/migrate_ceph_disk_to_ceph_volume/group_vars/all
+++ b/tests/functional/migrate_ceph_disk_to_ceph_volume/group_vars/all
@@ -19,4 +19,5 @@ os_tuning_params:
 ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1

--- a/tests/functional/ooo-collocation/hosts
+++ b/tests/functional/ooo-collocation/hosts
@@ -3,6 +3,7 @@ all:
     admin_secret: AQBSV4xaAAAAABAA3VUTiOZTHecau2SnAEVPYQ==
     ceph_conf_overrides:
       global: {osd_pool_default_pg_num: 8, osd_pool_default_pgp_num: 8, osd_pool_default_size: 1,
+        mon_warn_on_pool_no_redundancy: false,
         rgw_keystone_accepted_roles: 'Member, admin', rgw_keystone_admin_domain: default,
         rgw_keystone_admin_password: RtYPg7AUdsZCGv4Z4rF8FvnaR, rgw_keystone_admin_project: service,
         rgw_keystone_admin_user: swift, rgw_keystone_api_version: 3, rgw_keystone_implicit_tenants: 'true',

--- a/tests/functional/podman/group_vars/all
+++ b/tests/functional/podman/group_vars/all
@@ -14,6 +14,7 @@ rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: True
 openstack_glance_pool:

--- a/tests/functional/podman/group_vars/rgws
+++ b/tests/functional/podman/group_vars/rgws
@@ -2,6 +2,6 @@
 copy_admin_key: True
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16

--- a/tests/functional/rgw-multisite/container/group_vars/all
+++ b/tests/functional/rgw-multisite/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False

--- a/tests/functional/rgw-multisite/container/group_vars/rgws
+++ b/tests/functional/rgw-multisite/container/group_vars/rgws
@@ -13,8 +13,8 @@ system_access_key: 6kWkikvapSnHyE22P7nO
 system_secret_key: MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/rgw-multisite/container/secondary/group_vars/all
+++ b/tests/functional/rgw-multisite/container/secondary/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False

--- a/tests/functional/rgw-multisite/container/secondary/group_vars/rgws
+++ b/tests/functional/rgw-multisite/container/secondary/group_vars/rgws
@@ -1,8 +1,8 @@
 ---
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/rgw-multisite/group_vars/all
+++ b/tests/functional/rgw-multisite/group_vars/all
@@ -21,5 +21,6 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/rgw-multisite/group_vars/rgws
+++ b/tests/functional/rgw-multisite/group_vars/rgws
@@ -13,8 +13,8 @@ system_access_key: 6kWkikvapSnHyE22P7nO
 system_secret_key: MGecsMrWtKZgngOHZdrd6d3JxGO5CPWgT2lcnpSt
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/rgw-multisite/secondary/group_vars/all
+++ b/tests/functional/rgw-multisite/secondary/group_vars/all
@@ -21,6 +21,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp
 dashboard_enabled: False

--- a/tests/functional/rgw-multisite/secondary/group_vars/rgws
+++ b/tests/functional/rgw-multisite/secondary/group_vars/rgws
@@ -1,8 +1,8 @@
 ---
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/shrink_mds/container/group_vars/all
+++ b/tests/functional/shrink_mds/container/group_vars/all
@@ -11,6 +11,7 @@ public_network: "192.168.79.0/24"
 cluster_network: "192.168.80.0/24"
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False

--- a/tests/functional/shrink_mds/group_vars/all
+++ b/tests/functional/shrink_mds/group_vars/all
@@ -11,5 +11,6 @@ osd_scenario: lvm
 copy_admin_key: true
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/shrink_mgr/container/group_vars/all
+++ b/tests/functional/shrink_mgr/container/group_vars/all
@@ -11,6 +11,7 @@ public_network: "192.168.83.0/24"
 cluster_network: "192.168.84.0/24"
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False

--- a/tests/functional/shrink_mgr/group_vars/all
+++ b/tests/functional/shrink_mgr/group_vars/all
@@ -7,5 +7,6 @@ monitor_interface: eth1
 radosgw_interface: eth1
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/shrink_mon/container/group_vars/all
+++ b/tests/functional/shrink_mon/container/group_vars/all
@@ -11,6 +11,7 @@ public_network: "192.168.17.0/24"
 cluster_network: "192.168.18.0/24"
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False

--- a/tests/functional/shrink_mon/group_vars/all
+++ b/tests/functional/shrink_mon/group_vars/all
@@ -5,5 +5,6 @@ public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/shrink_osd/container/group_vars/all
+++ b/tests/functional/shrink_osd/container/group_vars/all
@@ -11,6 +11,7 @@ public_network: "192.168.73.0/24"
 cluster_network: "192.168.74.0/24"
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False

--- a/tests/functional/shrink_rbdmirror/container/group_vars/all
+++ b/tests/functional/shrink_rbdmirror/container/group_vars/all
@@ -10,6 +10,7 @@ ceph_mon_docker_subnet: "{{ public_network }}"
 ceph_docker_on_openstack: False
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False

--- a/tests/functional/shrink_rbdmirror/group_vars/all
+++ b/tests/functional/shrink_rbdmirror/group_vars/all
@@ -9,5 +9,6 @@ osd_scenario: lvm
 copy_admin_key: true
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/shrink_rgw/container/group_vars/all
+++ b/tests/functional/shrink_rgw/container/group_vars/all
@@ -12,6 +12,7 @@ ceph_mon_docker_subnet: "{{ public_network }}"
 ceph_docker_on_openstack: False
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False

--- a/tests/functional/shrink_rgw/container/group_vars/rgws
+++ b/tests/functional/shrink_rgw/container/group_vars/rgws
@@ -2,8 +2,8 @@
 copy_admin_key: true
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/shrink_rgw/group_vars/all
+++ b/tests/functional/shrink_rgw/group_vars/all
@@ -10,5 +10,6 @@ osd_scenario: lvm
 copy_admin_key: true
 ceph_conf_overrides:
   global:
+    mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/shrink_rgw/group_vars/rgws
+++ b/tests/functional/shrink_rgw/group_vars/rgws
@@ -2,8 +2,8 @@
 copy_admin_key: true
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400


### PR DESCRIPTION
The current ceph cluster health is in warning state:

health: HEALTH_WARN
        13 pool(s) have no replicas configured
        2 pool(s) have non-power-of-two pg_num

Because we're using only 1 replica then we need to disable the redundancy
check.
The pool pg num should be a power of two number (like 16).

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>