### PR TITLE
switch_to_containers: fix umount ceph partitions

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -250,7 +250,7 @@
 
     - name: check if containerized osds are already running
       command: >
-        {{ container_binary }} ps --filter='name=ceph-osd'
+        {{ container_binary }} ps -q --filter='name=ceph-osd'
       changed_when: false
       failed_when: false
       register: osd_running
@@ -260,6 +260,7 @@
         find /var/lib/ceph/osd {% if dmcrypt | bool %}/var/lib/ceph/osd-lockbox{% endif %} -maxdepth 1 -mindepth 1 -type d
       register: osd_dirs
       changed_when: false
+      failed_when: false
 
     - name: unmount all the osd directories
       command: >
@@ -267,7 +268,7 @@
       changed_when: false
       failed_when: false
       with_items: "{{ osd_dirs.stdout_lines }}"
-      when: osd_running.rc != 0
+      when: osd_running.rc != 0 or osd_running.stdout_lines | length == 0
 
   tasks:
     - import_role:


### PR DESCRIPTION
When a container is already running on a non containerized node then the
umount ceph partition task is skipped.
This is due to the container ps command which always returns 0 even if
the filter matches nothing.

We should run the umount task when:
1/ the container command is failing (not installed) : rc != 0
2/ the container command reports running ceph-osd containers : rc == 0

Also we should not fail on the ceph directory listing.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1616159

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>