### PR TITLE
NFS Ganesha Per-Host Exports

### DIFF
--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -6,7 +6,7 @@
     when: containerized_deployment | bool
 
   - name: check if rados index object exists
-    shell: "{{ container_exec_cmd_nfs | default('') }} rados -p {{ cephfs_data_pool.name }} --cluster {{ cluster }} ls|grep {{ ceph_nfs_rados_export_index }}"
+    shell: "{{ container_exec_cmd_nfs | default('') }} rados -p {{ cephfs_data_pool.name }} --cluster {{ cluster }} ls|grep conf-{{ ansible_hostname }}"
     changed_when: false
     failed_when: false
     register: rados_index_exists
@@ -16,7 +16,7 @@
     run_once: true
 
   - name: create an empty rados index object
-    command: "{{ container_exec_cmd_nfs | default('') }} rados -p {{ cephfs_data_pool.name }} --cluster {{ cluster }} put {{ ceph_nfs_rados_export_index }} /dev/null"
+    command: "{{ container_exec_cmd_nfs | default('') }} rados -p {{ cephfs_data_pool.name }} --cluster {{ cluster }} put conf-{{ ansible_hostname }} /dev/null"
     when:
       - ceph_nfs_rados_backend | bool
       - rados_index_exists.rc != 0

--- a/roles/ceph-nfs/templates/ganesha.conf.j2
+++ b/roles/ceph-nfs/templates/ganesha.conf.j2
@@ -30,7 +30,7 @@ RADOS_URLS {
    ceph_conf = '/etc/ceph/{{ cluster }}.conf';
    userid = "{{ ceph_nfs_ceph_user }}";
 }
-%url rados://{{ cephfs_data_pool.name }}/{{ ceph_nfs_rados_export_index }}
+%url rados://{{ cephfs_data_pool.name }}/conf-{{ ansible_hostname }}
 
 NFSv4 {
 	RecoveryBackend = 'rados_kv';


### PR DESCRIPTION
Addresses bugs 1 & 2 of #4467 - the task now creates a `conf-HOSTNAME` RADOS object if one doesn't already exist instead of the default `ganesha-export-index` object. This allows NFS Ganesha to pick up exports per-host rather than globally, and for Ceph's Dashboard to recognise what NFS Ganesha servers exist in the cluster. The NFS Ganesha configuration template has also been updated so that NFS Ganesha uses the host-specific RADOS object for determining exports.