### PR TITLE
common: add centos8 support

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -85,7 +85,7 @@ dummy:
 
 #centos_package_dependencies:
 #  - epel-release
-#  - libselinux-python
+#  - python3-libselinux
 
 #redhat_package_dependencies: []
 

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -85,7 +85,7 @@ fetch_directory: ~/ceph-ansible-keys
 
 #centos_package_dependencies:
 #  - epel-release
-#  - libselinux-python
+#  - python3-libselinux
 
 #redhat_package_dependencies: []
 

--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -480,6 +480,12 @@
 
   - import_role:
       name: ceph-facts
+      tasks_from: container_binary
+
+  - name: remove stopped/exited containers
+    command: >
+      {{ container_binary }} container prune{% if container_binary == 'docker' %} -f{% endif %}
+    changed_when: false
 
   - name: show container list on all the nodes (should be empty)
     command: >

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -499,23 +499,6 @@
         - noout
         - nodeep-scrub
 
-    - name: get osd versions
-      command: "{{ container_exec_cmd_update_osd|default('') }} ceph --cluster {{ cluster }} versions"
-      register: ceph_versions
-
-    - name: set_fact ceph_versions_osd
-      set_fact:
-        ceph_versions_osd: "{{ (ceph_versions.stdout|from_json).osd }}"
-
-    # length == 1 means there is a single osds versions entry
-    # thus all the osds are running the same version
-    - name: complete osds upgrade
-      command: "{{ container_exec_cmd_update_osd|default('') }} ceph --cluster {{ cluster }} osd require-osd-release luminous"
-      when:
-        - (ceph_versions.get('stdout', '{}')|from_json).get('osd', {}) | length == 1
-        - ceph_versions_osd | string is search("ceph version 12")
-
-
 - name: upgrade ceph mdss cluster, deactivate all rank > 0
   hosts: "{{ groups[mon_group_name|default('mons')][0] }}"
   become: true
@@ -926,14 +909,14 @@
     - import_role:
         name: ceph-facts
 
-    - name: container | disallow pre-nautilus OSDs and enable all new nautilus-only functionality
-      command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph osd require-osd-release nautilus"
+    - name: container | disallow pre-octopus OSDs and enable all new octopus-only functionality
+      command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph osd require-osd-release octopus"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
       when: containerized_deployment | bool
 
-    - name: non container | disallow pre-nautilus OSDs and enable all new nautilus-only functionality
-      command: "ceph --cluster {{ cluster }} osd require-osd-release nautilus"
+    - name: non container | disallow pre-octopus OSDs and enable all new octopus-only functionality
+      command: "ceph --cluster {{ cluster }} osd require-osd-release octopus"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
       when: not containerized_deployment | bool

--- a/roles/ceph-common/tasks/installs/redhat_community_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_community_repository.yml
@@ -5,6 +5,7 @@
   register: result
   until: result is succeeded
   tags: with_pkg
+  when: ansible_distribution_major_version | int == 7
 
 - name: configure red hat ceph community repository stable key
   rpm_key:

--- a/roles/ceph-common/tasks/installs/redhat_dev_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_dev_repository.yml
@@ -1,4 +1,27 @@
 ---
+- name: install dnf-plugins-core
+  package:
+    name: dnf-plugins-core
+  register: result
+  until: result is succeeded
+  tags: with_pkg
+
+- name: enable ceph-el8 copr
+  command: dnf copr enable -y ktdreyer/ceph-el8
+  args:
+    creates: /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:ktdreyer:ceph-el8.repo
+    warn: false
+  register: result
+  until: result is succeeded
+
+- name: enable ceph lab extras repository
+  yum_repository:
+    name: lab-extras
+    baseurl: http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
+    description: Sepia Lab Extras repository
+    enabled: true
+    gpgcheck: false
+
 - name: fetch ceph red hat development repository
   uri:
     # Use the centos repo since we don't currently have a dedicated red hat repo

--- a/roles/ceph-container-engine/tasks/main.yml
+++ b/roles/ceph-container-engine/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: include pre_requisites/prerequisites.yml
   include_tasks: pre_requisites/prerequisites.yml
-  when: not is_atomic
+  when: not is_atomic | bool

--- a/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
@@ -23,10 +23,12 @@
   tags:
     with_pkg
 
-- name: install container package
+- name: install container and lvm2 packages
   package:
-    name: ['{{ container_package_name }}', '{{ container_binding_name }}']
+    name: ['{{ container_package_name }}', '{{ container_binding_name }}', 'lvm2']
     update_cache: true
+  register: result
+  until: result is succeeded
   tags: with_pkg
 
 - name: start container service

--- a/roles/ceph-container-engine/vars/CentOS-8.yml
+++ b/roles/ceph-container-engine/vars/CentOS-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -77,7 +77,7 @@ debian_package_dependencies: []
 
 centos_package_dependencies:
   - epel-release
-  - libselinux-python
+  - python3-libselinux
 
 redhat_package_dependencies: []
 

--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -9,7 +9,6 @@
           - targetcli
         common_repos:
           - tcmu-runner
-          - python-rtslib
 
     - name: set_fact base iscsi pkgs if new style ceph-iscsi
       set_fact:

--- a/roles/ceph-nfs/tasks/ganesha_selinux_fix.yml
+++ b/roles/ceph-nfs/tasks/ganesha_selinux_fix.yml
@@ -17,17 +17,16 @@
       until: result is succeeded
       when: ansible_distribution_major_version == '7'
 
+    - name: install nfs-ganesha-selinux and python3-policycoreutils on RHEL 8
+      package:
+        name: ['nfs-ganesha-selinux', 'python3-policycoreutils']
+        state: present
+      register: result
+      until: result is succeeded
+      when: ansible_distribution_major_version == '8'
+
     - name: add ganesha_t to permissive domain
       selinux_permissive:
         name: ganesha_t
         permissive: true
       failed_when: false
-      when: ansible_distribution_major_version == '7'
-
-    - name: install nfs-ganesha-selinux on RHEL 8
-      package:
-        name: nfs-ganesha-selinux
-        state: present
-      register: result
-      until: result is succeeded
-      when: ansible_distribution_major_version == '8'

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
@@ -16,19 +16,23 @@
 
     - name: red hat based systems - dev repo related tasks
       block:
-        - name: fetch nfs-ganesha red hat development repository
-          uri:
-            url: https://shaman.ceph.com/api/repos/nfs-ganesha/next/latest/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/flavors/{{ nfs_ganesha_flavor }}/repo
-            return_content: yes
-          register: nfs_ganesha_dev_yum_repo
+        - name: add nfs-ganesha dev repo
+          yum_repository:
+            name: nfs-ganesha
+            baseurl: https://download.nfs-ganesha.org/3/LATEST/CentOS/el-$releasever/$basearch
+            description: nfs-ganesha repository
+            gpgcheck: true
+            gpgkey: https://download.nfs-ganesha.org/3/rsa.pub
+            file: nfs-ganesha-dev
 
-        - name: add nfs-ganesha development repository
-          copy:
-            content: "{{ nfs_ganesha_dev_yum_repo.content }}"
-            dest: /etc/yum.repos.d/nfs-ganesha-dev.repo
-            owner: root
-            group: root
-            backup: yes
+        - name: add nfs-ganesha dev noarch repo
+          yum_repository:
+            name: nfs-ganesha-noarch
+            baseurl: https://download.nfs-ganesha.org/3/LATEST/CentOS/el-$releasever/noarch
+            description: nfs-ganesha noarch repository
+            gpgcheck: true
+            gpgkey: https://download.nfs-ganesha.org/3/rsa.pub
+            file: nfs-ganesha-dev
       when:
         - nfs_ganesha_dev | bool
         - ceph_repository == 'dev'

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -22,14 +22,6 @@
     - ceph_osd_numactl_opts | length > 0
   tags: with_pkg
 
-- name: install lvm2
-  package:
-    name: lvm2
-  register: result
-  until: result is succeeded
-  when: not is_atomic | bool
-  tags: with_pkg
-
 - name: include_tasks common.yml
   include_tasks: common.yml
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,8 +64,6 @@ def setup(host):
     address = host.interface(public_interface).addresses[0]
 
     if docker:
-        container_binary = "docker"
-    if docker and str_to_bool(os.environ.get('IS_PODMAN', False)):  # noqa E501
         container_binary = "podman"
 
     data = dict(

--- a/tests/functional/all_daemons/container/hosts
+++ b/tests/functional/all_daemons/container/hosts
@@ -18,8 +18,8 @@ mds2
 [rgws]
 rgw0
 
-[nfss]
-nfs0
+#[nfss]
+#nfs0
 
 [clients]
 client0

--- a/tests/functional/all_daemons/container/vagrant_variables.yml
+++ b/tests/functional/all_daemons/container/vagrant_variables.yml
@@ -8,7 +8,7 @@ mon_vms: 3
 osd_vms: 2
 mds_vms: 3
 rgw_vms: 1
-nfs_vms: 1
+nfs_vms: 0
 grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -22,8 +22,8 @@ rgw0
 client0
 client1
 
-[nfss]
-nfs0
+#[nfss]
+#nfs0
 
 [rbdmirrors]
 rbd-mirror0

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -8,7 +8,7 @@ mon_vms: 3
 osd_vms: 2
 mds_vms: 3
 rgw_vms: 1
-nfs_vms: 1
+nfs_vms: 0
 grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2

--- a/tests/functional/rbd_map_devices.yml
+++ b/tests/functional/rbd_map_devices.yml
@@ -28,15 +28,19 @@
     - name: create an rbd image - non container
       command: "rbd create --size=1024 test/rbd_test"
       delegate_to: "mon0"
-      when: not is_atomic
+      when:
+        - not is_atomic | bool
+        - not containerized_deployment | default(false) | bool
 
     - name: create an rbd image - container
-      command: "docker run --rm -v /etc/ceph:/etc/ceph --net=host --entrypoint=rbd {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} create --size=1024 test/rbd_test"
+      command: "podman run --rm -v /etc/ceph:/etc/ceph --net=host --entrypoint=rbd {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} create --size=1024 test/rbd_test"
       delegate_to: "mon0"
-      when: is_atomic
+      when: is_atomic | bool or containerized_deployment | default(false) | bool
 
     - name: non container
-      when: not is_atomic
+      when:
+        - not is_atomic | bool
+        - not containerized_deployment | default(false) | bool
       block:
         - name: disable features unsupported by the kernel
           command: rbd feature disable test/rbd_test object-map fast-diff deep-flatten
@@ -45,10 +49,10 @@
           command: rbd map test/rbd_test
 
     - name: container
-      when: is_atomic
+      when: is_atomic | bool or containerized_deployment | default(false) | bool
       block:
         - name: disable features unsupported by the kernel
-          command: "docker run --rm -v /etc/ceph:/etc/ceph --net=host --entrypoint=rbd {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} feature disable test/rbd_test object-map fast-diff deep-flatten"
+          command: "podman run --rm -v /etc/ceph:/etc/ceph --net=host --entrypoint=rbd {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} feature disable test/rbd_test object-map fast-diff deep-flatten"
 
         - name: map a device
-          command: "docker run --rm --privileged -v /etc/ceph:/etc/ceph -v /dev:/dev --net=host --entrypoint=rbd {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} map test/rbd_test"
+          command: "podman run --rm --privileged -v /etc/ceph:/etc/ceph -v /dev:/dev --net=host --entrypoint=rbd {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} map test/rbd_test"

--- a/tests/functional/rgw_multisite.yml
+++ b/tests/functional/rgw_multisite.yml
@@ -25,7 +25,7 @@
 
     - name: generate and upload a random 10Mb file - containerized deployment
       command: >
-        docker run --rm --name=rgw_multisite_test --entrypoint=/bin/bash {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} -c 'dd if=/dev/urandom of=/tmp/testinfra.img bs=1M count=10; {{ s3cmd_cmd }} mb s3://testinfra; {{ s3cmd_cmd }} put /tmp/testinfra.img s3://testinfra'
+        podman run --rm --name=rgw_multisite_test --entrypoint=/bin/bash {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} -c 'dd if=/dev/urandom of=/tmp/testinfra.img bs=1M count=10; {{ s3cmd_cmd }} mb s3://testinfra; {{ s3cmd_cmd }} put /tmp/testinfra.img s3://testinfra'
       when:
         - rgw_zonemaster | bool
         - containerized_deployment | default(False) | bool
@@ -41,7 +41,7 @@
 
     - name: get info from replicated file - containerized deployment
       command: >
-        docker run --rm --name=rgw_multisite_test --entrypoint=/bin/bash {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} -c '{{ s3cmd_cmd }} info s3://testinfra/testinfra.img'
+        podman run --rm --name=rgw_multisite_test --entrypoint=/bin/bash {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} -c '{{ s3cmd_cmd }} info s3://testinfra/testinfra.img'
       register: s3cmd_info_status
       when:
         - not rgw_zonemaster | default(False) | bool

--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -66,6 +66,7 @@
             state: absent
       when:
         - ansible_distribution == 'CentOS'
+        - ansible_distribution_major_version | int == 7
         - not is_atomic | bool
 
     - name: resize logical volume for root partition to fill remaining free space

--- a/tox-filestore_to_bluestore.ini
+++ b/tox-filestore_to_bluestore.ini
@@ -20,8 +20,8 @@ setenv=
   ANSIBLE_STDOUT_CALLBACK = yaml
 #  non_container: DEV_SETUP = True
   # Set the vagrant box image to use
-  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/7
-  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/atomic-host
+  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
   ubuntu: CEPH_ANSIBLE_VAGRANT_BOX = guits/ubuntu-bionic64
 
   # Set the ansible inventory host file to be used according to which distrib we are running on

--- a/tox-podman.ini
+++ b/tox-podman.ini
@@ -22,12 +22,11 @@ setenv=
   # only available for ansible >= 2.5
   ANSIBLE_STDOUT_CALLBACK = yaml
   # Set the vagrant box image to use
-  CEPH_ANSIBLE_VAGRANT_BOX = centos/atomic-host
+  CEPH_ANSIBLE_VAGRANT_BOX = centos/8
 
   # Set the ansible inventory host file to be used according to which distrib we are running on
   INVENTORY = {env:_INVENTORY:hosts}
-  PLAYBOOK = site-docker.yml.sample
-  IS_PODMAN = TRUE
+  PLAYBOOK = site-container.yml.sample
   CEPH_STABLE_RELEASE = nautilus
 
 deps= -r{toxinidir}/tests/requirements.txt
@@ -48,10 +47,6 @@ commands=
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
-      container_binary=podman \
-      container_package_name=podman \
-      container_service_name=podman \
-      container_binding_name=podman \
   "
 
   # wait 30sec for services to be ready

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -20,8 +20,8 @@ setenv=
   ANSIBLE_STDOUT_CALLBACK = yaml
 #  non_container: DEV_SETUP = True
   # Set the vagrant box image to use
-  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/7
-  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/atomic-host
+  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
   ubuntu: CEPH_ANSIBLE_VAGRANT_BOX = guits/ubuntu-bionic64
 
   # Set the ansible inventory host file to be used according to which distrib we are running on

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -31,39 +31,32 @@ setenv=
   container: PLAYBOOK = site-docker.yml.sample
   non_container: PLAYBOOK = site.yml.sample
 
-  CEPH_DOCKER_IMAGE_TAG = latest-nautilus
   UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
   UPDATE_CEPH_DEV_BRANCH = master
   UPDATE_CEPH_DEV_SHA1 = latest
-  CEPH_STABLE_RELEASE = nautilus
   ROLLING_UPDATE = True
-
+deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
 commands=
   vagrant up --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
-  # use the stable-4.0 branch to deploy a nautilus cluster
-  git clone -b stable-4.0 --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
-  pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
-
-  bash -c 'ANSIBLE_CONFIG={envdir}/tmp/ceph-ansible/ansible.cfg ansible-playbook -vv -i {changedir}/{env:INVENTORY} {envdir}/tmp/ceph-ansible/tests/functional/setup.yml'
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/setup.yml
 
   # configure lvm
-  bash -c 'ANSIBLE_CONFIG={envdir}/tmp/ceph-ansible/ansible.cfg ansible-playbook -vv -i {changedir}/{env:INVENTORY} {envdir}/tmp/ceph-ansible/tests/functional/lvm_setup.yml --extra-vars "osd_scenario=lvm"'
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml
 
-  # deploy the cluster
-  ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/hosts {envdir}/tmp/ceph-ansible/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
+  non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup=True change_dir={changedir} ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:nautilus} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-nautilus} \
+      ceph_docker_image={env:UPDATE_CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:UPDATE_CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
+      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
   "
 
-  pip install -r {toxinidir}/tests/requirements.txt
-  non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup=True change_dir={changedir} ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --extra-vars "\
       ireallymeanit=yes \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \

--- a/tox.ini
+++ b/tox.ini
@@ -385,8 +385,8 @@ setenv=
   ANSIBLE_STDOUT_CALLBACK = yaml
   non_container: DEV_SETUP = True
   # Set the vagrant box image to use
-  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/7
-  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/atomic-host
+  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
   ubuntu: CEPH_ANSIBLE_VAGRANT_BOX = guits/ubuntu-bionic64
 
   # Set the ansible inventory host file to be used according to which distrib we are running on


### PR DESCRIPTION
Ceph octopus only supports CentOS 8.

This commit adds CentOS 8 support:
- update vagrant image in tox configurations.
- add CentOS 8 repository for el8 dependencies.
- CentOS 8 container engine is podman (same than RHEL 8).
- don't use the epel mirror on sepia because it's epel7 only.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
Co-authored-by: Dimitri Savineau <dsavinea@redhat.com>