### PR TITLE
dashboard: use fqdn url for active alert

### DIFF
--- a/roles/ceph-prometheus/templates/alertmanager.yml.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.yml.j2
@@ -11,5 +11,5 @@ receivers:
 - name: 'ceph-dashboard'
   webhook_configs:
 {% for host in groups['mgrs'] | default(groups['mons']) %}
-  - url: '{{ dashboard_protocol }}://{{ host }}:{{ dashboard_port }}/api/prometheus_receiver'
+  - url: '{{ dashboard_protocol }}://{{ hostvars[host]['ansible_fqdn'] }}:{{ dashboard_port }}/api/prometheus_receiver'
 {% endfor %}


### PR DESCRIPTION
When using the shortname, the URL for active alert launches with short
hostname and fails to connect to the server.

This commit changes the template in order to use the fqdn.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1765485

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>