### PR TITLE
dashboard: run node_export as privileged container

### DIFF
--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -12,6 +12,7 @@ After=network.target
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f node-exporter
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
+  --privileged \
   -v /proc:/host/proc:ro -v /sys:/host/sys:ro \
   --net=host \
   {{ node_exporter_container_image }} \


### PR DESCRIPTION
Typical error:
    
```
type=AVC msg=audit(1575367499.582:3210): avc:  denied  { search } for  pid=26680 comm="node_exporter" name="1" dev="proc" ino=11528 scontext=system_u:system_r:container_t:s0:c100,c1014 tcontext=system_u:system_r:init_t:s0 tclass=dir permissive=0
```
    
node_exporter needs to be run as privileged to avoid avc denied error
since it gathers lot of information on the host.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1762168

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>