### PR TITLE
backport: ceph-rgw-loadbalancer: add option for haproxy ssl frontend

### DIFF
--- a/group_vars/rgwloadbalancers.yml.sample
+++ b/group_vars/rgwloadbalancers.yml.sample
@@ -14,6 +14,17 @@ dummy:
 ###########
 
 #haproxy_frontend_port: 80
+#haproxy_frontend_ssl_port: 443
+#haproxy_frontend_ssl_certificate:
+#haproxy_ssl_dh_param: 4096
+#haproxy_ssl_ciphers:
+#  - EECDH+AESGCM
+#  - EDH+AESGCM
+#haproxy_ssl_options:
+#  - no-sslv3
+#  - no-tlsv10
+#  - no-tlsv11
+#  - no-tls-tickets
 #
 #virtual_ips:
 #   - 192.168.238.250

--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -6,6 +6,17 @@
 ###########
 
 haproxy_frontend_port: 80
+haproxy_frontend_ssl_port: 443
+haproxy_frontend_ssl_certificate:
+haproxy_ssl_dh_param: 4096
+haproxy_ssl_ciphers:
+  - EECDH+AESGCM
+  - EDH+AESGCM
+haproxy_ssl_options:
+  - no-sslv3
+  - no-tlsv10
+  - no-tlsv11
+  - no-tls-tickets
 #
 #virtual_ips:
 #   - 192.168.238.250

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -9,7 +9,11 @@ global
     group       haproxy
     daemon
     stats socket /var/lib/haproxy/stats
-
+{%- if haproxy_frontend_ssl_certificate %}
+    tune.ssl.default-dh-param {{ haproxy_ssl_dh_param }}
+    ssl-default-bind-ciphers {{ haproxy_ssl_ciphers | join(':') }}
+    ssl-default-bind-options {{ haproxy_ssl_options | join(' ') }}
+{% endif %}
 defaults
     mode                    http
     log                     global
@@ -29,7 +33,11 @@ defaults
     maxconn                 8000
 
 frontend rgw-frontend
+{% if haproxy_frontend_ssl_certificate %}
+    bind *:{{ haproxy_frontend_ssl_port }} ssl crt {{ haproxy_frontend_ssl_certificate }}
+{% else %}
     bind *:{{ haproxy_frontend_port }}
+{% endif %}
     default_backend rgw-backend
 
 backend rgw-backend


### PR DESCRIPTION
Backport into stable-4.0

Original PR: https://github.com/ceph/ceph-ansible/pull/4762

Signed-off-by: Stanley Lam <stanleylam_604@hotmail.com>
(cherry picked from commit ad7a5dad3f0b3f731107d3f7f1011dc129135e9a)