### PR TITLE
ceph-rgw-loadbalancer: Modify keepalived master selection

### DIFF
--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -19,10 +19,8 @@
 
 - name: set_fact vip to vrrp_instance
   set_fact:
-      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
+      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item }]) }}"
   loop: "{{ virtual_ips | flatten(levels=1) }}"
-  loop_control:
-      index_var: index
 
 - name: "generate keepalived: configuration file: keepalived.conf"
   template:

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -15,8 +15,8 @@ vrrp_script check_haproxy {
 
 {% for instance in vrrp_instances %}
 vrrp_instance {{ instance['name'] }} {
-    state {{ 'MASTER' if ansible_hostname == instance['master'] else 'BACKUP' }}
-    priority {{ '100' if ansible_hostname == instance['master'] else '90' }}
+    state {{ 'MASTER' if inventory_hostname == groups[rgwloadbalancer_group_name][0] else 'BACKUP' }}
+    priority {{ '100' if inventory_hostname == groups[rgwloadbalancer_group_name][0] else '90' }}
     interface {{ virtual_ip_interface }}
     virtual_router_id {{ 50 + loop.index }}
     advert_int 1


### PR DESCRIPTION
Currently the keepalived template only works when system hostnames exactly match the Ansible inventory name. If these are different, all generated templates become `BACKUP` without a `MASTER` assigned. Using the `inventory_hostname` in the template file resolves this issue.

Signed-off-by: Stanley Lam stanleylam_604@hotmail.com