### PR TITLE
purge: fix symlink to purge-container-cluster

### DIFF
--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -1,1 +1,1 @@
-infrastructure-playbooks/purge-container-cluster.yml
+purge-container-cluster.yml


### PR DESCRIPTION
ceph/ceph-ansible#4805 introduced a symlink to
purge-container-cluster.yml playbook which is broken.

This commit fixes it.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>