### PR TITLE
upgrade: add dashboard deployment

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -710,7 +710,7 @@ dummy:
 #dashboard_protocol: http
 #dashboard_port: 8443
 #dashboard_admin_user: admin
-#dashboard_admin_password: admin
+#dashboard_admin_password: p@ssw0rd
 # We only need this for SSL (https) connections
 #dashboard_crt: ''
 #dashboard_key: ''

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -710,7 +710,7 @@ ceph_docker_registry_auth: true
 #dashboard_protocol: http
 #dashboard_port: 8443
 #dashboard_admin_user: admin
-#dashboard_admin_password: admin
+#dashboard_admin_password: p@ssw0rd
 # We only need this for SSL (https) connections
 #dashboard_crt: ''
 #dashboard_key: ''

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -49,6 +49,7 @@
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ client_group_name|default('clients') }}"
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
+    - "{{ grafana_server_group_name|default('grafana-server') }}"
 
   become: True
   gather_facts: False
@@ -71,6 +72,15 @@
       with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
       run_once: true
       when: delegate_facts_host | bool
+
+    - import_role:
+        name: ceph-facts
+
+    - import_role:
+        name: ceph-infra
+
+    - import_role:
+        name: ceph-validate
 
     - set_fact: rolling_update=true
 
@@ -961,6 +971,10 @@
       vars:
         msgr2_migration: True
 
+- import_playbook: ../dashboard.yml
+  when:
+    - dashboard_enabled | bool
+    - groups.get(grafana_server_group_name, []) | length > 0
 
 - name: show ceph status
   hosts: "{{ mon_group_name|default('mons') }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -874,7 +874,6 @@
         - rbd-target-api
         - rbd-target-gw
         - tcmu-runner
-      when: not containerized_deployment | bool
 
     - import_role:
         name: ceph-defaults
@@ -892,18 +891,6 @@
         name: ceph-config
     - import_role:
         name: ceph-iscsi-gw
-
-    - name: start ceph iscsi services
-      systemd:
-        name: '{{ item }}'
-        state: started
-        enabled: yes
-        masked: no
-      with_items:
-        - tcmu-runner
-        - rbd-target-api
-        - rbd-target-gw
-      when: not containerized_deployment | bool
 
 
 - name: upgrade ceph client node

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -702,7 +702,7 @@ dashboard_enabled: True
 dashboard_protocol: http
 dashboard_port: 8443
 dashboard_admin_user: admin
-dashboard_admin_password: admin
+dashboard_admin_password: p@ssw0rd
 # We only need this for SSL (https) connections
 dashboard_crt: ''
 dashboard_key: ''


### PR DESCRIPTION
when upgrading from RHCS 3, dashboard has obviously never been deployed
and it forces us to deploy it later manually.
This commit adds the dashboard deployment as part of the upgrade to
RHCS 4.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1779092

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>