### PR TITLE
tests: reduce max_mds from 3 to 2

### DIFF
--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -41,4 +41,4 @@ openstack_pools:
 docker_pull_timeout: 600s
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
-mds_max_mds: 3
+mds_max_mds: 2

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -34,4 +34,4 @@ openstack_pools:
   - "{{ openstack_cinder_pool }}"
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
-mds_max_mds: 3
+mds_max_mds: 2


### PR DESCRIPTION
Having max_mds value equals to the number of mds nodes generates a
warning in the ceph cluster status:
```console
cluster:
id:     6d3e49a4-ab4d-4e03-a7d6-58913b8ec00a'
health: HEALTH_WARN'
        insufficient standby MDS daemons available'
(...)
services:
  mds:     cephfs:3 {0=mds1=up:active,1=mds0=up:active,2=mds2=up:active}'
```
Let's use 2 active and 1 standby mds.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>