### PR TITLE
upgrade: add dashboard deployment

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -49,6 +49,7 @@
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ client_group_name|default('clients') }}"
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
+    - "{{ grafana_server_group_name|default('grafana-server') }}"
 
   become: True
   gather_facts: False
@@ -71,6 +72,15 @@
       with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
       run_once: true
       when: delegate_facts_host | bool
+
+    - import_role:
+        name: ceph-facts
+
+    - import_role:
+        name: ceph-infra
+
+    - import_role:
+        name: ceph-validate
 
     - set_fact: rolling_update=true
 
@@ -896,7 +906,6 @@
         - rbd-target-api
         - rbd-target-gw
         - tcmu-runner
-      when: not containerized_deployment | bool
 
     - import_role:
         name: ceph-defaults
@@ -993,6 +1002,10 @@
       vars:
         msgr2_migration: True
 
+- import_playbook: ../dashboard.yml
+  when:
+    - dashboard_enabled | bool
+    - groups.get(grafana_server_group_name, []) | length > 0
 
 - name: show ceph status
   hosts: "{{ mon_group_name|default('mons') }}"


### PR DESCRIPTION
when upgrading from RHCS 3, dashboard has obviously never been deployed
and it forces us to deploy it later manually.
This commit adds the dashboard deployment as part of the upgrade to
RHCS 4.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1779092

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>