### PR TITLE
ceph-defaults: exclude md devices from discovery

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -384,7 +384,7 @@ dummy:
 #osd_objectstore: bluestore
 
 # Any device containing these patterns in their path will be excluded.
-#osd_auto_discovery_exclude: "dm-*|loop*"
+#osd_auto_discovery_exclude: "dm-*|loop*|md*"
 
 # xattrs. by default, 'filestore xattr use omap' is set to 'true' if
 # 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -384,7 +384,7 @@ ceph_iscsi_config_dev: false
 #osd_objectstore: bluestore
 
 # Any device containing these patterns in their path will be excluded.
-#osd_auto_discovery_exclude: "dm-*|loop*"
+#osd_auto_discovery_exclude: "dm-*|loop*|md*"
 
 # xattrs. by default, 'filestore xattr use omap' is set to 'true' if
 # 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -376,7 +376,7 @@ osd_mount_options_xfs: noatime,largeio,inode64,swalloc
 osd_objectstore: bluestore
 
 # Any device containing these patterns in their path will be excluded.
-osd_auto_discovery_exclude: "dm-*|loop*"
+osd_auto_discovery_exclude: "dm-*|loop*|md*"
 
 # xattrs. by default, 'filestore xattr use omap' is set to 'true' if
 # 'osd_mkfs_type' is set to 'ext4'; otherwise it isn't set. This can


### PR DESCRIPTION
The md devices (RAID software) aren't excluded from the devices list in
the auto discovery scenario.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1764601

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>