### PR TITLE
ceph-facts: move ntp/chrony facts to ceph-infra

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -277,30 +277,6 @@
   with_sequence: start=0 end={{ radosgw_num_instances|int - 1 }}
   when: inventory_hostname in groups.get(rgw_group_name, [])
 
-- name: set ntp service name depending on OS family
-  block:
-  - name: set ntp service name for Debian family
-    set_fact:
-      ntp_service_name: ntp
-    when: ansible_os_family == 'Debian'
-
-  - name: set ntp service name for Red Hat family
-    set_fact:
-      ntp_service_name: ntpd
-    when: ansible_os_family in ['RedHat', 'Suse']
-
-- name: set chrony daemon name RedHat and Ubuntu based OSs
-  block:
-    - name: set chronyd daemon name for RedHat based OSs
-      set_fact:
-        chrony_daemon_name: chronyd
-      when: ansible_os_family in ["RedHat", "Suse"]
-
-    - name: set chronyd daemon name for Ubuntu based OSs
-      set_fact:
-        chrony_daemon_name: chrony
-      when: ansible_os_family == "Debian"
-
 - name: set grafana_server_addr fact - ipv4
   set_fact:
     grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}"

--- a/roles/ceph-infra/tasks/setup_ntp.yml
+++ b/roles/ceph-infra/tasks/setup_ntp.yml
@@ -1,4 +1,16 @@
 ---
+- name: set ntp service and chrony daemon name for Debian family
+  set_fact:
+    chrony_daemon_name: chrony
+    ntp_service_name: ntp
+  when: ansible_os_family == 'Debian'
+
+- name: set ntp service and chrony daemon name for RedHat and Suse family
+  set_fact:
+    chrony_daemon_name: chronyd
+    ntp_service_name: ntpd
+  when: ansible_os_family in ['RedHat', 'Suse']
+
 # Installation of NTP daemons needs to be a separate task since installations
 # can't happen on Atomic
 - name: install the ntp daemon


### PR DESCRIPTION
The ntp/chrony facts are only used in the ceph-infra role so we don't
really need to set them in the ceph-facts roles.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>