### PR TITLE
ceph-validate: start with ansible version test

### DIFF
--- a/roles/ceph-validate/tasks/check_iscsi.yml
+++ b/roles/ceph-validate/tasks/check_iscsi.yml
@@ -24,3 +24,22 @@
     - item.status == "present"
     - item.chap
     - " '' in client_connections | selectattr('status', 'match', 'present') | map(attribute='chap') | list"
+
+- name: check if iscsi gateways is target on supported distros and versions
+  block:
+    - name: fail on unsupported distribution for iscsi gateways
+      fail:
+        msg: "iSCSI gateways can only be deployed on Red Hat Enterprise Linux, CentOS or Fedora"
+      when: ansible_distribution not in ['RedHat', 'CentOS', 'Fedora']
+
+    - name: fail on unsupported distribution version for iscsi gateways
+      command: 'grep -q {{ item }}=m {% if is_atomic|bool %}/usr/lib/ostree-boot{% else %}/boot{% endif %}/config-{{ ansible_kernel }}'
+      register: iscsi_kernel
+      changed_when: false
+      failed_when: iscsi_kernel.rc != 0
+      loop:
+        - CONFIG_TARGET_CORE
+        - CONFIG_TCM_USER2
+        - CONFIG_ISCSI_TARGET
+      when: ansible_distribution in ['RedHat', 'CentOS']
+  when: iscsi_gw_group_name in group_names

--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -1,4 +1,16 @@
 ---
+- name: fail on unsupported ansible version (1.X)
+  fail:
+    msg: "Ansible version must be >= 2.8.x, please update!"
+  when: ansible_version.major|int < 2
+
+- name: fail on unsupported ansible version
+  fail:
+    msg: "Ansible version must be 2.8!"
+  when:
+    - ansible_version.major|int == 2
+    - ansible_version.minor|int != 8
+
 - name: fail on unsupported system
   fail:
     msg: "System not supported {{ ansible_system }}"
@@ -53,39 +65,7 @@
     - ansible_distribution == 'openSUSE Leap' or ansible_distribution == 'SUSE'
     - ansible_distribution_major_version != '15'
 
-- name: fail on unsupported ansible version (1.X)
-  fail:
-    msg: "Ansible version must be >= 2.8.x, please update!"
-  when: ansible_version.major|int < 2
-
-- name: fail on unsupported ansible version
-  fail:
-    msg: "Ansible version must be 2.8!"
-  when:
-    - ansible_version.major|int == 2
-    - ansible_version.minor|int != 8
-
 - name: fail if systemd is not present
   fail:
     msg: "Systemd must be present"
   when: ansible_service_mgr != 'systemd'
-
-- name: check if iscsi gateways is target on supported distros and versions
-  block:
-    - name: fail on unsupported distribution for iscsi gateways
-      fail:
-        msg: "iSCSI gateways can only be deployed on Red Hat Enterprise Linux, CentOS or Fedora"
-      when: ansible_distribution not in ['RedHat', 'CentOS', 'Fedora']
-
-    - name: fail on unsupported distribution version for iscsi gateways
-      command: 'grep -q {{ item }}=m {% if is_atomic|bool %}/usr/lib/ostree-boot{% else %}/boot{% endif %}/config-{{ ansible_kernel }}'
-      register: iscsi_kernel
-      changed_when: false
-      failed_when: iscsi_kernel.rc != 0
-      loop:
-        - CONFIG_TARGET_CORE
-        - CONFIG_TCM_USER2
-        - CONFIG_ISCSI_TARGET
-      when: ansible_distribution in ['RedHat', 'CentOS']
-  when: iscsi_gw_group_name in group_names
-

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: include check_system.yml
+  include_tasks: check_system.yml
+
 - name: validate repository variables in non-containerized scenario
   when: not containerized_deployment | bool
   block:
@@ -152,9 +155,6 @@
     - journal_size|int < 5120
     - osd_objectstore == 'filestore'
     - osd_group_name in group_names
-
-- name: include check_system.yml
-  include_tasks: check_system.yml
 
 - name: include check_devices.yml
   include_tasks: check_devices.yml


### PR DESCRIPTION
It doesn't make sense to start validating configuration if the ansible
version isn't the good one.
This commit moves the check_system task as the first task in the
ceph-validate role.
The ansible version test tasks are moved at the top of this file.
Also moving the iscsi kernel tests from check_system to check_iscsi
file.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>