### PR TITLE
switch_to_containers: exclude clients nodes from facts gathering

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -38,12 +38,21 @@
 
   become: true
 
+  vars:
+    delegate_facts_host: True
+
   tasks:
+    - import_role:
+        name: ceph-defaults
+
     - name: gather and delegate facts
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items: "{{ groups['all'] }}"
+      with_items: "{{ groups['all'] | difference(groups.get(client_group_name, [])) }}"
+      run_once: true
+      when: delegate_facts_host | bool
+      tags: always
 
 - name: switching from non-containerized to containerized ceph mon
   vars:


### PR DESCRIPTION
just like site.yml and rolling_update, let's exclude clients node from
the fact gathering.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>