### PR TITLE
ceph-osd: update systemd unit script

### DIFF
--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -5,19 +5,10 @@ After=docker.service
 
 [Service]
 EnvironmentFile=-/etc/environment
-{% if osd_scenario == 'lvm' -%}
 ExecStartPre=-/usr/bin/docker stop ceph-osd-%i
 ExecStartPre=-/usr/bin/docker rm -f ceph-osd-%i
-{% else %}
-ExecStartPre=-/usr/bin/docker stop ceph-osd-{{ ansible_hostname }}-%i
-ExecStartPre=-/usr/bin/docker rm -f ceph-osd-{{ ansible_hostname }}-%i
-{% endif -%}
 ExecStart={{ ceph_osd_docker_run_script_path }}/ceph-osd-run.sh %i
-{% if osd_scenario == 'lvm' -%}
 ExecStop=-/usr/bin/docker stop ceph-osd-%i
-{% else %}
-ExecStop=-/usr/bin/docker stop ceph-osd-{{ ansible_hostname }}-%i
-{% endif -%}
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120


### PR DESCRIPTION
The systemd unit script wasn't updated with the new container name
format (without the hostname).
We now have the same start/stop docker commands for all scenarios.
During the device to id OSD migration we need to be sure that the
old container with the hostname are stopped.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1780688

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>