### PR TITLE
ansible.cfg: do not enforce PreferredAuthentications

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -32,7 +32,7 @@ timeout = 60
 [ssh_connection]
 # see: https://github.com/ansible/ansible/issues/11536
 control_path = %(directory)s/%%h-%%r-%%p
-ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s
 pipelining = True
 
 # Option to retry failed ssh executions if the failure is encountered in ssh itself


### PR DESCRIPTION
There's no need to enforce PreferredAuthentications by default.
Users can still choose to override the ansible.cfg with any additional
parameter like this one to fit their infrastructure.

Fixes: #4826

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>