### PR TITLE
defaults: change monitor|radosgw_address default value

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -326,7 +326,7 @@ dummy:
 # Eg. If you want to specify for each monitor which address the monitor will bind to you can set it in your **inventory host file** by using 'monitor_address' variable.
 # Preference will go to monitor_address if both monitor_address and monitor_interface are defined.
 #monitor_interface: interface
-#monitor_address: 0.0.0.0
+#monitor_address: x.x.x.x
 #monitor_address_block: subnet
 # set to either ipv4 or ipv6, whichever your network is using
 #ip_version: ipv4

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -326,7 +326,7 @@ ceph_iscsi_config_dev: false
 # Eg. If you want to specify for each monitor which address the monitor will bind to you can set it in your **inventory host file** by using 'monitor_address' variable.
 # Preference will go to monitor_address if both monitor_address and monitor_interface are defined.
 #monitor_interface: interface
-#monitor_address: 0.0.0.0
+#monitor_address: x.x.x.x
 #monitor_address_block: subnet
 # set to either ipv4 or ipv6, whichever your network is using
 #ip_version: ipv4

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -318,7 +318,7 @@ rbd_client_admin_socket_path: /var/run/ceph # must be writable by QEMU and allow
 # Eg. If you want to specify for each monitor which address the monitor will bind to you can set it in your **inventory host file** by using 'monitor_address' variable.
 # Preference will go to monitor_address if both monitor_address and monitor_interface are defined.
 monitor_interface: interface
-monitor_address: 0.0.0.0
+monitor_address: x.x.x.x
 monitor_address_block: subnet
 # set to either ipv4 or ipv6, whichever your network is using
 ip_version: ipv4
@@ -413,7 +413,7 @@ radosgw_thread_pool_size: 512
 # Eg. If you want to specify for each radosgw node which address the radosgw will bind to you can set it in your **inventory host file** by using 'radosgw_address' variable.
 # Preference will go to radosgw_address if both radosgw_address and radosgw_interface are defined.
 radosgw_interface: interface
-radosgw_address: 0.0.0.0
+radosgw_address: x.x.x.x
 radosgw_address_block: subnet
 radosgw_keystone_ssl: false # activate this when using keystone PKI keys
 radosgw_num_instances: 1

--- a/roles/ceph-facts/tasks/set_monitor_address.yml
+++ b/roles/ceph-facts/tasks/set_monitor_address.yml
@@ -26,7 +26,7 @@
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
     - hostvars[item]['monitor_address'] is defined
-    - hostvars[item]['monitor_address'] != '0.0.0.0'
+    - hostvars[item]['monitor_address'] != 'x.x.x.x'
 
 - name: set_fact _monitor_address to monitor_interface - ipv4
   set_fact:
@@ -36,7 +36,7 @@
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
     - ip_version == 'ipv4'
     - hostvars[item]['monitor_address_block'] | default('subnet')  == 'subnet'
-    - hostvars[item]['monitor_address'] | default('0.0.0.0') == '0.0.0.0'
+    - hostvars[item]['monitor_address'] | default('x.x.x.x') == 'x.x.x.x'
     - hostvars[item]['monitor_interface'] | default('interface') != 'interface'
 
 - name: set_fact _monitor_address to monitor_interface - ipv6
@@ -47,7 +47,7 @@
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
     - ip_version == 'ipv6'
     - hostvars[item]['monitor_address_block'] | default('subnet')  == 'subnet'
-    - hostvars[item]['monitor_address'] | default('0.0.0.0') == '0.0.0.0'
+    - hostvars[item]['monitor_address'] | default('x.x.x.x') == 'x.x.x.x'
     - hostvars[item]['monitor_interface'] | default('interface') != 'interface'
 
 - name: set_fact _current_monitor_address

--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -20,12 +20,12 @@
     _radosgw_address: "{{ radosgw_address | ipwrap }}"
   when:
     - radosgw_address is defined
-    - radosgw_address != '0.0.0.0'
+    - radosgw_address != 'x.x.x.x'
 
 - name: tasks for radosgw interface
   when:
     - radosgw_address_block == 'subnet'
-    - radosgw_address == '0.0.0.0'
+    - radosgw_address == 'x.x.x.x'
     - radosgw_interface != 'interface'
   block:
   - name: set_fact _interface

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -43,7 +43,7 @@
     msg: "Either monitor_address, monitor_address_block or monitor_interface must be provided"
   when:
     - mon_group_name in group_names
-    - monitor_address == '0.0.0.0'
+    - monitor_address == 'x.x.x.x'
     - monitor_address_block == 'subnet'
     - monitor_interface == 'interface'
 
@@ -52,7 +52,7 @@
     msg: "Either radosgw_address, radosgw_address_block or radosgw_interface must be provided"
   when:
     - rgw_group_name in group_names
-    - radosgw_address == '0.0.0.0'
+    - radosgw_address == 'x.x.x.x'
     - radosgw_address_block == 'subnet'
     - radosgw_interface == 'interface'
 
@@ -168,7 +168,7 @@
   when:
     - mon_group_name in group_names
     - monitor_interface != "dummy"
-    - monitor_address == "0.0.0.0"
+    - monitor_address == "x.x.x.x"
     - monitor_address_block == "subnet"
 
 - name: include check_ipaddr_mon.yml
@@ -176,7 +176,7 @@
   when:
     - mon_group_name in group_names
     - monitor_interface == "interface"
-    - monitor_address == "0.0.0.0"
+    - monitor_address == "x.x.x.x"
     - monitor_address_block != "subnet"
 
 - name: include check_eth_rgw.yml
@@ -184,7 +184,7 @@
   when:
     - rgw_group_name in group_names
     - radosgw_interface != "dummy"
-    - radosgw_address == "0.0.0.0"
+    - radosgw_address == "x.x.x.x"
     - radosgw_address_block == "subnet"
 
 - name: include check_rgw_multisite.yml


### PR DESCRIPTION
To avoid confusion, let's change the default value from `0.0.0.0` to
`x.x.x.x`.
Users might think setting `0.0.0.0` will make the daemon binding on all
interfaces.

Fixes: #4827

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>