### PR TITLE
ceph-facts: set use_new_ceph_iscsi on iscsi nodes

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -316,3 +316,4 @@
 - name: set_fact use_new_ceph_iscsi package or old ceph-iscsi-config/cli
   set_fact:
     use_new_ceph_iscsi: "{{ (gateway_ip_list  == '0.0.0.0' and gateway_iqn | length == 0 and client_connections | length == 0 and rbd_devices | length == 0) | bool | ternary(true, false) }}"
+  when: iscsi_gw_group_name in group_names

--- a/roles/ceph-validate/tasks/check_iscsi.yml
+++ b/roles/ceph-validate/tasks/check_iscsi.yml
@@ -1,4 +1,9 @@
 ---
+- name: fail on unsupported distribution for iscsi gateways
+  fail:
+    msg: "iSCSI gateways can only be deployed on Red Hat Enterprise Linux, CentOS or Fedora"
+  when: ansible_distribution not in ['RedHat', 'CentOS', 'Fedora']
+
 - name: make sure gateway_ip_list is configured
   fail:
     msg: "you must set a list of IPs (comma separated) for gateway_ip_list"
@@ -25,21 +30,13 @@
     - item.chap
     - " '' in client_connections | selectattr('status', 'match', 'present') | map(attribute='chap') | list"
 
-- name: check if iscsi gateways is target on supported distros and versions
-  block:
-    - name: fail on unsupported distribution for iscsi gateways
-      fail:
-        msg: "iSCSI gateways can only be deployed on Red Hat Enterprise Linux, CentOS or Fedora"
-      when: ansible_distribution not in ['RedHat', 'CentOS', 'Fedora']
-
-    - name: fail on unsupported distribution version for iscsi gateways
-      command: 'grep -q {{ item }}=m {% if is_atomic|bool %}/usr/lib/ostree-boot{% else %}/boot{% endif %}/config-{{ ansible_kernel }}'
-      register: iscsi_kernel
-      changed_when: false
-      failed_when: iscsi_kernel.rc != 0
-      loop:
-        - CONFIG_TARGET_CORE
-        - CONFIG_TCM_USER2
-        - CONFIG_ISCSI_TARGET
-      when: ansible_distribution in ['RedHat', 'CentOS']
-  when: iscsi_gw_group_name in group_names
+- name: fail on unsupported distribution version for iscsi gateways
+  command: 'grep -q {{ item }}=m {% if is_atomic|bool %}/usr/lib/ostree-boot{% else %}/boot{% endif %}/config-{{ ansible_kernel }}'
+  register: iscsi_kernel
+  changed_when: false
+  failed_when: iscsi_kernel.rc != 0
+  loop:
+    - CONFIG_TARGET_CORE
+    - CONFIG_TCM_USER2
+    - CONFIG_ISCSI_TARGET
+  when: ansible_distribution in ['RedHat', 'CentOS']


### PR DESCRIPTION
We don't need to set the use_new_ceph_iscsi fact on other nodes than
those present in the iscsigws group.
Also remove the duplicate iscsi_gw_group_name condition already present
on the include_task.
Finally validate the ansible distribution as the first task.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>