### PR TITLE
rgw: remove variable radosgw_num_instances

### DIFF
--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -52,8 +52,7 @@
 
 - name: set_fact rgw_instances with rgw multisite
   set_fact:
-    rgw_instances: "{{ rgw_instances|default([]) | union([{'instance_name': 'rgw' + item|string, 'radosgw_address': _radosgw_address, 'radosgw_frontend_port': radosgw_frontend_port|int, 'rgw_realm': rgw_realm|string, 'rgw_zonegroup': rgw_zonegroup|string, 'rgw_zone': rgw_zone|string}]) }}"
-  with_sequence: start=0 end={{ radosgw_num_instances|int - 1 }}
+    rgw_instances: "{{ rgw_instances|default([]) | union([{'instance_name': inventory_hostname, 'radosgw_address': _radosgw_address, 'radosgw_frontend_port': radosgw_frontend_port|int, 'rgw_realm': rgw_realm|string, 'rgw_zonegroup': rgw_zonegroup|string, 'rgw_zone': rgw_zone|string}]) }}"
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])
     - rgw_multisite | bool

--- a/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
@@ -3,7 +3,7 @@
 RETRIES="{{ handler_health_rgw_check_retries }}"
 DELAY="{{ handler_health_rgw_check_delay }}"
 HOST_NAME="{{ ansible_hostname }}"
-RGW_NUMS={{ radosgw_num_instances }}
+INSTANCE_NAME="{{ inventory_hostname }}"
 RGW_BASE_PORT={{ radosgw_frontend_port }}
 RGW_FRONTEND_SSL_CERT={{ radosgw_frontend_ssl_certificate }}
 if [ -n "$RGW_FRONTEND_SSL_CERT" ]; then
@@ -11,43 +11,40 @@ if [ -n "$RGW_FRONTEND_SSL_CERT" ]; then
 else
     RGW_PROTOCOL=http
 fi
-declare -a DOCKER_EXECS
-for ((i=0; i<${RGW_NUMS}; i++)); do
-  DOCKER_EXECS[i]=""
+declare -a DOCKER_EXEC
+DOCKER_EXEC=""
 {% if containerized_deployment | bool %}
-  CONTAINER_NAME="ceph-rgw-${HOST_NAME}-rgw${i}"
-  DOCKER_EXECS[i]="{{ container_binary }} exec ${CONTAINER_NAME}"
+  CONTAINER_NAME="ceph-rgw-${HOST_NAME}-${INSTANCE_NAME}"
+  DOCKER_EXEC="{{ container_binary }} exec ${CONTAINER_NAME}"
 {% endif %}
-done
+
 RGW_IP={{ hostvars[inventory_hostname]['_radosgw_address'] }}
-SOCKET_PREFIX="/var/run/ceph/{{ cluster }}-client.rgw.${HOST_NAME}.rgw"
+SOCKET_PREFIX="/var/run/ceph/{{ cluster }}-client.rgw.${HOST_NAME}.${INSTANCE_NAME}"
 
 check_socket() {
-  local i=$1
   local succ=0
   local count=10
   # Wait and ensure the socket exists after restarting the daemon
   while [ $count -ne 0 ]; do
-    SOCKET=$(grep ${SOCKET_PREFIX}${i} /proc/net/unix | awk '{ print $8 }')
+    SOCKET=$(grep ${SOCKET_PREFIX} /proc/net/unix | awk '{ print $8 }')
     if [ -n "${SOCKET}" ]; then
-      ${DOCKER_EXECS[i]} test -S ${SOCKET} && succ=$((succ+1)) && break
+      ${DOCKER_EXEC} test -S ${SOCKET} && succ=$((succ+1)) && break
     fi
     sleep $DELAY
     let count=count-1
   done
   if [ $succ -ne 1 ]; then
     echo "Socket file ${SOCKET} could not be found, which means Rados Gateway is not running. Showing ceph-rgw unit logs now:"
-    journalctl -u ceph-radosgw@rgw.${HOST_NAME}.rgw${i}
+    journalctl -u ceph-radosgw@rgw.${HOST_NAME}.${INSTANCE_NAME}
     exit 1
   fi
 }
 
 check_for_curl_or_wget() {
-  local i=$1
-  if ${DOCKER_EXECS[i]} command -v wget &>/dev/null; then
-    rgw_test_command="wget --no-check-certificate --tries 1 --quiet -O /dev/null"
-  elif ${DOCKER_EXECS[i]} command -v curl &>/dev/null; then
-    rgw_test_command="curl -k --fail --silent --output /dev/null"
+  if ${DOCKER_EXEC} command -v wget &>/dev/null; then
+    rgw_test_command="wget --no-check-certificate --tries 10 --quiet -O /dev/null"
+  elif ${DOCKER_EXEC} command -v curl &>/dev/null; then
+    rgw_test_command="curl -k --fail --silent --retry 10 --output /dev/null"
   else
     echo "It seems that neither curl nor wget are available on your system."
     echo "Cannot test rgw connection."
@@ -56,26 +53,23 @@ check_for_curl_or_wget() {
 }
 
 check_rest() {
-  local i=$1
-  check_for_curl_or_wget ${i}
+  check_for_curl_or_wget
   local succ=0
   while [ $RETRIES -ne 0 ]; do
-    ${DOCKER_EXECS[i]} $rgw_test_command $RGW_PROTOCOL://$RGW_IP:$((RGW_BASE_PORT+i)) && succ=$((succ+1)) && break
+    ${DOCKER_EXEC} $rgw_test_command $RGW_PROTOCOL://$RGW_IP:$RGW_BASE_PORT && succ=$((succ+1)) && break
     sleep $DELAY
     let RETRIES=RETRIES-1
   done
   if [ $succ -ne 1 ]; then
     # If we reach this point, it means there is a problem with the connection to rgw
-    echo "Error connecting locally to Rados Gateway service: $RGW_PROTOCOL://$RGW_IP:$((RGW_BASE_PORT+i))"
+    echo "Error connecting locally to Rados Gateway service: $RGW_PROTOCOL://$RGW_IP:$RGW_BASE_PORT"
     exit 1
   fi
 }
 
-for ((i=0; i<${RGW_NUMS}; i++)); do
-  # First, restart the daemon
-  systemctl restart ceph-radosgw@rgw.${HOST_NAME}.rgw${i}
-  # Check socket files
-  check_socket ${i}
-  # Check rest
-  check_rest ${i}
-done
+# First, restart the daemon
+systemctl restart ceph-radosgw@rgw.${HOST_NAME}.${INSTANCE_NAME}
+# Check socket files
+check_socket
+# Check rest
+check_rest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,6 @@ def node(host, request):
     rolling_update = os.environ.get("ROLLING_UPDATE", "False")
     group_names = ansible_vars["group_names"]
     docker = ansible_vars.get("docker")
-    radosgw_num_instances = ansible_vars.get("radosgw_num_instances", 1)
     ceph_release_num = {
         'jewel': 10,
         'kraken': 11,
@@ -140,7 +139,6 @@ def node(host, request):
         ceph_stable_release=ceph_stable_release,
         ceph_release_num=ceph_release_num,
         rolling_update=rolling_update,
-        radosgw_num_instances=radosgw_num_instances,
     )
     return data
 

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -6,7 +6,6 @@ docker: True
 containerized_deployment: True
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
-radosgw_num_instances: 2
 ceph_mon_docker_subnet: "{{ public_network }}"
 ceph_docker_on_openstack: False
 public_network: "192.168.15.0/24"

--- a/tests/functional/tests/rgw/test_rgw.py
+++ b/tests/functional/tests/rgw/test_rgw.py
@@ -12,17 +12,17 @@ class TestRGWs(object):
         assert result
 
     def test_rgw_service_enabled_and_running(self, node, host):
-        for i in range(int(node["radosgw_num_instances"])):
-            service_name = "ceph-radosgw@rgw.{hostname}.rgw{seq}".format(
-                hostname=node["vars"]["inventory_hostname"],
-                seq=i
-            )
-            s = host.service(service_name)
-            assert s.is_enabled
-            assert s.is_running
+        service_name = "ceph-radosgw@rgw.{hostname}.{instance_name}".format(
+            hostname=node["vars"]["inventory_hostname"],
+            hostname=node["vars"]["instance_name"]
+        )
+        s = host.service(service_name)
+        assert s.is_enabled
+        assert s.is_running
 
     def test_rgw_is_up(self, node, host, setup):
-        hostname = node["vars"]["inventory_hostname"]
+        hostname = node["vars"]["ansible_hostname"]
+        inventory_hostname = node["vars"]["inventory_hostname"]
         cluster = setup["cluster_name"]
         container_binary = setup["container_binary"]
         if node['docker']:
@@ -38,19 +38,17 @@ class TestRGWs(object):
         output = host.check_output(cmd)
         daemons = [i for i in json.loads(
             output)["servicemap"]["services"]["rgw"]["daemons"]]
-        for i in range(int(node["radosgw_num_instances"])):
-            instance_name = "{hostname}.rgw{seq}".format(
-                hostname=hostname,
-                seq=i
-            )
-            assert instance_name in daemons
+        instance_name = "{hostname}.{inventory_hostname}".format(
+            hostname=hostname,
+            inventory_hostname=inventory_hostname
+        )
+        assert instance_name in daemons
 
     @pytest.mark.no_docker
     def test_rgw_http_endpoint(self, node, host, setup):
         # rgw frontends ip_addr is configured on public_interface
         ip_addr = host.interface(setup['public_interface']).addresses[0]
-        for i in range(int(node["radosgw_num_instances"])):
-            assert host.socket(
-                "tcp://{ip_addr}:{port}".format(ip_addr=ip_addr,
-                                                port=(8080+i))
-            ).is_listening  # noqa E501
+        assert host.socket(
+            "tcp://{ip_addr}:{port}".format(ip_addr=ip_addr,
+                                                port=(8080))
+        ).is_listening  # noqa E501


### PR DESCRIPTION
Change the existing rgw naming conventions to use
the inventory_hostname instead of rgw+{radosgw_num_instance}.

This allows multiple rgws to be declared in the
inventory on the same host but with a different
port.

Signed-off-by: Ali Maredia <amaredia@redhat.com>