### PR TITLE
yum plugin priorities should only for centos

### DIFF
--- a/roles/ceph-common/tasks/installs/redhat_community_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_community_repository.yml
@@ -5,6 +5,7 @@
   register: result
   until: result is succeeded
   tags: with_pkg
+  when: ansible_distribution == 'CentOS'
 
 - name: configure red hat ceph community repository stable key
   rpm_key:


### PR DESCRIPTION
Fedora will execute this command
but yum plugin priorities could not be found in fedora, and this package is not needed in fedora
so this command should only for centos