### PR TITLE
ceph-infra: open dashboard port on monitor

### DIFF
--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -201,7 +201,8 @@
     when:
       - dashboard_enabled | bool
       - mgr_group_name is defined
-      - mgr_group_name in group_names
+      - (groups.get(mgr_group_name,[]) | length > 0 and mgr_group_name in group_names) or
+        (groups.get(mgr_group_name,[]) | length == 0 and mon_group_name in group_names)
 
   - block:
       - name: open grafana port

--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -173,64 +173,9 @@
       - iscsi_gw_group_name in group_names
     tags: firewall
 
-  - name: open node_exporter port
-    firewalld:
-      port: "{{ node_exporter_port }}/tcp"
-      zone: "{{ ceph_dashboard_firewall_zone }}"
-      permanent: true
-      immediate: true
-      state: enabled
+  - name: open dashboard ports
+    include_tasks: dashboard_firewall.yml
     when: dashboard_enabled | bool
-
-  - block:
-      - name: open dashboard port
-        firewalld:
-          port: "{{ dashboard_port }}/tcp"
-          zone: "{{ ceph_dashboard_firewall_zone }}"
-          permanent: true
-          immediate: true
-          state: enabled
-
-      - name: open mgr/prometheus port
-        firewalld:
-          port: "9283/tcp"
-          zone: "{{ ceph_dashboard_firewall_zone }}"
-          permanent: true
-          immediate: true
-          state: enabled
-    when:
-      - dashboard_enabled | bool
-      - mgr_group_name is defined
-      - (groups.get(mgr_group_name,[]) | length > 0 and mgr_group_name in group_names) or
-        (groups.get(mgr_group_name,[]) | length == 0 and mon_group_name in group_names)
-
-  - block:
-      - name: open grafana port
-        firewalld:
-          port: "{{ grafana_port }}/tcp"
-          zone: "{{ ceph_dashboard_firewall_zone }}"
-          permanent: true
-          immediate: true
-          state: enabled
-
-      - name: open prometheus port
-        firewalld:
-          port: "{{ prometheus_port }}/tcp"
-          zone: "{{ ceph_dashboard_firewall_zone }}"
-          permanent: true
-          immediate: true
-          state: enabled
-
-      - name: open alertmanager port
-        firewalld:
-          port: "{{ alertmanager_port }}/tcp"
-          zone: "{{ ceph_dashboard_firewall_zone }}"
-          permanent: true
-          immediate: true
-          state: enabled
-    when:
-      - dashboard_enabled | bool
-      - inventory_hostname in groups.get('grafana-server', [])
 
   - name: open haproxy ports
     firewalld:

--- a/roles/ceph-infra/tasks/dashboard_firewall.yml
+++ b/roles/ceph-infra/tasks/dashboard_firewall.yml
@@ -52,4 +52,6 @@
         permanent: true
         immediate: true
         state: enabled
-  when: inventory_hostname in groups.get('grafana-server', [])
+  when:
+    - grafana_server_group_name is defined
+    - grafana_server_group_name in group_names

--- a/roles/ceph-infra/tasks/dashboard_firewall.yml
+++ b/roles/ceph-infra/tasks/dashboard_firewall.yml
@@ -1,0 +1,55 @@
+---
+- name: open node_exporter port
+  firewalld:
+    port: "{{ node_exporter_port }}/tcp"
+    zone: "{{ ceph_dashboard_firewall_zone }}"
+    permanent: true
+    immediate: true
+    state: enabled
+
+- block:
+    - name: open dashboard port
+      firewalld:
+        port: "{{ dashboard_port }}/tcp"
+        zone: "{{ ceph_dashboard_firewall_zone }}"
+        permanent: true
+        immediate: true
+        state: enabled
+
+    - name: open mgr/prometheus port
+      firewalld:
+        port: "9283/tcp"
+        zone: "{{ ceph_dashboard_firewall_zone }}"
+        permanent: true
+        immediate: true
+        state: enabled
+  when:
+    - mgr_group_name is defined
+    - (groups.get(mgr_group_name,[]) | length > 0 and mgr_group_name in group_names) or
+      (groups.get(mgr_group_name,[]) | length == 0 and mon_group_name in group_names)
+
+- block:
+    - name: open grafana port
+      firewalld:
+        port: "{{ grafana_port }}/tcp"
+        zone: "{{ ceph_dashboard_firewall_zone }}"
+        permanent: true
+        immediate: true
+        state: enabled
+
+    - name: open prometheus port
+      firewalld:
+        port: "{{ prometheus_port }}/tcp"
+        zone: "{{ ceph_dashboard_firewall_zone }}"
+        permanent: true
+        immediate: true
+        state: enabled
+
+    - name: open alertmanager port
+      firewalld:
+        port: "{{ alertmanager_port }}/tcp"
+        zone: "{{ ceph_dashboard_firewall_zone }}"
+        permanent: true
+        immediate: true
+        state: enabled
+  when: inventory_hostname in groups.get('grafana-server', [])


### PR DESCRIPTION
When there's no mgr group defined in the ansible inventory then the
mgrs are deployed implicitly on the mons nodes.
If the dashboard is enabled then we need to open the dashboard port on
the node that is running the ceph mgr process (mgr or mon).
The current code only allow to open that port on the mgr nodes when they
are present explicitly in the inventory but not implicitly.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1783520

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>