### PR TITLE
[stable-3.2] switch_to_containers: set GUID on lockbox part

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -224,6 +224,33 @@
         - /usr/lib/systemd/system/ceph-volume@.service
         - /etc/systemd/system/ceph.target.wants
 
+    - name: dmcrypt extra operations
+      when:
+        - osd_scenario != 'lvm'
+        - dmcrypt | bool
+      block:
+        - name: remove zero(s) partuuid symlink
+          file:
+            path: /dev/disk/by-partuuid/00000000-0000-0000-0000-000000000000
+            state: absent
+
+        - name: get lockbox partitions
+          command: blkid -t PARTLABEL="ceph lockbox" -o device
+          changed_when: false
+          failed_when: false
+          register: lockbox_partitions
+
+        - name: get lockbox devices without partuuid
+          command: "blkid -t PARTUUID=00000000-0000-0000-0000-000000000000 -o device {{ item }}"
+          changed_when: false
+          failed_when: false
+          register: lockbox_devices
+          with_items: '{{ lockbox_partitions.stdout_lines }}'
+
+        - name: set guid on lockbox partition
+          shell: 'sgdisk --partition-guid=5:$(uuidgen) {{ item.stdout[:-2] if item.stdout is match("^/dev/(cciss|nvme|loop).*") else item.stdout[:-1] }}'
+          with_items: '{{ lockbox_devices.results }}'
+
     - set_fact:
         ceph_uid: 64045
       when: ceph_docker_image_tag | string is match("latest") or ceph_docker_image_tag | string is search("ubuntu")


### PR DESCRIPTION
The ceph lockbox partition (part number 5) used with non lvm scenarios
and in non containerized deployment don't have a valid PARTUUID.
The value is set to 00000000-0000-0000-0000-000000000000 for each OSD
devices.
```console
$ blkid -t PARTLABEL="ceph lockbox" -o value -s PARTUUID
00000000-0000-0000-0000-000000000000
00000000-0000-0000-0000-000000000000
00000000-0000-0000-0000-000000000000
00000000-0000-0000-0000-000000000000
00000000-0000-0000-0000-000000000000
```
When switching to containerized deployment we manually mount the lockbox
partition by using the PARTUUID.
Unfortunately because we have most of the time multiple OSD on the same
node we can't have the right symlink in /dev/disk/by-partuuid because it
will point to only one partition.

```console
/dev/disk/by-partuuid/00000000-0000-0000-0000-000000000000 -> ../../sdb5
```

After the switch_to_containers playbook then only one OSD will restart
correctly and the other will try to access to the wrong device causing
error like 'xxxx is still in use'.

When deploying with containers and dmcrypt OSDs we force a PARTUUID
value during the ceph-disk prepare task.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1616159

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>