### PR TITLE
[stable-3.2] ceph-mds: allow directory fragmentation

### DIFF
--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -40,6 +40,14 @@
   when:
     - check_existing_cephfs.rc != 0
 
+- name: allow directory fragmentation
+  command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} fs set {{ cephfs }} allow_dirfrags true --yes-i-really-mean-it"
+  changed_when: false
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  when:
+    - ceph_release_num[ceph_release] == ceph_release_num.luminous
+    - rolling_update | bool
+
 - name: allow multimds
   command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} fs set {{ cephfs }} allow_multimds true --yes-i-really-mean-it"
   changed_when: false


### PR DESCRIPTION
We need to explicitly enable the allow_dirfrags flag on cephfs pool
after upgrading to Luminous.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1776233

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>