### PR TITLE
filestore-to-bluestore: umount partitions before zapping them

### DIFF
--- a/infrastructure-playbooks/filestore-to-bluestore.yml
+++ b/infrastructure-playbooks/filestore-to-bluestore.yml
@@ -84,6 +84,24 @@
             - "{{ partlabel.results }}"
           when: item.1.stdout == 'ceph data'
 
+        - name: umount osd data
+          mount:
+            path: "/var/lib/ceph/osd/{{ cluster }}-{{ (item.0.stdout | from_json).whoami }}"
+            state: unmounted
+          with_together:
+            - "{{ simple_scan.results }}"
+            - "{{ partlabel.results }}"
+          when: item.1.stdout == 'ceph data'
+
+        - name: umount osd lockbox
+          mount:
+            path: "/var/lib/ceph/osd-lockbox/{{ (item.0.stdout | from_json).data.uuid }}"
+            state: unmounted
+          with_together:
+            - "{{ simple_scan.results }}"
+            - "{{ partlabel.results }}"
+          when: item.1.stdout == 'ceph data'
+
         - name: ensure dmcrypt for data device is closed
           command: cryptsetup close "{{ (item.0.stdout | from_json).data.uuid }}"
           with_together:


### PR DESCRIPTION
When an OSD is stopped, it leaves partitions mounted.
We must umount them before zapping them, otherwise error like "Device is
busy" will show up.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1729267

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>