### PR TITLE
Revert "nfs: do not run privileged nfs container"

### DIFF
--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -18,6 +18,10 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -v /etc/ganesha:/etc/ganesha:z \
   -v /var/run/ceph:/var/run/ceph:z \
   -v /var/log/ceph:/var/log/ceph:z \
+  {% if ceph_nfs_dynamic_exports %}
+  --privileged \
+  -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket \
+  {% endif -%}
   -v /etc/localtime:/etc/localtime:ro \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=NFS \


### PR DESCRIPTION
This reverts commit d06158e9d9ab4a706ca72a4940e7acb5fc25697d.

Otherwise ganesha consumers can't dynamically update exports using dbus.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1784562