### PR TITLE
handler: fix bug

### DIFF
--- a/roles/ceph-handler/tasks/handler_mdss.yml
+++ b/roles/ceph-handler/tasks/handler_mdss.yml
@@ -14,7 +14,7 @@
 - name: restart ceph mds daemon(s)
   command: /usr/bin/env bash /tmp/restart_mds_daemon.sh
   when:
-    - handler_mds_status | bool
+    - hostvars[item]['handler_mds_status'] | default(False) | bool
     - hostvars[item]['_mds_handler_called'] | default(False) | bool
   with_items: "{{ groups[mds_group_name] }}"
   delegate_to: "{{ item }}"

--- a/roles/ceph-handler/tasks/handler_mgrs.yml
+++ b/roles/ceph-handler/tasks/handler_mgrs.yml
@@ -14,7 +14,7 @@
 - name: restart ceph mgr daemon(s)
   command: /usr/bin/env bash /tmp/restart_mgr_daemon.sh
   when:
-    - handler_mgr_status | bool
+    - hostvars[item]['handler_mgr_status'] | default(False) | bool
     - hostvars[item]['_mgr_handler_called'] | default(False) | bool
   with_items: "{{ groups[mgr_group_name] }}"
   delegate_to: "{{ item }}"

--- a/roles/ceph-handler/tasks/handler_mons.yml
+++ b/roles/ceph-handler/tasks/handler_mons.yml
@@ -18,7 +18,7 @@
   command: /usr/bin/env bash /tmp/restart_mon_daemon.sh
   when:
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - handler_mon_status | bool
+    - hostvars[item]['handler_mon_status'] | default(False) | bool
     - hostvars[item]['_mon_handler_called'] | default(False) | bool
   with_items: "{{ groups[mon_group_name] }}"
   delegate_to: "{{ item }}"

--- a/roles/ceph-handler/tasks/handler_nfss.yml
+++ b/roles/ceph-handler/tasks/handler_nfss.yml
@@ -14,7 +14,7 @@
 - name: restart ceph nfs daemon(s)
   command: /usr/bin/env bash /tmp/restart_nfs_daemon.sh
   when:
-    - handler_nfs_status | bool
+    - hostvars[item]['handler_nfs_status'] | default(False) | bool
     - hostvars[item]['_nfs_handler_called'] | default(False) | bool
   with_items: "{{ groups[nfs_group_name] }}"
   delegate_to: "{{ item }}"

--- a/roles/ceph-handler/tasks/handler_osds.yml
+++ b/roles/ceph-handler/tasks/handler_osds.yml
@@ -20,7 +20,7 @@
 - name: restart ceph osds daemon(s)
   command: /usr/bin/env bash /tmp/restart_osd_daemon.sh
   when:
-    - handler_osd_status | bool
+    - hostvars[item]['handler_osd_status'] | default(False) | bool
     - handler_health_osd_check | bool
     - hostvars[item]['_osd_handler_called'] | default(False) | bool
   with_items: "{{ groups[osd_group_name] | intersect(ansible_play_batch) }}"

--- a/roles/ceph-handler/tasks/handler_rbdmirrors.yml
+++ b/roles/ceph-handler/tasks/handler_rbdmirrors.yml
@@ -14,7 +14,7 @@
 - name: restart ceph rbd mirror daemon(s)
   command: /usr/bin/env bash /tmp/restart_rbd_mirror_daemon.sh
   when:
-    - handler_rbd_mirror_status | bool
+    - hostvars[item]['handler_rbd_mirror_status'] | default(False) | bool
     - hostvars[item]['_rbdmirror_handler_called'] | default(False) | bool
   with_items: "{{ groups[rbdmirror_group_name] }}"
   delegate_to: "{{ item }}"

--- a/roles/ceph-handler/tasks/handler_rgws.yml
+++ b/roles/ceph-handler/tasks/handler_rgws.yml
@@ -14,7 +14,7 @@
 - name: restart ceph rgw daemon(s)
   command: /usr/bin/env bash /tmp/restart_rgw_daemon.sh
   when:
-    - handler_rgw_status | bool
+    - hostvars[item]['handler_rgw_status'] | default(False) | bool
     - hostvars[item]['_rgw_handler_called'] | default(False) | bool
   with_items: "{{ groups[rgw_group_name] }}"
   delegate_to: "{{ item }}"


### PR DESCRIPTION
411bd07d54fc3f585296b68f2fd04484328399b5 introduced a bug in handlers

using `handler_*_status` instead of `hostvars[item]['handler_*_status']`
causes handlers to be triggered in anycase even though
`handler_*_status` was set to `False` on a specific node.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1622688

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>