### PR TITLE
dashboard: use fqdn in external url

### DIFF
--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -23,6 +23,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=alertmanager \
   {{ alertmanager_container_image }} \
   --config.file=/etc/alertmanager/alertmanager.yml \
   --storage.path=/alertmanager \
+  --web.external-url=http://{{ ansible_fqdn }}:{{ alertmanager_port }}/ \
   --web.listen-address=:{{ alertmanager_port }}
 ExecStop=/usr/bin/{{ container_binary }} stop alertmanager
 Restart=always

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=prometheus \
   {{ prometheus_container_image }} \
   --config.file=/etc/prometheus/prometheus.yml \
   --storage.tsdb.path=/prometheus \
-  --web.external-url=http://{{ inventory_hostname }}:{{ prometheus_port }}/ \
+  --web.external-url=http://{{ ansible_fqdn }}:{{ prometheus_port }}/ \
   --web.listen-address=:{{ prometheus_port }}
 ExecStop=/usr/bin/{{ container_binary }} stop prometheus
 Restart=always


### PR DESCRIPTION
Force fqdn to be used in external url for prometheus and alertmanager.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1765485

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>