### PR TITLE
purge-cluster.yml: fix purge cluster failed when node-exporter image does not exist

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -154,6 +154,7 @@
 
     - name: remove node-exporter image
       command: "{{ container_binary }} rmi {{ node_exporter_container_image }}"
+      failed_when: false
       tags:
         - remove_img
 


### PR DESCRIPTION
This commit fix purge cluster failed when node-exporter image does not exist
Signed-off-by: wujie1993 qq594jj@gmail.com