### PR TITLE
purge-cluster.yml: fix purge cluster failed

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -154,6 +154,7 @@
 
     - name: remove node-exporter image
       command: "{{ container_binary }} rmi {{ node_exporter_container_image }}"
+      failed_when: false
       tags:
         - remove_img
 


### PR DESCRIPTION
fix purge cluster failed when the image of node-exporter does not exist

Signed-off-by: wujie1993 <qq594jj@gmail.com>