### PR TITLE
ceph-rgw: Fix custom pool size setting

### DIFF
--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -35,7 +35,7 @@
       run_once: true
 
     - name: customize pool size
-      command: "{{ container_exec_cmd }} ceph --connect-timeout 5 --cluster {{ cluster }} osd pool set {{ item.key }} size {{ item.size | default(osd_pool_default_size) }}"
+      command: "{{ container_exec_cmd }} ceph --connect-timeout 5 --cluster {{ cluster }} osd pool set {{ item.key }} size {{ item.value.size | default(osd_pool_default_size) }}"
       with_dict: "{{ rgw_create_pools }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false


### PR DESCRIPTION
RadosGW pools can be created by setting

```yaml
rgw_create_pools:
  .rgw.root:
    pg_num: 512
    size: 2
```

for instance. However, doing so would create pools of size
`osd_pool_default_size` regardless of the `size` value. This was due to
the fact that the Ansible task used

```
{{ item.size | default(osd_pool_default_size) }}
```

as the pool size value, but `item.size` is always undefined; the
correct variable is `item.value.size`.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>