### PR TITLE
ceph-grafana: Add ceph_grafana_docker_extra_env option

### DIFF
--- a/roles/ceph-grafana/defaults/main.yml
+++ b/roles/ceph-grafana/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+##########
+# DOCKER #
+##########
+
+ceph_grafana_docker_extra_env:

--- a/roles/ceph-grafana/templates/grafana-server.service.j2
+++ b/roles/ceph-grafana/templates/grafana-server.service.j2
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=grafana-server \
   --memory={{ grafana_container_memory }}GB \
   --memory-swap={{ grafana_container_memory * 2 }}GB \
   -e GF_INSTALL_PLUGINS={{ grafana_plugins|join(',') }} \
+  {{ ceph_grafana_docker_extra_env }} \
   {{ grafana_container_image }}
 ExecStop=-/usr/bin/{{ container_binary }} stop grafana-server
 Restart=always


### PR DESCRIPTION
This can be used to pass extra environment variables to the Grafana
container.

For instance, `HTTP_PROXY` and `HTTPS_PROXY` can be set if Grafana needs
to use an HTTP proxy to download its plugins:

```yaml
ceph_grafana_docker_extra_env:
  -e HTTP_PROXY=http://192.0.2.1 -e HTTPS_PROXY=http://192.0.2.1
```

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>