### PR TITLE
ceph-iscsi: manage ipv6 in trusted_ip_list

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -204,12 +204,21 @@
         - api_secure | default(false) | bool
         - generate_crt | default(false) | bool
 
-    - name: add iscsi gateways
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-add {{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_default_ipv4']['address'] }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+    - name: add iscsi gateways - ipv4
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-add {{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}:{{ hostvars[item]['api_port'] | default(5000) }}"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       with_items: "{{ groups[iscsi_gw_group_name] }}"
       run_once: true
+      when: ip_version == 'ipv4'
+
+    - name: add iscsi gateways - ipv6
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-add {{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+      changed_when: false
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      with_items: "{{ groups[iscsi_gw_group_name] }}"
+      run_once: true
+      when: ip_version == 'ipv6'
 
 - name: inject grafana dashboard layouts
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard grafana dashboards update"

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -22,11 +22,21 @@
     - cephx | bool
     - item.item.copy_key | bool
 
-- name: add mgr ip address to trusted list with dashboard
+- name: add mgr ip address to trusted list with dashboard - ipv4
   set_fact:
     trusted_ip_list: '{{ trusted_ip_list }},{{ hostvars[item]["ansible_all_ipv4_addresses"] | ips_in_ranges(public_network.split(",")) | first }}'
   with_items: '{{ groups[mgr_group_name] | default(groups[mon_group_name]) }}'
-  when: dashboard_enabled | bool
+  when:
+    - dashboard_enabled | bool
+    - ip_version == 'ipv4'
+
+- name: add mgr ip address to trusted list with dashboard - ipv6
+  set_fact:
+    trusted_ip_list: '{{ trusted_ip_list }},{{ hostvars[item]["ansible_all_ipv6_addresses"] | ips_in_ranges(public_network.split(",")) | last | ipwrap }}'
+  with_items: '{{ groups[mgr_group_name] | default(groups[mon_group_name]) }}'
+  when:
+    - dashboard_enabled | bool
+    - ip_version == 'ipv6'
 
 - name: deploy gateway settings, used by the ceph_iscsi_config modules
   config_template:


### PR DESCRIPTION
Only the ipv4 addresses from the nodes running the dashboard mgr module
were added to the trusted_ip_list configuration file on the iscsigws
nodes.
This also add the iscsi gateways with ipv6 configuration to the ceph
dashboard.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1787531

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>