### PR TITLE
shrink-mds: do not play ceph-facts entirely

### DIFF
--- a/infrastructure-playbooks/shrink-mds.yml
+++ b/infrastructure-playbooks/shrink-mds.yml
@@ -21,6 +21,7 @@
         name: ceph-defaults
     - import_role:
         name: ceph-facts
+        tasks_from: container_binary
 
 - name: perform checks, remove mds and print cluster health
   hosts: localhost


### PR DESCRIPTION
We only need to set `container_binary`.
Let's use `tasks_from` option.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>