### PR TITLE
ceph-nfs: add ganesha_t type to selinux

### DIFF
--- a/roles/ceph-nfs/tasks/ganesha_selinux_fix.yml
+++ b/roles/ceph-nfs/tasks/ganesha_selinux_fix.yml
@@ -17,17 +17,16 @@
       until: result is succeeded
       when: ansible_distribution_major_version == '7'
 
+    - name: install nfs-ganesha-selinux and python3-policycoreutils on RHEL 8
+      package:
+        name: ['nfs-ganesha-selinux', 'python3-policycoreutils']
+        state: present
+      register: result
+      until: result is succeeded
+      when: ansible_distribution_major_version == '8'
+
     - name: add ganesha_t to permissive domain
       selinux_permissive:
         name: ganesha_t
         permissive: true
       failed_when: false
-      when: ansible_distribution_major_version == '7'
-
-    - name: install nfs-ganesha-selinux on RHEL 8
-      package:
-        name: nfs-ganesha-selinux
-        state: present
-      register: result
-      until: result is succeeded
-      when: ansible_distribution_major_version == '8'


### PR DESCRIPTION
Since RHEL 8.1 we need to add the ganesha_t type to the permissive
SELinux list.
Otherwise the nfs-ganesha service won't start.
This was done on RHEL 7 previously and part of the nfs-ganesha-selinux
package on RHEL 8.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1786110

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit d75812529069244734732d05cc5aa3ddbc99b7c5)