### PR TITLE
config: exclude ceph-disk prepared osds in lvm batch report

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -15,31 +15,54 @@
       num_osds: "{{ lvm_volumes | length | int }}"
     when: lvm_volumes | default([]) | length > 0
 
-  - name: run 'ceph-volume lvm batch --report' to see how many osds are to be created
-    ceph_volume:
-      cluster: "{{ cluster }}"
-      objectstore: "{{ osd_objectstore }}"
-      batch_devices: "{{ devices }}"
-      osds_per_device: "{{ osds_per_device | default(1) | int }}"
-      journal_size: "{{ journal_size }}"
-      block_db_size: "{{ block_db_size }}"
-      report: true
-      action: "batch"
-    register: lvm_batch_report
-    environment:
-      CEPH_VOLUME_DEBUG: 1
-      CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-      CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-      PYTHONIOENCODING: utf-8
-    changed_when: false
-    when: devices | default([]) | length > 0
+  - block:
+      - name: look up for ceph-volume rejected devices
+        ceph_volume:
+          cluster: "{{ cluster }}"
+          action: "inventory"
+        register: rejected_devices
+        environment:
+          CEPH_VOLUME_DEBUG: 1
+          CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+          CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+          PYTHONIOENCODING: utf-8
+
+      - name: set_fact rejected_devices
+        set_fact:
+          _rejected_devices: "{{ _rejected_devices | default([]) + [item.path] }}"
+        with_items: "{{ rejected_devices.stdout | default('{}') | from_json }}"
+        when: "'Used by ceph-disk' in item.rejected_reasons"
+
+      - name: set_fact _devices
+        set_fact:
+          _devices: "{{ devices | difference(_rejected_devices | default([])) }}"
+
+      - name: run 'ceph-volume lvm batch --report' to see how many osds are to be created
+        ceph_volume:
+          cluster: "{{ cluster }}"
+          objectstore: "{{ osd_objectstore }}"
+          batch_devices: "{{ _devices }}"
+          osds_per_device: "{{ osds_per_device | default(1) | int }}"
+          journal_size: "{{ journal_size }}"
+          block_db_size: "{{ block_db_size }}"
+          report: true
+          action: "batch"
+        register: lvm_batch_report
+        environment:
+          CEPH_VOLUME_DEBUG: 1
+          CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+          CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+          PYTHONIOENCODING: utf-8
+        when: _devices | default([]) | length > 0
+    when:
+      - devices | default([]) | length > 0
 
   - name: set_fact num_osds from the output of 'ceph-volume lvm batch --report'
     set_fact:
-      num_osds: "{{ (lvm_batch_report.stdout | from_json).osds | length | int }}"
+      num_osds: "{{ ((lvm_batch_report.stdout | default('{}') | from_json).osds | default([]) | length | int) + (_rejected_devices | default([]) | length | int) }}"
     when:
       - devices | default([]) | length > 0
-      - (lvm_batch_report.stdout | from_json).changed
+      - (lvm_batch_report.stdout | default('{}') | from_json).changed | default(true) | bool
 
   - name: run 'ceph-volume lvm list' to see how many osds have already been created
     ceph_volume:
@@ -53,14 +76,14 @@
     changed_when: false
     when:
       - devices | default([]) | length > 0
-      - not (lvm_batch_report.stdout | from_json).changed
+      - not (lvm_batch_report.stdout | default('{}') | from_json).changed | default(false) | bool
 
   - name: set_fact num_osds from the output of 'ceph-volume lvm list'
     set_fact:
-      num_osds: "{{ lvm_list.stdout | from_json | length | int }}"
+      num_osds: "{{ lvm_list.stdout | default('{}') | from_json | length | int }}"
     when:
       - devices | default([]) | length > 0
-      - not (lvm_batch_report.stdout | from_json).changed
+      - not (lvm_batch_report.stdout | default('{}') | from_json).changed | default(false) | bool
 
 # ceph-common
 - name: config file operation for non-containerized scenarios


### PR DESCRIPTION
We must exclude the devices already used and prepared by ceph-disk when
doing the lvm batch report. Otherwise it fails because ceph-volume
complains about GPT header.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1786682

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>