### PR TITLE
rolling_update: run registry auth before upgrading

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -80,6 +80,13 @@
         name: ceph-infra
 
     - import_role:
+        name: ceph-container-common
+        tasks_from: registry
+      when:
+        - containerized_deployment | bool
+        - ceph_docker_registry_auth | bool
+
+    - import_role:
         name: ceph-validate
 
     - set_fact: rolling_update=true


### PR DESCRIPTION
There's some tasks using the new container image during the rolling
upgrade playbook that needs to execute the registry login first otherwise
the nodes won't be able to pull the container image.
```console
Unable to find image 'xxx.io/foo/bar:latest' locally
Trying to pull repository xxx.io/foo/bar ...
/usr/bin/docker-current: Get https://xxx.io/v2/foo/bar/manifests/latest:
unauthorized
```
Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>