### PR TITLE
containers: use --cpus instead --cpu-quota

### DIFF
--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -61,16 +61,6 @@
     - import_role:
         name: ceph-handler
 
-    - name: get docker version
-      command: docker --version
-      changed_when: false
-      check_mode: no
-      register: ceph_docker_version
-
-    - name: set_fact ceph_docker_version ceph_docker_version.stdout.split
-      set_fact:
-        ceph_docker_version: "{{ ceph_docker_version.stdout.split(' ')[2] }}"
-
 
   tasks:
     - import_role:

--- a/roles/ceph-container-common/tasks/main.yml
+++ b/roles/ceph-container-common/tasks/main.yml
@@ -2,19 +2,6 @@
 - name: include prerequisites.yml
   include_tasks: prerequisites.yml
 
-- name: get docker version
-  block:
-    - name: get docker version
-      command: docker --version
-      changed_when: false
-      check_mode: no
-      register: ceph_docker_version
-
-    - name: set_fact ceph_docker_version ceph_docker_version.stdout.split
-      set_fact:
-        ceph_docker_version: "{{ ceph_docker_version.stdout.split(' ')[2] }}"
-  when: container_binary == 'docker'
-
 - name: include registry.yml
   include_tasks: registry.yml
   when: ceph_docker_registry_auth | bool

--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -12,11 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-api
 ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-api
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --memory={{ ceph_rbd_target_api_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_rbd_target_api_docker_cpu_limit }} \
-  {% else -%}
-  --cpu-quota={{ ceph_rbd_target_api_docker_cpu_limit * 100000 }} \
-  {% endif -%}
   -v /etc/localtime:/etc/localtime:ro \
   --privileged \
   --cap-add=ALL \

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -12,11 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-gw
 ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-gw
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --memory={{ ceph_rbd_target_gw_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_rbd_target_gw_docker_cpu_limit }} \
-  {% else -%}
-  --cpu-quota={{ ceph_rbd_target_gw_docker_cpu_limit * 100000 }} \
-  {% endif -%}
   -v /etc/localtime:/etc/localtime:ro \
   --privileged \
   --cap-add=ALL \

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -12,11 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop tcmu-runner
 ExecStartPre=-/usr/bin/{{ container_binary }} rm tcmu-runner
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --memory={{ ceph_tcmu_runner_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_tcmu_runner_docker_cpu_limit }} \
-  {% else -%}
-  --cpu-quota={{ ceph_tcmu_runner_docker_cpu_limit * 100000 }} \
-  {% endif -%}
   -v /etc/localtime:/etc/localtime:ro \
   --privileged \
   --net=host \

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -13,11 +13,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mds-{{ ansible_hostname 
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mds-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_mds_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ cpu_limit }} \
-  {% else -%}
-  --cpu-quota={{ cpu_limit * 100000 }} \
-  {% endif -%}
   -v /var/lib/ceph:/var/lib/ceph:z \
   -v /etc/ceph:/etc/ceph:z \
   -v /var/run/ceph:/var/run/ceph:z \

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -12,11 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mgr-{{ ansible_hostname 
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mgr-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_mgr_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_mgr_docker_cpu_limit }} \
-  {% else -%}
-  --cpu-quota={{ ceph_mgr_docker_cpu_limit * 100000 }} \
-  {% endif -%}
   -v /var/lib/ceph:/var/lib/ceph:z \
   -v /etc/ceph:/etc/ceph:z \
   -v /var/run/ceph:/var/run/ceph:z \

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -12,11 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mon-%i
 ExecStartPre=/bin/sh -c '"$(command -v mkdir)" -p /etc/ceph /var/lib/ceph/mon'
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
   --memory={{ ceph_mon_docker_memory_limit }} \
-{% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_mon_docker_cpu_limit }} \
-{% else -%}
-  --cpu-quota={{ ceph_mon_docker_cpu_limit * 100000 }} \
-{% endif -%}
   -v /var/lib/ceph:/var/lib/ceph:z \
   -v /etc/ceph:/etc/ceph:z \
   -v /var/run/ceph:/var/run/ceph:z \

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -20,11 +20,7 @@ numactl \
   {% if osd_objectstore == 'filestore' -%}
   --memory={{ ceph_osd_docker_memory_limit }} \
   {% endif -%}
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ cpu_limit }} \
-  {% else -%}
-  --cpu-quota={{ cpu_limit * 100000 }} \
-  {% endif -%}
   {% if ceph_osd_docker_cpuset_cpus is defined -%}
   --cpuset-cpus='{{ ceph_osd_docker_cpuset_cpus }}' \
   {% endif -%}

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -12,11 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rbd-mirror-{{ ansible_ho
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_rbd_mirror_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_rbd_mirror_docker_cpu_limit }} \
-  {% else -%}
-  --cpu-quota={{ ceph_rbd_mirror_docker_cpu_limit * 100000 }} \
-  {% endif -%}
   -v /var/lib/ceph:/var/lib/ceph:z \
   -v /etc/ceph:/etc/ceph:z \
   -v /var/run/ceph:/var/run/ceph:z \

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -13,11 +13,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rgw-{{ ansible_hostname 
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_rgw_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ cpu_limit }} \
-  {% else -%}
-  --cpu-quota={{ cpu_limit * 100000 }} \
-  {% endif -%}
   {% if ceph_rgw_docker_cpuset_cpus is defined -%}
   --cpuset-cpus="{{ ceph_rgw_docker_cpuset_cpus }}" \
   {% endif -%}


### PR DESCRIPTION
When using docker 1.13.1, the current condition:

```
{% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
```

is wrong because it compares the first digit (1) whereas it should
compare the second one.
It means we always use `--cpu-quota` although documentation recommend
using `--cpus` when docker version is 1.13.1 or higher.

From the doc:
> --cpu-quota=<value>	Impose a CPU CFS quota on the container. The number of
> microseconds per --cpu-period that the container is limited to before
> throttled. As such acting as the effective ceiling.
> If you use Docker 1.13 or higher, use --cpus instead.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>