### PR TITLE
purge-iscsi-gateways: don't run all ceph-facts

### DIFF
--- a/infrastructure-playbooks/purge-iscsi-gateways.yml
+++ b/infrastructure-playbooks/purge-iscsi-gateways.yml
@@ -78,6 +78,12 @@
       block:
         - import_role:
             name: ceph-facts
+            tasks_from: container_binary
+
+        - name: set_fact container_exec_cmd
+          set_fact:
+            container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ ansible_hostname }}"
+          when: containerized_deployment | bool
 
         - name: get iscsi gateway list
           command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-list -f json"


### PR DESCRIPTION
We only need to have the container_binary fact. Because we're not
gathering the facts from all nodes then the purge fails trying to get
one of the grafana fact.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1786686

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>