### PR TITLE
tests/setup: update mount options on EL 8

### DIFF
--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -22,11 +22,9 @@
       mount:
         path: '{{ rootmount.mount }}'
         src: '{{ rootmount.device }}'
-        opts: noatime,nodiratime,nobarrier
+        opts: 'noatime,nodiratime{% if ansible_os_family == "RedHat" and ansible_distribution_major_version | int < 8 %},nobarrier{% endif %}'
         fstype: '{{ rootmount.fstype }}'
         state: mounted
-      when: not (ansible_os_family == 'RedHat' and
-                 ansible_distribution_major_version == '8')
 
       # we need to install this so the Socket testinfra module
       # can use netcat for testing


### PR DESCRIPTION
The nobarrier mount flag doesn't exist anymoer on XFS in the EL 8
kernel. That's why the task wasn't working on those systems.
We can still use the other options instead of skipping the task.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>