### PR TITLE
facts: fix osp/ceph external use case

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -38,84 +38,87 @@
     monitor_name: "{{ ansible_fqdn }}"
   when: mon_use_fqdn | bool
 
-- name: set_fact container_exec_cmd
-  set_fact:
-    container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] if not rolling_update else hostvars[mon_host | default(groups[mon_group_name][0])]['ansible_hostname'] }}"
-  when:
-    - containerized_deployment | bool
-    - groups.get(mon_group_name, []) | length > 0
+- name: find a running monitor
+  when: groups.get(mon_group_name, []) | length > 0
+  block:
+    - name: set_fact container_exec_cmd
+      set_fact:
+        container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] if not rolling_update else hostvars[mon_host | default(groups[mon_group_name][0])]['ansible_hostname'] }}"
+      when:
+        - containerized_deployment | bool
 
-- name: find a running mon container
-  command: "{{ container_binary }} ps -q --filter name=ceph-mon-{{ hostvars[item]['ansible_hostname'] }}"
-  register: find_running_mon_container
-  failed_when: false
-  run_once: true
-  delegate_to: "{{ item }}"
-  with_items: "{{ groups.get(mon_group_name, []) }}"
-  when: containerized_deployment | bool
+    - name: find a running mon container
+      command: "{{ container_binary }} ps -q --filter name=ceph-mon-{{ hostvars[item]['ansible_hostname'] }}"
+      register: find_running_mon_container
+      failed_when: false
+      run_once: true
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups.get(mon_group_name, []) }}"
+      when:
+        - containerized_deployment | bool
 
-- name: check for a ceph mon socket
-  shell: stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-mon*.asok
-  changed_when: false
-  failed_when: false
-  check_mode: no
-  register: mon_socket_stat
-  run_once: true
-  delegate_to: "{{ item }}"
-  with_items: "{{ groups.get(mon_group_name, []) }}"
-  when: not containerized_deployment | bool
+    - name: check for a ceph mon socket
+      shell: stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-mon*.asok
+      changed_when: false
+      failed_when: false
+      check_mode: no
+      register: mon_socket_stat
+      run_once: true
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups.get(mon_group_name, []) }}"
+      when:
+        - not containerized_deployment | bool
 
-- name: check if the ceph mon socket is in-use
-  command: grep -q {{ item.stdout }} /proc/net/unix
-  changed_when: false
-  failed_when: false
-  check_mode: no
-  register: mon_socket
-  run_once: true
-  with_items: "{{ mon_socket_stat.results }}"
-  when:
-    - not containerized_deployment | bool
-    - item.rc == 0
+    - name: check if the ceph mon socket is in-use
+      command: grep -q {{ item.stdout }} /proc/net/unix
+      changed_when: false
+      failed_when: false
+      check_mode: no
+      register: mon_socket
+      run_once: true
+      with_items: "{{ mon_socket_stat.results }}"
+      when:
+        - not containerized_deployment | bool
+        - item.rc == 0
 
-- name: set_fact running_mon - non_container
-  set_fact:
-    running_mon: "{{ hostvars[item.item.item]['inventory_hostname'] }}"
-  with_items: "{{ mon_socket.results }}"
-  run_once: true
-  when:
-    - not containerized_deployment | bool
-    - item.rc is defined
-    - item.rc == 1
+    - name: set_fact running_mon - non_container
+      set_fact:
+        running_mon: "{{ hostvars[item.item.item]['inventory_hostname'] }}"
+      with_items: "{{ mon_socket.results }}"
+      run_once: true
+      when:
+        - not containerized_deployment | bool
+        - item.rc is defined
+        - item.rc == 1
 
-- name: set_fact running_mon - container
-  set_fact:
-    running_mon: "{{ item.item }}"
-  run_once: true
-  with_items: "{{ find_running_mon_container.results }}"
-  when:
-    - containerized_deployment | bool
-    - item.stdout_lines | default([]) | length > 0
+    - name: set_fact running_mon - container
+      set_fact:
+        running_mon: "{{ item.item }}"
+      run_once: true
+      with_items: "{{ find_running_mon_container.results }}"
+      when:
+        - containerized_deployment | bool
+        - item.stdout_lines | default([]) | length > 0
 
-- name: set_fact _container_exec_cmd
-  set_fact:
-    _container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] if running_mon is undefined else running_mon }}"
-  when:
-    - containerized_deployment | bool
+    - name: set_fact _container_exec_cmd
+      set_fact:
+        _container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] if running_mon is undefined else running_mon }}"
+      when:
+        - containerized_deployment | bool
 
-# this task shouldn't run in a rolling_update situation
-# because it blindly picks a mon, which may be down because
-# of the rolling update
-- name: is ceph running already?
-  command: "{{ timeout_command }} {{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json"
-  changed_when: false
-  failed_when: false
-  check_mode: no
-  register: ceph_current_status
-  run_once: true
-  delegate_to: "{{ groups[mon_group_name][0] if running_mon is undefined else running_mon }}"
-  when:
-    - not rolling_update | bool
-    - groups.get(mon_group_name, []) | length > 0
+    # this task shouldn't run in a rolling_update situation
+    # because it blindly picks a mon, which may be down because
+    # of the rolling update
+    - name: is ceph running already?
+      command: "{{ timeout_command }} {{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json"
+      changed_when: false
+      failed_when: false
+      check_mode: no
+      register: ceph_current_status
+      run_once: true
+      delegate_to: "{{ groups[mon_group_name][0] if running_mon is undefined else running_mon }}"
+      when:
+        - not rolling_update | bool
 
 # set this as a default when performing a rolling_update
 # so the rest of the tasks here will succeed


### PR DESCRIPTION
d6da508a9b6829d2d0633c7200efdffce14f403f broke the osp/ceph external use case.

We must skip these tasks when no monitor is present in the inventory.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1790508

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>