### PR TITLE
ceph-facts: move grafana fact to dedicated file

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -58,6 +58,10 @@
         name: ceph-facts
       tags: ['ceph_update_config']
     - import_role:
+        name: ceph-facts
+        tasks_from: grafana
+      tags: ['ceph_update_config']
+    - import_role:
         name: ceph-prometheus
     - import_role:
         name: ceph-grafana
@@ -91,6 +95,10 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-facts
+      tags: ['ceph_update_config']
+    - import_role:
+        name: ceph-facts
+        tasks_from: grafana
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-dashboard

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -334,42 +334,6 @@
   with_sequence: start=0 end={{ radosgw_num_instances|int - 1 }}
   when: inventory_hostname in groups.get(rgw_group_name, [])
 
-- name: set grafana_server_addr fact - ipv4
-  set_fact:
-    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}"
-  when:
-    - groups.get(grafana_server_group_name, []) | length > 0
-    - ip_version == 'ipv4'
-    - dashboard_enabled | bool
-    - inventory_hostname in groups[grafana_server_group_name]
-
-- name: set grafana_server_addr fact - ipv6
-  set_fact:
-    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}"
-  when:
-    - groups.get(grafana_server_group_name, []) | length > 0
-    - ip_version == 'ipv6'
-    - dashboard_enabled | bool
-    - inventory_hostname in groups[grafana_server_group_name]
-
-- name: set grafana_server_addr fact - ipv4 - (external instance)
-  set_fact:
-    grafana_server_addr: "{{ hostvars[groups.get(grafana_server_group_name, []) | first]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}"
-  when:
-    - groups.get(grafana_server_group_name, []) | length > 0
-    - ip_version == 'ipv4'
-    - dashboard_enabled | bool
-    - inventory_hostname not in groups[grafana_server_group_name]
-
-- name: set grafana_server_addr fact - ipv6 - (external instance)
-  set_fact:
-    grafana_server_addr: "{{ hostvars[groups.get(grafana_server_group_name, []) | first]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}"
-  when:
-    - groups.get(grafana_server_group_name, []) | length > 0
-    - ip_version == 'ipv6'
-    - dashboard_enabled | bool
-    - inventory_hostname not in groups[grafana_server_group_name]
-
 - name: set_fact use_new_ceph_iscsi package or old ceph-iscsi-config/cli
   set_fact:
     use_new_ceph_iscsi: "{{ (gateway_ip_list  == '0.0.0.0' and gateway_iqn | length == 0 and client_connections | length == 0 and rbd_devices | length == 0) | bool | ternary(true, false) }}"

--- a/roles/ceph-facts/tasks/grafana.yml
+++ b/roles/ceph-facts/tasks/grafana.yml
@@ -1,0 +1,35 @@
+- name: set grafana_server_addr fact - ipv4
+  set_fact:
+    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}"
+  when:
+    - groups.get(grafana_server_group_name, []) | length > 0
+    - ip_version == 'ipv4'
+    - dashboard_enabled | bool
+    - inventory_hostname in groups[grafana_server_group_name]
+
+- name: set grafana_server_addr fact - ipv6
+  set_fact:
+    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}"
+  when:
+    - groups.get(grafana_server_group_name, []) | length > 0
+    - ip_version == 'ipv6'
+    - dashboard_enabled | bool
+    - inventory_hostname in groups[grafana_server_group_name]
+
+- name: set grafana_server_addr fact - ipv4 - (external instance)
+  set_fact:
+    grafana_server_addr: "{{ hostvars[groups.get(grafana_server_group_name, []) | first]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}"
+  when:
+    - groups.get(grafana_server_group_name, []) | length > 0
+    - ip_version == 'ipv4'
+    - dashboard_enabled | bool
+    - inventory_hostname not in groups[grafana_server_group_name]
+
+- name: set grafana_server_addr fact - ipv6 - (external instance)
+  set_fact:
+    grafana_server_addr: "{{ hostvars[groups.get(grafana_server_group_name, []) | first]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}"
+  when:
+    - groups.get(grafana_server_group_name, []) | length > 0
+    - ip_version == 'ipv6'
+    - dashboard_enabled | bool
+    - inventory_hostname not in groups[grafana_server_group_name]


### PR DESCRIPTION
We don't need to execute the grafana fact everytime but only during
the dashboard deployment.
Especially for ceph-grafana, ceph-prometheus and ceph-dashboard roles.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1790303

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>