### PR TITLE
osd: ensure osd ids collected are well restarted

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -40,7 +40,7 @@
     enabled: yes
     masked: no
     daemon_reload: yes
-  with_items: "{{ ((ceph_osd_ids.stdout | from_json).keys() | list) if not containerized_deployment else osd_ids_non_container.stdout_lines }}"
+  with_items: "{{ ((ceph_osd_ids.stdout | default('{}') | from_json).keys() | list) + osd_ids_non_container.stdout_lines | default([]) }}"
 
 - name: ensure systemd service override directory exists
   file:


### PR DESCRIPTION
This commit refact the condition in the loop of that task so all
potential osd ids found are well started.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1790212

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>