### PR TITLE
osd: use _devices fact in lvm batch scenario

### DIFF
--- a/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
@@ -4,7 +4,7 @@
   ceph_volume:
     cluster: "{{ cluster }}"
     objectstore: "{{ osd_objectstore }}"
-    batch_devices: "{{ devices }}"
+    batch_devices: "{{ _devices }}"
     dmcrypt: "{{ dmcrypt|default(omit) }}"
     crush_device_class: "{{ crush_device_class|default(omit) }}"
     osds_per_device: "{{ osds_per_device }}"
@@ -18,3 +18,4 @@
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     PYTHONIOENCODING: utf-8
+  when: _devices | default([]) | length > 0


### PR DESCRIPTION
since fd1718f3796312e29cd5fd64fcc46826741303d2, we must use `_devices`
when deploying with lvm batch scenario.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>