### PR TITLE
ceph-iscsi: don't use bracket with trusted_ip_list

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -32,7 +32,7 @@
 
 - name: add mgr ip address to trusted list with dashboard - ipv6
   set_fact:
-    trusted_ip_list: '{{ trusted_ip_list }},{{ hostvars[item]["ansible_all_ipv6_addresses"] | ips_in_ranges(public_network.split(",")) | last | ipwrap }}'
+    trusted_ip_list: '{{ trusted_ip_list }},{{ hostvars[item]["ansible_all_ipv6_addresses"] | ips_in_ranges(public_network.split(",")) | last }}'
   with_items: '{{ groups[mgr_group_name] | default(groups[mon_group_name]) }}'
   when:
     - dashboard_enabled | bool


### PR DESCRIPTION
The trusted_ip_list parameter for the rbd-target-api service doesn't
support ipv6 address with bracket.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1787531

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>