### PR TITLE
container: move lvm2 package installation

### DIFF
--- a/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
@@ -23,10 +23,12 @@
   tags:
     with_pkg
 
-- name: install container package
+- name: install container and lvm2 packages
   package:
-    name: ['{{ container_package_name }}', '{{ container_binding_name }}']
+    name: ['{{ container_package_name }}', '{{ container_binding_name }}', 'lvm2']
     update_cache: true
+  register: result
+  until: result is succeeded
   tags: with_pkg
 
 - name: start container service

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -26,14 +26,6 @@
     - ceph_osd_numactl_opts | length > 0
   tags: with_pkg
 
-- name: install lvm2
-  package:
-    name: lvm2
-  register: result
-  until: result is succeeded
-  when: not is_atomic | bool
-  tags: with_pkg
-
 - name: include_tasks common.yml
   include_tasks: common.yml
 


### PR DESCRIPTION
Before this patch, the lvm2 package installation was done during the
ceph-osd role.
However we were running ceph-volume command in the ceph-config role
before ceph-osd. If lvm2 wasn't installed then the ceph-volume command
fails:
```console
error checking path "/run/lock/lvm": stat /run/lock/lvm: no such file or
directory
```
This wasn't visible before because lvm2 was automatically installed as
docker dependency but it's not the same for podman on CentOS 8.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit de8f2a9f83194e465d10207c7ae0569700345b9c)