### PR TITLE
drop use_fqdn variables

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -330,7 +330,6 @@ dummy:
 #monitor_address_block: subnet
 # set to either ipv4 or ipv6, whichever your network is using
 #ip_version: ipv4
-#mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 
 #mon_host_v1:
 #  enabled: True
@@ -395,7 +394,6 @@ dummy:
 
 ## MDS options
 #
-#mds_use_fqdn: false # if set to true, the MDS name used will be the fqdn in the ceph.conf
 #mds_max_mds: 1
 
 ## Rados Gateway options
@@ -833,7 +831,6 @@ dummy:
 # DEPRECATION #
 ###############
 
-#use_fqdn_yes_i_am_sure: false
 
 
 ######################################################

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -330,7 +330,6 @@ ceph_iscsi_config_dev: false
 #monitor_address_block: subnet
 # set to either ipv4 or ipv6, whichever your network is using
 #ip_version: ipv4
-#mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 
 #mon_host_v1:
 #  enabled: True
@@ -395,7 +394,6 @@ ceph_iscsi_config_dev: false
 
 ## MDS options
 #
-#mds_use_fqdn: false # if set to true, the MDS name used will be the fqdn in the ceph.conf
 #mds_max_mds: 1
 
 ## Rados Gateway options
@@ -833,7 +831,6 @@ alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alert
 # DEPRECATION #
 ###############
 
-#use_fqdn_yes_i_am_sure: false
 
 
 ######################################################

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -26,9 +26,7 @@ osd crush chooseleaf type = 0
 
 {% if nb_mon > 0 and inventory_hostname in groups.get(mon_group_name, []) %}
 mon initial members = {% for host in groups[mon_group_name] %}
-      {% if hostvars[host]['ansible_fqdn'] is defined and mon_use_fqdn -%}
-        {{ hostvars[host]['ansible_fqdn'] }}
-      {%- elif hostvars[host]['ansible_hostname'] is defined -%}
+      {% if hostvars[host]['ansible_hostname'] is defined -%}
         {{ hostvars[host]['ansible_hostname'] }}
       {%- endif %}
       {%- if not loop.last %},{% endif %}

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -322,7 +322,6 @@ monitor_address: x.x.x.x
 monitor_address_block: subnet
 # set to either ipv4 or ipv6, whichever your network is using
 ip_version: ipv4
-mon_use_fqdn: false # if set to true, the MON name used will be the fqdn in the ceph.conf
 
 mon_host_v1:
   enabled: True
@@ -387,7 +386,6 @@ filestore_xattr_use_omap: null
 
 ## MDS options
 #
-mds_use_fqdn: false # if set to true, the MDS name used will be the fqdn in the ceph.conf
 mds_max_mds: 1
 
 ## Rados Gateway options
@@ -825,7 +823,6 @@ client_connections: {}
 # DEPRECATION #
 ###############
 
-use_fqdn_yes_i_am_sure: false
 
 
 ######################################################

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -31,12 +31,6 @@
 - name: set_fact monitor_name ansible_hostname
   set_fact:
     monitor_name: "{{ ansible_hostname }}"
-  when: not mon_use_fqdn | bool
-
-- name: set_fact monitor_name ansible_fqdn
-  set_fact:
-    monitor_name: "{{ ansible_fqdn }}"
-  when: mon_use_fqdn | bool
 
 - name: find a running monitor
   when: groups.get(mon_group_name, []) | length > 0
@@ -180,12 +174,6 @@
 - name: set_fact mds_name ansible_hostname
   set_fact:
     mds_name: "{{ ansible_hostname }}"
-  when: not mds_use_fqdn | bool
-
-- name: set_fact mds_name ansible_fqdn
-  set_fact:
-    mds_name: "{{ ansible_fqdn }}"
-  when: mds_use_fqdn | bool
 
 - name: set_fact rbd_client_directory_owner ceph
   set_fact:

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -89,13 +89,6 @@
         - item.data is undefined
       with_items: '{{ lvm_volumes }}'
 
-- name: warning deprecation for fqdn configuration
-  fail:
-    msg: "fqdn configuration is not supported anymore. Use 'use_fqdn_yes_i_am_sure: true' if you really want to use it. See release notes for more details"
-  when:
-    - mon_use_fqdn | bool or mds_use_fqdn | bool
-    - not use_fqdn_yes_i_am_sure | bool
-
 - name: debian based systems tasks
   when: ansible_os_family == 'Debian'
   block:


### PR DESCRIPTION
This has been deprecated in the previous releases. Let's drop it.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>