### PR TITLE
shrink-mds: fix condition on fs deletion

### DIFF
--- a/infrastructure-playbooks/shrink-mds.yml
+++ b/infrastructure-playbooks/shrink-mds.yml
@@ -149,7 +149,9 @@
     - name: delete the filesystem when killing last mds
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} fs rm --yes-i-really-mean-it {{ cephfs }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
-      when: (ceph_status.stdout | from_json)['fsmap']['up'] | int == 1
+      when:
+        - (ceph_status.stdout | from_json)['fsmap']['up'] | int == 0
+        - (ceph_status.stdout | from_json)['fsmap']['up:standby'] | int == 0
 
     - name: purge mds store
       file:


### PR DESCRIPTION
the new ceph status registered in `ceph_status` will report `fsmap.up` =
0 when it's the last mds given that it's done after we shrink the mds,
it means the condition is wrong.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1787543

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>