### PR TITLE
remove container_exec_cmd_mgr fact

### DIFF
--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -56,10 +56,10 @@
           - { 'name': "mgr.{{ ansible_hostname }}", 'path': "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring", 'copy_key': true }
 
     - name: get keys from monitors
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      command: "{{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
       register: _mgr_keys
       with_items: "{{ _mgr_keys }}"
-      delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+      delegate_to: "{{ running_mon }}"
       when:
         - cephx | bool
         - item.copy_key | bool

--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -1,7 +1,11 @@
 ---
 - name: set_fact container_exec_cmd
   set_fact:
-    container_exec_cmd_mgr: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
+    container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[item]['ansible_hostname'] }}"
+  with_items: "{{ groups.get(mon_group_name, []) }}"
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  run_once: true
   when: containerized_deployment | bool
 
 - name: include common.yml

--- a/roles/ceph-mgr/tasks/mgr_modules.yml
+++ b/roles/ceph-mgr/tasks/mgr_modules.yml
@@ -5,7 +5,7 @@
   when: dashboard_enabled | bool
 
 - name: wait for all mgr to be up
-  command: "{{ container_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr dump -f json"
+  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} mgr dump -f json"
   register: mgr_dump
   retries: 30
   delay: 5
@@ -16,7 +16,7 @@
     - (mgr_dump.stdout | from_json).available | bool
 
 - name: get enabled modules from ceph-mgr
-  command: "{{ container_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} --format json mgr module ls"
+  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} --format json mgr module ls"
   check_mode: no
   changed_when: false
   register: _ceph_mgr_modules
@@ -31,13 +31,13 @@
     _disabled_ceph_mgr_modules: "{% if _ceph_mgr_modules.disabled_modules | length == 0 %}[]{% elif _ceph_mgr_modules.disabled_modules[0] | type_debug != 'dict' %}{{ _ceph_mgr_modules['disabled_modules'] }}{% else %}{{ _ceph_mgr_modules['disabled_modules'] | map(attribute='name') | list }}{% endif %}"
 
 - name: disable ceph mgr enabled modules
-  command: "{{ container_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module disable {{ item }}"
+  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} mgr module disable {{ item }}"
   with_items: "{{ _ceph_mgr_modules.get('enabled_modules', []) }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when: item not in ceph_mgr_modules
 
 - name: add modules to ceph-mgr
-  command: "{{ container_exec_cmd_mgr | default('') }} ceph --cluster {{ cluster }} mgr module enable {{ item }}"
+  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} mgr module enable {{ item }}"
   with_items: "{{ ceph_mgr_modules }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when: (item in _disabled_ceph_mgr_modules or _disabled_ceph_mgr_modules == [])


### PR DESCRIPTION
Iterating over all monitors in order to delegate a `
{{ container_binary }}` fails when collocating mgrs with mons, because
ceph-facts reset `container_exec_cmd` to point to the first member of
the monitor group.

The idea is to force `container_exec_cmd` to be reset in ceph-mgr.
This commit also removes the `container_exec_cmd_mgr` fact.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1791282

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>