### PR TITLE
vagrant: temp workaround for CentOS 8 cloud image

### DIFF
--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+vagrant box add --provider libvirt --name centos/8 https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-Vagrant-8.1.1911-20200113.3.x86_64.vagrant-libvirt.box
+
 retries=0
 until [ $retries -ge 5 ]
 do

--- a/tox-filestore_to_bluestore.ini
+++ b/tox-filestore_to_bluestore.ini
@@ -38,7 +38,7 @@ setenv=
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/filestore-to-bluestore{env:CONTAINER_DIR:}
 commands=
-  vagrant up --no-provision {posargs:--provider=virtualbox}
+  bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/setup.yml

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -38,7 +38,7 @@ setenv=
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
 commands=
-  vagrant up --no-provision {posargs:--provider=virtualbox}
+  bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/setup.yml

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ setenv=
   ANSIBLE_STDOUT_CALLBACK = yaml
 changedir={toxinidir}/tests/functional/migrate_ceph_disk_to_ceph_volume
 commands=
-  vagrant up --no-provision {posargs:--provider=virtualbox}
+  bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   # use the stable-3.2 branch to deploy a luminous cluster
@@ -96,7 +96,7 @@ setenv=
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/infra_lv_create
 commands=
-  vagrant up --no-provision {posargs:--provider=virtualbox}
+  bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/infrastructure-playbooks/lv-create.yml
@@ -335,7 +335,7 @@ commands=
 
 [rgw-multisite]
 commands=
-  bash -c "cd {changedir}/secondary && vagrant up --no-provision {posargs:--provider=virtualbox}"
+  bash -c "cd {changedir}/secondary && bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}"
   bash -c "cd {changedir}/secondary && bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}/secondary"
   ansible-playbook --ssh-common-args='-F {changedir}/secondary/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir}/secondary ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"


### PR DESCRIPTION
The CentOS cloud infrastructure storing the vagrant CentOS 8 image
changed the directory path and remove the old 8.0 image so the vagrant
box add centos/8 fails returning a 404 http error.
As a workaround we can pull the image from CentOS instead of letting
vagrant doing the resolution.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>