### PR TITLE
Ignore failure when attempting to purge node_exporter

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -155,6 +155,7 @@
       command: "{{ container_binary }} rmi {{ node_exporter_container_image }}"
       tags:
         - remove_img
+      failed_when: false
 
 
 - name: purge ceph grafana-server


### PR DESCRIPTION
When a deployment fails or is interrupted early, this task prevents
purging the deployment from completing.  By ignoring failures for this
task, purging will continue as expected.