### PR TITLE
tests: add dashboard testinfra configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,7 @@ def node(host, request):
     rolling_update = os.environ.get("ROLLING_UPDATE", "False")
     group_names = ansible_vars["group_names"]
     docker = ansible_vars.get("docker")
+    dashboard = ansible_vars.get("dashboard_enabled", True)
     radosgw_num_instances = ansible_vars.get("radosgw_num_instances", 1)
     ceph_release_num = {
         'jewel': 10,
@@ -133,6 +134,9 @@ def node(host, request):
         pytest.skip(
             "Not a valid test for non-containerized deployments or atomic hosts")  # noqa E501
 
+    if request.node.get_closest_marker("dashboard") and not dashboard:
+        pytest.skip(
+            "Not a valid test with dashboard disabled")
 
     data = dict(
         vars=ansible_vars,
@@ -164,6 +168,8 @@ def pytest_collection_modifyitems(session, config, items):
             item.add_marker(pytest.mark.nfss)
         elif "iscsi" in test_path:
             item.add_marker(pytest.mark.iscsigws)
+        elif "grafana" in test_path:
+            item.add_marker(pytest.mark.grafanas)
         else:
             item.add_marker(pytest.mark.all)
 

--- a/tests/functional/tests/grafana/test_grafana.py
+++ b/tests/functional/tests/grafana/test_grafana.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+class TestGrafanas(object):
+
+    @pytest.mark.dashboard
+    @pytest.mark.no_docker
+    def test_grafana_dashboard_is_installed(self, node, host):
+        assert host.package("ceph-grafana-dashboards").is_installed
+
+    @pytest.mark.dashboard
+    @pytest.mark.parametrize('svc', [
+        'alertmanager', 'grafana-server', 'prometheus'
+    ])
+    def test_grafana_service_enabled_and_running(self, node, host, svc):
+        s = host.service(svc)
+        assert s.is_enabled
+        assert s.is_running
+
+    @pytest.mark.dashboard
+    @pytest.mark.parametrize('port', [
+        '3000', '9092', '9093'
+    ])
+    def test_grafana_socket(self, node, host, setup, port):
+        s = host.socket('tcp://%s:%s' % (setup["address"], port))
+        assert s.is_listening

--- a/tests/functional/tests/mgr/test_mgr.py
+++ b/tests/functional/tests/mgr/test_mgr.py
@@ -8,17 +8,25 @@ class TestMGRs(object):
     def test_mgr_is_installed(self, node, host):
         assert host.package("ceph-mgr").is_installed
 
-    def test_mgr_service_is_running(self, node, host):
-        service_name = "ceph-mgr@{hostname}".format(
-            hostname=node["vars"]["inventory_hostname"]
-        )
-        assert host.service(service_name).is_running
+    @pytest.mark.dashboard
+    @pytest.mark.no_docker
+    def test_mgr_dashboard_is_installed(self, node, host):
+        assert host.package("ceph-mgr-dashboard").is_installed
 
-    def test_mgr_service_is_enabled(self, node, host):
+    def test_mgr_service_is_enabled_and_running(self, node, host):
         service_name = "ceph-mgr@{hostname}".format(
             hostname=node["vars"]["inventory_hostname"]
         )
-        assert host.service(service_name).is_enabled
+        s = host.service(service_name)
+        assert s.is_enabled
+        assert s.is_running
+
+    @pytest.mark.dashboard
+    @pytest.mark.parametrize('port', [
+        '8443', '9283'
+    ])
+    def test_mgr_dashboard_is_listening(self, node, host, port):
+        assert host.socket('tcp://%s' % port).is_listening
 
     def test_mgr_is_up(self, node, host, setup):
         hostname = node["vars"]["inventory_hostname"]

--- a/tests/functional/tests/node-exporter/test_node_exporter.py
+++ b/tests/functional/tests/node-exporter/test_node_exporter.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+class TestNodeExporter(object):
+
+    @pytest.mark.dashboard
+    def test_node_exporter_service_enabled_and_running(self, node, host):
+        s = host.service("node_exporter")
+        assert s.is_enabled
+        assert s.is_running
+
+    @pytest.mark.dashboard
+    def test_node_exporter_socket(self, node, host):
+        assert host.socket('tcp://9100').is_listening

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,2 +1,17 @@
 # this is just a placeholder so that we can define what the 'root' of the tests
 # dir really is. 
+[pytest]
+markers =
+  dashboard: environment with dashboard enabled
+  no_docker: environment without containers
+  docker: environment with containers
+  all: for all nodes
+  iscsigws: for iscsigw nodes
+  mdss: for mds nodes
+  mgrs: for mgr nodes
+  mons: for mon nodes
+  nfss: for nfs nodes
+  osds: for osd nodes
+  rbdmirrors: for rbdmirror nodes
+  rgws: for rgw nodes
+  grafanas: for grafana nodes


### PR DESCRIPTION
This commit adds basic tests for grafana, prometheus, node-exporter and
ceph mgr dashboard services.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>