### PR TITLE
ceph-facts: move facts to defaults value

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -272,6 +272,8 @@ dummy:
 
 #ceph_conf_key_directory: /etc/ceph
 
+#ceph_uid: 167
+
 # Permissions for keyring files in /etc/ceph
 #ceph_keyring_permissions: '0600'
 
@@ -311,9 +313,9 @@ dummy:
 # 'rbd_client_directory_mode: "0755"', *not*
 # 'rbd_client_directory_mode: 0755', or Ansible will complain: mode
 # must be in octal or symbolic form
-#rbd_client_directory_owner: null
-#rbd_client_directory_group: null
-#rbd_client_directory_mode: null
+#rbd_client_directory_owner: ceph
+#rbd_client_directory_group: ceph
+#rbd_client_directory_mode: "0770"
 
 #rbd_client_log_path: /var/log/ceph
 #rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -272,6 +272,8 @@ ceph_iscsi_config_dev: false
 
 #ceph_conf_key_directory: /etc/ceph
 
+#ceph_uid: 167
+
 # Permissions for keyring files in /etc/ceph
 #ceph_keyring_permissions: '0600'
 
@@ -311,9 +313,9 @@ ceph_iscsi_config_dev: false
 # 'rbd_client_directory_mode: "0755"', *not*
 # 'rbd_client_directory_mode: 0755', or Ansible will complain: mode
 # must be in octal or symbolic form
-#rbd_client_directory_owner: null
-#rbd_client_directory_group: null
-#rbd_client_directory_mode: null
+#rbd_client_directory_owner: ceph
+#rbd_client_directory_group: ceph
+#rbd_client_directory_mode: "0770"
 
 #rbd_client_log_path: /var/log/ceph
 #rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -264,6 +264,8 @@ generate_fsid: true
 
 ceph_conf_key_directory: /etc/ceph
 
+ceph_uid: 167
+
 # Permissions for keyring files in /etc/ceph
 ceph_keyring_permissions: '0600'
 
@@ -303,9 +305,9 @@ rbd_client_directories: true # this will create rbd_client_log_path and rbd_clie
 # 'rbd_client_directory_mode: "0755"', *not*
 # 'rbd_client_directory_mode: 0755', or Ansible will complain: mode
 # must be in octal or symbolic form
-rbd_client_directory_owner: null
-rbd_client_directory_group: null
-rbd_client_directory_mode: null
+rbd_client_directory_owner: ceph
+rbd_client_directory_group: ceph
+rbd_client_directory_mode: "0770"
 
 rbd_client_log_path: /var/log/ceph
 rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -175,24 +175,6 @@
   set_fact:
     mds_name: "{{ ansible_hostname }}"
 
-- name: set_fact rbd_client_directory_owner ceph
-  set_fact:
-    rbd_client_directory_owner: ceph
-  when: rbd_client_directory_owner is not defined
-      or not rbd_client_directory_owner
-
-- name: set_fact rbd_client_directory_group rbd_client_directory_group
-  set_fact:
-    rbd_client_directory_group: ceph
-  when: rbd_client_directory_group is not defined
-      or not rbd_client_directory_group
-
-- name: set_fact rbd_client_directory_mode 0770
-  set_fact:
-    rbd_client_directory_mode: "0770"
-  when: rbd_client_directory_mode is not defined
-      or not rbd_client_directory_mode
-
 - name: resolve device link(s)
   command: readlink -f {{ item }}
   changed_when: false
@@ -240,31 +222,6 @@
   when:
     - not containerized_deployment | bool
     - ansible_os_family == 'Debian'
-
-- name: set_fact ceph_uid for red hat or suse based system - non container
-  set_fact:
-    ceph_uid: 167
-  when:
-    - not containerized_deployment | bool
-    - ansible_os_family in ['RedHat', 'Suse']
-
-- name: set_fact ceph_uid for debian based system - container
-  set_fact:
-    ceph_uid: 64045
-  when:
-    - containerized_deployment | bool
-    - ceph_docker_image_tag | string is search("ubuntu")
-
-- name: set_fact ceph_uid for red hat based system - container
-  set_fact:
-    ceph_uid: 167
-  when:
-    - containerized_deployment | bool
-    - (ceph_docker_image_tag | string is search("latest")
-      or ceph_docker_image_tag | string is search("centos")
-      or ceph_docker_image_tag | string is search("fedora")
-      or ceph_docker_image_tag | string is search("rhceph")
-      or (ansible_distribution == 'RedHat'))
 
 - name: set_fact rgw_hostname
   set_fact:


### PR DESCRIPTION
There's no need to define a variable via a fact if we can do it via a
default value. Using a fact could be interesseting to override the
default value on some condition.

- ceph_uid could be set to 167 by default because it's only different on
non containerized deployment on Debian/Ubuntu.
- rbd_client_directory_{owner,group,mode} could be set to ceph,ceph,0770
by default install of null as we are doing in the facts.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>