### PR TITLE
Fix application for openstack_cephfs pools

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -660,7 +660,7 @@ dummy:
 #  type: 1
 #  erasure_profile: ""
 #  expected_num_objects: ""
-#  application: "rbd"
+#  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 #openstack_cephfs_metadata_pool:
@@ -671,7 +671,7 @@ dummy:
 #  type: 1
 #  erasure_profile: ""
 #  expected_num_objects: ""
-#  application: "rbd"
+#  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -660,7 +660,7 @@ ceph_docker_registry_auth: true
 #  type: 1
 #  erasure_profile: ""
 #  expected_num_objects: ""
-#  application: "rbd"
+#  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 #openstack_cephfs_metadata_pool:
@@ -671,7 +671,7 @@ ceph_docker_registry_auth: true
 #  type: 1
 #  erasure_profile: ""
 #  expected_num_objects: ""
-#  application: "rbd"
+#  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -652,7 +652,7 @@ openstack_cephfs_data_pool:
   type: 1
   erasure_profile: ""
   expected_num_objects: ""
-  application: "rbd"
+  application: "cephfs"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
 openstack_cephfs_metadata_pool:
@@ -663,7 +663,7 @@ openstack_cephfs_metadata_pool:
   type: 1
   erasure_profile: ""
   expected_num_objects: ""
-  application: "rbd"
+  application: "cephfs"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
 


### PR DESCRIPTION
RBD is invalid application for cephfs pools, so it was change to cephfs.

Signed-off-by: Dmitriy Rabotyagov <drabotyagov@vexxhost.com>