### PR TITLE
Fix undefined running_mon

### DIFF
--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -59,7 +59,7 @@
       command: "{{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
       register: _mgr_keys
       with_items: "{{ _mgr_keys }}"
-      delegate_to: "{{ running_mon }}"
+      delegate_to: "{{ groups[mon_group_name][0] if running_mon is undefined else running_mon }}"
       when:
         - cephx | bool
         - item.copy_key | bool


### PR DESCRIPTION
Since commit [1] running_mon introduced, it can be not defined
which results in fatal error [2]. This patch defines default value which
was used before patch [1]

[1] https://github.com/ceph/ceph-ansible/commit/8dcbcecd713b0cd7769d3b4d04ef5c2f15881377
[2] https://zuul.opendev.org/t/openstack/build/c82a73aeabd64fd583694ed04b947731/log/job-output.txt#14011

Signed-off-by: Dmitriy Rabotyagov <drabotyagov@vexxhost.com>