### PR TITLE
ceph-facts: set devices osd_auto_discovery on OSDs

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -209,6 +209,7 @@
   with_dict: "{{ ansible_devices }}"
   when:
     - osd_auto_discovery | default(False) | bool
+    - inventory_hostname in groups.get(osd_group_name, [])
     - ansible_devices is defined
     - item.value.removable == "0"
     - item.value.sectors != "0"


### PR DESCRIPTION
We only need to set the devices fact with osd_auto_discovery on OSD
nodes.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>