### PR TITLE
purge-cluster: update package list to remove

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -609,26 +609,29 @@
 
     ceph_packages:
       - ceph
+      - ceph-base
       - ceph-common
-      - ceph-fs-common
       - ceph-fuse
       - ceph-mds
       - ceph-mgr
+      - ceph-mon
+      - ceph-osd
       - ceph-release
       - ceph-radosgw
-      - calamari-server
       - ceph-grafana-dashboards
+      - rbd-mirror
 
     ceph_remaining_packages:
-      - libcephfs1
       - libcephfs2
       - librados2
       - libradosstriper1
       - librbd1
-      - python-ceph-argparse
-      - python-cephfs
-      - python-rados
-      - python-rbd
+      - librgw2
+      - python3-ceph-argparse
+      - python3-cephfs
+      - python3-rados
+      - python3-rbd
+      - python3-rgw
 
     extra_packages:
       - keepalived


### PR DESCRIPTION
We only support python3 so renaming all ceph python packages.
Some ceph packages were missing from the list (ceph-mon, ceph-osd or
rbd-mirror) or didn't exist anymore (ceph-fs-common, libcephfs1).

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>