### PR TITLE
fix `container_exec_cmd` calls for --limit runs

### DIFF
--- a/roles/ceph-handler/tasks/handler_osds.yml
+++ b/roles/ceph-handler/tasks/handler_osds.yml
@@ -6,6 +6,7 @@
 - name: unset noup flag
   command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd unset noup"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
   changed_when: False
 
 # This does not just restart OSDs but everything else too. Unfortunately

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -1,6 +1,14 @@
 ---
 - name: keyring related tasks
   block:
+    - name: set_fact container_exec_cmd
+      set_fact:
+        container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[item]['ansible_hostname'] }}"
+      with_items: "{{ groups.get(mon_group_name, []) }}"
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      run_once: true
+
     - name: get keys from monitors
       command: "{{ hostvars[groups.get(mon_group_name)[0]]['container_exec_cmd'] }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
       register: _rgw_keys

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -3,6 +3,15 @@
   set_fact:
     add_osd: "{{ groups[osd_group_name] | length != ansible_play_hosts_all | length }}"
 
+- name: set_fact container_exec_cmd
+  set_fact:
+    container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[item]['ansible_hostname'] }}"
+  with_items: "{{ groups.get(mon_group_name, []) }}"
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  run_once: true
+  when: containerized_deployment | bool
+
 - name: include_tasks system_tuning.yml
   include_tasks: system_tuning.yml
 


### PR DESCRIPTION
When unsetting the noup flag, we must call container_exec_cmd from the
delegated node (first mon member)

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1792320

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>