### PR TITLE
ceph-rgw: Fix customize pool size "when" condition

### DIFF
--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -42,7 +42,7 @@
       run_once: true
       register: result
       until: result is succeeded
-      when: item.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
+      when: item.value.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
 
     - name: set the rgw_create_pools pools application to rgw
       command: "{{ container_exec_cmd }} ceph --connect-timeout 5 --cluster {{ cluster }} osd pool application enable {{ item.key }} rgw"


### PR DESCRIPTION
In 3c31b19ab39f297635c84edb9e8a5de6c2da7707, I fixed the `customize pool
size` task by replacing `item.size` with `item.value.size`. However, I
missed the same issue in the `when` condition.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>