### PR TITLE
ceph-rgw: Support creation of erasure coded pools

### DIFF
--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -26,7 +26,7 @@
   when: rgw_create_pools is defined
   block:
     - name: create rgw pools if rgw_create_pools is defined
-      command: "{{ container_exec_cmd }} ceph --connect-timeout 5 --cluster {{ cluster }} osd pool create {{ item.key }} {{ item.value.pg_num | default(osd_pool_default_pg_num) }}"
+      command: "{{ container_exec_cmd }} ceph --connect-timeout 5 --cluster {{ cluster }} osd pool create {{ item.key }} {{ item.value.pg_num | default(osd_pool_default_pg_num) }} {{ item.value.type | default('replicated') }} {{ item.value.profile | default('') }}"
       changed_when: false
       with_dict: "{{ rgw_create_pools }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -42,7 +42,9 @@
       run_once: true
       register: result
       until: result is succeeded
-      when: item.value.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
+      when:
+        - item.value.type | default('replicated') == 'replicated'
+        - item.value.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
 
     - name: set the rgw_create_pools pools application to rgw
       command: "{{ container_exec_cmd }} ceph --connect-timeout 5 --cluster {{ cluster }} osd pool application enable {{ item.key }} rgw"


### PR DESCRIPTION
Add `type` and `profile` attributes to `rgw_create_pools` items; `type`
can be `replicated` (default) or `erasure`, and `profile` can be set to
an existing erasure code profile, if one wants to use something else
than the default.

For instance, the following will create a replicated
`default.rgw.buckets.index` pool, and an erasure-coded
`default.rgw.buckets.data` pool (with the default erasure code profile):

```
rgw_create_pools:
  default.rgw.buckets.index:
    pg_num: 512
  default.rgw.buckets.data:
    type: erasure
    pg_num: 512
```

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>