### PR TITLE
ceph-osd: set container objectstore env variables

### DIFF
--- a/roles/ceph-osd/tasks/container_options_facts.yml
+++ b/roles/ceph-osd/tasks/container_options_facts.yml
@@ -1,32 +1,28 @@
 ---
-- name: set_fact docker_env_args '-e osd_bluestore=0 -e osd_filestore=1 -e osd_dmcrypt=0'
+- name: set_fact container_env_args '-e osd_bluestore=0 -e osd_filestore=1 -e osd_dmcrypt=0'
   set_fact:
-    docker_env_args: -e OSD_BLUESTORE=0 -e OSD_FILESTORE=1 -e OSD_DMCRYPT=0
+    container_env_args: -e OSD_BLUESTORE=0 -e OSD_FILESTORE=1 -e OSD_DMCRYPT=0
   when:
-    - containerized_deployment | bool
     - osd_objectstore == 'filestore'
     - not dmcrypt | bool
 
-- name: set_fact docker_env_args '-e osd_bluestore=0 -e osd_filestore=1 -e osd_dmcrypt=1'
+- name: set_fact container_env_args '-e osd_bluestore=0 -e osd_filestore=1 -e osd_dmcrypt=1'
   set_fact:
-    docker_env_args: -e OSD_BLUESTORE=0 -e OSD_FILESTORE=1 -e OSD_DMCRYPT=1
+    container_env_args: -e OSD_BLUESTORE=0 -e OSD_FILESTORE=1 -e OSD_DMCRYPT=1
   when:
-    - containerized_deployment | bool
     - osd_objectstore == 'filestore'
     - dmcrypt | bool
 
-- name: set_fact docker_env_args '-e osd_bluestore=1 -e osd_filestore=0 -e osd_dmcrypt=0'
+- name: set_fact container_env_args '-e osd_bluestore=1 -e osd_filestore=0 -e osd_dmcrypt=0'
   set_fact:
-    docker_env_args: -e OSD_BLUESTORE=1 -e OSD_FILESTORE=0 -e OSD_DMCRYPT=0
+    container_env_args: -e OSD_BLUESTORE=1 -e OSD_FILESTORE=0 -e OSD_DMCRYPT=0
   when:
-    - containerized_deployment | bool
     - osd_objectstore == 'bluestore'
     - not dmcrypt | bool
 
-- name: set_fact docker_env_args '-e osd_bluestore=1 -e osd_filestore=0 -e osd_dmcrypt=1'
+- name: set_fact container_env_args '-e osd_bluestore=1 -e osd_filestore=0 -e osd_dmcrypt=1'
   set_fact:
-    docker_env_args: -e OSD_BLUESTORE=1 -e OSD_FILESTORE=0 -e OSD_DMCRYPT=1
+    container_env_args: -e OSD_BLUESTORE=1 -e OSD_FILESTORE=0 -e OSD_DMCRYPT=1
   when:
-    - containerized_deployment | bool
     - osd_objectstore == 'bluestore'
     - dmcrypt | bool

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -47,6 +47,7 @@
 
 - name: include container_options_facts.yml
   include_tasks: container_options_facts.yml
+  when: containerized_deployment | bool
 
 - name: include_tasks scenarios/lvm.yml
   include_tasks: scenarios/lvm.yml

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -37,11 +37,7 @@ numactl \
   {% if ansible_distribution == 'Ubuntu' -%}
   --security-opt apparmor:unconfined \
   {% endif -%}
-  {% if dmcrypt -%}
-  -e OSD_DMCRYPT=1 \
-  {% else -%}
-  -e OSD_DMCRYPT=0 \
-  {% endif -%}
+  {{ container_env_args }} \
   -e CLUSTER={{ cluster }} \
   {% if (ceph_tcmalloc_max_total_thread_cache | int) > 0 and osd_objectstore == 'filestore' -%}
   -e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }} \


### PR DESCRIPTION
Because we need to manage legacy ceph-disk based OSD with ceph-volume
then we need a way to know the osd_objectstore in the container.
This was done like this previously with ceph-disk so we should also
do it with ceph-volume.
Note that this won't have any impact for ceph-volume lvm based OSD.

Rename docker_env_args fact to container_env_args and move the container
condition on the include_tasks call.
Remove OSD_DMCRYPT env variable from the ceph-osd template because it's
now included in the container_env_args variable.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1792122

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>