### PR TITLE
common: add a default value for ceph_directories_mode

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -115,7 +115,7 @@ dummy:
 #upgrade_ceph_packages: False
 
 #ceph_use_distro_backports: false # DEBIAN ONLY
-
+#ceph_directories_mode: "0755"
 
 ###########
 # INSTALL #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -115,7 +115,7 @@ fetch_directory: ~/ceph-ansible-keys
 #upgrade_ceph_packages: False
 
 #ceph_use_distro_backports: false # DEBIAN ONLY
-
+#ceph_directories_mode: "0755"
 
 ###########
 # INSTALL #

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -95,7 +95,7 @@
       state: directory
       owner: "ceph"
       group: "ceph"
-      mode: "{{ ceph_directories_mode | default('0755') }}"
+      mode: "{{ ceph_directories_mode }}"
 
   - name: "generate ceph configuration file: {{ cluster }}.conf"
     action: config_template
@@ -122,7 +122,7 @@
     file:
       path: "{{ fetch_directory }}/{{ fsid }}/etc/ceph"
       state: directory
-      mode: "{{ ceph_directories_mode | default('0755') }}"
+      mode: "{{ ceph_directories_mode }}"
     delegate_to: localhost
     when: ceph_conf_local | bool
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -107,7 +107,7 @@ bootstrap_dirs_group: "64045"
 upgrade_ceph_packages: False
 
 ceph_use_distro_backports: false # DEBIAN ONLY
-
+ceph_directories_mode: "0755"
 
 ###########
 # INSTALL #

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "{{ ceph_directories_mode | default('0755') }}"
+    mode: "{{ ceph_directories_mode }}"
   with_items:
     - /var/lib/ceph/bootstrap-mds/
     - /var/lib/ceph/mds/{{ cluster }}-{{ mds_name }}

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "{{ ceph_directories_mode | default('0755') }}"
+    mode: "{{ ceph_directories_mode }}"
 
 - name: fetch ceph mgr keyring
   ceph_key:

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -56,7 +56,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "{{ ceph_directories_mode | default('0755') }}"
+    mode: "{{ ceph_directories_mode }}"
     recurse: true
 
 - name: create custom admin keyring

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -31,7 +31,7 @@
     state: directory
     owner: "ceph"
     group: "ceph"
-    mode: "{{ ceph_directories_mode | default('0755') }}"
+    mode: "{{ ceph_directories_mode }}"
   with_items:
     - { name: "/var/lib/ceph/bootstrap-rgw", create: "{{ nfs_obj_gw }}" }
     - { name: "/var/lib/ceph/radosgw", create: "{{ nfs_obj_gw }}" }

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "{{ ceph_directories_mode | default('0755') }}"
+    mode: "{{ ceph_directories_mode }}"
   when: cephx | bool
   with_items:
     - /var/lib/ceph/bootstrap-osd/

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "{{ ceph_directories_mode | default('0755') }}"
+    mode: "{{ ceph_directories_mode }}"
   with_items: "{{ rbd_client_admin_socket_path }}"
 
 - name: create rados gateway instance directories
@@ -14,7 +14,7 @@
     state: directory
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-    mode: "{{ ceph_directories_mode | default('0755') }}"
+    mode: "{{ ceph_directories_mode }}"
   with_items: "{{ rgw_instances }}"
   when: rgw_instances is defined
 


### PR DESCRIPTION
Since this variable makes it possible to customize the mode for ceph
directories, let's make it a bit more explicit by adding a default value
in ceph-defaults.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>