### PR TITLE
rolling_update: support upgrading 3.x + ceph-metrics on a dedicated node

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -902,7 +902,16 @@
         name: ceph-client
 
 - name: complete upgrade
-  hosts: all
+  hosts:
+  - "{{ mon_group_name | default('mons') }}"
+  - "{{ mgr_group_name | default('mgrs') }}"
+  - "{{ osd_group_name | default('osds') }}"
+  - "{{ mds_group_name | default('mdss') }}"
+  - "{{ rgw_group_name | default('rgws') }}"
+  - "{{ nfs_group_name | default('nfss') }}"
+  - "{{ rbdmirror_group_name | default('rbdmirrors') }}"
+  - "{{ client_group_name | default('clients') }}"
+  - "{{ iscsi_gw_group_name | default('iscsigws') }}"
   become: True
   tasks:
     - import_role:


### PR DESCRIPTION
When upgrading from RHCS 3.x where ceph-metrics was deployed on a
dedicated node to RHCS 4.0, it fails like following:

```
fatal: [magna005]: FAILED! => changed=false
  gid: 0
  group: root
  mode: '0755'
  msg: 'chown failed: failed to look up user ceph'
  owner: root
  path: /etc/ceph
  secontext: unconfined_u:object_r:etc_t:s0
  size: 4096
  state: directory
  uid: 0
```

because we are trying to run `ceph-config` on this node, it doesn't make
sense so we should simply run this play on all groups except
`[grafana-server]`.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1793885

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>