### PR TITLE
site-container: don't skip ceph-container-common

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -57,7 +57,7 @@
     - import_role:
         name: ceph-container-common
       tags: fetch_container_image
-      when: not (inventory_hostname in groups.get('clients', [])) or (inventory_hostname == groups.get('clients', [''])|first)
+      when: (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
 
 - hosts: mons
   gather_facts: false


### PR DESCRIPTION
On HCI environment the OSD and Client nodes are collocated. Because we
aren't running the ceph-container-common role on the client nodes except
the first one (for keyring purpose) then the ceph-role execution fails
due to undefined variables.

Closes: #4970
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1794195

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>