### PR TITLE
ceph-facts: Fix for 'running_mon is undefined' error

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -83,7 +83,7 @@
       when:
         - not containerized_deployment | bool
         - item.rc is defined
-        - item.rc == 1
+        - item.rc == 0
 
     - name: set_fact running_mon - container
       set_fact:


### PR DESCRIPTION
fact 'running_mon' is set once 'grep' successfully exits with 'rc == 0'

Fixes: [#4977](https://github.com/ceph/ceph-ansible/issues/4977)

Signed-off-by: Vytenis Sabaliauskas <vytenis.sabaliauskas@protonmail.com>