### PR TITLE
handler: read container_exec_cmd value from first mon

### DIFF
--- a/roles/ceph-handler/tasks/handler_osds.yml
+++ b/roles/ceph-handler/tasks/handler_osds.yml
@@ -4,7 +4,7 @@
     _osd_handler_called: True
 
 - name: unset noup flag
-  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd unset noup"
+  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd unset noup"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   changed_when: False


### PR DESCRIPTION
Given that we delegate to the first monitor, we must read the value of
`container_exec_cmd` from this node.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1792320

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>