### PR TITLE
filestore-to-bluestore: don't fail when with no PV

### DIFF
--- a/infrastructure-playbooks/filestore-to-bluestore.yml
+++ b/infrastructure-playbooks/filestore-to-bluestore.yml
@@ -209,6 +209,7 @@
         - name: ensure all pv are removed
           command: "pvremove --yes {{ item.devices[0] }}"
           with_items: "{{ _lvm_list }}"
+          failed_when: false
           when:
             - item.type == 'data'
             - item.lv_name.startswith('osd-data-') | bool


### PR DESCRIPTION
When the PV is already removed from the devices then we should not fail
to avoid errors like:

stderr: No PV found on device /dev/sdb.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1729267

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>