### PR TITLE
LVM vg/lv preparation for multiple NVMe devices with bluestore

### DIFF
--- a/infrastructure-playbooks/lv-create.yml
+++ b/infrastructure-playbooks/lv-create.yml
@@ -2,35 +2,12 @@
   become: true
   hosts: osds
 
-  vars:
-    logfile: |
-      Suggested cut and paste under "lvm_volumes:" in "group_vars/osds.yml"
-      -----------------------------------------------------------------------------------------------------------
-      {% for lv in nvme_device_lvs %}
-        - data: {{ lv.lv_name }}
-          data_vg: {{ nvme_vg_name }}
-          journal: {{ lv.journal_name }}
-          journal_vg: {{ nvme_vg_name }}
-      {% endfor %}
-      {% for hdd in hdd_devices %}
-        - data: {{ hdd_lv_prefix }}-{{ hdd.split('/')[-1] }}
-          data_vg: {{ hdd_vg_prefix }}-{{ hdd.split('/')[-1] }}
-          journal: {{ hdd_journal_prefix }}-{{ hdd.split('/')[-1] }}
-          journal_vg: {{ nvme_vg_name }}
-      {% endfor %}
-
   tasks:
 
   - name: include vars of lv_vars.yaml
     include_vars:
       file: lv_vars.yaml
     failed_when: false
-
-  # ensure nvme_device is set
-  - name: fail if nvme_device is not defined
-    fail:
-      msg: "nvme_device has not been set by the user"
-    when: nvme_device is undefined or nvme_device == 'dummy'
 
   # need to check if lvm2 is installed
   - name: install lvm2
@@ -40,59 +17,13 @@
     register: result
     until: result is succeeded
 
-  # Make entire nvme device a VG
-  - name: add nvme device as lvm pv
-    lvg:
-      force: yes
-      pvs: "{{ nvme_device }}"
-      pesize: 4
-      state: present
-      vg: "{{ nvme_vg_name }}"
-
-  - name: create lvs for fs journals for the bucket index on the nvme device
-    lvol:
-      lv: "{{ item.journal_name }}"
-      vg: "{{ nvme_vg_name }}"
-      size: "{{ journal_size }}"
-      pvs: "{{ nvme_device }}"
-    with_items: "{{ nvme_device_lvs }}"
-
-  - name: create lvs for fs journals for hdd devices
-    lvol:
-      lv: "{{ hdd_journal_prefix }}-{{ item.split('/')[-1] }}"
-      vg: "{{ nvme_vg_name }}"
-      size: "{{ journal_size }}"
-    with_items: "{{ hdd_devices }}"
-
-  - name: create the lv for data portion of the bucket index on the nvme device
-    lvol:
-      lv: "{{ item.lv_name }}"
-      vg: "{{ nvme_vg_name }}"
-      size: "{{ item.size }}"
-      pvs: "{{ nvme_device }}"
-    with_items: "{{ nvme_device_lvs }}"
-
-    # Make sure all hdd devices have a unique volume group
-  - name: create vgs for all hdd devices
-    lvg:
-      force: yes
-      pvs: "{{ item }}"
-      pesize: 4
-      state: present
-      vg: "{{ hdd_vg_prefix }}-{{ item.split('/')[-1] }}"
-    with_items: "{{ hdd_devices }}"
-
-  - name: create lvs for the data portion on hdd devices
-    lvol:
-      lv: "{{ hdd_lv_prefix }}-{{ item.split('/')[-1] }}"
-      vg: "{{ hdd_vg_prefix }}-{{ item.split('/')[-1] }}"
-      size: "{{ hdd_lv_size }}"
-      pvs: "{{ item }}"
-    with_items: "{{ hdd_devices }}"
-
-  - name: "write output for osds.yml to {{ logfile_path }}"
-    become: false
-    copy:
-      content: "{{ logfile }}"
-      dest: "{{ logfile_path }}"
-    delegate_to: localhost
+  - include_role:
+      name: ceph-lvm-create
+    vars:
+      nvme_device: "{{ outer.nvme_device | default('dummy')}}"
+      hdd_devices: "{{ outer.hdd_devices }}"
+      nvme_device_lvs: "{{ outer.nvme_device_lvs }}"
+    with_items:
+     - "{{ lvm_devices }}"
+    loop_control:
+      loop_var: outer

--- a/infrastructure-playbooks/lv-teardown.yml
+++ b/infrastructure-playbooks/lv-teardown.yml
@@ -44,57 +44,13 @@
     command: "killall -q lvcreate pvcreate vgcreate lvconvert || echo -n"
     failed_when: false
 
-  ## Logcal Vols
-  - name: tear down existing lv for bucket index
-    lvol:
-      lv: "{{ item.lv_name }}"
-      vg: "{{ nvme_vg_name }}"
-      state: absent
-      force: yes
-    with_items: "{{ nvme_device_lvs }}"
-
-  - name: tear down any existing hdd data lvs 
-    lvol:
-      lv: "{{ hdd_lv_prefix }}-{{ item.split('/')[-1] }}"
-      vg: "{{ hdd_vg_prefix }}-{{ item.split('/')[-1] }}"
-      state: absent
-      force: yes
-    with_items: "{{ hdd_devices }}"
-
-  - name: tear down any existing lv of journal for bucket index
-    lvol:
-      lv: "{{ item.journal_name }}"
-      vg: "{{ nvme_vg_name }}"
-      state: absent
-      force: yes
-    with_items: "{{ nvme_device_lvs }}"
-
-  - name: tear down any existing lvs of hdd journals
-    lvol:
-      lv: "{{ hdd_journal_prefix }}-{{ item.split('/')[-1] }}"
-      vg: "{{ nvme_vg_name }}"
-      state: absent
-      force: yes
-    with_items: "{{ hdd_devices }}"
-
-  ## Volume Groups
-  - name: remove vg on nvme device
-    lvg:
-      vg: "{{ nvme_vg_name }}"
-      state: absent
-      force: yes
-
-  - name: remove vg for each hdd device
-    lvg:
-      vg: "{{ hdd_vg_prefix }}-{{ item.split('/')[-1] }}"
-      state: absent
-      force: yes
-    with_items: "{{ hdd_devices }}"
-
-  ## Physical Vols
-  - name: tear down pv for nvme device
-    command: "pvremove --force --yes {{ nvme_device }}"
-
-  - name: tear down pv for each hdd device
-    command: "pvremove --force --yes {{ item }}"
-    with_items: "{{ hdd_devices }}"
+  - include_role:
+      name: ceph-lvm-teardown
+    vars:
+      nvme_device: "{{ outer.nvme_device | default('dummy')}}"
+      hdd_devices: "{{ outer.hdd_devices }}"
+      nvme_device_lvs: "{{ outer.nvme_device_lvs }}"
+    with_items:
+     - "{{ lvm_devices }}"
+    loop_control:
+      loop_var: outer

--- a/infrastructure-playbooks/vars/lv_vars.yaml.sample
+++ b/infrastructure-playbooks/vars/lv_vars.yaml.sample
@@ -24,7 +24,7 @@ lvm_devices:
     nvme_device_lvs:
      - lv_name: "ceph-bucket-index-1"
        size: 100%FREE
-       journal_name: "ceph-journal-bucket-index-1-{{ nvme_device_basename }}"
+       journal_name: "ceph-journal-bucket-index-1-dummy"
   - nvme_device: dummy
     hdd_devices:
      - /dev/sdi
@@ -35,7 +35,7 @@ lvm_devices:
     nvme_device_lvs:
      - lv_name: "ceph-bucket-index-2"
        size: 100%FREE
-       journal_name: "ceph-journal-bucket-index-1-{{ nvme_device_basename }}"
+       journal_name: "ceph-journal-bucket-index-1-dummy"
 
 # Per the lvol module documentation, "size" and "journal_size" is the size of the logical volume, according to lvcreate(8) --size. 
 # This is by default in megabytes or optionally with one of [bBsSkKmMgGtTpPeE] units; or according to lvcreate(8) --extents as a percentage of [VG|PVS|FREE]; Float values must begin with a digit.

--- a/infrastructure-playbooks/vars/lv_vars.yaml.sample
+++ b/infrastructure-playbooks/vars/lv_vars.yaml.sample
@@ -1,7 +1,6 @@
 # This file configures logical volume creation for FS Journals on NVMe, a NVMe based bucket index, and HDD based OSDs.
-# This playbook configures one NVMe device at a time. If your OSD systems contain multiple NVMe devices, you will need to edit the key variables ("nvme_device", "hdd_devices") for each run.
-# It is meant to be used when osd_objectstore=filestore and it outputs the necessary input for group_vars/osds.yml.
-# The LVs for journals are created first then the LVs for data. All LVs for journals correspond to a LV for data.
+# It outputs the necessary input for group_vars/osds.yml.
+# The LVs for journals/DB/WAL are created first then the LVs for data. All LVs for journals/DB/WAL correspond to a LV for data.
 #
 ## CHANGE THESE VARS ##
 #
@@ -11,29 +10,42 @@
 # Having leftover signatures can result in ansible errors that say "device $device_name excluded by a filter" after running the lv-create.yml playbook.
 # This can be done by running `wipefs -a $device_name`.
 
-# Path of nvme device primed for LV creation for journals and data. Only one NVMe device is allowed at a time. Providing a list will not work in this case.
-nvme_device: dummy
-
-# Path of hdd devices designated for LV creation.
-hdd_devices:
-  - /dev/sdd
-  - /dev/sde
-  - /dev/sdf
-  - /dev/sdg
-  - /dev/sdh
+# nvme_device is the Path of nvme device primed for LV creation for journals/DB/WAL and data.
+# hdd_devices is a list of Path of hdd devices designated for LV creation.
+# lv_name var is a list of bucket index LVs created on the NVMe device. We recommend one be created but you can add others
+lvm_devices:
+  - nvme_device: dummy
+    hdd_devices:
+     - /dev/sdd
+     - /dev/sde
+     - /dev/sdf
+     - /dev/sdg
+     - /dev/sdh
+    nvme_device_lvs:
+     - lv_name: "ceph-bucket-index-1"
+       size: 100%FREE
+       journal_name: "ceph-journal-bucket-index-1-{{ nvme_device_basename }}"
+  - nvme_device: dummy
+    hdd_devices:
+     - /dev/sdi
+     - /dev/sdj
+     - /dev/sdk
+     - /dev/sdl
+     - /dev/sdm
+    nvme_device_lvs:
+     - lv_name: "ceph-bucket-index-2"
+       size: 100%FREE
+       journal_name: "ceph-journal-bucket-index-1-{{ nvme_device_basename }}"
 
 # Per the lvol module documentation, "size" and "journal_size" is the size of the logical volume, according to lvcreate(8) --size. 
 # This is by default in megabytes or optionally with one of [bBsSkKmMgGtTpPeE] units; or according to lvcreate(8) --extents as a percentage of [VG|PVS|FREE]; Float values must begin with a digit.
 # For further reading and examples see: https://docs.ansible.com/ansible/2.6/modules/lvol_module.html
+# journal size will allso be the size of the WAL device. You can set it to 0 if you dont need WAL devices.
 
 # Suggested journal size is 5500
 journal_size: 5500
-
-# This var is a list of bucket index LVs created on the NVMe device. We recommend one be created but you can add others
-nvme_device_lvs:
-  - lv_name: "ceph-bucket-index-1"
-    size: 100%FREE
-    journal_name: "ceph-journal-bucket-index-1-{{ nvme_device_basename }}"
+# recommadet db size is 1% - 4% (4% for RGW workload) of data partition size. if set, set it to "{{ bluestore_block_db_size }}b"
+db_size: 1234
 
 ## TYPICAL USERS WILL NOT NEED TO CHANGE VARS FROM HERE DOWN ##
 
@@ -43,15 +55,10 @@ logfile_path: ./lv-create.log
 # all hdd's have to be the same size and the LVs on them are dedicated for OSD data
 hdd_lv_size: 100%FREE
 
-# Since this playbook can be run multiple times across different devices, {{ var.split('/')[-1] }} is used quite frequently in this play-book.
-# This is used to strip the device name away from its path (ex: sdc from /dev/sdc) to differenciate the names of vgs, journals, or lvs if the prefixes are not changed across multiple runs.
-nvme_device_basename: "{{ nvme_device.split('/')[-1] }}"
-
-# Only one volume group is created in the playbook for all the LVs on NVMe. This volume group takes up the entire device specified in "nvme_device".
-nvme_vg_name: "ceph-nvme-vg-{{ nvme_device_basename }}"
-
 hdd_vg_prefix: "ceph-hdd-vg"
 hdd_lv_prefix: "ceph-hdd-lv"
+# the jurnal prefix is allso used for WAL
 hdd_journal_prefix: "ceph-journal"
+hdd_db_prefix: "ceph-db"
 
 # Journals are created on NVMe device

--- a/roles/ceph-lvm-create/defaults/main.yml
+++ b/roles/ceph-lvm-create/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+logfile: |
+  Suggested cut and paste under "lvm_volumes:" in "group_vars/osds.yml"
+  -----------------------------------------------------------------------------------------------------------
+  {% for lv in nvme_device_lvs %}
+    - data: {{ lv.lv_name }}
+      data_vg: {{ nvme_vg_name }}
+  {% if osd_objectstore == "filestore" %}
+      journal: {{ lv.journal_name }}
+      journal_vg: {{ nvme_vg_name }}
+  {% endif %}
+  {% endfor %}
+  {% for hdd in hdd_devices %}
+    - data: {{ hdd_lv_prefix }}-{{ hdd.split('/')[-1] }}
+      data_vg: {{ hdd_vg_prefix }}-{{ hdd.split('/')[-1] }}
+  {% if osd_objectstore == "filestore" %}
+      journal: {{ hdd_journal_prefix }}-{{ hdd.split('/')[-1] }}
+      journal_vg: {{ nvme_vg_name }}
+  {% else %}
+      db: {{ hdd_db_prefix }}-{{ hdd.split('/')[-1] }}
+      db_vg: {{ nvme_vg_name }}
+  {% if journal_size > 0 %}
+      wal: {{ hdd_journal_prefix }}-{{ hdd.split('/')[-1] }}
+      wal_vg: {{ nvme_vg_name }}
+  {% endif %}
+  {% endif %}
+  {% endfor %}
+
+# Since this playbook can be run multiple times across different devices, {{ var.split('/')[-1] }} is used quite frequently in this play-book.
+# This is used to strip the device name away from its path (ex: sdc from /dev/sdc) to differenciate the names of vgs, journals, or lvs if the prefixes are not changed across multiple runs.
+nvme_device_basename: "{{ nvme_device.split('/')[-1] }}"
+# Only one volume group is created in the playbook for all the LVs on NVMe. This volume group takes up the entire device specified in "nvme_device".
+nvme_vg_name: "ceph-nvme-vg-{{ nvme_device_basename }}"

--- a/roles/ceph-lvm-create/tasks/main.yml
+++ b/roles/ceph-lvm-create/tasks/main.yml
@@ -1,0 +1,72 @@
+# ensure nvme_device is set
+- name: fail if nvme_device is not defined
+  fail:
+    msg: "nvme_device has not been set by the user"
+  when: nvme_device is undefined or nvme_device == 'dummy'
+
+# Make entire nvme device a VG
+- name: add nvme device as lvm pv
+  lvg:
+    force: yes
+    pvs: "{{ nvme_device }}"
+    pesize: 4
+    state: present
+    vg: "{{ nvme_vg_name }}"
+
+- name: create lvs for fs journals for the bucket index on the nvme device
+  lvol:
+    lv: "{{ item.journal_name }}"
+    vg: "{{ nvme_vg_name }}"
+    size: "{{ journal_size }}"
+    pvs: "{{ nvme_device }}"
+  with_items: "{{ nvme_device_lvs }}"
+  when: osd_objectstore == "filestore"
+
+- name: create lvs for fs journals/WAL for hdd devices
+  lvol:
+    lv: "{{ hdd_journal_prefix }}-{{ item.split('/')[-1] }}"
+    vg: "{{ nvme_vg_name }}"
+    size: "{{ journal_size }}"
+  with_items: "{{ hdd_devices }}"
+  when: journal_size > 0
+
+- name: create lvs for fs DB for hdd devices
+  lvol:
+    lv: "{{ hdd_db_prefix }}-{{ item.split('/')[-1] }}"
+    vg: "{{ nvme_vg_name }}"
+    size: "{{ db_size }}"
+  with_items: "{{ hdd_devices }}"
+  when: osd_objectstore == "bluestore"
+
+- name: create the lv for data portion of the bucket index on the nvme device
+  lvol:
+    lv: "{{ item.lv_name }}"
+    vg: "{{ nvme_vg_name }}"
+    size: "{{ item.size }}"
+    pvs: "{{ nvme_device }}"
+  with_items: "{{ nvme_device_lvs }}"
+
+  # Make sure all hdd devices have a unique volume group
+- name: create vgs for all hdd devices
+  lvg:
+    force: yes
+    pvs: "{{ item }}"
+    pesize: 4
+    state: present
+    vg: "{{ hdd_vg_prefix }}-{{ item.split('/')[-1] }}"
+  with_items: "{{ hdd_devices }}"
+
+- name: create lvs for the data portion on hdd devices
+  lvol:
+    lv: "{{ hdd_lv_prefix }}-{{ item.split('/')[-1] }}"
+    vg: "{{ hdd_vg_prefix }}-{{ item.split('/')[-1] }}"
+    size: "{{ hdd_lv_size }}"
+    pvs: "{{ item }}"
+  with_items: "{{ hdd_devices }}"
+
+- name: "write output for osds.yml to {{ logfile_path }}"
+  become: false
+  copy:
+    content: "{{ logfile }}"
+    dest: "{{ logfile_path }}"
+  delegate_to: localhost

--- a/roles/ceph-lvm-teardown/defaults/main.yml
+++ b/roles/ceph-lvm-teardown/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Since this playbook can be run multiple times across different devices, {{ var.split('/')[-1] }} is used quite frequently in this play-book.
+# This is used to strip the device name away from its path (ex: sdc from /dev/sdc) to differenciate the names of vgs, journals, or lvs if the prefixes are not changed across multiple runs.
+nvme_device_basename: "{{ nvme_device.split('/')[-1] }}"
+# Only one volume group is created in the playbook for all the LVs on NVMe. This volume group takes up the entire device specified in "nvme_device".
+nvme_vg_name: "ceph-nvme-vg-{{ nvme_device_basename }}"

--- a/roles/ceph-lvm-teardown/tasks/main.yml
+++ b/roles/ceph-lvm-teardown/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+## Logcal Vols
+- name: tear down existing lv for bucket index
+  lvol:
+    lv: "{{ item.lv_name }}"
+    vg: "{{ nvme_vg_name }}"
+    state: absent
+    force: yes
+  with_items: "{{ nvme_device_lvs }}"
+
+- name: tear down any existing hdd data lvs
+  lvol:
+    lv: "{{ hdd_lv_prefix }}-{{ item.split('/')[-1] }}"
+    vg: "{{ hdd_vg_prefix }}-{{ item.split('/')[-1] }}"
+    state: absent
+    force: yes
+  with_items: "{{ hdd_devices }}"
+
+- name: tear down any existing lv of journal for bucket index
+  lvol:
+    lv: "{{ item.journal_name }}"
+    vg: "{{ nvme_vg_name }}"
+    state: absent
+    force: yes
+  with_items: "{{ nvme_device_lvs }}"
+
+- name: tear down any existing lv of db
+  lvol:
+    lv: "{{ hdd_db_prefix }}-{{ item.split('/')[-1] }}"
+    vg: "{{ nvme_vg_name }}"
+    state: absent
+    force: yes
+  with_items: "{{ hdd_devices }}"
+
+- name: tear down any existing lvs of hdd journals
+  lvol:
+    lv: "{{ hdd_journal_prefix }}-{{ item.split('/')[-1] }}"
+    vg: "{{ nvme_vg_name }}"
+    state: absent
+    force: yes
+  with_items: "{{ hdd_devices }}"
+
+## Volume Groups
+- name: remove vg on nvme device
+  lvg:
+    vg: "{{ nvme_vg_name }}"
+    state: absent
+    force: yes
+
+- name: remove vg for each hdd device
+  lvg:
+    vg: "{{ hdd_vg_prefix }}-{{ item.split('/')[-1] }}"
+    state: absent
+    force: yes
+  with_items: "{{ hdd_devices }}"
+
+## Physical Vols
+- name: tear down pv for nvme device
+  command: "pvremove --force --yes {{ nvme_device }}"
+
+- name: tear down pv for each hdd device
+  command: "pvremove --force --yes {{ item }}"
+  with_items: "{{ hdd_devices }}"


### PR DESCRIPTION
This extends the existing lv-create and lv-teardown playbooks by the possibility to prepare journal/wal/db devices for filestore and bluestore  OSDs.