### PR TITLE
ceph-mgr: Add option to configure balancer mode

### DIFF
--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -34,6 +34,12 @@ dummy:
 #  - ceph-mgr-dashboard
 #  - ceph-mgr-diskprediction-local
 
+# Ceph balancer: https://docs.ceph.com/docs/nautilus/rados/operations/balancer/
+#
+# When defined, sets the Ceph balancer mode to `none`, `crush-compat` or `upmap`.
+# If set to `none`, the balancer is disabled; otherwise, it is enabled. When
+# undefined, the balancer configuration is left unchanged.
+#ceph_mgr_balancer_mode:
 
 ##########
 # DOCKER #

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -26,6 +26,12 @@ ceph_mgr_packages:
   - ceph-mgr-dashboard
   - ceph-mgr-diskprediction-local
 
+# Ceph balancer: https://docs.ceph.com/docs/nautilus/rados/operations/balancer/
+#
+# When defined, sets the Ceph balancer mode to `none`, `crush-compat` or `upmap`.
+# If set to `none`, the balancer is disabled; otherwise, it is enabled. When
+# undefined, the balancer configuration is left unchanged.
+#ceph_mgr_balancer_mode:
 
 ##########
 # DOCKER #

--- a/roles/ceph-mgr/tasks/balancer.yml
+++ b/roles/ceph-mgr/tasks/balancer.yml
@@ -1,0 +1,27 @@
+---
+- name: get balancer status
+  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} balancer status"
+  check_mode: false
+  changed_when: false
+  register: _ceph_balancer_status
+  failed_when: _ceph_balancer_status.rc not in (0, 22)
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+
+- name: set _ceph_balancer_status fact
+  set_fact:
+    _ceph_balancer_status: "{{ _ceph_balancer_status.stdout | default('{}', true) | from_json }}"
+
+- name: configure balancer
+  block:
+  - name: set balancer state
+    command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} balancer {{ (ceph_mgr_balancer_mode != 'none') | ternary('on', 'off') }}"
+    changed_when: (ceph_mgr_balancer_mode != 'none') | bool != _ceph_balancer_status.active | bool
+  - name: set balancer mode
+    command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} balancer mode {{ ceph_mgr_balancer_mode }}"
+    changed_when: ceph_mgr_balancer_mode != _ceph_balancer_status.mode
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  when:
+    - _ceph_balancer_status.active is defined
+    - ceph_mgr_balancer_mode is defined

--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -24,3 +24,6 @@
     - ceph_mgr_modules | length > 0 or dashboard_enabled
     - ((groups[mgr_group_name] | default([]) | length == 0 and inventory_hostname == groups[mon_group_name] | last) or
       (groups[mgr_group_name] | default([]) | length > 0 and inventory_hostname == groups[mgr_group_name] | last))
+
+- name: include balancer.yml
+  include_tasks: balancer.yml

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -226,3 +226,10 @@
     - ceph_docker_registry_auth | bool
     - (ceph_docker_registry_username is not defined or ceph_docker_registry_password is not defined) or
       (ceph_docker_registry_username | length == 0 or ceph_docker_registry_password | length == 0)
+
+- name: validate ceph-mgr balancer mode
+  fail:
+    msg: ceph_mgr_balancer_mode should be one of none, crush-compat or upmap
+  when:
+    - ceph_mgr_balancer_mode is defined
+    - ceph_mgr_balancer_mode not in ('none', 'crush-compat', 'upmap')


### PR DESCRIPTION
If `ceph_mgr_balancer_mode` is defined, set the balancer mode
accordingly. If the mode is anything other than `none`, the balancer is
enabled.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>