### PR TITLE
node_exporter is only enabled when dashboard is enabled

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -145,16 +145,19 @@
         state: stopped
         enabled: no
       failed_when: false
+      when: dashboard_enabled
 
     - name: remove node_exporter service file
       file:
         name: /etc/systemd/system/node_exporter.service
         state: absent
+      when: dashboard_enabled
 
     - name: remove node-exporter image
       command: "{{ container_binary }} rmi {{ node_exporter_container_image }}"
       tags:
         - remove_img
+      when: dashboard_enabled
 
 
 - name: purge ceph grafana-server


### PR DESCRIPTION
	- purge_cluster failed when dashboard_enabled was false due to
	not having the node-exporter container image