### PR TITLE
ceph-facts: remove is_podman fact

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -11,10 +11,6 @@
 - name: import_tasks container_binary.yml
   import_tasks: container_binary.yml
 
-- name: set_fact is_podman
-  set_fact:
-    is_podman: "{{ podman_binary.stat.exists }}"
-
 # In case ansible_python_interpreter is set by the user,
 # ansible will not discover python and discovered_interpreter_python
 # will not be set


### PR DESCRIPTION
This was used before the CentOS 8 requirement when using CentOS 7
atomic which has both docker and podman installed.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>