### PR TITLE
validate: fail if dashboard|grafana_admin_password aren't set

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -710,6 +710,7 @@ dummy:
 #dashboard_protocol: http
 #dashboard_port: 8443
 #dashboard_admin_user: admin
+# This variable must be set with a strong custom password when dashboard_enabled is True
 #dashboard_admin_password: p@ssw0rd
 # We only need this for SSL (https) connections
 #dashboard_crt: ''
@@ -720,6 +721,7 @@ dummy:
 #node_exporter_container_image: "prom/node-exporter:v0.17.0"
 #node_exporter_port: 9100
 #grafana_admin_user: admin
+# This variable must be set with a strong custom password when dashboard_enabled is True
 #grafana_admin_password: admin
 # We only need this for SSL (https) connections
 #grafana_crt: ''

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -710,6 +710,7 @@ ceph_docker_registry_auth: true
 #dashboard_protocol: http
 #dashboard_port: 8443
 #dashboard_admin_user: admin
+# This variable must be set with a strong custom password when dashboard_enabled is True
 #dashboard_admin_password: p@ssw0rd
 # We only need this for SSL (https) connections
 #dashboard_crt: ''
@@ -720,6 +721,7 @@ ceph_docker_registry_auth: true
 node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1
 #node_exporter_port: 9100
 #grafana_admin_user: admin
+# This variable must be set with a strong custom password when dashboard_enabled is True
 #grafana_admin_password: admin
 # We only need this for SSL (https) connections
 #grafana_crt: ''

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -81,10 +81,10 @@
 
 - name: set or update dashboard admin username and password
   shell: |
-    if {{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard ac-user-show {{ dashboard_admin_user }}; then
-      {{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard ac-user-set-password {{ dashboard_admin_user }} {{ dashboard_admin_password }}
+    if {{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard ac-user-show {{ dashboard_admin_user | quote }}; then
+      {{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard ac-user-set-password {{ dashboard_admin_user | quote }} {{ dashboard_admin_password | quote }}
     else
-      {{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard ac-user-create {{ dashboard_admin_user }} {{ dashboard_admin_password }} administrator
+      {{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard ac-user-create {{ dashboard_admin_user | quote }} {{ dashboard_admin_password | quote }} administrator
     fi
   retries: 6
   delay: 5

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -702,7 +702,8 @@ dashboard_enabled: True
 dashboard_protocol: http
 dashboard_port: 8443
 dashboard_admin_user: admin
-dashboard_admin_password: p@ssw0rd
+# This variable must be set with a strong custom password when dashboard_enabled is True
+#dashboard_admin_password: p@ssw0rd
 # We only need this for SSL (https) connections
 dashboard_crt: ''
 dashboard_key: ''
@@ -712,7 +713,8 @@ dashboard_rgw_api_no_ssl_verify: False
 node_exporter_container_image: "prom/node-exporter:v0.17.0"
 node_exporter_port: 9100
 grafana_admin_user: admin
-grafana_admin_password: admin
+# This variable must be set with a strong custom password when dashboard_enabled is True
+#grafana_admin_password: admin
 # We only need this for SSL (https) connections
 grafana_crt: ''
 grafana_key: ''

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -217,6 +217,13 @@
       fail:
         msg: "you must add at least one node in the [grafana-server] hosts group"
       when: groups[grafana_server_group_name] | length < 1
+
+    - name: fail when dashboard_admin_password and/or grafana_admin_password are not set
+      fail:
+        msg: "you must set dashboard_admin_password and grafana_admin_password."
+      when:
+        - dashboard_admin_password is undefined
+          or grafana_admin_password is undefined
   when: dashboard_enabled | bool
 
 - name: validate container registry credentials

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -42,3 +42,5 @@ docker_pull_timeout: 600s
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 mds_max_mds: 2
+dashboard_admin_password: $sX!cD$rYU6qR^B!
+grafana_admin_password: +xFRe+RES@7vg24n

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -35,3 +35,5 @@ openstack_pools:
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 mds_max_mds: 2
+dashboard_admin_password: $sX!cD$rYU6qR^B!
+grafana_admin_password: +xFRe+RES@7vg24n

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -20,3 +20,5 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
+dashboard_admin_password: $sX!cD$rYU6qR^B!
+grafana_admin_password: +xFRe+RES@7vg24n

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -17,3 +17,5 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
+dashboard_admin_password: $sX!cD$rYU6qR^B!
+grafana_admin_password: +xFRe+RES@7vg24n

--- a/tests/functional/docker2podman/group_vars/all
+++ b/tests/functional/docker2podman/group_vars/all
@@ -40,3 +40,5 @@ openstack_pools:
   - "{{ openstack_cinder_pool }}"
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
+dashboard_admin_password: $sX!cD$rYU6qR^B!
+grafana_admin_password: +xFRe+RES@7vg24n

--- a/tests/functional/migrate_ceph_disk_to_ceph_volume/group_vars/all
+++ b/tests/functional/migrate_ceph_disk_to_ceph_volume/group_vars/all
@@ -21,3 +21,5 @@ ceph_conf_overrides:
     osd_pool_default_pg_num: 8
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
+dashboard_admin_password: $sX!cD$rYU6qR^B!
+grafana_admin_password: +xFRe+RES@7vg24n

--- a/tests/functional/podman/group_vars/all
+++ b/tests/functional/podman/group_vars/all
@@ -40,3 +40,5 @@ openstack_pools:
   - "{{ openstack_cinder_pool }}"
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
+dashboard_admin_password: $sX!cD$rYU6qR^B!
+grafana_admin_password: +xFRe+RES@7vg24n


### PR DESCRIPTION
validate: fail if dashboard|grafana_admin_password aren't set
    
This commit adds a task to make sure the user set a custom password for
`grafana_admin_password` and `dashboard_admin_password` variables.
    
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1795509
    
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>