### PR TITLE
ceph-defaults: remove rgw from ceph_conf_overrides

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -534,7 +534,7 @@ dummy:
 # instead of [client.radosgw.*].
 # For more examples check the profiles directory of https://github.com/ceph/ceph-ansible.
 #
-# The following sections are supported: [global], [mon], [osd], [mds], [rgw]
+# The following sections are supported: [global], [mon], [osd], [mds], [client]
 #
 # Example:
 # ceph_conf_overrides:

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -534,7 +534,7 @@ ceph_iscsi_config_dev: false
 # instead of [client.radosgw.*].
 # For more examples check the profiles directory of https://github.com/ceph/ceph-ansible.
 #
-# The following sections are supported: [global], [mon], [osd], [mds], [rgw]
+# The following sections are supported: [global], [mon], [osd], [mds], [client]
 #
 # Example:
 # ceph_conf_overrides:

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -526,7 +526,7 @@ rgw_pull_proto: "http" # should be the same as rgw_multisite_proto for the maste
 # instead of [client.radosgw.*].
 # For more examples check the profiles directory of https://github.com/ceph/ceph-ansible.
 #
-# The following sections are supported: [global], [mon], [osd], [mds], [rgw]
+# The following sections are supported: [global], [mon], [osd], [mds], [client]
 #
 # Example:
 # ceph_conf_overrides:


### PR DESCRIPTION
The [rgw] section in the ceph.conf file or via the ceph_conf_overrides
variable doesn't exist and has no effect.
To apply overrides to all radosgw instances we should use either the
[global] or [client] sections.
Overrides per radosgw instance should still use the
[client.rgw.{instance-name}] section.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1794552

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>