### PR TITLE
Fixed directory reference

### DIFF
--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -26,7 +26,7 @@
     delegate_facts_host: True
 
   pre_tasks:
-    - import_tasks: "{{ playbook_dir }}/../raw_install_python.yml"
+    - import_tasks: "{{ playbook_dir }}/raw_install_python.yml"
 
     - name: gather facts
       setup:


### PR DESCRIPTION
Per the README.md, infrastructure playbooks should be moved to the root directory before running.  To maintain consistency with this policy, we need to fix the assumption that we are running from within the "infrastructure-playbooks" directory when searching for a dependency.

Also apparently this file was missing a newline at the end which github auto-added.