### PR TITLE
iscsi: Fix crashes during rolling update

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/main.yml
+++ b/roles/ceph-iscsi-gw/tasks/main.yml
@@ -19,6 +19,10 @@
     - not containerized_deployment | bool
     - not use_new_ceph_iscsi | bool
 
+- name: include non-container/postrequisites.yml
+  include_tasks: non-container/postrequisites.yml
+  when: not containerized_deployment | bool
+
 - name: include containerized.yml
   include_tasks: containerized.yml
   when: containerized_deployment | bool

--- a/roles/ceph-iscsi-gw/tasks/non-container/postrequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/postrequisites.yml
@@ -1,0 +1,9 @@
+- name: start rbd-target-api and rbd-target-gw
+  service:
+    name: "{{ item }}"
+    state: started
+    enabled: yes
+    masked: no
+  with_items:
+    - rbd-target-api
+    - rbd-target-gw

--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -72,13 +72,13 @@
     - target.stat.exists
     - not target.stat.islnk
 
-- name: start tcmu-runner, rbd-target-api and rbd-target-gw
+# Only start tcmu-runner, so configure_iscsi.yml can create disks.
+# We must start rbd-target-gw/api after configure_iscsi.yml to avoid
+# races where they are both trying to setup the same object during
+# a rolling update.
+- name: start tcmu-runner
   service:
-    name: "{{ item }}"
+    name: tcmu-runner
     state: started
     enabled: yes
     masked: no
-  with_items:
-    - tcmu-runner
-    - rbd-target-gw
-    - rbd-target-api


### PR DESCRIPTION
During a rolling update we will run the ceph iscsigw tasks that start
the daemons then run the configure_iscsi.yml tasks which can create
iscsi objects like targets, disks, clients, etc. The problem is that
once the daemons are started they will accept confifguration requests,
or may want to update the system themself. Those operations can then
conflict with the configure_iscsi.yml tasks that setup objects and we
can end up in crashes due to the kernel being in a unsupported state.

This could also happen during creation, but is less likely due to no
objects being setup yet, so there are no watchers or users accessing the
gws yet. The fix in this patch works for both update and initial setup.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1795806

Signed-off-by: Mike Christie <mchristi@redhat.com>