### PR TITLE
ceph-container-engine: lvm2 on OSD nodes only

### DIFF
--- a/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
@@ -23,13 +23,21 @@
   tags:
     with_pkg
 
-- name: install container and lvm2 packages
+- name: install container packages
   package:
-    name: ['{{ container_package_name }}', '{{ container_binding_name }}', 'lvm2']
+    name: ['{{ container_package_name }}', '{{ container_binding_name }}']
     update_cache: true
   register: result
   until: result is succeeded
   tags: with_pkg
+
+- name: install lvm2 package
+  package:
+    name: lvm2
+  register: result
+  until: result is succeeded
+  tags: with_pkg
+  when: inventory_hostname in groups.get(osd_group_name, [])
 
 - name: start container service
   service:


### PR DESCRIPTION
Since de8f2a9 the lvm2 package installation has been moved from ceph-osd
role to ceph-container-engine role.
But the scope wasn't limited to the OSD nodes only.
This commit fixes this behaviour.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>