### PR TITLE
dashboard: do not try to create rgw system user on secondary cluster

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -134,6 +134,10 @@
       retries: 3
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
+      when:
+        - (rgw_multisite | bool and
+          not rgw_zonesecondary | bool)
+          or not rgw_multisite | bool
 
     - name: get the rgw access and secret keys
       set_fact:


### PR DESCRIPTION
When deploying/upgrading a secondary rgw multisite cluster, this task
fails with following message:

```
Please run the command on master zone. Performing this operation on non-master zone leads to inconsistent metadata between zones
Are you sure you want to go ahead? (requires --yes-i-really-mean-it)
```

Let's skip this task when the node is a secondary one.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1794351

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>