### PR TITLE
defaults: update doc about ceph_conf_overrides

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -534,16 +534,15 @@ dummy:
 # instead of [client.radosgw.*].
 # For more examples check the profiles directory of https://github.com/ceph/ceph-ansible.
 #
-# The following sections are supported: [global], [mon], [osd], [mds], [rgw]
-#
-# Example:
+# The following sections are supported: [global], [mon], [osd], [mds], [client.radosgw.instance-name]
+# If the daemon you specify is a Ceph Gateway client, specify the daemon and the instance, delimited by a period (.).
+# For example:
 # ceph_conf_overrides:
 #   global:
 #     foo: 1234
-#     bar: 5678
-#   "client.rgw.{{ hostvars[groups.get(rgw_group_name)[0]]['ansible_hostname'] }}":
-#     rgw_zone: zone1
-#
+#     bar: 4556
+#   client.radosgw.rgw001:
+#     rgw_zone: zone1 
 #ceph_conf_overrides: {}
 
 

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -534,16 +534,15 @@ ceph_iscsi_config_dev: false
 # instead of [client.radosgw.*].
 # For more examples check the profiles directory of https://github.com/ceph/ceph-ansible.
 #
-# The following sections are supported: [global], [mon], [osd], [mds], [rgw]
-#
-# Example:
+# The following sections are supported: [global], [mon], [osd], [mds], [client.radosgw.instance-name]
+# If the daemon you specify is a Ceph Gateway client, specify the daemon and the instance, delimited by a period (.).
+# For example:
 # ceph_conf_overrides:
 #   global:
 #     foo: 1234
-#     bar: 5678
-#   "client.rgw.{{ hostvars[groups.get(rgw_group_name)[0]]['ansible_hostname'] }}":
-#     rgw_zone: zone1
-#
+#     bar: 4556
+#   client.radosgw.rgw001:
+#     rgw_zone: zone1 
 #ceph_conf_overrides: {}
 
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -526,16 +526,15 @@ rgw_pull_proto: "http" # should be the same as rgw_multisite_proto for the maste
 # instead of [client.radosgw.*].
 # For more examples check the profiles directory of https://github.com/ceph/ceph-ansible.
 #
-# The following sections are supported: [global], [mon], [osd], [mds], [rgw]
-#
-# Example:
+# The following sections are supported: [global], [mon], [osd], [mds], [client.radosgw.instance-name]
+# If the daemon you specify is a Ceph Gateway client, specify the daemon and the instance, delimited by a period (.).
+# For example:
 # ceph_conf_overrides:
 #   global:
 #     foo: 1234
-#     bar: 5678
-#   "client.rgw.{{ hostvars[groups.get(rgw_group_name)[0]]['ansible_hostname'] }}":
+#     bar: 4556
+#   client.radosgw.rgw001:
 #     rgw_zone: zone1
-#
 ceph_conf_overrides: {}
 
 


### PR DESCRIPTION
Currently, the documentation in ceph-defaults says `[rgw]` is a
supported section in ceph.conf which is wrong.

The right syntax for a rgw daemon is:

`[client.radosgw.instance-name]`

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1794552

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>