### PR TITLE
switch_to_containers: increase health check values

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -474,6 +474,14 @@ dummy:
 #handler_health_mgr_check_retries: 5
 #handler_health_mgr_check_delay: 10
 
+## health mon/osds check retries/delay:
+
+#health_mon_check_retries: 20
+#health_mon_check_delay: 10
+#health_osd_check_retries: 20
+#health_osd_check_delay: 10
+
+
 ###############
 # NFS-GANESHA #
 ###############

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -474,6 +474,14 @@ ceph_iscsi_config_dev: false
 #handler_health_mgr_check_retries: 5
 #handler_health_mgr_check_delay: 10
 
+## health mon/osds check retries/delay:
+
+#health_mon_check_retries: 20
+#health_mon_check_delay: 10
+#health_osd_check_retries: 20
+#health_osd_check_delay: 10
+
+
 ###############
 # NFS-GANESHA #
 ###############

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -56,8 +56,6 @@
 
 - name: switching from non-containerized to containerized ceph mon
   vars:
-    health_mon_check_retries: 5
-    health_mon_check_delay: 15
     containerized_deployment: true
     switch_to_containers: True
     mon_group_name:       mons
@@ -197,8 +195,6 @@
 - name: switching from non-containerized to containerized ceph osd
 
   vars:
-    health_osd_check_retries: 5
-    health_osd_check_delay: 15
     containerized_deployment: true
     osd_group_name: osds
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -466,6 +466,14 @@ handler_health_rbd_mirror_check_delay: 10
 handler_health_mgr_check_retries: 5
 handler_health_mgr_check_delay: 10
 
+## health mon/osds check retries/delay:
+
+health_mon_check_retries: 20
+health_mon_check_delay: 10
+health_osd_check_retries: 20
+health_osd_check_delay: 10
+
+
 ###############
 # NFS-GANESHA #
 ###############


### PR DESCRIPTION
This commit increases the default values for the following variable
consumed in switch-from-non-containerized-to-containerized-ceph-daemons.yml
playbook.
This also moves these variables in `ceph-defaults` role so the user can
set different values if needed.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1783223

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>