### PR TITLE
validate: allow running ceph-ansible 3.2 against ansible 2.7

### DIFF
--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -67,10 +67,10 @@
 
 - name: fail on unsupported ansible version
   fail:
-    msg: "Ansible version must be between 2.4.x and 2.6.x!"
+    msg: "Ansible version must be between 2.4.x and 2.7.x!"
   when:
     - ansible_version.major|int == 2
-    - (ansible_version.minor|int < 4 or ansible_version.minor|int > 6)
+    - (ansible_version.minor|int < 4 or ansible_version.minor|int > 7)
 
 - name: fail if systemd is not present
   fail:


### PR DESCRIPTION
This commit allows ceph-ansible 3.2 to be run against ansible 2.7

However, note that this might break the playbook, only ansible 2.6 is
officially supported.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1781635

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>