### PR TITLE
ceph-common: rhcs 4 repositories for rhel 7

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -174,7 +174,7 @@ dummy:
 #
 # Enabled when ceph_repository == 'rhcs'
 #
-# This version is only supported on RHEL >= 8.0
+# This version is supported on RHEL 7 and 8
 #
 #ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(4) }}"
 #valid_ceph_repository_type:

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -174,7 +174,7 @@ ceph_repository: rhcs
 #
 # Enabled when ceph_repository == 'rhcs'
 #
-# This version is only supported on RHEL >= 8.0
+# This version is supported on RHEL 7 and 8
 #
 ceph_rhcs_version: 4
 #valid_ceph_repository_type:

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
@@ -1,15 +1,36 @@
 ---
-- name: enable red hat storage monitor repository
-  rhsm_repository:
-    name: "rhceph-{{ ceph_rhcs_version }}-mon-for-rhel-8-{{ ansible_architecture }}-rpms"
-  when: (mon_group_name in group_names or mgr_group_name in group_names)
+- name: "rhcs {{ ceph_rhcs_version }} on rhel 8"
+  when: ansible_distribution_major_version | int == 8
+  block:
+    - name: enable red hat storage monitor repository
+      rhsm_repository:
+        name: "rhceph-{{ ceph_rhcs_version }}-mon-for-rhel-8-{{ ansible_architecture }}-rpms"
+      when: (mon_group_name in group_names or mgr_group_name in group_names)
 
-- name: enable red hat storage osd repository
-  rhsm_repository:
-    name: "rhceph-{{ ceph_rhcs_version }}-osd-for-rhel-8-{{ ansible_architecture }}-rpms"
-  when: osd_group_name in group_names
+    - name: enable red hat storage osd repository
+      rhsm_repository:
+        name: "rhceph-{{ ceph_rhcs_version }}-osd-for-rhel-8-{{ ansible_architecture }}-rpms"
+      when: osd_group_name in group_names
 
-- name: enable red hat storage tools repository
-  rhsm_repository:
-    name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_architecture }}-rpms"
-  when: (rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names)
+    - name: enable red hat storage tools repository
+      rhsm_repository:
+        name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_architecture }}-rpms"
+      when: (rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names)
+
+- name: "rhcs {{ ceph_rhcs_version }} on rhel 7"
+  when: ansible_distribution_major_version | int == 7
+  block:
+    - name: enable red hat storage monitor repository
+      rhsm_repository:
+        name: "rhel-7-server-rhceph-{{ ceph_rhcs_version }}-mon-rpms"
+      when: (mon_group_name in group_names or mgr_group_name in group_names)
+
+    - name: enable red hat storage osd repository
+      rhsm_repository:
+        name: "rhel-7-server-rhceph-{{ ceph_rhcs_version }}-osd-rpms"
+      when: osd_group_name in group_names
+
+    - name: enable red hat storage tools repository
+      rhsm_repository:
+        name: "rhel-7-server-rhceph-{{ ceph_rhcs_version }}-tools-rpms"
+      when: (rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names)

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -166,7 +166,7 @@ ceph_stable_redhat_distro: el7
 #
 # Enabled when ceph_repository == 'rhcs'
 #
-# This version is only supported on RHEL >= 8.0
+# This version is supported on RHEL 7 and 8
 #
 ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(4) }}"
 valid_ceph_repository_type:


### PR DESCRIPTION
RHCS 4 is available for both RHEL 7 and 8 so we should also enable the
cdn repositories for that distribution.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1796853

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>