### PR TITLE
tests: remove legacy `osd_scenario` variable

### DIFF
--- a/tests/functional/add-mgrs/container/group_vars/all
+++ b/tests/functional/add-mgrs/container/group_vars/all
@@ -10,7 +10,6 @@ monitor_interface: eth1
 radosgw_interface: eth1
 journal_size: 100
 osd_objectstore: "bluestore"
-osd_scenario: lvm
 copy_admin_key: true
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sdb
 lvm_volumes:

--- a/tests/functional/add-mgrs/group_vars/all
+++ b/tests/functional/add-mgrs/group_vars/all
@@ -8,7 +8,6 @@ monitor_interface: eth1
 radosgw_interface: eth1
 journal_size: 100
 osd_objectstore: "bluestore"
-osd_scenario: lvm
 copy_admin_key: true
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sdb
 lvm_volumes:

--- a/tests/functional/add-mons/container/group_vars/all
+++ b/tests/functional/add-mons/container/group_vars/all
@@ -10,7 +10,6 @@ monitor_interface: eth1
 radosgw_interface: eth1
 journal_size: 100
 osd_objectstore: "bluestore"
-osd_scenario: lvm
 copy_admin_key: true
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sdb
 lvm_volumes:

--- a/tests/functional/add-mons/group_vars/all
+++ b/tests/functional/add-mons/group_vars/all
@@ -8,7 +8,6 @@ monitor_interface: eth1
 radosgw_interface: eth1
 journal_size: 100
 osd_objectstore: "bluestore"
-osd_scenario: lvm
 copy_admin_key: true
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sdb
 lvm_volumes:

--- a/tests/functional/add-rbdmirrors/container/group_vars/all
+++ b/tests/functional/add-rbdmirrors/container/group_vars/all
@@ -10,7 +10,6 @@ monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 journal_size: 100
 osd_objectstore: "bluestore"
-osd_scenario: lvm
 copy_admin_key: true
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sdb
 lvm_volumes:

--- a/tests/functional/add-rbdmirrors/group_vars/all
+++ b/tests/functional/add-rbdmirrors/group_vars/all
@@ -8,7 +8,6 @@ monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 journal_size: 100
 osd_objectstore: "bluestore"
-osd_scenario: lvm
 copy_admin_key: true
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sdb
 lvm_volumes:

--- a/tests/functional/add-rgws/container/group_vars/all
+++ b/tests/functional/add-rgws/container/group_vars/all
@@ -10,7 +10,6 @@ monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 journal_size: 100
 osd_objectstore: "bluestore"
-osd_scenario: lvm
 copy_admin_key: true
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sdb
 lvm_volumes:

--- a/tests/functional/add-rgws/group_vars/all
+++ b/tests/functional/add-rgws/group_vars/all
@@ -8,7 +8,6 @@ monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 journal_size: 100
 osd_objectstore: "bluestore"
-osd_scenario: lvm
 copy_admin_key: true
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sdb
 lvm_volumes:

--- a/tests/functional/shrink_mds/group_vars/all
+++ b/tests/functional/shrink_mds/group_vars/all
@@ -7,7 +7,6 @@ monitor_interface: eth1
 radosgw_interface: eth1
 journal_size: 100
 osd_objectstore: "bluestore"
-osd_scenario: lvm
 copy_admin_key: true
 ceph_conf_overrides:
   global:

--- a/tests/functional/shrink_rbdmirror/group_vars/all
+++ b/tests/functional/shrink_rbdmirror/group_vars/all
@@ -5,7 +5,6 @@ public_network: "192.168.85.0/24"
 cluster_network: "192.168.86.0/24"
 monitor_interface: eth1
 osd_objectstore: "bluestore"
-osd_scenario: lvm
 copy_admin_key: true
 ceph_conf_overrides:
   global:

--- a/tests/functional/shrink_rgw/group_vars/all
+++ b/tests/functional/shrink_rgw/group_vars/all
@@ -6,7 +6,6 @@ cluster_network: "192.168.90.0/24"
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 osd_objectstore: "bluestore"
-osd_scenario: lvm
 copy_admin_key: true
 ceph_conf_overrides:
   global:


### PR DESCRIPTION
As of stable-4.0 most of these references aren't needed anymore.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>