### PR TITLE
ceph-rgw-loadbalancer: Fix SSL newline issue

### DIFF
--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -9,7 +9,7 @@ global
     group       haproxy
     daemon
     stats socket /var/lib/haproxy/stats
-{%- if haproxy_frontend_ssl_certificate %}
+{% if haproxy_frontend_ssl_certificate %}
     tune.ssl.default-dh-param {{ haproxy_ssl_dh_param }}
     ssl-default-bind-ciphers {{ haproxy_ssl_ciphers | join(':') }}
     ssl-default-bind-options {{ haproxy_ssl_options | join(' ') }}


### PR DESCRIPTION
The ad7a5da commit introduced a regression when using TLS on haproxy
via the haproxy_frontend_ssl_certificate variable.
This cause the "stats socket" and the "tune.ssl.default-dh-param"
parameters to be on the same line resulting haproxy failing to start.

[ALERT] 351/140240 (21388) : parsing [xxxxx] : 'stats socket' : unknown
keyword 'tune.ssl.default-dh-param'. Registered
[ALERT] 351/140240 (21388) : Fatal errors found in configuration.

Fixes: #4869

Signed-off-by: Florian Faltermeier <florian.faltermeier@uibk.ac.at>