### PR TITLE
Revert "vagrant: temp workaround for CentOS 8 cloud image"

### DIFF
--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-vagrant box add --provider libvirt --name centos/8 https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-Vagrant-8.1.1911-20200113.3.x86_64.vagrant-libvirt.box
-
 retries=0
 until [ $retries -ge 5 ]
 do


### PR DESCRIPTION
The CentOS 8 vagrant image download is now fixed.

This reverts commit a5385e104884a3692954e4691f3348847a35c7fa.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>