### PR TITLE
tox: pin ceph_dev_sha1 value for ceph-volume

### DIFF
--- a/tox-external_clients.ini
+++ b/tox-external_clients.ini
@@ -31,6 +31,8 @@ setenv=
   container: PLAYBOOK = site-docker.yml.sample
   non_container: PLAYBOOK = site.yml.sample
 
+  CEPH_DEV_SHA1 = b92cbad0603d9794a0893a73cd6a71de895ff46f
+
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/external_clients{env:CONTAINER_DIR:}
 commands=
@@ -50,7 +52,7 @@ commands=
       ceph_docker_image=ceph/daemon \
       ceph_docker_image_tag=latest-master \
       ceph_dev_branch=master \
-      ceph_dev_sha1=latest \
+      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
 
   ansible-playbook -vv -i {changedir}/external_clients-hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
@@ -63,7 +65,7 @@ commands=
       ceph_docker_image=ceph/daemon \
       ceph_docker_image_tag=latest-master \
       ceph_dev_branch=master \
-      ceph_dev_sha1=latest \
+      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
 
   bash -c "CEPH_STABLE_RELEASE={env:UPDATE_CEPH_STABLE_RELEASE:octopus} py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests"

--- a/tox-filestore_to_bluestore.ini
+++ b/tox-filestore_to_bluestore.ini
@@ -34,6 +34,7 @@ setenv=
 
   CEPH_DOCKER_IMAGE_TAG = latest-master
   CEPH_STABLE_RELEASE = octopus
+  CEPH_DEV_SHA1 = b92cbad0603d9794a0893a73cd6a71de895ff46f
 
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/filestore-to-bluestore{env:CONTAINER_DIR:}

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -31,6 +31,7 @@ setenv=
   container: PLAYBOOK = site-docker.yml.sample
   non_container: PLAYBOOK = site.yml.sample
 
+  CEPH_DEV_SHA1 = b92cbad0603d9794a0893a73cd6a71de895ff46f
   UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
   UPDATE_CEPH_DEV_BRANCH = master
   UPDATE_CEPH_DEV_SHA1 = latest

--- a/tox.ini
+++ b/tox.ini
@@ -403,6 +403,7 @@ setenv=
 
   CEPH_DOCKER_IMAGE_TAG = latest-master
   CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-master
+  CEPH_DEV_SHA1 = b92cbad0603d9794a0893a73cd6a71de895ff46f
   UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
   UPDATE_CEPH_DEV_BRANCH = master
   UPDATE_CEPH_DEV_SHA1 = latest


### PR DESCRIPTION
Since this commit [1] there's a race condition in ceph-volume when using
multiple LV in the same VG for the OSDs causing multiple scenarios to
fail.
This temporary workaround pin the ceph dev sha1 to the previous shaman
build working.

[1] https://github.com/ceph/ceph/commit/ec2e53f

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>