### PR TITLE
ceph-validate: update registry password to accept vault value

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -236,7 +236,7 @@
   when:
     - ceph_docker_registry_auth | bool
     - (ceph_docker_registry_username is not defined or ceph_docker_registry_password is not defined) or
-      (ceph_docker_registry_username | length == 0 or ceph_docker_registry_password | length == 0)
+      (ceph_docker_registry_username | length == 0 or ceph_docker_registry_password | string | length == 0)
 
 - name: validate openstack_keys key format
   fail:


### PR DESCRIPTION
Add vault value password support for docker registry credentials

resolves_stderr: object of type 'AnsibleVaultEncryptedUnicode' has no len()

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1797734
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1797787

Signed-off-by: Randy J. Martinez ramartin@redhat.com