### PR TITLE
ceph-defaults: update default dashboard_enabled variable

### DIFF
--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -694,7 +694,7 @@ openstack_keys:
 #############
 # DASHBOARD #
 #############
-dashboard_enabled: True
+dashboard_enabled: False
 # Choose http or https
 # For https, you should set dashboard.crt/key and grafana.crt/key
 # If you define the dashboard_crt and dashboard_key variables, but leave them as '',


### PR DESCRIPTION
We should not force the deployment of ceph metrics.
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1797765
Signed-off-by: Randy J. Martinez ramartin@redhat.com