### PR TITLE
ceph-osd: update crush_rule condition

### DIFF
--- a/roles/ceph-osd/tasks/crush_rules.yml
+++ b/roles/ceph-osd/tasks/crush_rules.yml
@@ -24,7 +24,7 @@
   with_items: "{{ hostvars[groups[mon_group_name][0]]['crush_rules'] | unique }}"
   delegate_to: '{{ groups[mon_group_name][0] }}'
   run_once: true
-  when: item.default | bool
+  when: item.default | default(omit) | bool
 
 # If multiple rules are set as default (should not be) then the last one is taken as actual default.
 # the with_items statement overrides each iteration with the new one.


### PR DESCRIPTION
During evaluation, when item.default is not defined the following error is thrown: "dict object' has no attribute 'default'"
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1797774
Signed-off-by: Randy J. Martinez ramartin@redhat.com