### PR TITLE
Fix rolling update playbook

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -951,7 +951,7 @@
       vars:
         msgr2_migration: True
 
-- import_playbook: ../dashboard.yml
+- import_playbook: dashboard.yml
   when:
     - dashboard_enabled | bool
     - groups.get(grafana_server_group_name, []) | length > 0

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -263,6 +263,26 @@
       delay: "{{ health_mon_check_delay }}"
       when: containerized_deployment | bool
 
+    - name: unset osd flags
+      command: ceph --cluster {{ cluster }} osd unset {{ item }}
+      with_items:
+        - noout
+        - norebalance
+      delegate_to: "{{ mon_host }}"
+      when:
+        - inventory_hostname == groups[mon_group_name] | last
+        - not containerized_deployment | bool
+    - name: unset containerized osd flags
+      command: >
+        {{ container_binary }} exec ceph-mon-{{ hostvars[mon_host]['ansible_hostname'] }} ceph --cluster {{ cluster }} osd unset {{ item }}
+      with_items:
+        - noout
+        - norebalance
+      delegate_to: "{{ mon_host }}"
+      when:
+        - inventory_hostname == groups[mon_group_name] | last
+        - containerized_deployment | bool
+
 
 - name: reset mon_host
   hosts: "{{ mon_group_name|default('mons') }}"

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -38,7 +38,7 @@ osd pool default crush rule = {{ osd_pool_default_crush_rule | default(ceph_osd_
 fsid = {{ fsid }}
 mon host = {% if nb_mon > 0 %}
 {% for host in _monitor_addresses -%}
-{% if msgr2_migration | default(False) %}
+{% if msgr2_migration | default(False) and mon_host_v1.enabled %}
 [{{ "v2:" + host.addr + mon_host_v2.suffix }},{{ "v1:" + host.addr + mon_host_v1.suffix }}]
 {%- elif not msgr2_migration | default(False) and rolling_update -%}
 {{ host.addr }}


### PR DESCRIPTION
Running `ansible-playbook rolling_update.yml` to upgrade a Ceph cluster from 14.2.6 to 14.2.7 failed due to the three issues addressed by the three commits in this PR:

- Wrong `dashboard.yml` playbook import path;
- `norebalance` flag remains set after upgrade;
- `ceph.conf.j2` template fails to render if `mon_host_v1` is disabled.