### PR TITLE
ceph-mon: use interactive session with aliases

### DIFF
--- a/roles/ceph-mon/templates/ceph-aliases.sh.j2
+++ b/roles/ceph-mon/templates/ceph-aliases.sh.j2
@@ -1,17 +1,17 @@
 #!/bin/bash
 # Sets up handy aliases for ceph.
 ceph() {
-  sudo {{ docker_exec_cmd }} ceph --cluster {{ cluster }} ${@}
+  sudo docker exec -it ceph-mon-{{ ansible_hostname }} ceph --cluster {{ cluster }} ${@}
 }
 
 radosgw-admin() {
-  sudo {{ docker_exec_cmd }} radosgw-admin --cluster {{ cluster }} ${@}
+  sudo docker exec -it ceph-mon-{{ ansible_hostname }} radosgw-admin --cluster {{ cluster }} ${@}
 }
 
 rados() {
-  sudo {{ docker_exec_cmd }} rados --cluster {{ cluster }} ${@}
+  sudo docker exec -it ceph-mon-{{ ansible_hostname }} rados --cluster {{ cluster }} ${@}
 }
 
 rbd() {
-  sudo {{ docker_exec_cmd }} rbd --cluster {{ cluster }} ${@}
+  sudo docker exec -it ceph-mon-{{ ansible_hostname }} rbd --cluster {{ cluster }} ${@}
 }


### PR DESCRIPTION
When using ceph aliases with commands that require manual intervention
to stop then the command will keep running inside the container (like
using Ctrl+c).
For handling this, we should use the interactive session option (-it)
with the docker commands.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1797874

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>