### PR TITLE
rhcs: update container image name

### DIFF
--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -567,7 +567,7 @@ ceph_iscsi_config_dev: false
 ##########
 # DOCKER #
 ##########
-ceph_docker_image: "rhceph/rhceph-4-rhel8"
+ceph_docker_image: "rhceph/rhceph-4"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"
 ceph_docker_registry_auth: true

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -3,7 +3,7 @@ ceph_origin: repository
 ceph_iscsi_config_dev: false
 fetch_directory: ~/ceph-ansible-keys
 ceph_rhcs_version: 4
-ceph_docker_image: "rhceph/rhceph-4-rhel8"
+ceph_docker_image: "rhceph/rhceph-4"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"
 ceph_docker_registry_auth: true


### PR DESCRIPTION
The RHCS 4 container image is rhceph/rhceph-4

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1797743

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>