### PR TITLE
The _filtered_clients list should intersect with ansible_play_batch

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -19,7 +19,7 @@
   add_host:
     name: "{{ item }}"
     groups: _filtered_clients
-  with_items: "{{ groups[client_group_name] }}"
+  with_items: "{{ groups[client_group_name] | intersect(ansible_play_batch) }}"
   when: (hostvars[item]['ansible_architecture'] == 'x86_64') or (not containerized_deployment | bool)
 
 - name: set_fact delegated_node


### PR DESCRIPTION
Client configuration with --limit fails without this patch
because certain tasks are only done to the first host in the
_filtered_clients list and it's likely that first host will
not be included in what's sepcified with --limit. To fix this
the _filtered_clients list should be built from all clients
in the inventory that are also in the running play.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1798781

Signed-off-by: John Fulton <fulton@redhat.com>