### PR TITLE
ceph-rgw-loadbalancer: Allow connect rgw-backend with ssl

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -333,7 +333,7 @@
 
 - name: set_fact rgw_instances
   set_fact:
-    rgw_instances: "{{ rgw_instances|default([]) | union([{'instance_name': 'rgw' + item|string, 'radosgw_address': _radosgw_address, 'radosgw_frontend_port': radosgw_frontend_port|int + item|int}]) }}"
+    rgw_instances: "{{ rgw_instances|default([]) | union([{'instance_name': 'rgw' + item|string, 'radosgw_address': _radosgw_address, 'radosgw_frontend_port': radosgw_frontend_port|int + item|int, 'radosgw_frontend_ssl_certificate': radosgw_frontend_ssl_certificate}]) }}"
   with_sequence: start=0 end={{ radosgw_num_instances|int - 1 }}
   when: inventory_hostname in groups.get(rgw_group_name, [])
 

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -46,6 +46,6 @@ backend rgw-backend
     option httpchk Get /
 {% for host in groups[rgw_group_name] %}
 {% for instance in hostvars[host]['rgw_instances'] %}
-	server {{ 'server-' + hostvars[host]['ansible_hostname'] + '-' + instance['instance_name'] }} {{ instance['radosgw_address'] }}:{{ instance['radosgw_frontend_port'] }} weight 100
+	server {{ 'server-' + hostvars[host]['ansible_hostname'] + '-' + instance['instance_name'] }} {{ instance['radosgw_address'] }}:{{ instance['radosgw_frontend_port'] }} weight 100 {{ 'ssl verify none' if instance['radosgw_frontend_ssl_certificate'] else '' }}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Make haproxy connect rgw with ssl when rgw certificates is used.

Signed-off-by: Yu Chih <secret104278@gmail.com>