### PR TITLE
ceph-nfs: add nfs-ganesha-rados-urls package

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
@@ -49,7 +49,7 @@
 
     - name: install redhat nfs-ganesha-rgw and ceph-radosgw packages
       package:
-        name: ['nfs-ganesha-rgw', 'nfs-ganesha-rados-grace', 'ceph-radosgw']
+        name: ['nfs-ganesha-rgw', 'nfs-ganesha-rados-grace', 'nfs-ganesha-rados-urls', 'ceph-radosgw']
         state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
       register: result
       until: result is succeeded


### PR DESCRIPTION
Since nfs-ganesha 2.8.3 the rados-urls library has been move to a
dedicated package.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>