### PR TITLE
ceph-nfs: add nfs-ganesha-rados-urls package

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
@@ -50,3 +50,13 @@
       register: result
       until: result is succeeded
       when: nfs_obj_gw | bool
+
+    - name: install nfs-ganesha-rados-urls
+      package:
+        name: nfs-ganesha-rados-urls
+        state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
+      register: result
+      until: result is succeeded
+      when:
+        - nfs_obj_gw | bool
+        - ceph_repository == 'rhcs'


### PR DESCRIPTION
Since nfs-ganesha 2.8.3 the rados-urls library has been move to a
dedicated package.
We don't have the same nfs-ganesha 2.8.x between the community and rhcs
repositories.

community: 2.8.1
rhcs: 2.8.3

As a workaround we will install that package only for rhcs setup.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>