### PR TITLE
ceph-nfs: fix ceph_nfs_ceph_user variable

### DIFF
--- a/roles/ceph-nfs/tasks/main.yml
+++ b/roles/ceph-nfs/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: copy rgw keyring when deploying internal ganesha with external ceph cluster
   copy:
-    src: "/etc/ceph/{{ cluster }}.{{ ceph_nfs_ceph_user.name }}.keyring"
+    src: "/etc/ceph/{{ cluster }}.{{ ceph_nfs_ceph_user }}.keyring"
     dest: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}/keyring"
     mode: '0600'
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"


### PR DESCRIPTION
The ceph_nfs_ceph_user variable is a string for the ceph-nfs role but a
list in ceph-client role.
6a6785b introduced a confusion between both variable type in the ceph-nfs
role for external ceph with ganesha.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1801319

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>