### PR TITLE
container: use --storage with podman rm

### DIFF
--- a/roles/ceph-grafana/templates/grafana-server.service.j2
+++ b/roles/ceph-grafana/templates/grafana-server.service.j2
@@ -11,7 +11,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} stop grafana-server
-ExecStartPre=-/usr/bin/{{ container_binary }} rm grafana-server
+ExecStartPre=-/usr/bin/{{ container_binary }} rm {% if container_binary == 'podman' %}--storage{% endif %} grafana-server
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=grafana-server \
   -v /etc/grafana:/etc/grafana:Z \
   -v /var/lib/grafana:/var/lib/grafana:Z \

--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -9,7 +9,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-api
-ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-api
+ExecStartPre=-/usr/bin/{{ container_binary }} rm {% if container_binary == 'podman' %}--storage{% endif %} rbd-target-api
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --memory={{ ceph_rbd_target_api_docker_memory_limit }} \
   --cpus={{ ceph_rbd_target_api_docker_cpu_limit }} \

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -9,7 +9,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-gw
-ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-gw
+ExecStartPre=-/usr/bin/{{ container_binary }} rm {% if container_binary == 'podman' %}--storage{% endif %} rbd-target-gw
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --memory={{ ceph_rbd_target_gw_docker_memory_limit }} \
   --cpus={{ ceph_rbd_target_gw_docker_cpu_limit }} \

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -9,7 +9,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} stop tcmu-runner
-ExecStartPre=-/usr/bin/{{ container_binary }} rm tcmu-runner
+ExecStartPre=-/usr/bin/{{ container_binary }} rm {% if container_binary == 'podman' %}--storage{% endif %} tcmu-runner
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --memory={{ ceph_tcmu_runner_docker_memory_limit }} \
   --cpus={{ ceph_tcmu_runner_docker_cpu_limit }} \

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -10,7 +10,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mds-{{ ansible_hostname }}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mds-{{ ansible_hostname }}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm {% if container_binary == 'podman' %}--storage{% endif %} ceph-mds-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_mds_docker_memory_limit }} \
   --cpus={{ cpu_limit }} \

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -9,7 +9,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mgr-{{ ansible_hostname }}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mgr-{{ ansible_hostname }}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm {% if container_binary == 'podman' %}--storage{% endif %} ceph-mgr-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_mgr_docker_memory_limit }} \
   --cpus={{ ceph_mgr_docker_cpu_limit }} \

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -8,7 +8,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mon-%i
+ExecStartPre=-/usr/bin/{{ container_binary }} rm {% if container_binary == 'podman' %}--storage{% endif %} ceph-mon-%i
 ExecStartPre=/bin/sh -c '"$(command -v mkdir)" -p /etc/ceph /var/lib/ceph/mon'
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
   --memory={{ ceph_mon_docker_memory_limit }} \

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -9,7 +9,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-nfs-%i
+ExecStartPre=-/usr/bin/{{ container_binary }} rm {% if container_binary == 'podman' %}--storage{% endif %} ceph-nfs-%i
 ExecStartPre={{ '/bin/mkdir' if ansible_os_family == 'Debian' else '/usr/bin/mkdir' }} -p /etc/ceph /etc/ganesha /var/lib/nfs/ganesha
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -v /var/lib/ceph:/var/lib/ceph:z \

--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -10,7 +10,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
-ExecStartPre=-/usr/bin/{{ container_binary }} rm -f node-exporter
+ExecStartPre=-/usr/bin/{{ container_binary }} rm -f {% if container_binary == 'podman' %}--storage{% endif %} node-exporter
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
   --privileged \
   -v /proc:/host/proc:ro -v /sys:/host/sys:ro \

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -10,7 +10,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-osd-%i
-ExecStartPre=-/usr/bin/{{ container_binary }} rm -f ceph-osd-%i
+ExecStartPre=-/usr/bin/{{ container_binary }} rm -f {% if container_binary == 'podman' %}--storage{% endif %} ceph-osd-%i
 ExecStart={{ ceph_osd_docker_run_script_path }}/ceph-osd-run.sh %i
 ExecStop=-/usr/bin/{{ container_binary }} stop ceph-osd-%i
 Restart=always

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -11,7 +11,7 @@ After=network.target
 [Service]
 WorkingDirectory={{ alertmanager_data_dir }}
 EnvironmentFile=-/etc/environment
-ExecStartPre=-/usr/bin/{{ container_binary }} rm -f alertmanager
+ExecStartPre=-/usr/bin/{{ container_binary }} rm -f {% if container_binary == 'podman' %}--storage{% endif %} alertmanager
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=alertmanager \
   -v "{{ alertmanager_conf_dir }}:/etc/alertmanager:Z" \
   -v "{{ alertmanager_data_dir }}:/alertmanager:Z" \

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -10,7 +10,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
-ExecStartPre=-/usr/bin/{{ container_binary }} rm -f prometheus
+ExecStartPre=-/usr/bin/{{ container_binary }} rm -f {% if container_binary == 'podman' %}--storage{% endif %} prometheus
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=prometheus \
   -v "{{ prometheus_conf_dir }}:/etc/prometheus:Z" \
   -v "{{ prometheus_data_dir }}:/prometheus:Z" \

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -9,7 +9,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rbd-mirror-{{ ansible_hostname }}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rbd-mirror-{{ ansible_hostname }}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm {% if container_binary == 'podman' %}--storage{% endif %} ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_rbd_mirror_docker_memory_limit }} \
   --cpus={{ ceph_rbd_mirror_docker_cpu_limit }} \

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -10,7 +10,7 @@ After=network.target
 [Service]
 EnvironmentFile=/var/lib/ceph/radosgw/{{ cluster }}-%i/EnvironmentFile
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm {% if container_binary == 'podman' %}--storage{% endif %} ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_rgw_docker_memory_limit }} \
   --cpus={{ cpu_limit }} \


### PR DESCRIPTION
Until we have podman 1.7.0 that fixes an issue where the container is
still referenced after being stopped and removed (--rm) then we should
use --storage with podman rm commands.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>