### PR TITLE
containers: add KillMode=none to systemd templates

### DIFF
--- a/roles/ceph-grafana/templates/grafana-server.service.j2
+++ b/roles/ceph-grafana/templates/grafana-server.service.j2
@@ -23,6 +23,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=grafana-server \
   -e GF_INSTALL_PLUGINS={{ grafana_plugins|join(',') }} \
   {{ grafana_container_image }}
 ExecStop=-/usr/bin/{{ container_binary }} stop grafana-server
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -28,6 +28,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --name=rbd-target-api \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop rbd-target-api
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -28,6 +28,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --name=rbd-target-gw \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop rbd-target-gw
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -27,6 +27,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --name=tcmu-runner \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop tcmu-runner
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -26,6 +26,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --name=ceph-mds-{{ ansible_hostname }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop ceph-mds-{{ ansible_hostname }}
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -25,6 +25,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --name=ceph-mgr-{{ ansible_hostname }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop ceph-mgr-{{ ansible_hostname }}
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -39,6 +39,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
   {{ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStop=-/usr/bin/{{ container_binary }} stop ceph-mon-%i
 ExecStopPost=-/bin/rm -f /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -30,6 +30,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --name=ceph-nfs-{{ ceph_nfs_service_suffix | default(ansible_hostname) }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop ceph-nfs-%i
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
   --no-collector.timex \
   --web.listen-address=:{{ node_exporter_port }}
 ExecStop=-/usr/bin/{{ container_binary }} stop node-exporter
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -13,6 +13,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-osd-%i
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f ceph-osd-%i
 ExecStart={{ ceph_osd_docker_run_script_path }}/ceph-osd-run.sh %i
 ExecStop=-/usr/bin/{{ container_binary }} stop ceph-osd-%i
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -26,6 +26,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=alertmanager \
   --web.external-url=http://{{ ansible_fqdn }}:{{ alertmanager_port }}/ \
   --web.listen-address=:{{ alertmanager_port }}
 ExecStop=/usr/bin/{{ container_binary }} stop alertmanager
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -26,6 +26,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=prometheus \
   --web.external-url=http://{{ ansible_fqdn }}:{{ prometheus_port }}/ \
   --web.listen-address=:{{ prometheus_port }}
 ExecStop=/usr/bin/{{ container_binary }} stop prometheus
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -25,6 +25,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   {{ ceph_rbd_mirror_docker_extra_env }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop ceph-rbd-mirror-{{ ansible_hostname }}
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -40,6 +40,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   {{ ceph_rgw_docker_extra_env }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
+KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120


### PR DESCRIPTION
Because we are relying on docker|podman for managing containers then we
don't need systemd to manage the process (like kill).

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>