### PR TITLE
ceph-validate: fail if no mgr host is present

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -158,6 +158,13 @@
     - osd_objectstore == 'filestore'
     - osd_group_name in group_names
 
+- name: fail if no mgr host is present in the inventory
+  fail:
+    msg: "Please add a mgr host to your inventory."
+  when:
+    - groups.get(mon_group_name, []) | length > 0
+    - groups.get(mgr_group_name, []) | length == 0
+
 - name: include check_system.yml
   include_tasks: check_system.yml
 


### PR DESCRIPTION
We already stop the upgrade playbook (rolling_update.yml) if there's
no mgr node present so we should also do the same for initial
deployment.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1788644

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>