### PR TITLE
Configure ceph dashboard backend and dashboard_frontend_vip

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -720,6 +720,7 @@ dummy:
 #dashboard_rgw_api_user_id: ceph-dashboard
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
+#dashboard_frontend_vip: ''
 #node_exporter_container_image: "prom/node-exporter:v0.17.0"
 #node_exporter_port: 9100
 #grafana_admin_user: admin

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -720,6 +720,7 @@ ceph_docker_registry_auth: true
 #dashboard_rgw_api_user_id: ceph-dashboard
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
+#dashboard_frontend_vip: ''
 node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1
 #node_exporter_port: 9100
 #grafana_admin_user: admin

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -123,6 +123,18 @@
   vars:
     grafana_server_addr: '{{ item }}'
 
+- name: config grafana api url vip
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ dashboard_frontend_vip }}:{{ grafana_port }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  changed_when: false
+  when: dashboard_frontend_vip is defined and dashboard_frontend_vip |length > 0
+
+- include_tasks: configure_dashboard_backends.yml
+  with_items: '{{ groups[mgr_group_name] | default(groups[mon_group_name]) }}'
+  vars:
+    dashboard_backend: '{{ item }}'
+
 - name: dashboard object gateway management frontend
   when: groups.get(rgw_group_name, []) | length > 0
   block:

--- a/roles/ceph-dashboard/tasks/configure_dashboard_backends.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard_backends.yml
@@ -1,0 +1,16 @@
+---
+- name: get current mgr backend - ipv4
+  set_fact:
+    mgr_server_addr: "{{ hostvars[dashboard_backend]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}"
+  when: ip_version == 'ipv4'
+
+- name: get current mgr backend - ipv6
+  set_fact:
+    mgr_server_addr: "{{ hostvars[dashboard_backend]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}"
+  when: ip_version == 'ipv6'
+
+- name: config the current dashboard backend
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} config set mgr mgr/dashboard/{{ hostvars[dashboard_backend]['ansible_hostname'] }}/server_addr {{ mgr_server_addr }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  changed_when: false
+  run_once: true

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -712,6 +712,7 @@ dashboard_key: ''
 dashboard_rgw_api_user_id: ceph-dashboard
 dashboard_rgw_api_admin_resource: ''
 dashboard_rgw_api_no_ssl_verify: False
+dashboard_frontend_vip: ''
 node_exporter_container_image: "prom/node-exporter:v0.17.0"
 node_exporter_port: 9100
 grafana_admin_user: admin

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -24,7 +24,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=prometheus \
   --config.file=/etc/prometheus/prometheus.yml \
   --storage.tsdb.path=/prometheus \
   --web.external-url=http://{{ ansible_fqdn }}:{{ prometheus_port }}/ \
-  --web.listen-address=:{{ prometheus_port }}
+  --web.listen-address={{ grafana_server_addr }}:{{ prometheus_port }}
 ExecStop=/usr/bin/{{ container_binary }} stop prometheus
 KillMode=none
 Restart=always


### PR DESCRIPTION
This change introduces a new set of tasks to configure the
ceph dashboard backend and listen just on the mgr related
subnet (and not on '*'). For the same reason the proper
server address is added in both prometheus and alertmanger
systemd units.
This patch also adds the "dashboard_frontend_vip" parameter
to make sure we're able to support the HA model when multiple
grafana instances are deployed.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1792230
Signed-off-by: Francesco Pantano <fpantano@redhat.com>