### PR TITLE
ceph-defaults: remove bootstrap_dirs_xxx vars

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -102,13 +102,6 @@ dummy:
 # Note that this selection is currently ignored on containerized deployments
 #ntp_daemon_type: chronyd
 
-
-# Set uid/gid to default '64045' for bootstrap directories.
-# '64045' is used for debian based distros. It must be set to 167 in case of rhel based distros.
-# These values have to be set according to the base OS used by the container image, NOT the host.
-#bootstrap_dirs_owner: "64045"
-#bootstrap_dirs_group: "64045"
-
 # This variable determines if ceph packages can be updated.  If False, the
 # package resources will use "state=present".  If True, they will use
 # "state=latest".

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -102,13 +102,6 @@ fetch_directory: ~/ceph-ansible-keys
 # Note that this selection is currently ignored on containerized deployments
 #ntp_daemon_type: chronyd
 
-
-# Set uid/gid to default '64045' for bootstrap directories.
-# '64045' is used for debian based distros. It must be set to 167 in case of rhel based distros.
-# These values have to be set according to the base OS used by the container image, NOT the host.
-#bootstrap_dirs_owner: "64045"
-#bootstrap_dirs_group: "64045"
-
 # This variable determines if ceph packages can be updated.  If False, the
 # package resources will use "state=present".  If True, they will use
 # "state=latest".

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -94,13 +94,6 @@ ntp_service_enabled: true
 # Note that this selection is currently ignored on containerized deployments
 ntp_daemon_type: chronyd
 
-
-# Set uid/gid to default '64045' for bootstrap directories.
-# '64045' is used for debian based distros. It must be set to 167 in case of rhel based distros.
-# These values have to be set according to the base OS used by the container image, NOT the host.
-bootstrap_dirs_owner: "64045"
-bootstrap_dirs_group: "64045"
-
 # This variable determines if ceph packages can be updated.  If False, the
 # package resources will use "state=present".  If True, they will use
 # "state=latest".


### PR DESCRIPTION
Both bootstrap_dirs_owner and bootstrap_dirs_group variables aren't
used anymore in the code.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>