### PR TITLE
[skip ci] tests: pg num should be a power of two number

### DIFF
--- a/tests/functional/all_daemons/container/group_vars/rgws
+++ b/tests/functional/all_daemons/container/group_vars/rgws
@@ -2,6 +2,6 @@
 copy_admin_key: True
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16

--- a/tests/functional/all_daemons/group_vars/rgws
+++ b/tests/functional/all_daemons/group_vars/rgws
@@ -1,8 +1,8 @@
 copy_admin_key: true
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/bs-osds/container/group_vars/rgws.yml
+++ b/tests/functional/bs-osds/container/group_vars/rgws.yml
@@ -1,8 +1,8 @@
 copy_admin_key: true
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/bs-osds/group_vars/rgws.yml
+++ b/tests/functional/bs-osds/group_vars/rgws.yml
@@ -1,8 +1,8 @@
 copy_admin_key: true
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/collocation/container/group_vars/rgws
+++ b/tests/functional/collocation/container/group_vars/rgws
@@ -1,6 +1,6 @@
 ---
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16

--- a/tests/functional/collocation/group_vars/rgws
+++ b/tests/functional/collocation/group_vars/rgws
@@ -1,6 +1,6 @@
 ---
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16

--- a/tests/functional/fs-osds/container/group_vars/rgws.yml
+++ b/tests/functional/fs-osds/container/group_vars/rgws.yml
@@ -1,8 +1,8 @@
 copy_admin_key: true
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/fs-osds/group_vars/rgws.yml
+++ b/tests/functional/fs-osds/group_vars/rgws.yml
@@ -1,8 +1,8 @@
 copy_admin_key: true
 rgw_create_pools:
   foo:
-    pg_num: 17
+    pg_num: 16
   bar:
-    pg_num: 19
+    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400


### PR DESCRIPTION
This patch changes the pg_num value of the rgw pools foo and bar to be
a power of two number.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>