### PR TITLE
ceph-mds: Allow standby replay mds to be configured

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -408,6 +408,13 @@ dummy:
 ## MDS options
 #
 #mds_max_mds: 1
+# Once an MDS has entered the standby-replay state, it will only be 
+# used as a standby for the rank that it is following. If another
+# rank fails, this standby-replay daemon will not be used as a replacement,
+# even if no other standbys are available. For this reason, it is advised 
+# that if standby-replay is used then every active MDS should have a 
+# standby-replay daemon.
+#mds_allow_standby_replay: false
 
 ## Rados Gateway options
 #

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -408,6 +408,13 @@ ceph_iscsi_config_dev: false
 ## MDS options
 #
 #mds_max_mds: 1
+# Once an MDS has entered the standby-replay state, it will only be 
+# used as a standby for the rank that it is following. If another
+# rank fails, this standby-replay daemon will not be used as a replacement,
+# even if no other standbys are available. For this reason, it is advised 
+# that if standby-replay is used then every active MDS should have a 
+# standby-replay daemon.
+#mds_allow_standby_replay: false
 
 ## Rados Gateway options
 #

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -400,6 +400,13 @@ filestore_xattr_use_omap: null
 ## MDS options
 #
 mds_max_mds: 1
+# Once an MDS has entered the standby-replay state, it will only be 
+# used as a standby for the rank that it is following. If another
+# rank fails, this standby-replay daemon will not be used as a replacement,
+# even if no other standbys are available. For this reason, it is advised 
+# that if standby-replay is used then every active MDS should have a 
+# standby-replay daemon.
+mds_allow_standby_replay: false
 
 ## Rados Gateway options
 #

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -96,3 +96,8 @@
   when:
     - mds_max_mds > 1
     - not rolling_update
+
+- name: set allow_standby_replay
+  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} fs set {{ cephfs }} allow_standby_replay {{ mds_allow_standby_replay }}"
+  changed_when: false
+  delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
Allow standby replay mds to be configured.
Resolve https://github.com/ceph/ceph-ansible/issues/5060

https://docs.ceph.com/docs/master/cephfs/standby/#configuring-standby-replay

Signed-off-by: Yu Chih secret104278@gmail.com