### PR TITLE
common: support OSDs with more than 2 digits

### DIFF
--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -251,7 +251,7 @@
 
   - name: get all the running osds
     shell: |
-      systemctl list-units | grep 'loaded[[:space:]]\+active' | grep -oE "ceph-osd@([0-9]{1,2}|[a-z]+).service"
+      systemctl list-units | grep 'loaded[[:space:]]\+active' | grep -oE "ceph-osd@([0-9]+).service"
     register: osd_units
     ignore_errors: true
 

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -385,7 +385,7 @@
       when: not containerized_deployment | bool
 
     - name: get osd unit names - container
-      shell: systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-osd@([a-z0-9]+).service"
+      shell: systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-osd@([0-9]+).service"
       register: osd_names
       changed_when: false
       when: containerized_deployment | bool

--- a/roles/ceph-handler/templates/restart_osd_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_osd_daemon.sh.j2
@@ -55,7 +55,7 @@ get_container_id_from_dev_name() {
 
 # For containerized deployments, the unit file looks like: ceph-osd@sda.service
 # For non-containerized deployments, the unit file looks like: ceph-osd@NNN.service where NNN is OSD ID
-for unit in $(systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-osd@([0-9]+|[a-z]+).service"); do
+for unit in $(systemctl list-units | grep -E "loaded * active" | grep -oE "ceph-osd@([0-9]+).service"); do
   # First, restart daemon(s)
   systemctl restart "${unit}"
   # We need to wait because it may take some time for the socket to actually exists


### PR DESCRIPTION
purge-container-cluster: support OSDs with 3 digits
    
When running environment with OSDs having ID with more than 2 digits,
this task doesn't match the system units and therefore, fails the playbook.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1805643

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>