### PR TITLE
doc: update infra playbooks statements

### DIFF
--- a/infrastructure-playbooks/README.md
+++ b/infrastructure-playbooks/README.md
@@ -4,4 +4,4 @@ Infrastructure playbooks
 This directory contains a variety of playbooks that can be used independently of the Ceph roles we have.
 They aim to perform infrastructure related tasks that would help use managing a Ceph cluster or performing certain operational tasks.
 
-To use them, **you must move them to ceph-ansible's root directory**, then run using `ansible-playbook <playbook>`.
+To use them, run `ansible-playbook infrastructure-playbooks/<playbook>`.


### PR DESCRIPTION
We don't need to copy the infrastructure playbooks in the root
ceph-ansible directory.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>