### PR TITLE
shrink: don't use localhost node

### DIFF
--- a/infrastructure-playbooks/shrink-mds.yml
+++ b/infrastructure-playbooks/shrink-mds.yml
@@ -24,7 +24,7 @@
         tasks_from: container_binary
 
 - name: perform checks, remove mds and print cluster health
-  hosts: localhost
+  hosts: "{{ groups[mon_group_name][0] }}"
   become: true
   vars_prompt:
     - name: ireallymeanit
@@ -61,14 +61,13 @@
 
     - name: set_fact container_exec_cmd for mon0
       set_fact:
-        container_exec_cmd: "{{ hostvars[groups[mon_group_name][0]]['container_binary'] }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
+        container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ ansible_hostname }}"
       when: containerized_deployment | bool
 
     - name: exit playbook, if can not connect to the cluster
       command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} health"
       register: ceph_health
       until: ceph_health is succeeded
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       retries: 5
       delay: 2
 
@@ -82,12 +81,10 @@
     - name: exit mds if it the deployment is containerized
       when: containerized_deployment | bool
       command: "{{ container_exec_cmd | default('') }} ceph tell mds.{{ mds_to_kill }} exit"
-      delegate_to: "{{ groups[mon_group_name][0] }}"
 
     - name: get ceph status
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json"
       register: ceph_status
-      delegate_to: "{{ groups[mon_group_name][0] }}"
 
     - name: set_fact current_max_mds
       set_fact:
@@ -123,7 +120,6 @@
         - name: get new ceph status
           command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json"
           register: ceph_status
-          delegate_to: "{{ groups[mon_group_name][0] }}"
 
         - name: get active mds nodes list
           set_fact:
@@ -133,7 +129,6 @@
         - name: get ceph fs dump status
           command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} fs dump -f json"
           register: ceph_fs_status
-          delegate_to: "{{ groups[mon_group_name][0] }}"
 
         - name: create a list of standby mdss
           set_fact:
@@ -148,7 +143,6 @@
 
     - name: delete the filesystem when killing last mds
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} fs rm --yes-i-really-mean-it {{ cephfs }}"
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       when:
         - (ceph_status.stdout | from_json)['fsmap']['up'] | int == 0
         - (ceph_status.stdout | from_json)['fsmap']['up:standby'] | int == 0
@@ -162,4 +156,3 @@
   post_tasks:
     - name: show ceph health
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s"
-      delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/infrastructure-playbooks/shrink-mds.yml
+++ b/infrastructure-playbooks/shrink-mds.yml
@@ -108,7 +108,7 @@
           failed_when: false
 
         - name: ensure that the mds is stopped
-          command: "systemctl is-active ceph_mds@{{ mds_to_kill_hostname }}"
+          command: "systemctl is-active ceph-mds@{{ mds_to_kill_hostname }}"
           register: mds_to_kill_status
           failed_when: mds_to_kill_status.rc == 0
           delegate_to: "{{ mds_to_kill }}"

--- a/infrastructure-playbooks/shrink-mgr.yml
+++ b/infrastructure-playbooks/shrink-mgr.yml
@@ -21,7 +21,7 @@
         msg: gather facts on all Ceph hosts for following reference
 
 - name: confirm if user really meant to remove manager from the ceph cluster
-  hosts: localhost
+  hosts: "{{ groups[mon_group_name][0] }}"
   become: true
   vars_prompt:
     - name: ireallymeanit
@@ -34,17 +34,17 @@
 
     - import_role:
         name: ceph-facts
+        tasks_from: container_binary
 
     - name: set_fact container_exec_cmd
       when: containerized_deployment | bool
       set_fact:
-        container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
+        container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ ansible_hostname }}"
 
     - name: exit playbook, if can not connect to the cluster
       command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} health"
       register: ceph_health
       until: ceph_health is succeeded
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       retries: 5
       delay: 2
 
@@ -53,7 +53,6 @@
         - name: save mgr dump output
           command: "{{ container_exec_cmd | default('') }} ceph --cluster {{cluster}} mgr dump"
           register: mgr_dump
-          delegate_to: "{{ groups[mon_group_name][0] }}"
 
         - name: get a list of names of standby mgrs
           set_fact:
@@ -120,7 +119,6 @@
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | grep {{ mgr_to_kill }}"
       register: mgr_in_ceph_status
       failed_when: mgr_in_ceph_status.rc == 0
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       retries: 3
       delay: 5
 
@@ -133,4 +131,3 @@
   post_tasks:
     - name: show ceph health
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s"
-      delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/infrastructure-playbooks/shrink-mgr.yml
+++ b/infrastructure-playbooks/shrink-mgr.yml
@@ -51,21 +51,18 @@
     - name: get total number of mgrs in cluster
       block:
         - name: save mgr dump output
-          command: "{{ container_exec_cmd | default('') }} ceph --cluster {{cluster}} mgr dump"
+          command: "{{ container_exec_cmd | default('') }} ceph --cluster {{cluster}} mgr dump -f json"
           register: mgr_dump
 
-        - name: get a list of names of standby mgrs
-          set_fact:
-            standby_mgrs: "{{ (mgr_dump.stdout | from_json)['standbys'] | map(attribute='name') | list }}"
-
-        - name: get active mgr
+        - name: get active and standbys mgr list
           set_fact:
             active_mgr: "{{ [mgr_dump.stdout | from_json] | map(attribute='active_name') | list }}"
+            standbys_mgr: "{{ (mgr_dump.stdout | from_json)['standbys'] | map(attribute='name') | list }}"
 
     - name: exit playbook, if there's no standby manager
       fail:
         msg: "You are about to shrink the only manager present in the cluster."
-      when: standby_mgrs | length | int < 1
+      when: standbys_mgr | length | int < 1
 
     - name: exit playbook, if no manager was given
       fail:
@@ -82,7 +79,7 @@
               please make sure it is."
       when:
         - mgr_to_kill not in active_mgr
-        - mgr_to_kill not in standby_mgrs
+        - mgr_to_kill not in standbys_mgr
 
     - name: exit playbook, if user did not mean to shrink cluster
       fail:
@@ -107,20 +104,21 @@
           delegate_to: "{{ mgr_to_kill }}"
           failed_when: false
 
-        - name: ensure that the mds is stopped
-          command: "systemctl is-active ceph_mds@{{ mgr_to_kill_hostname }}"
+        - name: ensure that the mgr is stopped
+          command: "systemctl is-active ceph-mgr@{{ mgr_to_kill_hostname }}"
           register: mgr_to_kill_status
           failed_when: mgr_to_kill_status.rc == 0
           delegate_to: "{{ mgr_to_kill }}"
           retries: 5
           delay: 2
 
-    - name: fail if the mgr is reported in ceph status
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json | grep {{ mgr_to_kill }}"
-      register: mgr_in_ceph_status
-      failed_when: mgr_in_ceph_status.rc == 0
-      retries: 3
-      delay: 5
+    - name: fail if the mgr is reported in ceph mgr dump
+      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} mgr dump -f json"
+      register: mgr_dump
+      failed_when: mgr_to_kill_hostname in (([mgr_dump.stdout | from_json] | map(attribute='active_name') | list) + (mgr_dump.stdout | from_json)['standbys'] | map(attribute='name') | list)
+      until: mgr_to_kill_hostname not in (([mgr_dump.stdout | from_json] | map(attribute='active_name') | list) + (mgr_dump.stdout | from_json)['standbys'] | map(attribute='name') | list)
+      retries: 12
+      delay: 10
 
     - name: purge manager store
       file:

--- a/infrastructure-playbooks/shrink-mon.yml
+++ b/infrastructure-playbooks/shrink-mon.yml
@@ -22,7 +22,7 @@
     - debug: msg="gather facts on all Ceph hosts for following reference"
 
 - name: confirm whether user really meant to remove monitor from the ceph cluster
-  hosts: localhost
+  hosts: "{{ groups[mon_group_name][0] }}"
   become: true
   vars_prompt:
     - name: ireallymeanit
@@ -65,6 +65,7 @@
 
     - import_role:
         name: ceph-facts
+        tasks_from: container_binary
 
   tasks:
     - name: pick a monitor different than the one we want to remove

--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -60,12 +60,12 @@
 
     - import_role:
         name: ceph-facts
-        tasks_from: container_binary.yml
+        tasks_from: container_binary
 
   post_tasks:
     - name: set_fact container_exec_cmd build docker exec command (containerized)
       set_fact:
-        container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
+        container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ ansible_hostname }}"
       when: containerized_deployment | bool
 
     - name: set_fact container_run_cmd

--- a/infrastructure-playbooks/shrink-rbdmirror.yml
+++ b/infrastructure-playbooks/shrink-rbdmirror.yml
@@ -87,7 +87,7 @@
       set_fact:
         rbdmirror_to_kill_gid: "{{ (ceph_health.stdout | from_json)['servicemap']['services']['rbd-mirror']['daemons'][item]['gid'] }}"
       with_items: "{{ rbdmirror_gids }}"
-      when: (ceph_health.stdout | from_json)['servicemap']['services']['rbd-mirror']['daemons'][item]['metadata']['hostname'] == rbdmirror_to_kill_hostname
+      when: (ceph_health.stdout | from_json)['servicemap']['services']['rbd-mirror']['daemons'][item]['metadata']['id'] == rbdmirror_to_kill_hostname
 
   tasks:
     - name: stop rbdmirror service
@@ -108,22 +108,15 @@
     - name: get servicemap details
       command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} -s -f json"
       register: ceph_health
-
-    - name: set_fact rbdmirror_gids
-      set_fact:
-        post_rbdmirror_gids: "{{ post_rbdmirror_gids | default([]) + [ item ] }}"
-      with_items: "{{  (ceph_health.stdout | from_json)['servicemap']['services']['rbd-mirror']['daemons'].keys() | list }}"
-      when:
+      failed_when:
         - "'rbd-mirror' in (ceph_health.stdout | from_json)['servicemap']['services'].keys() | list"
-        - item != 'summary'
+        - rbdmirror_to_kill_gid in (ceph_health.stdout | from_json)['servicemap']['services']['rbd-mirror']['daemons'].keys() | list
+      until:
+        - "'rbd-mirror' in (ceph_health.stdout | from_json)['servicemap']['services'].keys() | list"
+        - rbdmirror_to_kill_gid not in (ceph_health.stdout | from_json)['servicemap']['services']['rbd-mirror']['daemons'].keys() | list
+      when: rbdmirror_to_kill_gid is defined
+      retries: 12
+      delay: 10
 
     - name: show ceph health
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s"
-
-    - name: check presence of "{{ rbdmirror_to_kill_hostname }}"
-      fail:
-        msg: "{{ rbdmirror_to_kill_hostname }} still active!"
-      when:
-        - rbdmirror_to_kill_gid is defined
-        - post_rbdmirror_gids is defined
-        - rbdmirror_to_kill_gid in post_rbdmirror_gids

--- a/infrastructure-playbooks/shrink-rbdmirror.yml
+++ b/infrastructure-playbooks/shrink-rbdmirror.yml
@@ -22,7 +22,7 @@
 
 - name: confirm whether user really meant to remove rbd mirror from the ceph
         cluster
-  hosts: localhost
+  hosts: "{{ groups[mon_group_name][0] }}"
   become: true
   vars_prompt:
     - name: ireallymeanit
@@ -35,6 +35,7 @@
 
     - import_role:
         name: ceph-facts
+        tasks_from: container_binary
 
     - name: exit playbook, if no rbdmirror was given
       fail:
@@ -63,13 +64,12 @@
     - name: set_fact container_exec_cmd for mon0
       when: containerized_deployment | bool
       set_fact:
-        container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
+        container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ ansible_hostname }}"
 
     - name: exit playbook, if can not connect to the cluster
       command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} -s -f json"
       register: ceph_health
       until: ceph_health is succeeded
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       retries: 5
       delay: 2
 
@@ -108,7 +108,6 @@
     - name: get servicemap details
       command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} -s -f json"
       register: ceph_health
-      delegate_to: "{{ groups[mon_group_name][0] }}"
 
     - name: set_fact rbdmirror_gids
       set_fact:
@@ -120,7 +119,6 @@
 
     - name: show ceph health
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s"
-      delegate_to: "{{ groups[mon_group_name][0] }}"
 
     - name: check presence of "{{ rbdmirror_to_kill_hostname }}"
       fail:

--- a/tox.ini
+++ b/tox.ini
@@ -177,13 +177,12 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/shrink-mon.yml --extra-vars "\
       ireallymeanit=yes \
       mon_to_kill={env:MON_TO_KILL:mon2} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
   "
 [shrink-osd]
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/shrink-osd.yml --extra-vars "\
       ireallymeanit=yes \
-      osd_to_kill=0 \
+      osd_to_kill={env:OSD_TO_KILL:0} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
@@ -193,39 +192,28 @@ commands=
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/shrink-mgr.yml --extra-vars "\
       ireallymeanit=yes \
-      mgr_to_kill=mgr1 \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      mgr_to_kill={env:MGR_TO_KILL:mgr1} \
   "
-  py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-2 --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 
 [shrink-mds]
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/shrink-mds.yml --extra-vars "\
       ireallymeanit=yes \
-      mds_to_kill=mds0 \
-      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      mds_to_kill={env:MDS_TO_KILL:mds0} \
   "
 
 [shrink-rbdmirror]
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/shrink-rbdmirror.yml --extra-vars "\
       ireallymeanit=yes \
-      rbdmirror_to_kill=rbd-mirror0 \
-      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      rbdmirror_to_kill={env:RBDMIRROR_TO_KILL:rbd-mirror0} \
   "
 
 [shrink-rgw]
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/shrink-rgw.yml --extra-vars "\
       ireallymeanit=yes \
-      rgw_to_kill=rgw0.rgw0 \
-      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      rgw_to_kill={env:RGW_TO_KILL:rgw0.rgw0} \
   "
 
 [switch-to-containers]
@@ -396,8 +384,12 @@ setenv=
   container: PLAYBOOK = site-docker.yml.sample
   container: PURGE_PLAYBOOK = purge-container-cluster.yml
   non_container: PLAYBOOK = site.yml.sample
-  shrink_mon: MON_TO_KILL = mon2
+  shrink_mds: MDS_TO_KILL = mds0
   shrink_mgr: MGR_TO_KILL = mgr1
+  shrink_mon: MON_TO_KILL = mon2
+  shrink_osd: OSD_TO_KILL = 0
+  shrink_rbdmirror: RBDMIRROR_TO_KILL = rbd-mirror0
+  shrink_rgw: RGW_TO_KILL = rgw0.rgw0
 
   lvm_osds: CEPH_STABLE_RELEASE = luminous
 


### PR DESCRIPTION
The ceph-facts are running on localhost so if this node is using a
different OS/release that the ceph node we can have a mismatch between
docker/podman container binary.
This commit also reduces the scope of the ceph-facts role because we only
need the container_binary tasks.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>