### PR TITLE
ceph-rgw-loadbalancer: Add keepalived non-distro install option

### DIFF
--- a/group_vars/rgwloadbalancers.yml.sample
+++ b/group_vars/rgwloadbalancers.yml.sample
@@ -13,6 +13,9 @@ dummy:
 # GENERAL #
 ###########
 
+#keepalived_url: "https://www.keepalived.org/software/keepalived-{{ keepalived_version }}.tar.gz"
+#keepalived_version: distro
+
 #haproxy_frontend_port: 80
 #haproxy_frontend_ssl_port: 443
 #haproxy_frontend_ssl_certificate:

--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -5,6 +5,9 @@
 # GENERAL #
 ###########
 
+keepalived_url: "https://www.keepalived.org/software/keepalived-{{ keepalived_version }}.tar.gz"
+keepalived_version: distro
+
 haproxy_frontend_port: 80
 haproxy_frontend_ssl_port: 443
 haproxy_frontend_ssl_certificate:

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -5,9 +5,9 @@
       - keepalived_version == 'distro' or keepalived_version is version('0.0.0', '>', strict=True)
     fail_msg: keepalived_version must either be 'distro' or valid version number
 
-- name: install haproxy and keepalived
+- name: install haproxy, keepalived, and make
   package:
-    name: ['haproxy', 'keepalived']
+    name: ['haproxy', 'keepalived', 'make']
     state: present
   register: result
   until: result is succeeded

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -1,10 +1,68 @@
 ---
+- name: assert that keepalived_version is defined
+  assert:
+    that:
+      - keepalived_version == 'distro' or keepalived_version is version('0.0.0', '>', strict=True)
+    fail_msg: keepalived_version must either be 'distro' or valid version number
+
 - name: install haproxy and keepalived
   package:
     name: ['haproxy', 'keepalived']
     state: present
   register: result
   until: result is succeeded
+
+- name: install non-distro version of keepalived
+  block:
+
+    - name: install required packages for keepalived on debian
+      apt:
+        name: ['curl', 'gcc', 'libssl-dev', 'libnl-3-dev', 'libnl-genl-3-dev', 'libsnmp-dev']
+        state: present
+      when: ansible_os_family == 'Debian'
+
+    - name: install required packages for keepalived on redhat
+      yum:
+        name: ['curl', 'gcc', 'openssl-devel', 'libnl3-devel', 'net-snmp-devel']
+        state: present
+      when: ansible_os_family == 'RedHat'
+
+    - name: check if specified keepalived version already exists
+      command: "ls /usr/sbin/keepalived-{{ keepalived_version }}"
+      failed_when: false
+      changed_when: false
+      register: check_keepalived_version
+
+    - name: unarchive keepalived
+      unarchive:
+        src: "{{ keepalived_url }}"
+        dest: /tmp/
+        remote_src: true
+        owner: root
+        group: root
+      when: check_keepalived_version.rc != 0
+
+    - name: build keepalived
+      command: "./configure --prefix=/usr/sbin/keepalived-{{ keepalived_version }}"
+      args:
+        chdir: "/tmp/keepalived-{{ keepalived_version }}/"
+      when: check_keepalived_version.rc != 0
+
+    - name: install keepalived
+      make:
+        chdir: "/tmp/keepalived-{{ keepalived_version }}/"
+        target: install
+      when: check_keepalived_version.rc != 0
+
+    - name: update binary to updated keepalived version
+      file:
+        path: /usr/sbin/keepalived
+        src: "/usr/sbin/keepalived-{{ keepalived_version }}/sbin/keepalived"
+        state: link
+        force: true
+      notify: restart keepalived
+
+  when: keepalived_version != 'distro'
 
 - name: "generate haproxy configuration file: haproxy.cfg"
   template:


### PR DESCRIPTION
Currently keepalived installs the distro version which is 2 years behind.
Add feature which allows the user the option to specify the version number of keepalived to install.

Signed-off-by: Stanley Lam <stanleylam_604@hotmail.com>