### PR TITLE
ceph-rgw-loadbalancer: Add keepalived extended options

### DIFF
--- a/group_vars/rgwloadbalancers.yml.sample
+++ b/group_vars/rgwloadbalancers.yml.sample
@@ -32,4 +32,19 @@ dummy:
 #
 #virtual_ip_netmask: 24
 #virtual_ip_interface: ens33
+#
+#virtual_ips_extended:
+#  - address: 192.168.238.250
+#    netmask: 24
+#    interface: ens33
+#    virtual_route_gateway:
+#    virtual_route_source:
+#  - address: 192.168.1.250
+#    netmask: 24
+#    interface: ens34
+#    virtual_route_gateway: 192.168.1.254
+#    virtual_route_source:
+#      - 10.10.10.1
+#      - 10.10.10.2
+#      - 10.10.10.3
 

--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -24,3 +24,18 @@ haproxy_ssl_options:
 #
 #virtual_ip_netmask: 24
 #virtual_ip_interface: ens33
+#
+#virtual_ips_extended:
+#  - address: 192.168.238.250
+#    netmask: 24
+#    interface: ens33
+#    virtual_route_gateway:
+#    virtual_route_source:
+#  - address: 192.168.1.250
+#    netmask: 24
+#    interface: ens34
+#    virtual_route_gateway: 192.168.1.254
+#    virtual_route_source:
+#      - 10.10.10.1
+#      - 10.10.10.2
+#      - 10.10.10.3

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -22,6 +22,13 @@
       vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item }]) }}"
   loop: "{{ virtual_ips | flatten(levels=1) }}"
 
+- name: set_fact vip to vrrp_instance_extended
+  set_fact:
+      vrrp_instances_extended: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item.address, 'master': groups[rgwloadbalancer_group_name][index], 'netmask': item.netmask, 'interface': item.interface, 'virtual_route_gateway': item.virtual_route_gateway, 'virtual_route_source': item.virtual_route_source }]) }}"
+  loop: "{{ virtual_ips_extended | flatten(levels=1) }}"
+  loop_control:
+      index_var: index
+
 - name: "generate keepalived: configuration file: keepalived.conf"
   template:
     src: keepalived.conf.j2

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -13,7 +13,29 @@ vrrp_script check_haproxy {
     fall 2
 }
 
-{% for instance in vrrp_instances %}
+{% if virtual_ips_extended %}
+  {% for instance in vrrp_instances_extended %}
+vrrp_instance {{ instance['name'] }} {
+    state {{ 'MASTER' if ansible_hostname == instance['master'] else 'BACKUP' }}
+    priority {{ '100' if ansible_hostname == instance['master'] else '90' }}
+    interface {{ instance['interface'] }}
+    virtual_router_id {{ 50 + loop.index }}
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass 1234
+    }
+    virtual_ipaddress {
+        {{ instance['vip'] }}/{{ instance['netmask'] }} dev {{ instance['interface'] }}
+    }
+    {% if instance['virtual_route_source'] and instance['virtual_route_gateway'] %}
+    virtual_routes {
+      {% for source in instance['virtual_route_source'] %}
+        {{ source }} via {{ instance['virtual_route_gateway'] }} dev {{ instance['interface'] }}{{ '\n'}}
+      {%- endfor %}    }
+    {% endif %}
+  {% endfor %}
+{% else %}{% for instance in vrrp_instances %}
 vrrp_instance {{ instance['name'] }} {
     state {{ 'MASTER' if inventory_hostname == groups[rgwloadbalancer_group_name][0] else 'BACKUP' }}
     priority {{ '100' if inventory_hostname == groups[rgwloadbalancer_group_name][0] else '90' }}
@@ -27,9 +49,9 @@ vrrp_instance {{ instance['name'] }} {
     virtual_ipaddress {
         {{ instance['vip'] }}/{{ virtual_ip_netmask }} dev {{ virtual_ip_interface }}
     }
+{% endfor %}
+{% endif %}
     track_script {
         check_haproxy
     }
 }
-
-{% endfor %}


### PR DESCRIPTION
Currently keepalived does not support multiple interfaces, multiple IP addresses, and virtual routes. Additional options provided in the virtual_ips variable can be defined to add these extended options.

Signed-off-by: Stanley Lam <stanleylam_604@hotmail.com>