### PR TITLE
osd: add pg autoscaler support

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -335,6 +335,22 @@ dummy:
 ##########
 # CEPHFS #
 ##########
+# When pg_autoscale_mode is set to True, you must add the target_size_ratio key with a correct value
+# `pg_num` and `pgp_num` keys will be ignored, even if specified.
+# eg:
+#  cephfs_data_pool:
+#    name: "{{ cephfs_data if cephfs_data is defined else 'cephfs_data' }}"
+#    pg_num: "{{ osd_pool_default_pg_num }}"
+#    pgp_num: "{{ osd_pool_default_pg_num }}"
+#    rule_name: "replicated_rule"
+#    type: 1
+#    erasure_profile: ""
+#    expected_num_objects: ""
+#    application: "cephfs"
+#    size: "{{ osd_pool_default_size }}"
+#    min_size: "{{ osd_pool_default_min_size }}"
+#    pg_autoscale_mode: False
+#    target_size_ratio: 0.2
 #cephfs: cephfs # name of the ceph filesystem
 #cephfs_data_pool:
 #  name: "{{ cephfs_data if cephfs_data is defined else 'cephfs_data' }}"
@@ -347,6 +363,7 @@ dummy:
 #  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #cephfs_metadata_pool:
 #  name: "{{ cephfs_metadata if cephfs_metadata is defined else 'cephfs_metadata' }}"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -358,6 +375,7 @@ dummy:
 #  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #cephfs_pools:
 #  - "{{ cephfs_data_pool }}"
 #  - "{{ cephfs_metadata_pool }}"
@@ -601,6 +619,22 @@ dummy:
 # OPENSTACK #
 #############
 #openstack_config: false
+# When pg_autoscale_mode is set to True, you must add the target_size_ratio key with a correct value
+# `pg_num` and `pgp_num` keys will be ignored, even if specified.
+# eg:
+#  openstack_glance_pool:
+#    name: "images"
+#    pg_num: "{{ osd_pool_default_pg_num }}"
+#    pgp_num: "{{ osd_pool_default_pg_num }}"
+#    rule_name: "replicated_rule"
+#    type: 1
+#    erasure_profile: ""
+#    expected_num_objects: ""
+#    application: "rbd"
+#    size: "{{ osd_pool_default_size }}"
+#    min_size: "{{ osd_pool_default_min_size }}"
+#    pg_autoscale_mode: False
+#    target_size_ratio: 0.2
 #openstack_glance_pool:
 #  name: "images"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -612,6 +646,7 @@ dummy:
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_cinder_pool:
 #  name: "volumes"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -623,6 +658,7 @@ dummy:
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_nova_pool:
 #  name: "vms"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -634,6 +670,7 @@ dummy:
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_cinder_backup_pool:
 #  name: "backups"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -645,6 +682,7 @@ dummy:
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_gnocchi_pool:
 #  name: "metrics"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -656,6 +694,7 @@ dummy:
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_cephfs_data_pool:
 #  name: "manila_data"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -667,6 +706,7 @@ dummy:
 #  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_cephfs_metadata_pool:
 #  name: "manila_metadata"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -678,7 +718,7 @@ dummy:
 #  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
-
+#  pg_autoscale_mode: False
 #openstack_pools:
 #  - "{{ openstack_glance_pool }}"
 #  - "{{ openstack_cinder_pool }}"

--- a/group_vars/clients.yml.sample
+++ b/group_vars/clients.yml.sample
@@ -18,6 +18,22 @@ dummy:
 #copy_admin_key: false
 
 #user_config: false
+# When pg_autoscale_mode is set to True, you must add the target_size_ratio key with a correct value
+# `pg_num` and `pgp_num` keys will be ignored, even if specified.
+# eg:
+#  test:
+#    name: "test"
+#    pg_num: "{{ osd_pool_default_pg_num }}"
+#    pgp_num: "{{ osd_pool_default_pg_num }}"
+#    rule_name: "replicated_rule"
+#    application: "rbd"
+#    type: 1
+#    erasure_profile: ""
+#    expected_num_objects: ""
+#    size: "{{ osd_pool_default_size }}"
+#    min_size: "{{ osd_pool_default_min_size }}"
+#    pg_autoscale_mode: False
+#    target_size_ratio: 0.2
 #test:
 #  name: "test"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -29,6 +45,7 @@ dummy:
 #  expected_num_objects: ""
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #test2:
 #  name: "test2"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -40,6 +57,7 @@ dummy:
 #  expected_num_objects: ""
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #pools:
 #  - "{{ test }}"
 #  - "{{ test2 }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -335,6 +335,22 @@ ceph_iscsi_config_dev: false
 ##########
 # CEPHFS #
 ##########
+# When pg_autoscale_mode is set to True, you must add the target_size_ratio key with a correct value
+# `pg_num` and `pgp_num` keys will be ignored, even if specified.
+# eg:
+#  cephfs_data_pool:
+#    name: "{{ cephfs_data if cephfs_data is defined else 'cephfs_data' }}"
+#    pg_num: "{{ osd_pool_default_pg_num }}"
+#    pgp_num: "{{ osd_pool_default_pg_num }}"
+#    rule_name: "replicated_rule"
+#    type: 1
+#    erasure_profile: ""
+#    expected_num_objects: ""
+#    application: "cephfs"
+#    size: "{{ osd_pool_default_size }}"
+#    min_size: "{{ osd_pool_default_min_size }}"
+#    pg_autoscale_mode: False
+#    target_size_ratio: 0.2
 #cephfs: cephfs # name of the ceph filesystem
 #cephfs_data_pool:
 #  name: "{{ cephfs_data if cephfs_data is defined else 'cephfs_data' }}"
@@ -347,6 +363,7 @@ ceph_iscsi_config_dev: false
 #  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #cephfs_metadata_pool:
 #  name: "{{ cephfs_metadata if cephfs_metadata is defined else 'cephfs_metadata' }}"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -358,6 +375,7 @@ ceph_iscsi_config_dev: false
 #  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #cephfs_pools:
 #  - "{{ cephfs_data_pool }}"
 #  - "{{ cephfs_metadata_pool }}"
@@ -601,6 +619,22 @@ ceph_docker_registry_auth: true
 # OPENSTACK #
 #############
 #openstack_config: false
+# When pg_autoscale_mode is set to True, you must add the target_size_ratio key with a correct value
+# `pg_num` and `pgp_num` keys will be ignored, even if specified.
+# eg:
+#  openstack_glance_pool:
+#    name: "images"
+#    pg_num: "{{ osd_pool_default_pg_num }}"
+#    pgp_num: "{{ osd_pool_default_pg_num }}"
+#    rule_name: "replicated_rule"
+#    type: 1
+#    erasure_profile: ""
+#    expected_num_objects: ""
+#    application: "rbd"
+#    size: "{{ osd_pool_default_size }}"
+#    min_size: "{{ osd_pool_default_min_size }}"
+#    pg_autoscale_mode: False
+#    target_size_ratio: 0.2
 #openstack_glance_pool:
 #  name: "images"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -612,6 +646,7 @@ ceph_docker_registry_auth: true
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_cinder_pool:
 #  name: "volumes"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -623,6 +658,7 @@ ceph_docker_registry_auth: true
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_nova_pool:
 #  name: "vms"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -634,6 +670,7 @@ ceph_docker_registry_auth: true
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_cinder_backup_pool:
 #  name: "backups"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -645,6 +682,7 @@ ceph_docker_registry_auth: true
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_gnocchi_pool:
 #  name: "metrics"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -656,6 +694,7 @@ ceph_docker_registry_auth: true
 #  application: "rbd"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_cephfs_data_pool:
 #  name: "manila_data"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -667,6 +706,7 @@ ceph_docker_registry_auth: true
 #  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
+#  pg_autoscale_mode: False
 #openstack_cephfs_metadata_pool:
 #  name: "manila_metadata"
 #  pg_num: "{{ osd_pool_default_pg_num }}"
@@ -678,7 +718,7 @@ ceph_docker_registry_auth: true
 #  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
-
+#  pg_autoscale_mode: False
 #openstack_pools:
 #  - "{{ openstack_glance_pool }}"
 #  - "{{ openstack_cinder_pool }}"

--- a/roles/ceph-client/defaults/main.yml
+++ b/roles/ceph-client/defaults/main.yml
@@ -10,6 +10,22 @@
 copy_admin_key: false
 
 user_config: false
+# When pg_autoscale_mode is set to True, you must add the target_size_ratio key with a correct value
+# `pg_num` and `pgp_num` keys will be ignored, even if specified.
+# eg:
+#  test:
+#    name: "test"
+#    pg_num: "{{ osd_pool_default_pg_num }}"
+#    pgp_num: "{{ osd_pool_default_pg_num }}"
+#    rule_name: "replicated_rule"
+#    application: "rbd"
+#    type: 1
+#    erasure_profile: ""
+#    expected_num_objects: ""
+#    size: "{{ osd_pool_default_size }}"
+#    min_size: "{{ osd_pool_default_min_size }}"
+#    pg_autoscale_mode: False
+#    target_size_ratio: 0.2
 test:
   name: "test"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -21,6 +37,7 @@ test:
   expected_num_objects: ""
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
+  pg_autoscale_mode: False
 test2:
   name: "test2"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -32,6 +49,7 @@ test2:
   expected_num_objects: ""
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
+  pg_autoscale_mode: False
 pools:
   - "{{ test }}"
   - "{{ test2 }}"

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -122,6 +122,8 @@
       changed_when: false
       when:
         - pools | length > 0
+        - item.type | default(1) | int != 3
+        - item.type | default('replicated') != 'erasure'
         - item.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
 
     - name: customize pool min_size
@@ -134,6 +136,8 @@
       when:
         - pools | length > 0
         - (item.min_size | default(osd_pool_default_min_size))|int > ceph_osd_pool_default_min_size
+        - item.type | default(1) | int != 3
+        - item.type | default('replicated') != 'erasure'
 
     - name: assign application to pool(s)
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -83,17 +83,16 @@
       command: >
         {{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }}
         osd pool create {{ item.0.name }}
-        {{ item.0.pg_num | default(osd_pool_default_pg_num) }}
-        {{ item.0.pgp_num | default(item.0.pg_num) | default(osd_pool_default_pg_num) }}
+        {{ item.0.pg_num | default(osd_pool_default_pg_num) if not item.0.pg_autoscale_mode | default(False) | bool else 16 }}
+        {{ item.0.pgp_num | default(item.0.pg_num) | default(osd_pool_default_pg_num) if not item.0.pg_autoscale_mode | default(False) | bool else '' }}
         {%- if item.0.type | default(1) | int == 1 or item.0.type | default('replicated') == 'replicated' %}
         replicated
         {{ item.0.rule_name | default(osd_pool_default_crush_rule) }}
+        {{ item.0.expected_num_objects | default(0) }}
         {%- else %}
         erasure
         {{ item.0.erasure_profile }}
-        {{ item.0.rule_name | default('erasure-code') }}
         {%- endif %}
-        {{ item.0.expected_num_objects | default(0) }}
       with_together:
         - "{{ pools }}"
         - "{{ created_pools.results }}"
@@ -102,6 +101,17 @@
       when:
         - pools | length > 0
         - item.1.rc != 0
+
+    - name: set the target ratio on pool(s)
+      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} target_size_ratio {{ item.target_size_ratio }}"
+      with_items: "{{ pools | unique }}"
+      delegate_to: "{{ delegated_node }}"
+      when: item.pg_autoscale_mode | default(False) | bool
+
+    - name: set pg_autoscale_mode value on pool(s)
+      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"
+      delegate_to: "{{ delegated_node }}"
+      with_items: "{{ pools | unique }}"
 
     - name: customize pool size
       command: >

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -85,12 +85,15 @@
         osd pool create {{ item.0.name }}
         {{ item.0.pg_num | default(osd_pool_default_pg_num) }}
         {{ item.0.pgp_num | default(item.0.pg_num) | default(osd_pool_default_pg_num) }}
-        {{ 'replicated_rule' if not item.0.rule_name | default('replicated_rule') else item.0.rule_name | default('replicated_rule') }}
-        {{ 1 if item.0.type|default(1) == 'replicated' else 3 if item.0.type|default(1) == 'erasure' else item.0.type|default(1) }}
-        {%- if (item.0.type | default("1") == '3' or item.0.type | default("1") == 'erasure') and item.0.erasure_profile %}
+        {%- if item.0.type | default(1) | int == 1 or item.0.type | default('replicated') == 'replicated' %}
+        replicated
+        {{ item.0.rule_name | default(osd_pool_default_crush_rule) }}
+        {%- else %}
+        erasure
         {{ item.0.erasure_profile }}
+        {{ item.0.rule_name | default('erasure-code') }}
         {%- endif %}
-        {{ item.0.expected_num_objects | default('') }}
+        {{ item.0.expected_num_objects | default(0) }}
       with_together:
         - "{{ pools }}"
         - "{{ created_pools.results }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -327,6 +327,22 @@ mon_host_v2:
 ##########
 # CEPHFS #
 ##########
+# When pg_autoscale_mode is set to True, you must add the target_size_ratio key with a correct value
+# `pg_num` and `pgp_num` keys will be ignored, even if specified.
+# eg:
+#  cephfs_data_pool:
+#    name: "{{ cephfs_data if cephfs_data is defined else 'cephfs_data' }}"
+#    pg_num: "{{ osd_pool_default_pg_num }}"
+#    pgp_num: "{{ osd_pool_default_pg_num }}"
+#    rule_name: "replicated_rule"
+#    type: 1
+#    erasure_profile: ""
+#    expected_num_objects: ""
+#    application: "cephfs"
+#    size: "{{ osd_pool_default_size }}"
+#    min_size: "{{ osd_pool_default_min_size }}"
+#    pg_autoscale_mode: False
+#    target_size_ratio: 0.2
 cephfs: cephfs # name of the ceph filesystem
 cephfs_data_pool:
   name: "{{ cephfs_data if cephfs_data is defined else 'cephfs_data' }}"
@@ -339,6 +355,7 @@ cephfs_data_pool:
   application: "cephfs"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
+  pg_autoscale_mode: False
 cephfs_metadata_pool:
   name: "{{ cephfs_metadata if cephfs_metadata is defined else 'cephfs_metadata' }}"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -350,6 +367,7 @@ cephfs_metadata_pool:
   application: "cephfs"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
+  pg_autoscale_mode: False
 cephfs_pools:
   - "{{ cephfs_data_pool }}"
   - "{{ cephfs_metadata_pool }}"
@@ -593,6 +611,22 @@ docker_pull_timeout: "300s"
 # OPENSTACK #
 #############
 openstack_config: false
+# When pg_autoscale_mode is set to True, you must add the target_size_ratio key with a correct value
+# `pg_num` and `pgp_num` keys will be ignored, even if specified.
+# eg:
+#  openstack_glance_pool:
+#    name: "images"
+#    pg_num: "{{ osd_pool_default_pg_num }}"
+#    pgp_num: "{{ osd_pool_default_pg_num }}"
+#    rule_name: "replicated_rule"
+#    type: 1
+#    erasure_profile: ""
+#    expected_num_objects: ""
+#    application: "rbd"
+#    size: "{{ osd_pool_default_size }}"
+#    min_size: "{{ osd_pool_default_min_size }}"
+#    pg_autoscale_mode: False
+#    target_size_ratio: 0.2
 openstack_glance_pool:
   name: "images"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -604,6 +638,7 @@ openstack_glance_pool:
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
+  pg_autoscale_mode: False
 openstack_cinder_pool:
   name: "volumes"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -615,6 +650,7 @@ openstack_cinder_pool:
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
+  pg_autoscale_mode: False
 openstack_nova_pool:
   name: "vms"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -626,6 +662,7 @@ openstack_nova_pool:
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
+  pg_autoscale_mode: False
 openstack_cinder_backup_pool:
   name: "backups"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -637,6 +674,7 @@ openstack_cinder_backup_pool:
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
+  pg_autoscale_mode: False
 openstack_gnocchi_pool:
   name: "metrics"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -648,6 +686,7 @@ openstack_gnocchi_pool:
   application: "rbd"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
+  pg_autoscale_mode: False
 openstack_cephfs_data_pool:
   name: "manila_data"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -659,6 +698,7 @@ openstack_cephfs_data_pool:
   application: "cephfs"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
+  pg_autoscale_mode: False
 openstack_cephfs_metadata_pool:
   name: "manila_metadata"
   pg_num: "{{ osd_pool_default_pg_num }}"
@@ -670,7 +710,7 @@ openstack_cephfs_metadata_pool:
   application: "cephfs"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
-
+  pg_autoscale_mode: False
 openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -27,12 +27,15 @@
             osd pool create {{ item.name }}
             {{ item.pg_num | default(osd_pool_default_pg_num) }}
             {{ item.pgp_num | default(item.pg_num) | default(osd_pool_default_pg_num) }}
-            {{ 'replicated_rule' if not item.rule_name | default('replicated_rule') else item.rule_name | default('replicated_rule') }}
-            {{ 1 if item.type|default(1) == 'replicated' else 3 if item.type|default(1) == 'erasure' else item.type|default(1) }}
-            {%- if (item.type | default("1") == '3' or item.type | default("1") == 'erasure') and item.erasure_profile | length > 0 %}
+            {%- if item.type | default(1) | int == 1 or item.type | default('replicated') == 'replicated' %}
+            replicated
+            {{ item.rule_name | default(osd_pool_default_crush_rule) }}
+            {%- else %}
+            erasure
             {{ item.erasure_profile }}
+            {{ item.rule_name | default('erasure-code') }}
             {%- endif %}
-            {{ item.expected_num_objects | default('') }}
+            {{ item.expected_num_objects | default(0) }}
           changed_when: false
           with_items:
             - "{{ cephfs_pools }}"

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -54,13 +54,19 @@
           command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} size {{ item.size | default(osd_pool_default_size) }}"
           with_items: "{{ cephfs_pools | unique }}"
           changed_when: false
-          when: item.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
+          when:
+            - item.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
+            - item.type | default(1) | int != 3
+            - item.type | default('replicated') != 'erasure'
 
         - name: customize pool min_size
           command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} min_size {{ item.min_size | default(osd_pool_default_min_size) }}"
           with_items: "{{ cephfs_pools | unique }}"
           changed_when: false
-          when: (item.min_size | default(osd_pool_default_min_size))|int > ceph_osd_pool_default_min_size
+          when:
+            - (item.min_size | default(osd_pool_default_min_size))|int > ceph_osd_pool_default_min_size
+            - item.type | default(1) | int != 3
+            - item.type | default('replicated') != 'erasure'
 
         - name: assign application to cephfs pools
           command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -25,20 +25,30 @@
           command: >
             {{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }}
             osd pool create {{ item.name }}
-            {{ item.pg_num | default(osd_pool_default_pg_num) }}
-            {{ item.pgp_num | default(item.pg_num) | default(osd_pool_default_pg_num) }}
+            {{ item.pg_num | default(osd_pool_default_pg_num) if not item.pg_autoscale_mode | default(False) | bool else 16 }}
+            {{ item.pgp_num | default(item.pg_num) | default(osd_pool_default_pg_num) if not item.pg_autoscale_mode | default(False) | bool else '' }}
             {%- if item.type | default(1) | int == 1 or item.type | default('replicated') == 'replicated' %}
             replicated
             {{ item.rule_name | default(osd_pool_default_crush_rule) }}
+            {{ item.expected_num_objects | default(0) }}
             {%- else %}
             erasure
             {{ item.erasure_profile }}
-            {{ item.rule_name | default('erasure-code') }}
             {%- endif %}
-            {{ item.expected_num_objects | default(0) }}
           changed_when: false
           with_items:
             - "{{ cephfs_pools }}"
+
+        - name: set the target ratio on pool(s)
+          command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} target_size_ratio {{ item.target_size_ratio }}"
+          with_items: "{{ cephfs_pools | unique }}"
+          delegate_to: "{{ groups[mon_group_name][0] }}"
+          when: item.pg_autoscale_mode | default(False) | bool
+
+        - name: set pg_autoscale_mode value on pool(s)
+          command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"
+          delegate_to: "{{ groups[mon_group_name][0] }}"
+          with_items: "{{ cephfs_pools | unique }}"
 
         - name: customize pool size
           command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} size {{ item.size | default(osd_pool_default_size) }}"

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -17,12 +17,15 @@
         osd pool create {{ item.0.name }}
         {{ item.0.pg_num | default(osd_pool_default_pg_num) }}
         {{ item.0.pgp_num | default(item.0.pg_num) | default(osd_pool_default_pg_num) }}
-        {{ 'replicated_rule' if not item.0.rule_name | default('replicated_rule') else item.0.rule_name | default('replicated_rule') }}
-        {{ 1 if item.0.type|default(1) == 'replicated' else 3 if item.0.type|default(1) == 'erasure' else item.0.type|default(1) }}
-        {%- if (item.0.type | default("1") == '3' or item.0.type | default("1") == 'erasure') and item.0.erasure_profile %}
+        {%- if item.0.type | default(1) | int == 1 or item.0.type | default('replicated') == 'replicated' %}
+        replicated
+        {{ item.0.rule_name | default(osd_pool_default_crush_rule) }}
+        {%- else %}
+        erasure
         {{ item.0.erasure_profile }}
+        {{ item.0.rule_name | default('erasure-code') }}
         {%- endif %}
-        {{ item.0.expected_num_objects | default('') }}
+        {{ item.0.expected_num_objects | default(0) }}
       with_together:
         - "{{ openstack_pools | unique }}"
         - "{{ created_pools.results }}"

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -50,7 +50,10 @@
       with_items: "{{ openstack_pools | unique }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
-      when: item.size | default(osd_pool_default_size)
+      when:
+        - item.size | default(osd_pool_default_size)
+        - item.type | default(1) | int != 3
+        - item.type | default('replicated') != 'erasure'
 
     - name: customize pool min_size
       command: >
@@ -59,7 +62,10 @@
       with_items: "{{ openstack_pools | unique }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
-      when: (item.min_size | default(osd_pool_default_min_size))|int > ceph_osd_pool_default_min_size
+      when:
+        - (item.min_size | default(osd_pool_default_min_size))|int > ceph_osd_pool_default_min_size
+        - item.type | default(1) | int != 3
+        - item.type | default('replicated') != 'erasure'
 
     - name: assign application to pool(s)
       command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -15,23 +15,33 @@
       command: >
         {{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
         osd pool create {{ item.0.name }}
-        {{ item.0.pg_num | default(osd_pool_default_pg_num) }}
-        {{ item.0.pgp_num | default(item.0.pg_num) | default(osd_pool_default_pg_num) }}
+        {{ item.0.pg_num | default(osd_pool_default_pg_num) if not item.0.pg_autoscale_mode | default(False) | bool else 16 }}
+        {{ item.0.pgp_num | default(item.0.pg_num) | default(osd_pool_default_pg_num) if not item.0.pg_autoscale_mode | default(False) | bool else '' }}
         {%- if item.0.type | default(1) | int == 1 or item.0.type | default('replicated') == 'replicated' %}
         replicated
         {{ item.0.rule_name | default(osd_pool_default_crush_rule) }}
+        {{ item.0.expected_num_objects | default(0) }}
         {%- else %}
         erasure
         {{ item.0.erasure_profile }}
-        {{ item.0.rule_name | default('erasure-code') }}
         {%- endif %}
-        {{ item.0.expected_num_objects | default(0) }}
       with_together:
         - "{{ openstack_pools | unique }}"
         - "{{ created_pools.results }}"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       when: item.1.get('rc', 0) != 0
+
+    - name: set the target ratio on pool(s)
+      command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} target_size_ratio {{ item.target_size_ratio }}"
+      with_items: "{{ openstack_pools | unique }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      when: item.pg_autoscale_mode | default(False) | bool
+
+    - name: set pg_autoscale_mode value on pool(s)
+      command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      with_items: "{{ openstack_pools | unique }}"
 
     - name: customize pool size
       command: >

--- a/roles/ceph-validate/tasks/check_pools.yml
+++ b/roles/ceph-validate/tasks/check_pools.yml
@@ -1,0 +1,11 @@
+---
+- name: fail if target_size_ratio is not set when pg_autoscale_mode is True
+  fail:
+    msg: "You must set a target_size_ratio value on following pool: {{ item.name }}."
+  with_items:
+    - "{{ openstack_pools | default([]) }}"
+    - "{{ cephfs_pools | default([]) }}"
+    - "{{ pools | default([]) }}"
+  when:
+    - item.pg_autoscale_mode | default(False) | bool
+    - item.target_size_ratio is undefined

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -22,7 +22,7 @@ openstack_glance_pool:
   pg_num: "{{ osd_pool_default_pg_num }}"
   pgp_num: "{{ osd_pool_default_pg_num }}"
   rule_name: "HDD"
-  type: 1
+  type: 3
   erasure_profile: ""
   expected_num_objects: ""
   size: 1

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -26,6 +26,8 @@ openstack_glance_pool:
   erasure_profile: ""
   expected_num_objects: ""
   size: 1
+  pg_autoscale_mode: True
+  target_size_ratio: 0.2
 openstack_cinder_pool:
   name: "volumes"
   pg_num: "{{ osd_pool_default_pg_num }}"

--- a/tests/functional/all_daemons/container/hosts
+++ b/tests/functional/all_daemons/container/hosts
@@ -9,6 +9,9 @@ mgr0
 [osds]
 osd0 osd_crush_location="{ 'root': 'HDD', 'rack': 'mon-rackkkk', 'pod': 'monpod', 'host': 'osd0' }"
 osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"
+osd2 osd_crush_location="{ 'root': 'default', 'host': 'osd2' }"
+osd3 osd_crush_location="{ 'root': 'default', 'host': 'osd3' }"
+osd4 osd_crush_location="{ 'root': 'default', 'host': 'osd4' }"
 
 [mdss]
 mds0

--- a/tests/functional/all_daemons/container/vagrant_variables.yml
+++ b/tests/functional/all_daemons/container/vagrant_variables.yml
@@ -5,7 +5,7 @@ docker: True
 
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 3
-osd_vms: 2
+osd_vms: 5
 mds_vms: 3
 rgw_vms: 1
 nfs_vms: 0

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -19,6 +19,8 @@ openstack_glance_pool:
   expected_num_objects: ""
   size: 1
   application: rbd
+  pg_autoscale_mode: True
+  target_size_ratio: 0.2
 openstack_cinder_pool:
   name: "volumes"
   pg_num: "{{ osd_pool_default_pg_num }}"

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -14,7 +14,7 @@ openstack_glance_pool:
   pg_num: "{{ osd_pool_default_pg_num }}"
   pgp_num: "{{ osd_pool_default_pg_num }}"
   rule_name: "HDD"
-  type: 1
+  type: 3
   erasure_profile: ""
   expected_num_objects: ""
   size: 1

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -9,6 +9,9 @@ mgr0
 [osds]
 osd0 osd_crush_location="{ 'root': 'HDD', 'rack': 'mon-rackkkk', 'pod': 'monpod', 'host': 'osd0' }"
 osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"
+osd2 osd_crush_location="{ 'root': 'default', 'host': 'osd2' }"
+osd3 osd_crush_location="{ 'root': 'default', 'host': 'osd3' }"
+osd4 osd_crush_location="{ 'root': 'default', 'host': 'osd4' }"
 
 [mdss]
 mds0

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -5,7 +5,7 @@ docker: false
 
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 3
-osd_vms: 2
+osd_vms: 5
 mds_vms: 3
 rgw_vms: 1
 nfs_vms: 0

--- a/tests/functional/ooo-collocation/hosts
+++ b/tests/functional/ooo-collocation/hosts
@@ -58,11 +58,11 @@ all:
       - {key: AQAN0RdbAAAAABAAtV5Dq28z4H6XxwhaNEaFZg==, mds_cap: 'allow *', mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow r, allow command "auth del", allow command "auth caps", allow command "auth get", allow command "auth get-or-create"', name: client.manila, osd_cap: 'allow rw'}
       - {key: AQAN0RdbAAAAABAAH5D3WgMN9Rxw3M8jkpMIfg==, mgr_cap: 'allow *', mode: '0600', mon_cap: 'allow rw', name: client.radosgw, osd_cap: 'allow rwx'}
     openstack_pools:
-    - {name: images, pg_num: 8, rule_name: ''}
-    - {name: metrics, pg_num: 8, rule_name: ''}
-    - {name: backups, pg_num: 8, rule_name: ''}
-    - {name: vms, pg_num: 8, rule_name: ''}
-    - {name: volumes, pg_num: 8, rule_name: ''}
+    - {name: images, pg_num: 8, rule_name: 'replicated_rule'}
+    - {name: metrics, pg_num: 8, rule_name: 'replicated_rule'}
+    - {name: backups, pg_num: 8, rule_name: 'replicated_rule'}
+    - {name: vms, pg_num: 8, rule_name: 'replicated_rule'}
+    - {name: volumes, pg_num: 8, rule_name: 'replicated_rule'}
     ceph_osd_docker_run_script_path: /opt
     pools: []
     public_network: 192.168.95.0/24


### PR DESCRIPTION
This commit adds the pg autoscaler support.
    
The structure for pool definition has now two additional attributes
`pg_autoscale_mode` and `target_size_ratio`, eg:
    
```
    test:
      name: "test"
      pg_num: "{{ osd_pool_default_pg_num }}"
      pgp_num: "{{ osd_pool_default_pg_num }}"
      rule_name: "replicated_rule"
      application: "rbd"
      type: 1
      erasure_profile: ""
      expected_num_objects: ""
      size: "{{ osd_pool_default_size }}"
      min_size: "{{ osd_pool_default_min_size }}"
      pg_autoscale_mode: False
      target_size_ratio: 0.1
```
    
when `pg_autoscale_mode` is `True` user has to set a decent value in
`target_size_ratio`.
    
Given that it's a new feature, it's still disabled by default.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1782253

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>