### PR TITLE
osd: add journal option in ceph_volume call (batch)

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -277,6 +277,7 @@ def batch(module, container_image):
     objectstore = module.params['objectstore']
     batch_devices = module.params.get('batch_devices', None)
     crush_device_class = module.params.get('crush_device_class', None)
+    journal_devices = module.params.get('journal_devices', None)
     journal_size = module.params.get('journal_size', None)
     block_db_size = module.params.get('block_db_size', None)
     block_db_devices = module.params.get('block_db_devices', None)
@@ -318,6 +319,9 @@ def batch(module, container_image):
         cmd.extend(['--block-db-size', block_db_size])
 
     cmd.extend(batch_devices)
+
+    if journal_devices and objectstore == 'filestore':
+        cmd.extend(['--journal-devices', ' '.join(journal_devices)])
 
     if block_db_devices and objectstore == 'bluestore':
         cmd.extend(['--db-devices', ' '.join(block_db_devices)])
@@ -512,6 +516,7 @@ def run_module():
         batch_devices=dict(type='list', required=False, default=[]),
         osds_per_device=dict(type='int', required=False, default=1),
         journal_size=dict(type='str', required=False, default='5120'),
+        journal_devices=dict(type='str', required=False, default=False),
         block_db_size=dict(type='str', required=False, default='-1'),
         block_db_devices=dict(type='list', required=False, default=[]),
         wal_devices=dict(type='list', required=False, default=[]),

--- a/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
@@ -12,6 +12,7 @@
     block_db_size: "{{ block_db_size }}"
     block_db_devices: "{{ dedicated_devices | unique if dedicated_devices | length > 0 else omit }}"
     wal_devices: "{{ bluestore_wal_devices | unique if bluestore_wal_devices | length > 0 else omit }}"
+    journal_devices: "{{ dedicated_devices | unique if dedicated_devices | length > 0 else omit }}"
     action: "batch"
   environment:
     CEPH_VOLUME_DEBUG: 1

--- a/tests/library/test_ceph_volume.py
+++ b/tests/library/test_ceph_volume.py
@@ -344,3 +344,29 @@ class TestCephVolumeModule(object):
         result = ceph_volume.batch(
             fake_module, fake_container_image)
         assert result == expected_command_list
+
+    def test_batch_filestore_with_dedicated_journal(self):
+        fake_module = MagicMock()
+        fake_module.params = {'objectstore': 'filestore',
+                              'journal_size': '100',
+                              'cluster': 'ceph',
+                              'batch_devices': ["/dev/sda", "/dev/sdb"],
+                              'journal_devices': ["/dev/sdc"]}
+
+        fake_container_image = None
+        expected_command_list = ['ceph-volume',
+                                 '--cluster',
+                                 'ceph',
+                                 'lvm',
+                                 'batch',
+                                 '--filestore',
+                                 '--yes',
+                                 '--journal-size',
+                                 '100',
+                                 '/dev/sda',
+                                 '/dev/sdb',
+                                 '--journal-devices',
+                                 '/dev/sdc']
+        result = ceph_volume.batch(
+            fake_module, fake_container_image)
+        assert result == expected_command_list


### PR DESCRIPTION
This commit adds the journal option to the ceph_volume call when
scenario is lvm batch

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>