### PR TITLE
Check if containerized_deployment is 'true' before validating contain…

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -236,6 +236,7 @@
   fail:
     msg: 'ceph_docker_registry_username and/or ceph_docker_registry_password variables need to be set'
   when:
+    - containerized_deployment | bool
     - ceph_docker_registry_auth | bool
     - (ceph_docker_registry_username is not defined or ceph_docker_registry_password is not defined) or
       (ceph_docker_registry_username | length == 0 or ceph_docker_registry_password | length == 0)


### PR DESCRIPTION
Check if containerized_deployment is 'true' before validating container registry credentials.
In Baremetal deployment, we may need to pass ceph_docker_registry_username and ceph_docker_registry_password

Fixes BZ : https://bugzilla.redhat.com/show_bug.cgi?id=1808982

Signed-off-by: Ashish Singh <assingh@redhat.com>