### PR TITLE
tests: add lvm batch filestore testing

### DIFF
--- a/tests/functional/lvm-batch/container/group_vars/all
+++ b/tests/functional/lvm-batch/container/group_vars/all
@@ -12,7 +12,7 @@ public_network: "192.168.39.0/24"
 cluster_network: "192.168.40.0/24"
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
-journal_size: 100
+journal_size: 2048
 osd_objectstore: "bluestore"
 crush_device_class: test
 copy_admin_key: true

--- a/tests/functional/lvm-batch/container/hosts
+++ b/tests/functional/lvm-batch/container/hosts
@@ -3,3 +3,4 @@ mon0
 
 [osds]
 osd0
+osd1 osd_objectstore=filestore devices="['/dev/sda', '/dev/sdb']" dedicated_devices="['/dev/sdc']" journal_size=2048

--- a/tests/functional/lvm-batch/container/vagrant_variables.yml
+++ b/tests/functional/lvm-batch/container/vagrant_variables.yml
@@ -5,7 +5,7 @@ docker: true
 
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 1
-osd_vms: 1
+osd_vms: 2
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0

--- a/tests/functional/lvm-batch/hosts
+++ b/tests/functional/lvm-batch/hosts
@@ -3,3 +3,4 @@ mon0
 
 [osds]
 osd0
+osd1 osd_objectstore=filestore devices="['/dev/sda', '/dev/sdb']" dedicated_devices="['/dev/sdc']" journal_size=2048

--- a/tests/functional/lvm-batch/vagrant_variables.yml
+++ b/tests/functional/lvm-batch/vagrant_variables.yml
@@ -5,7 +5,7 @@ docker: false
 
 # DEFINE THE NUMBER OF VMS TO RUN
 mon_vms: 1
-osd_vms: 1
+osd_vms: 2
 mds_vms: 0
 rgw_vms: 0
 nfs_vms: 0


### PR DESCRIPTION
This commit adds an OSD node in lvm-batch scenario in order to test
filestore backend.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>