### PR TITLE
Vagrant: Add random generator passthrough for OSD

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -551,6 +551,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
         lv.memory = MEMORY
         lv.random_hostname = true
+        lv.random :model => 'random'
       end
 
       # Parallels


### PR DESCRIPTION
This could help the encrypted OSDs.

https://github.com/vagrant-libvirt/vagrant-libvirt#random-number-generator-passthrough

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>