### PR TITLE
client: skip create_users_keys.yml when rolling_update

### DIFF
--- a/roles/ceph-client/tasks/main.yml
+++ b/roles/ceph-client/tasks/main.yml
@@ -4,4 +4,6 @@
 
 - name: include create_users_keys.yml
   include_tasks: create_users_keys.yml
-  when: user_config | bool
+  when:
+    - user_config | bool
+    - not rolling_update | default(False) | bool


### PR DESCRIPTION
There's no need to run this part of the role when upgrading clients
node. Let's skip it when rolling_update.yml is being run.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>