### PR TITLE
[skip ci] tests: add inventory host for 4.0 upgrade job

### DIFF
--- a/tests/functional/all_daemons/container/hosts-upgrade-to-nautilus
+++ b/tests/functional/all_daemons/container/hosts-upgrade-to-nautilus
@@ -1,0 +1,34 @@
+[mons]
+mon0
+mon1
+mon2
+
+[mgrs]
+mgr0
+
+[osds]
+osd0 osd_crush_location="{ 'root': 'HDD', 'rack': 'mon-rackkkk', 'pod': 'monpod', 'host': 'osd0' }"
+osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"
+osd2 osd_crush_location="{ 'root': 'default', 'host': 'osd2' }"
+osd3 osd_crush_location="{ 'root': 'default', 'host': 'osd3' }"
+
+[mdss]
+mds0
+mds1
+mds2
+
+[rgws]
+rgw0
+
+[nfss]
+nfs0
+
+[clients]
+client0
+client1
+
+[rbdmirrors]
+rbd-mirror0
+
+[iscsigws]
+iscsi-gw0

--- a/tests/functional/all_daemons/hosts-upgrade-to-nautilus
+++ b/tests/functional/all_daemons/hosts-upgrade-to-nautilus
@@ -1,0 +1,40 @@
+[mons]
+mon0 monitor_address=192.168.1.10
+mon1 monitor_interface=eth1
+mon2 monitor_address=192.168.1.12
+
+[mgrs]
+mgr0
+
+[osds]
+osd0 osd_crush_location="{ 'root': 'HDD', 'rack': 'mon-rackkkk', 'pod': 'monpod', 'host': 'osd0' }"
+osd1 osd_crush_location="{ 'root': 'default', 'host': 'osd1' }"
+osd2 osd_crush_location="{ 'root': 'default', 'host': 'osd2' }"
+osd3 osd_crush_location="{ 'root': 'default', 'host': 'osd3' }"
+
+[mdss]
+mds0
+mds1
+mds2
+
+[rgws]
+rgw0
+
+[clients]
+client0
+client1
+
+[nfss]
+nfs0
+
+[rbdmirrors]
+rbd-mirror0
+
+[iscsigws]
+iscsi-gw0
+
+[all:vars]
+nfs_ganesha_stable=True
+nfs_ganesha_dev=False
+nfs_ganesha_stable_branch="V2.7-stable"
+nfs_ganesha_flavor="ceph_master"


### PR DESCRIPTION
This inventory is intended to be used in the upgrade scenario in
stable-4.0 branch.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>