### PR TITLE
tests/requirements: bump testinfra

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 # These are Python requirements needed to run the functional tests
 six==1.10.0
-testinfra>=3.2,<3.3
+testinfra>=3,<4
 pytest-xdist==1.28.0
 pytest>=4.6,<5.0
 ansible>=2.8.8,<2.9


### PR DESCRIPTION
3.4 is the latest testinfra release available but python2 is dropped
starting 4.0.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>