### PR TITLE
Fix HAProxy httpchk parameter for Ceph RGW

### DIFF
--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -43,9 +43,9 @@ frontend rgw-frontend
 backend rgw-backend
     option forwardfor
     balance static-rr
-    option httpchk Get /
+    option httpchk HEAD /
 {% for host in groups[rgw_group_name] %}
 {% for instance in hostvars[host]['rgw_instances'] %}
-	server {{ 'server-' + hostvars[host]['ansible_hostname'] + '-' + instance['instance_name'] }} {{ instance['radosgw_address'] }}:{{ instance['radosgw_frontend_port'] }} weight 100
+	server {{ 'server-' + hostvars[host]['ansible_hostname'] + '-' + instance['instance_name'] }} {{ instance['radosgw_address'] }}:{{ instance['radosgw_frontend_port'] }} weight 100 check
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Fix the `httpchk` parameter to use valid HTTP verb.

Currently traffic will be forwarded to offline `radosgw` services. These changes resolve the issue.

Signed-off-by: Niko Smeds nikosmeds@gmail.com