### PR TITLE
doc: Fixed a minor typo in the document

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -296,7 +296,7 @@ Demos
 Vagrant Demo
 ------------
 
-Deployment from scratch on bare metal machines: https://youtu.be/E8-96NamLDo
+Deployment from scratch on vagrant machines: https://youtu.be/E8-96NamLDo
 
 Bare metal demo
 ---------------


### PR DESCRIPTION
In the Demo part of the Document, for both Vagrant and Bare metal the description was mentioned as "Deployment from scratch on bare metal machines".
Changed "bare metal" to "vagrant" for Vagrant section

Signed-off-by: Nizamudeen <nia@redhat.com>