### PR TITLE
Add a second confirmation to the cluster purge playbooks

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -21,15 +21,21 @@
       default: 'no'
       private: no
 
+    - name: ireallyreallymeanit
+      prompt: Are you really sure you want to purge the cluster?
+      default: 'no'
+      private: no
+
   tasks:
   - name: exit playbook, if user did not mean to purge cluster
     fail:
       msg: >
         "Exiting purge-cluster playbook, cluster was NOT purged.
-         To purge the cluster, either say 'yes' on the prompt or
-         or use `-e ireallymeanit=yes` on the command line when
-         invoking the playbook"
-    when: ireallymeanit != 'yes'
+         To purge the cluster, either say 'yes' and 'ireallyreallymeanit'
+         on the prompt or use `-e ireallymeanit=yes` and
+         `-e ireallyreallymeanit=ireallyreallymeanit` on the
+         command line when invoking the playbook"
+      when: ireallymeanit != 'yes' or ireallyreallymeanit != 'ireallyreallymeanit'
 
 - name: gather facts on all hosts
 

--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -18,15 +18,21 @@
       default: 'no'
       private: no
 
+    - name: ireallyreallymeanit
+      prompt: Are you really sure you want to purge the cluster?
+      default: 'no'
+      private: no
+
   tasks:
   - name: exit playbook, if user did not mean to purge cluster
     fail:
       msg: >
         "Exiting purge-container-cluster playbook, cluster was NOT purged.
-         To purge the cluster, either say 'yes' on the prompt or
-         or use `-e ireallymeanit=yes` on the command line when
-         invoking the playbook"
-    when: ireallymeanit != 'yes'
+         To purge the cluster, either say 'yes' and 'ireallyreallymeanit'
+         on the prompt or use `-e ireallymeanit=yes` and
+         `-e ireallyreallymeanit=ireallyreallymeanit` on the command line
+         when invoking the playbook"
+    when: ireallymeanit != 'yes' or ireallyreallymeanit != 'ireallyreallymeanit'
 
   - name: set ceph_docker_registry value if not set
     set_fact:

--- a/tox.ini
+++ b/tox.ini
@@ -121,6 +121,7 @@ commands=
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
       ireallymeanit=yes \
+      ireallyreallymeanit=ireallyreallymeanit \
       remove_packages=yes \
       ceph_stable_release={env:CEPH_STABLE_RELEASE:nautilus} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
@@ -149,6 +150,7 @@ commands=
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
       ireallymeanit=yes \
+      ireallyreallymeanit=ireallyreallymeanit \
       remove_packages=yes \
       ceph_stable_release={env:CEPH_STABLE_RELEASE:nautilus} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \


### PR DESCRIPTION
When running the cluster purge playbooks, a cluster is completely
deleted. Therefore the Playbook should not be executable with a
simple 'yes'.