### PR TITLE
infra: add retries/until on firewalld start task

### DIFF
--- a/roles/ceph-infra/tasks/configure_firewall.yml
+++ b/roles/ceph-infra/tasks/configure_firewall.yml
@@ -24,6 +24,10 @@
         name: firewalld
         state: started
         enabled: yes
+      register: result
+      retries: 5
+      delay: 3
+      until: result is succeeded
 
     - name: open ceph networks on monitor
       firewalld:


### PR DESCRIPTION
This commit make that task retrying 5 times to start the service
firewalld to avoid failure like following:

```
TASK [ceph-infra : start firewalld] ********************************************
task path: /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-purge/roles/ceph-infra/tasks/configure_firewall.yml:22
Monday 09 March 2020  08:58:48 +0000 (0:00:00.963)       0:02:16.457 **********
fatal: [osd4]: FAILED! => changed=false
  msg: |-
    Unable to enable service firewalld: Created symlink from /etc/systemd/system/dbus-org.fedoraproject.FirewallD1.service to /usr/lib/systemd/system/firewalld.service.
    Created symlink from /etc/systemd/system/multi-user.target.wants/firewalld.service to /usr/lib/systemd/system/firewalld.service.
    Failed to execute operation: Connection reset by peer
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>