### PR TITLE
rgw: fix a typo in create_realm_zonegroup_zone_lists

### DIFF
--- a/roles/ceph-rgw/tasks/multisite/create_realm_zonegroup_zone_lists.yml
+++ b/roles/ceph-rgw/tasks/multisite/create_realm_zonegroup_zone_lists.yml
@@ -24,7 +24,7 @@
 
 - name: make all items in secondary_realms unique
   set_fact:
-    realms: "{{ secondary_realms | unique }}"
+    secondary_realms: "{{ secondary_realms | unique }}"
   run_once: true
   when:
     - secondary_realms is defined


### PR DESCRIPTION
This commit fixes a typo.

`s/realms/secondary_realms`

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>