### PR TITLE
update osd pool set size command

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -116,7 +116,7 @@
     - name: customize pool size
       command: >
         {{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }}
-        osd pool set {{ item.name }} size {{ item.size | default(osd_pool_default_size) }}
+        osd pool set {{ item.name }} size {{ item.size | default(osd_pool_default_size) }} {{ '--yes-i-really-mean-it' if item.size | default(osd_pool_default_size) | int == 1 else '' }}
       with_items: "{{ pools | unique }}"
       delegate_to: "{{ delegated_node }}"
       changed_when: false

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -72,7 +72,7 @@
       run_once: True
 
     - name: customize pool size
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool set {{ iscsi_pool_name }} size {{ iscsi_pool_size | default(osd_pool_default_size) }}"
+      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool set {{ iscsi_pool_name }} size {{ iscsi_pool_size | default(osd_pool_default_size) }} {{ '--yes-i-really-mean-it' if iscsi_pool_size | default(osd_pool_default_size) | int == 1 else '' }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
       when: iscsi_pool_size | default(osd_pool_default_size) != ceph_osd_pool_default_size

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -51,7 +51,7 @@
           with_items: "{{ cephfs_pools | unique }}"
 
         - name: customize pool size
-          command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} size {{ item.size | default(osd_pool_default_size) }}"
+          command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} size {{ item.size | default(osd_pool_default_size) }} {{ '--yes-i-really-mean-it' if item.size | default(osd_pool_default_size) | int == 1 else '' }}"
           with_items: "{{ cephfs_pools | unique }}"
           changed_when: false
           when:

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -46,7 +46,7 @@
     - name: customize pool size
       command: >
         {{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
-        osd pool set {{ item.name }} size {{ item.size | default(osd_pool_default_size) }}
+        osd pool set {{ item.name }} size {{ item.size | default(osd_pool_default_size) }} {{ '--yes-i-really-mean-it' if item.size | default(osd_pool_default_size) | int == 1 else '' }}
       with_items: "{{ openstack_pools | unique }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false

--- a/roles/ceph-rgw/tasks/rgw_create_pools.yml
+++ b/roles/ceph-rgw/tasks/rgw_create_pools.yml
@@ -48,7 +48,7 @@
   when: item.value.type is not defined or item.value.type == 'replicated'
 
 - name: customize replicated pool size
-  command: "{{ container_exec_cmd }} ceph --connect-timeout 10 --cluster {{ cluster }} osd pool set {{ item.key }} size {{ item.value.size | default(osd_pool_default_size) }}"
+  command: "{{ container_exec_cmd }} ceph --connect-timeout 10 --cluster {{ cluster }} osd pool set {{ item.key }} size {{ item.value.size | default(osd_pool_default_size) }} {{ '--yes-i-really-mean-it' if item.value.size | default(osd_pool_default_size) | int == 1 else '' }}"
   register: result
   retries: 60
   delay: 3

--- a/tests/functional/add-mdss/container/group_vars/all
+++ b/tests/functional/add-mdss/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/add-mdss/group_vars/all
+++ b/tests/functional/add-mdss/group_vars/all
@@ -21,6 +21,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/add-mgrs/container/group_vars/all
+++ b/tests/functional/add-mgrs/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/add-mgrs/group_vars/all
+++ b/tests/functional/add-mgrs/group_vars/all
@@ -21,6 +21,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/add-mons/container/group_vars/all
+++ b/tests/functional/add-mons/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/add-mons/group_vars/all
+++ b/tests/functional/add-mons/group_vars/all
@@ -21,6 +21,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/add-osds/container/group_vars/all
+++ b/tests/functional/add-osds/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/add-osds/group_vars/all
+++ b/tests/functional/add-osds/group_vars/all
@@ -21,6 +21,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/add-rbdmirrors/container/group_vars/all
+++ b/tests/functional/add-rbdmirrors/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/add-rbdmirrors/group_vars/all
+++ b/tests/functional/add-rbdmirrors/group_vars/all
@@ -21,6 +21,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/add-rgws/container/group_vars/all
+++ b/tests/functional/add-rgws/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/add-rgws/group_vars/all
+++ b/tests/functional/add-rgws/group_vars/all
@@ -21,6 +21,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/all-in-one/container/group_vars/all
+++ b/tests/functional/all-in-one/container/group_vars/all
@@ -18,6 +18,7 @@ dashboard_enabled: false
 ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 handler_health_mon_check_delay: 10

--- a/tests/functional/all-in-one/group_vars/all
+++ b/tests/functional/all-in-one/group_vars/all
@@ -15,6 +15,7 @@ rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 handler_health_mon_check_delay: 10

--- a/tests/functional/all_daemons/ceph-override.json
+++ b/tests/functional/all_daemons/ceph-override.json
@@ -3,6 +3,7 @@
     "global": {
       "osd_pool_default_pg_num": 12,
       "osd_pool_default_size": 1,
+      "mon_allow_pool_size_one": true,
       "mon_warn_on_pool_no_redundancy": false
     }
   },

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -14,6 +14,7 @@ rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: True

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -6,6 +6,7 @@ cluster_network: "192.168.2.0/24"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: True

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -16,6 +16,7 @@ rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 handler_health_mon_check_delay: 10

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -13,6 +13,7 @@ rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 handler_health_mon_check_delay: 10

--- a/tests/functional/docker2podman/ceph-override.json
+++ b/tests/functional/docker2podman/ceph-override.json
@@ -3,6 +3,7 @@
     "global": {
       "osd_pool_default_pg_num": 12,
       "osd_pool_default_size": 1,
+      "mon_allow_pool_size_one": true,
       "mon_warn_on_pool_no_redundancy": false
     }
   },

--- a/tests/functional/docker2podman/group_vars/all
+++ b/tests/functional/docker2podman/group_vars/all
@@ -14,6 +14,7 @@ rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False

--- a/tests/functional/external_clients/container/group_vars/all
+++ b/tests/functional/external_clients/container/group_vars/all
@@ -18,6 +18,7 @@ dashboard_enabled: false
 ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 handler_health_mon_check_delay: 10

--- a/tests/functional/external_clients/group_vars/all
+++ b/tests/functional/external_clients/group_vars/all
@@ -15,6 +15,7 @@ rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 handler_health_mon_check_delay: 10

--- a/tests/functional/filestore-to-bluestore/container/group_vars/all
+++ b/tests/functional/filestore-to-bluestore/container/group_vars/all
@@ -17,6 +17,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/filestore-to-bluestore/group_vars/all
+++ b/tests/functional/filestore-to-bluestore/group_vars/all
@@ -12,6 +12,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/lvm-auto-discovery/container/group_vars/all
+++ b/tests/functional/lvm-auto-discovery/container/group_vars/all
@@ -21,6 +21,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/lvm-auto-discovery/group_vars/all
+++ b/tests/functional/lvm-auto-discovery/group_vars/all
@@ -15,6 +15,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/lvm-batch/container/group_vars/all
+++ b/tests/functional/lvm-batch/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/lvm-batch/group_vars/all
+++ b/tests/functional/lvm-batch/group_vars/all
@@ -17,6 +17,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/lvm-osds/container/group_vars/all
+++ b/tests/functional/lvm-osds/container/group_vars/all
@@ -17,6 +17,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/lvm-osds/group_vars/all
+++ b/tests/functional/lvm-osds/group_vars/all
@@ -12,6 +12,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/migrate_ceph_disk_to_ceph_volume/group_vars/all
+++ b/tests/functional/migrate_ceph_disk_to_ceph_volume/group_vars/all
@@ -19,6 +19,7 @@ os_tuning_params:
 ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_admin_password: $sX!cD$rYU6qR^B!

--- a/tests/functional/ooo-collocation/hosts
+++ b/tests/functional/ooo-collocation/hosts
@@ -3,6 +3,7 @@ all:
     admin_secret: AQBSV4xaAAAAABAA3VUTiOZTHecau2SnAEVPYQ==
     ceph_conf_overrides:
       global: {osd_pool_default_pg_num: 8, osd_pool_default_pgp_num: 8, osd_pool_default_size: 1,
+        mon_allow_pool_size_one: true,
         mon_warn_on_pool_no_redundancy: false,
         rgw_keystone_accepted_roles: 'Member, admin', rgw_keystone_admin_domain: default,
         rgw_keystone_admin_password: RtYPg7AUdsZCGv4Z4rF8FvnaR, rgw_keystone_admin_project: service,

--- a/tests/functional/podman/group_vars/all
+++ b/tests/functional/podman/group_vars/all
@@ -14,6 +14,7 @@ rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: True

--- a/tests/functional/rgw-multisite/container/group_vars/all
+++ b/tests/functional/rgw-multisite/container/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/rgw-multisite/container/secondary/group_vars/all
+++ b/tests/functional/rgw-multisite/container/secondary/group_vars/all
@@ -23,6 +23,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/rgw-multisite/group_vars/all
+++ b/tests/functional/rgw-multisite/group_vars/all
@@ -21,6 +21,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/rgw-multisite/secondary/group_vars/all
+++ b/tests/functional/rgw-multisite/secondary/group_vars/all
@@ -21,6 +21,7 @@ os_tuning_params:
   - { name: fs.file-max, value: 26234859 }
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 ceph_osd_docker_run_script_path: /var/tmp

--- a/tests/functional/shrink_mds/container/group_vars/all
+++ b/tests/functional/shrink_mds/container/group_vars/all
@@ -11,6 +11,7 @@ public_network: "192.168.79.0/24"
 cluster_network: "192.168.80.0/24"
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False

--- a/tests/functional/shrink_mds/group_vars/all
+++ b/tests/functional/shrink_mds/group_vars/all
@@ -10,6 +10,7 @@ osd_objectstore: "bluestore"
 copy_admin_key: true
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/shrink_mgr/container/group_vars/all
+++ b/tests/functional/shrink_mgr/container/group_vars/all
@@ -11,6 +11,7 @@ public_network: "192.168.83.0/24"
 cluster_network: "192.168.84.0/24"
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False

--- a/tests/functional/shrink_mgr/group_vars/all
+++ b/tests/functional/shrink_mgr/group_vars/all
@@ -7,6 +7,7 @@ monitor_interface: eth1
 radosgw_interface: eth1
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/shrink_mon/container/group_vars/all
+++ b/tests/functional/shrink_mon/container/group_vars/all
@@ -11,6 +11,7 @@ public_network: "192.168.17.0/24"
 cluster_network: "192.168.18.0/24"
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False

--- a/tests/functional/shrink_mon/group_vars/all
+++ b/tests/functional/shrink_mon/group_vars/all
@@ -5,6 +5,7 @@ public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/shrink_osd/container/group_vars/all
+++ b/tests/functional/shrink_osd/container/group_vars/all
@@ -11,6 +11,7 @@ public_network: "192.168.73.0/24"
 cluster_network: "192.168.74.0/24"
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False

--- a/tests/functional/shrink_rbdmirror/container/group_vars/all
+++ b/tests/functional/shrink_rbdmirror/container/group_vars/all
@@ -10,6 +10,7 @@ ceph_mon_docker_subnet: "{{ public_network }}"
 ceph_docker_on_openstack: False
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False

--- a/tests/functional/shrink_rbdmirror/group_vars/all
+++ b/tests/functional/shrink_rbdmirror/group_vars/all
@@ -8,6 +8,7 @@ osd_objectstore: "bluestore"
 copy_admin_key: true
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False

--- a/tests/functional/shrink_rgw/container/group_vars/all
+++ b/tests/functional/shrink_rgw/container/group_vars/all
@@ -12,6 +12,7 @@ ceph_mon_docker_subnet: "{{ public_network }}"
 ceph_docker_on_openstack: False
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 openstack_config: False

--- a/tests/functional/shrink_rgw/group_vars/all
+++ b/tests/functional/shrink_rgw/group_vars/all
@@ -9,6 +9,7 @@ osd_objectstore: "bluestore"
 copy_admin_key: true
 ceph_conf_overrides:
   global:
+    mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False


### PR DESCRIPTION
Since [1] we can't use osd pool without replicas (size: 1) by default.
We now need to set the mon_allow_pool_size_one flag to true in the ceph
configuration and add the --yes-i-really-mean-it flag to the osd pool
set size cli.

[1] https://github.com/ceph/ceph/commit/21508bd

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>