### PR TITLE
osd: support changing default rule even without osd_crush_location

### DIFF
--- a/roles/ceph-osd/tasks/crush_rules.yml
+++ b/roles/ceph-osd/tasks/crush_rules.yml
@@ -43,7 +43,6 @@
   with_items: "{{ groups[mon_group_name] }}"
   run_once: true
   when:
-    - not config_crush_hierarchy.get('skipped', false)
     - info_ceph_default_crush_rule_yaml | default('') | length > 0
 
 - name: "add new default crush rule to {{ cluster }}.conf"
@@ -56,5 +55,4 @@
   with_items: "{{ groups[mon_group_name] }}"
   run_once: true
   when:
-    - not config_crush_hierarchy.get('skipped', false)
     - info_ceph_default_crush_rule_yaml | default('') | length > 0


### PR DESCRIPTION
Creating crush rules even with no crush hierarchy configuration is a
valid scenario so we shouldn't be bound to the first task result (which
configure crush hierarchy) to be able to add new crush rules.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1816989

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>