### PR TITLE
purge-container: clean legacy code

### DIFF
--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -273,7 +273,6 @@
     file:
       path: /var/lib/ceph/osd/
       state: absent
-    register: remove_osd_mountpoints
     ignore_errors: true
 
   - name: default lvm_volumes if not defined


### PR DESCRIPTION
This commit removes a register which isn't used in this playbook.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>