### PR TITLE
config: remove legacy option in ceph.conf.j2

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -6,7 +6,6 @@
 auth cluster required = none
 auth service required = none
 auth client required = none
-auth supported = none
 {% endif %}
 {% if ip_version == 'ipv6'  %}
 ms bind ipv6 = true


### PR DESCRIPTION
This option has been deprecated (As of 0.51).
By the way, ceph-ansible already sets the
auth_{service,client,cluster}_required variables.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1623586

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>