### PR TITLE
rhcs_edits: Update grafana version

### DIFF
--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -771,7 +771,7 @@ node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node
 # We only need this for SSL (https) connections
 #grafana_crt: ''
 #grafana_key: ''
-grafana_container_image: registry.redhat.io/rhceph/rhceph-3-dashboard-rhel7:3
+grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
 #grafana_container_cpu_period: 100000
 #grafana_container_cpu_cores: 2
 # container_memory is in GB

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -8,7 +8,7 @@ ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"
 ceph_docker_registry_auth: true
 node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1
-grafana_container_image: registry.redhat.io/rhceph/rhceph-3-dashboard-rhel7:3
+grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
 prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
 alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:4.1
 # END OF FILE, DO NOT TOUCH ME!


### PR DESCRIPTION
We are planning to release updated grafana image for ceph dashboard in
RHCS 4.1. We need to update the rhcs edut to point to the new image
then.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1786107

Signed-off-by: Boris Ranto <branto@redhat.com>