### PR TITLE
ceph-defaults: update grafana container tag

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -771,7 +771,7 @@ dummy:
 # We only need this for SSL (https) connections
 #grafana_crt: ''
 #grafana_key: ''
-#grafana_container_image: "grafana/grafana:5.2.4"
+#grafana_container_image: "grafana/grafana:5.4.3"
 #grafana_container_cpu_period: 100000
 #grafana_container_cpu_cores: 2
 # container_memory is in GB

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -763,7 +763,7 @@ grafana_admin_user: admin
 # We only need this for SSL (https) connections
 grafana_crt: ''
 grafana_key: ''
-grafana_container_image: "grafana/grafana:5.2.4"
+grafana_container_image: "grafana/grafana:5.4.3"
 grafana_container_cpu_period: 100000
 grafana_container_cpu_cores: 2
 # container_memory is in GB


### PR DESCRIPTION
Since 8e8aa73 we're using grafana 5.4.3 in RHCS 4.1 via [1].
We should also update the grafana container tag from docker.io when
using the community release.

[1] registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>