### PR TITLE
Fix for TLS dashboard

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -768,6 +768,8 @@ dummy:
 # We only need this for SSL (https) connections
 #grafana_crt: ''
 #grafana_key: ''
+# When using https, please fill with a hostname for which grafana_crt is valid.
+#grafana_server_fqdn: ''
 #grafana_container_image: "docker.io/grafana/grafana:5.4.3"
 #grafana_container_cpu_period: 100000
 #grafana_container_cpu_cores: 2

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -768,6 +768,8 @@ node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node
 # We only need this for SSL (https) connections
 #grafana_crt: ''
 #grafana_key: ''
+# When using https, please fill with a hostname for which grafana_crt is valid.
+#grafana_server_fqdn: ''
 grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
 #grafana_container_cpu_period: 100000
 #grafana_container_cpu_cores: 2

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -107,13 +107,13 @@
   changed_when: false
 
 - name: set alertmanager host
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-alertmanager-api-host {{ dashboard_protocol }}://{{ grafana_server_addrs | first }}:{{ alertmanager_port }}"
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-alertmanager-api-host http://{{ grafana_server_addrs | first }}:{{ alertmanager_port }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   changed_when: false
 
 - name: set prometheus host
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-prometheus-api-host {{ dashboard_protocol }}://{{ grafana_server_addrs | first }}:{{ prometheus_port }}"
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-prometheus-api-host http://{{ grafana_server_addrs | first }}:{{ prometheus_port }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   changed_when: false

--- a/roles/ceph-dashboard/tasks/configure_grafana_layouts.yml
+++ b/roles/ceph-dashboard/tasks/configure_grafana_layouts.yml
@@ -1,6 +1,6 @@
 ---
 - name: set grafana url
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ grafana_server_addr }}:{{ grafana_port }}"
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ grafana_server_fqdn | default(grafana_server_addr, true) }}:{{ grafana_port }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   changed_when: false

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -760,6 +760,8 @@ grafana_admin_user: admin
 # We only need this for SSL (https) connections
 grafana_crt: ''
 grafana_key: ''
+# When using https, please fill with a hostname for which grafana_crt is valid.
+grafana_server_fqdn: ''
 grafana_container_image: "docker.io/grafana/grafana:5.4.3"
 grafana_container_cpu_period: 100000
 grafana_container_cpu_cores: 2


### PR DESCRIPTION
Setting up a TLS dashboard currently causes some issues, as initially reported in #5053. Problems were partially fixed by #5055, but some issues remain:

- Setting `dashboard_protocol` to `https` causes the dashboard to try accessing Prometheus API though https too. However, Prometheus [does not](https://prometheus.io/docs/guides/tls-encryption/) support TLS natively. Setting up a reverse proxy such as nginx would be needed for this. For now, we just fix the protocol as plain http, which is what Prometheus supports.

- People are currently using `ceph dashboard set-grafana-api-ssl-verify False` as a workaround to get Grafana to work with TLS. In order to get the certificate to validate correctly, we can allow the user to override `grafana_server_addr` with a FQDN listed in the certificate's CN or altsubjects.

Just for reference, I'm deploying with the following config:

```
dashboard_protocol: https
dashboard_admin_user: admin
dashboard_admin_password: ommited
dashboard_crt: 'ceph.crt'
dashboard_key: 'ceph.key'
grafana_admin_user: admin
grafana_admin_password: ommited
grafana_crt: 'ceph.crt'
grafana_key: 'ceph.key'
grafana_server_addr: somedomain.ufscar.br
```