### PR TITLE
ceph-defaults: add registry name on dashboard vars

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -763,7 +763,7 @@ dummy:
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
 #dashboard_frontend_vip: ''
-#node_exporter_container_image: "prom/node-exporter:v0.17.0"
+#node_exporter_container_image: "docker.io/prom/node-exporter:v0.17.0"
 #node_exporter_port: 9100
 #grafana_admin_user: admin
 # This variable must be set with a strong custom password when dashboard_enabled is True
@@ -771,7 +771,7 @@ dummy:
 # We only need this for SSL (https) connections
 #grafana_crt: ''
 #grafana_key: ''
-#grafana_container_image: "grafana/grafana:5.4.3"
+#grafana_container_image: "docker.io/grafana/grafana:5.4.3"
 #grafana_container_cpu_period: 100000
 #grafana_container_cpu_cores: 2
 # container_memory is in GB
@@ -797,7 +797,7 @@ dummy:
 #  - grafana-piechart-panel
 #grafana_allow_embedding: True
 #grafana_port: 3000
-#prometheus_container_image: "prom/prometheus:v2.7.2"
+#prometheus_container_image: "docker.io/prom/prometheus:v2.7.2"
 #prometheus_container_cpu_period: 100000
 #prometheus_container_cpu_cores: 2
 # container_memory is in GB
@@ -806,7 +806,7 @@ dummy:
 #prometheus_conf_dir: /etc/prometheus
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 #prometheus_port: 9092
-#alertmanager_container_image: "prom/alertmanager:v0.16.2"
+#alertmanager_container_image: "docker.io/prom/alertmanager:v0.16.2"
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2
 # container_memory is in GB

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -755,7 +755,7 @@ dashboard_rgw_api_user_id: ceph-dashboard
 dashboard_rgw_api_admin_resource: ''
 dashboard_rgw_api_no_ssl_verify: False
 dashboard_frontend_vip: ''
-node_exporter_container_image: "prom/node-exporter:v0.17.0"
+node_exporter_container_image: "docker.io/prom/node-exporter:v0.17.0"
 node_exporter_port: 9100
 grafana_admin_user: admin
 # This variable must be set with a strong custom password when dashboard_enabled is True
@@ -763,7 +763,7 @@ grafana_admin_user: admin
 # We only need this for SSL (https) connections
 grafana_crt: ''
 grafana_key: ''
-grafana_container_image: "grafana/grafana:5.4.3"
+grafana_container_image: "docker.io/grafana/grafana:5.4.3"
 grafana_container_cpu_period: 100000
 grafana_container_cpu_cores: 2
 # container_memory is in GB
@@ -789,7 +789,7 @@ grafana_plugins:
   - grafana-piechart-panel
 grafana_allow_embedding: True
 grafana_port: 3000
-prometheus_container_image: "prom/prometheus:v2.7.2"
+prometheus_container_image: "docker.io/prom/prometheus:v2.7.2"
 prometheus_container_cpu_period: 100000
 prometheus_container_cpu_cores: 2
 # container_memory is in GB
@@ -798,7 +798,7 @@ prometheus_data_dir: /var/lib/prometheus
 prometheus_conf_dir: /etc/prometheus
 prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 prometheus_port: 9092
-alertmanager_container_image: "prom/alertmanager:v0.16.2"
+alertmanager_container_image: "docker.io/prom/alertmanager:v0.16.2"
 alertmanager_container_cpu_period: 100000
 alertmanager_container_cpu_cores: 2
 # container_memory is in GB


### PR DESCRIPTION
We don't use the registry name when using the community dashboard
container images (grafana, prometheus, alertmanager & node exporter).
This commit adds the docker.io registry explicitly in the default
dashboard container image name values.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>