### PR TITLE
Fix  ceph grafana/dashboard validation task

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -230,6 +230,7 @@
       when:
         - dashboard_admin_password is undefined
           or grafana_admin_password is undefined
+      run_once: true
   when: dashboard_enabled | bool
 
 - name: validate container registry credentials


### PR DESCRIPTION
This patch fix the way we run the ceph-validate
tasks against grafana/dashboard involved hosts.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1814588
Signed-off-by: fpantano <fpantano@redhat.com>