### PR TITLE
dashboard: allow to set read-only admin user

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -754,6 +754,7 @@ dummy:
 #dashboard_protocol: http
 #dashboard_port: 8443
 #dashboard_admin_user: admin
+#dashboard_admin_user_ro: false
 # This variable must be set with a strong custom password when dashboard_enabled is True
 #dashboard_admin_password: p@ssw0rd
 # We only need this for SSL (https) connections

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -754,6 +754,7 @@ ceph_docker_registry_auth: true
 #dashboard_protocol: http
 #dashboard_port: 8443
 #dashboard_admin_user: admin
+#dashboard_admin_user_ro: false
 # This variable must be set with a strong custom password when dashboard_enabled is True
 #dashboard_admin_password: p@ssw0rd
 # We only need this for SSL (https) connections

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -84,7 +84,7 @@
     if {{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard ac-user-show {{ dashboard_admin_user | quote }}; then
       {{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard ac-user-set-password {{ dashboard_admin_user | quote }} {{ dashboard_admin_password | quote }}
     else
-      {{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard ac-user-create {{ dashboard_admin_user | quote }} {{ dashboard_admin_password | quote }} administrator
+      {{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard ac-user-create {{ dashboard_admin_user | quote }} {{ dashboard_admin_password | quote }} {{ 'read-only' if dashboard_admin_user_ro | bool else 'administrator' }}
     fi
   retries: 6
   delay: 5

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -746,6 +746,7 @@ dashboard_enabled: True
 dashboard_protocol: http
 dashboard_port: 8443
 dashboard_admin_user: admin
+dashboard_admin_user_ro: false
 # This variable must be set with a strong custom password when dashboard_enabled is True
 #dashboard_admin_password: p@ssw0rd
 # We only need this for SSL (https) connections

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -22,4 +22,5 @@ ceph_conf_overrides:
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 dashboard_admin_password: $sX!cD$rYU6qR^B!
+dashboard_admin_user_ro: true
 grafana_admin_password: +xFRe+RES@7vg24n

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -19,4 +19,5 @@ ceph_conf_overrides:
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 dashboard_admin_password: $sX!cD$rYU6qR^B!
+dashboard_admin_user_ro: true
 grafana_admin_password: +xFRe+RES@7vg24n


### PR DESCRIPTION
This commit allows one to set the role for the admin user as read-only.
This can be controlled via the dashboard_admin_user_ro variable but the
default value is false for backward compatibility.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1810176

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>