### PR TITLE
osd: add a default value for 'default' in crush_rules

### DIFF
--- a/roles/ceph-osd/tasks/crush_rules.yml
+++ b/roles/ceph-osd/tasks/crush_rules.yml
@@ -24,7 +24,7 @@
   with_items: "{{ hostvars[groups[mon_group_name][0]]['crush_rules'] | default(crush_rules) | unique }}"
   delegate_to: '{{ groups[mon_group_name][0] }}'
   run_once: true
-  when: item.default | bool
+  when: item.default | default(False) | bool
 
 # If multiple rules are set as default (should not be) then the last one is taken as actual default.
 # the with_items statement overrides each iteration with the new one.


### PR DESCRIPTION
Let's default to `False` for the `default` attribute in `crush_rules`
variable.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1797774

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>