### PR TITLE
doc/tests: bump to ansible 2.9 on master

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -16,8 +16,8 @@ Obsoletes:      ceph-iscsi-ansible <= 1.5
 
 BuildArch:      noarch
 
-BuildRequires: ansible >= 2.8
-Requires: ansible >= 2.8
+BuildRequires: ansible >= 2.9
+Requires: ansible >= 2.9
 
 %if 0%{?rhel} == 7
 BuildRequires: python2-devel

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -79,7 +79,9 @@ The ``master`` branch should be considered experimental and used with caution.
 
 - ``stable-4.0`` Supports Ceph version ``nautilus``. This branch requires Ansible version ``2.8``.
 
-- ``master`` Supports the master branch of Ceph. This branch requires Ansible version ``2.8``.
+- ``stable-5.0`` Supports Ceph version ``octopus``. This branch requires Ansible version ``2.9``.
+
+- ``master`` Supports the master branch of Ceph. This branch requires Ansible version ``2.9``.
 
 Configuration and Usage
 =======================

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # These are Python requirements needed to run ceph-ansible master
-ansible>=2.8.8,<2.9
+ansible>=2.9,<2.10
 netaddr

--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -6,10 +6,8 @@
 
 - name: fail on unsupported ansible version
   fail:
-    msg: "Ansible version must be 2.8 or 2.9!"
-  when:
-    - ansible_version.major|int == 2
-    - ansible_version.minor|int not in [8, 9]
+    msg: "Ansible version must be 2.9!"
+  when: ansible_version.minor|int != 9
 
 - name: fail on unsupported system
   fail:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ six==1.10.0
 testinfra>=3,<4
 pytest-xdist==1.28.0
 pytest>=4.6,<5.0
-ansible>=2.8.8,<2.9
+ansible>=2.9,<2.10
 Jinja2>=2.10
 netaddr
 mock


### PR DESCRIPTION
Add testing against ansible 2.9 on master branch.
    This commit also updates the documentation.
