### PR TITLE
tests: update mgr dashboard socket listening test

### DIFF
--- a/tests/functional/tests/mgr/test_mgr.py
+++ b/tests/functional/tests/mgr/test_mgr.py
@@ -25,8 +25,9 @@ class TestMGRs(object):
     @pytest.mark.parametrize('port', [
         '8443', '9283'
     ])
-    def test_mgr_dashboard_is_listening(self, node, host, port):
-        assert host.socket('tcp://%s' % port).is_listening
+    def test_mgr_dashboard_is_listening(self, node, host, setup, port):
+        s = host.socket('tcp://%s:%s' % (setup["address"], port))
+        assert s.is_listening
 
     def test_mgr_is_up(self, node, host, setup):
         hostname = node["vars"]["inventory_hostname"]


### PR DESCRIPTION
Since 15ed9ee the ceph-mgr daemon binds on the IP address on the public
network instead of binding on all addresses.
This commit updates the testinfra code to reflect that change.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>