### PR TITLE
ceph-defaults: update ceph_stable_redhat_distro

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -161,7 +161,7 @@ dummy:
 
 # This option is needed for _both_ stable and dev version, so please always fill the right version
 # # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
-#ceph_stable_redhat_distro: el7
+#ceph_stable_redhat_distro: el8
 
 
 # REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -161,7 +161,7 @@ ceph_repository: rhcs
 
 # This option is needed for _both_ stable and dev version, so please always fill the right version
 # # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
-#ceph_stable_redhat_distro: el7
+#ceph_stable_redhat_distro: el8
 
 
 # REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -153,7 +153,7 @@ nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_s
 
 # This option is needed for _both_ stable and dev version, so please always fill the right version
 # # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
-ceph_stable_redhat_distro: el7
+ceph_stable_redhat_distro: el8
 
 
 # REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)


### PR DESCRIPTION
Since octopus the ceph_stable_redhat_distro variable should be set to
el8 instead of el7.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>