### PR TITLE
defaults: remove legacy comment

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -100,7 +100,6 @@ dummy:
 #ntp_service_enabled: true
 
 # Set type of NTP client daemon to use, valid entries are chronyd, ntpd or timesyncd
-# Note that this selection is currently ignored on containerized deployments
 #ntp_daemon_type: chronyd
 
 # This variable determines if ceph packages can be updated.  If False, the

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -100,7 +100,6 @@ fetch_directory: ~/ceph-ansible-keys
 #ntp_service_enabled: true
 
 # Set type of NTP client daemon to use, valid entries are chronyd, ntpd or timesyncd
-# Note that this selection is currently ignored on containerized deployments
 #ntp_daemon_type: chronyd
 
 # This variable determines if ceph packages can be updated.  If False, the

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -92,7 +92,6 @@ ceph_test: false
 ntp_service_enabled: true
 
 # Set type of NTP client daemon to use, valid entries are chronyd, ntpd or timesyncd
-# Note that this selection is currently ignored on containerized deployments
 ntp_daemon_type: chronyd
 
 # This variable determines if ceph packages can be updated.  If False, the


### PR DESCRIPTION
This is no longer true, let's remove this comment given that this option
is not ignored in containerized deployments.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>