### PR TITLE
rhcs: update release to 5 for octopus

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -163,13 +163,13 @@ dummy:
 #ceph_stable_redhat_distro: el8
 
 
-# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)
+# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 5.0)
 #
 # Enabled when ceph_repository == 'rhcs'
 #
-# This version is supported on RHEL 7 and 8
+# This version is supported on RHEL 8
 #
-#ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(4) }}"
+#ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(5) }}"
 #valid_ceph_repository_type:
 #  - cdn
 #  - iso

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -163,13 +163,13 @@ ceph_repository: rhcs
 #ceph_stable_redhat_distro: el8
 
 
-# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)
+# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 5.0)
 #
 # Enabled when ceph_repository == 'rhcs'
 #
-# This version is supported on RHEL 7 and 8
+# This version is supported on RHEL 8
 #
-ceph_rhcs_version: 4
+ceph_rhcs_version: 5
 #valid_ceph_repository_type:
 #  - cdn
 #  - iso
@@ -589,7 +589,7 @@ ceph_iscsi_config_dev: false
 ##########
 # DOCKER #
 ##########
-ceph_docker_image: "rhceph/rhceph-4-rhel8"
+ceph_docker_image: "rhceph/rhceph-5-rhel8"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"
 ceph_docker_registry_auth: true

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -2,8 +2,8 @@ ceph_repository: rhcs
 ceph_origin: repository
 ceph_iscsi_config_dev: false
 fetch_directory: ~/ceph-ansible-keys
-ceph_rhcs_version: 4
-ceph_docker_image: "rhceph/rhceph-4-rhel8"
+ceph_rhcs_version: 5
+ceph_docker_image: "rhceph/rhceph-5-rhel8"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"
 ceph_docker_registry_auth: true

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
@@ -1,36 +1,15 @@
 ---
-- name: "rhcs {{ ceph_rhcs_version }} on rhel 8"
-  when: ansible_distribution_major_version | int == 8
-  block:
-    - name: enable red hat storage monitor repository
-      rhsm_repository:
-        name: "rhceph-{{ ceph_rhcs_version }}-mon-for-rhel-8-{{ ansible_architecture }}-rpms"
-      when: (mon_group_name in group_names or mgr_group_name in group_names)
+- name: enable red hat storage monitor repository
+  rhsm_repository:
+    name: "rhceph-{{ ceph_rhcs_version }}-mon-for-rhel-8-{{ ansible_architecture }}-rpms"
+  when: (mon_group_name in group_names or mgr_group_name in group_names)
 
-    - name: enable red hat storage osd repository
-      rhsm_repository:
-        name: "rhceph-{{ ceph_rhcs_version }}-osd-for-rhel-8-{{ ansible_architecture }}-rpms"
-      when: osd_group_name in group_names
+- name: enable red hat storage osd repository
+  rhsm_repository:
+    name: "rhceph-{{ ceph_rhcs_version }}-osd-for-rhel-8-{{ ansible_architecture }}-rpms"
+  when: osd_group_name in group_names
 
-    - name: enable red hat storage tools repository
-      rhsm_repository:
-        name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_architecture }}-rpms"
-      when: (rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names)
-
-- name: "rhcs {{ ceph_rhcs_version }} on rhel 7"
-  when: ansible_distribution_major_version | int == 7
-  block:
-    - name: enable red hat storage monitor repository
-      rhsm_repository:
-        name: "rhel-7-server-rhceph-{{ ceph_rhcs_version }}-mon-rpms"
-      when: (mon_group_name in group_names or mgr_group_name in group_names)
-
-    - name: enable red hat storage osd repository
-      rhsm_repository:
-        name: "rhel-7-server-rhceph-{{ ceph_rhcs_version }}-osd-rpms"
-      when: osd_group_name in group_names
-
-    - name: enable red hat storage tools repository
-      rhsm_repository:
-        name: "rhel-7-server-rhceph-{{ ceph_rhcs_version }}-tools-rpms"
-      when: (rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names)
+- name: enable red hat storage tools repository
+  rhsm_repository:
+    name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_architecture }}-rpms"
+  when: (rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names)

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -155,13 +155,13 @@ nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_s
 ceph_stable_redhat_distro: el8
 
 
-# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)
+# REPOSITORY: RHCS VERSION RED HAT STORAGE (from 5.0)
 #
 # Enabled when ceph_repository == 'rhcs'
 #
-# This version is supported on RHEL 7 and 8
+# This version is supported on RHEL 8
 #
-ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(4) }}"
+ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(5) }}"
 valid_ceph_repository_type:
   - cdn
   - iso


### PR DESCRIPTION
RHCS 5 will be based on Ceph Octopus release and only supported on
RHEL 8.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>