### PR TITLE
ceph-defaults: update container tag for nautilus

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -582,7 +582,7 @@ dummy:
 # DOCKER #
 ##########
 #ceph_docker_image: "ceph/daemon"
-#ceph_docker_image_tag: latest
+#ceph_docker_image_tag: latest-nautilus
 #ceph_docker_registry: docker.io
 #ceph_docker_registry_auth: false
 #ceph_docker_registry_username:

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -574,7 +574,7 @@ ceph_tcmalloc_max_total_thread_cache: 0
 # DOCKER #
 ##########
 ceph_docker_image: "ceph/daemon"
-ceph_docker_image_tag: latest
+ceph_docker_image_tag: latest-nautilus
 ceph_docker_registry: docker.io
 ceph_docker_registry_auth: false
 #ceph_docker_registry_username:


### PR DESCRIPTION
The latest Ceph stable release is now Octopus so the "latest" container
image tag is pointing to Octopus and not Nautilus anymore.
This commit updates the ceph_docker_image_tag with "latest-nautilus".

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>