### PR TITLE
purge-container: get *all* osds id

### DIFF
--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -258,7 +258,7 @@
 
   - name: get all the running osds
     shell: |
-      systemctl list-units | grep 'loaded[[:space:]]\+active' | grep -oE "ceph-osd@([0-9]+).service"
+      systemctl list-units --all | grep -oE "ceph-osd@([0-9]+).service"
     register: osd_units
     ignore_errors: true
 


### PR DESCRIPTION
Adding `--all` to the `systemctl list-units` command in order to get
*all* osds id on the node (including stoppped osds). Otherwise, it will
purge the cluster but there will be leftover after that.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1814542

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>