### PR TITLE
docker2podman: call `container_options_facts.yml` on osd nodes

### DIFF
--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -102,6 +102,11 @@
 
     - import_role:
         name: ceph-osd
+        tasks_from: container_options_facts.yml
+      when: inventory_hostname in groups.get(osd_group_name, [])
+
+    - import_role:
+        name: ceph-osd
         tasks_from: systemd.yml
       when: inventory_hostname in groups.get(osd_group_name, [])
 


### PR DESCRIPTION
We must call `ceph-osd` role from `container_options_facts.yml` because
ceph-osd-run.sh.j2 needs variables set in this file.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1819681

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>