### PR TITLE
[skip ci] infra-playbooks: load group_vars from root directory

### DIFF
--- a/infrastructure-playbooks/group_vars
+++ b/infrastructure-playbooks/group_vars
@@ -1,0 +1,1 @@
+../group_vars/


### PR DESCRIPTION
Add a symlink so group_vars are well loaded from root directory even
when invoking a playbook from infrastructure-playbooks directory.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1819052

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>