### PR TITLE
vagrant: force centos 8.1 libvirt image

### DIFF
--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+vagrant box remove --provider libvirt --box-version 1905.1 centos/8 || true
+vagrant box add --provider libvirt --name centos/8 https://cloud.centos.org/centos/8/vagrant/x86_64/images/CentOS-8-Vagrant-8.1.1911-20200113.3.x86_64.vagrant-libvirt.box || true
+
 retries=0
 until [ $retries -ge 5 ]
 do


### PR DESCRIPTION
The current centos/8 vagrant image (libvirt) is still using the
CentOS 8.0 release (1905) while the 8.1 release (1911) is already
available since few months.
Using an update CentOS 8 release fixes slow ceph-volume/lvm commands.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>