### PR TITLE
tests: add mgr nodes to shrink_mon inventory

### DIFF
--- a/tests/functional/shrink_mon/container/hosts
+++ b/tests/functional/shrink_mon/container/hosts
@@ -3,5 +3,8 @@ mon0
 mon1
 mon2
 
+[mgrs]
+mon0
+
 [osds]
 osd0

--- a/tests/functional/shrink_mon/hosts
+++ b/tests/functional/shrink_mon/hosts
@@ -3,5 +3,8 @@ mon0 monitor_address=192.168.1.10
 mon1 monitor_interface=eth1
 mon2 monitor_address=192.168.1.12
 
+[mgrs]
+mon0
+
 [osds]
 osd0


### PR DESCRIPTION
Since 306ce82 we explicitly fail when there's no mgr node preent in the
inventory.
```console
fatal: [mon0]: FAILED! => {
    "changed": false
}

MSG:

Please add a mgr host to your inventory.
```
Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>