### PR TITLE
Readd CentOS 7 with conditions

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -86,7 +86,7 @@ dummy:
 
 #centos_package_dependencies:
 #  - epel-release
-#  - python3-libselinux
+#  - "{{ 'python3-libselinux' if ansible_distribution_major_version | int >= 8 else 'libselinux-python' }}"
 
 #redhat_package_dependencies: []
 
@@ -157,10 +157,6 @@ dummy:
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/
 # for more info read: https://github.com/ceph/ceph-ansible/issues/305
 #ceph_stable_distro_source: "{{ ansible_distribution_release }}"
-
-# This option is needed for _both_ stable and dev version, so please always fill the right version
-# # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
-#ceph_stable_redhat_distro: el8
 
 
 # REPOSITORY: RHCS VERSION RED HAT STORAGE (from 5.0)

--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -31,8 +31,6 @@ dummy:
 # Ceph mgr packages to install, ceph-mgr + extra module packages.
 #ceph_mgr_packages:
 #  - ceph-mgr
-#  - ceph-mgr-dashboard
-#  - ceph-mgr-diskprediction-local
 
 
 ##########

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -86,7 +86,7 @@ fetch_directory: ~/ceph-ansible-keys
 
 #centos_package_dependencies:
 #  - epel-release
-#  - python3-libselinux
+#  - "{{ 'python3-libselinux' if ansible_distribution_major_version | int >= 8 else 'libselinux-python' }}"
 
 #redhat_package_dependencies: []
 
@@ -157,10 +157,6 @@ ceph_repository: rhcs
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/
 # for more info read: https://github.com/ceph/ceph-ansible/issues/305
 #ceph_stable_distro_source: "{{ ansible_distribution_release }}"
-
-# This option is needed for _both_ stable and dev version, so please always fill the right version
-# # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
-#ceph_stable_redhat_distro: el8
 
 
 # REPOSITORY: RHCS VERSION RED HAT STORAGE (from 5.0)

--- a/roles/ceph-common/tasks/installs/redhat_community_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_community_repository.yml
@@ -21,7 +21,7 @@
     gpgcheck: yes
     state: present
     gpgkey: "{{ ceph_stable_key }}"
-    baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_stable_release }}/{{ ceph_stable_redhat_distro }}/$basearch"
+    baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_stable_release }}/el{{ ansible_distribution_major_version }}/$basearch"
     file: ceph_stable
     priority: 2
   register: result
@@ -34,7 +34,7 @@
     gpgcheck: yes
     state: present
     gpgkey: "{{ ceph_stable_key }}"
-    baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_stable_release }}/{{ ceph_stable_redhat_distro }}/noarch"
+    baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_stable_release }}/el{{ ansible_distribution_major_version }}/noarch"
     file: ceph_stable
     priority: 2
   register: result

--- a/roles/ceph-common/tasks/installs/redhat_dev_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_dev_repository.yml
@@ -1,26 +1,29 @@
 ---
-- name: install dnf-plugins-core
-  package:
-    name: dnf-plugins-core
-  register: result
-  until: result is succeeded
-  tags: with_pkg
+- name: specific el 8 dependencies
+  when: ansible_distribution_major_version | int == 8
+  block:
+    - name: install dnf-plugins-core
+      package:
+        name: dnf-plugins-core
+      register: result
+      until: result is succeeded
+      tags: with_pkg
 
-- name: enable ceph-el8 copr
-  command: dnf copr enable -y ktdreyer/ceph-el8
-  args:
-    creates: /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:ktdreyer:ceph-el8.repo
-    warn: false
-  register: result
-  until: result is succeeded
+    - name: enable ceph-el8 copr
+      command: dnf copr enable -y ktdreyer/ceph-el8
+      args:
+        creates: /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:ktdreyer:ceph-el8.repo
+        warn: false
+      register: result
+      until: result is succeeded
 
-- name: enable ceph lab extras repository
-  yum_repository:
-    name: lab-extras
-    baseurl: http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
-    description: Sepia Lab Extras repository
-    enabled: true
-    gpgcheck: false
+    - name: enable ceph lab extras repository
+      yum_repository:
+        name: lab-extras
+        baseurl: http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
+        description: Sepia Lab Extras repository
+        enabled: true
+        gpgcheck: false
 
 - name: fetch ceph red hat development repository
   uri:

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -78,7 +78,7 @@ debian_package_dependencies: []
 
 centos_package_dependencies:
   - epel-release
-  - python3-libselinux
+  - "{{ 'python3-libselinux' if ansible_distribution_major_version | int >= 8 else 'libselinux-python' }}"
 
 redhat_package_dependencies: []
 
@@ -149,10 +149,6 @@ nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_s
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/
 # for more info read: https://github.com/ceph/ceph-ansible/issues/305
 #ceph_stable_distro_source: "{{ ansible_distribution_release }}"
-
-# This option is needed for _both_ stable and dev version, so please always fill the right version
-# # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
-ceph_stable_redhat_distro: el8
 
 
 # REPOSITORY: RHCS VERSION RED HAT STORAGE (from 5.0)

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -23,8 +23,6 @@ ceph_mgr_modules: []
 # Ceph mgr packages to install, ceph-mgr + extra module packages.
 ceph_mgr_packages:
   - ceph-mgr
-  - ceph-mgr-dashboard
-  - ceph-mgr-diskprediction-local
 
 
 ##########

--- a/roles/ceph-mgr/tasks/mgr_modules.yml
+++ b/roles/ceph-mgr/tasks/mgr_modules.yml
@@ -1,7 +1,7 @@
 ---
 - name: append dashboard modules to ceph_mgr_modules
   set_fact:
-    ceph_mgr_modules: "{{ (ceph_mgr_modules + [ 'dashboard', 'prometheus' ]) | unique }}"
+    ceph_mgr_modules: "{{ ceph_mgr_modules | union(['dashboard', 'prometheus']) }}"
   when: dashboard_enabled | bool
 
 - name: wait for all mgr to be up

--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -6,6 +6,18 @@
     - dashboard_enabled | bool
     - ansible_distribution == 'RedHat'
 
+- name: set_fact ceph_mgr_packages for dashboard
+  set_fact:
+    ceph_mgr_packages: "{{ ceph_mgr_packages | union(['ceph-mgr-dashboard']) }}"
+  when: dashboard_enabled | bool
+
+- name: set_fact ceph_mgr_packages for non el7 distribution
+  set_fact:
+    ceph_mgr_packages: "{{ ceph_mgr_packages | union(['ceph-mgr-diskprediction-local']) }}"
+  when:
+    - ansible_os_family != 'RedHat'
+    - ansible_distribution_major_version | int != 7
+
 - name: install ceph-mgr packages on RedHat or SUSE
   package:
     name: '{{ ceph_mgr_packages }}'

--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -26,10 +26,12 @@
 
 - name: fail on unsupported CentOS release
   fail:
-    msg: "CentOS release not supported {{ ansible_distribution_major_version }}"
+    msg: "CentOS release not supported {{ ansible_distribution_major_version }} with dashboard"
   when:
     - ansible_distribution == 'CentOS'
-    - ansible_distribution_major_version | int != 8
+    - ansible_distribution_major_version | int == 7
+    - not containerized_deployment | bool
+    - dashboard_enabled | true
 
 - name: red hat based systems tasks
   when:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ def str_to_bool(val):
 @pytest.fixture(scope="module")
 def setup(host):
     cluster_address = ""
-    container_binary = ""
     osd_ids = []
     osds = []
 
@@ -25,6 +24,7 @@ def setup(host):
     ansible_facts = host.ansible("setup")
 
     docker = ansible_vars.get("docker")
+    container_binary = ansible_vars.get("container_binary", "")
     osd_auto_discovery = ansible_vars.get("osd_auto_discovery")
     group_names = ansible_vars["group_names"]
     fsid = ansible_vars.get("fsid")
@@ -63,7 +63,7 @@ def setup(host):
 
     address = host.interface(public_interface).addresses[0]
 
-    if docker:
+    if docker and not container_binary:
         container_binary = "podman"
 
     data = dict(

--- a/tests/functional/docker2podman/group_vars/all
+++ b/tests/functional/docker2podman/group_vars/all
@@ -2,6 +2,7 @@
 # this is only here to let the CI tests know
 # that this scenario is using docker
 docker: True
+container_binary: docker
 
 containerized_deployment: True
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
@@ -41,5 +42,4 @@ openstack_pools:
   - "{{ openstack_cinder_pool }}"
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
-dashboard_admin_password: $sX!cD$rYU6qR^B!
-grafana_admin_password: +xFRe+RES@7vg24n
+dashboard_enabled: false

--- a/tests/functional/docker2podman/hosts
+++ b/tests/functional/docker2podman/hosts
@@ -4,9 +4,6 @@ mon0
 [osds]
 osd0
 
-[grafana-server]
-mon0
-
 [mgrs]
 mon0
 


### PR DESCRIPTION
The CentOS 7 distribution could still be used be deploying ceph if
  - it's a containerized deployment
  - it's a non containerized deployment without the dashboard (due to
missing python3 libraries).

The ceph_stable_redhat_distro variable has been remove because we can
rely on the ansible_distribution_major_version fact instead.

The copr el8 repository configuration is only applied for CentOS 8.

The ceph-mgr-dashboard package is only installed when the
dashboard_enabled variable is set to true.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>