### PR TITLE
tox-docker2podman: update container image tag

### DIFF
--- a/tox-docker2podman.ini
+++ b/tox-docker2podman.ini
@@ -41,7 +41,7 @@ commands=
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-nautilus} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
   "
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/infrastructure-playbooks/docker-to-podman.yml


### PR DESCRIPTION
The current docker to podman scenario is using the nautilus container
image tag instead of master.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>