### PR TITLE
tox: replace testinfra by pytest for add-mgrs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -197,7 +197,7 @@ commands=
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       "
-  testinfra -n 8 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-2 {toxinidir}/tests/functional/tests
+  py.test --reruns 5 --reruns-delay 1 -n 8 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-2 --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 
 [add-mdss]
 commands=


### PR DESCRIPTION
The add-mgrs scenario is still using the testinfra command instead of
pytest so the tests exectution are failling.
```console
ERROR: InvocationError for command could not find executable testinfra
```
This also adds the missing `--ssh-config` option to testinfra.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>