### PR TITLE
ceph-mgr: add saml python lib for dashboard SSO

### DIFF
--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
@@ -12,4 +12,4 @@
 - name: enable red hat storage tools repository
   rhsm_repository:
     name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_architecture }}-rpms"
-  when: (rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names)
+  when: (mgr_group_name in group_names or rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names)

--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -1,4 +1,11 @@
 ---
+- name: set_fact ceph_mgr_packages for sso
+  set_fact:
+    ceph_mgr_packages: "{{ ceph_mgr_packages | union(['python3-saml' if ansible_distribution_major_version | int == 8 else 'python-saml']) }}"
+  when:
+    - dashboard_enabled | bool
+    - ansible_distribution == 'RedHat'
+
 - name: install ceph-mgr packages on RedHat or SUSE
   package:
     name: '{{ ceph_mgr_packages }}'


### PR DESCRIPTION
The dashboard SSO mgr module requires the saml python library to be
installed. This is only a valid scenario for RHCS deployment because
the saml python library isn't available in other classic repositories.
This package is present in RHCS Tools repository so we also need to
enable it on the mgr nodes.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1820233

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>