### PR TITLE
add-osd: unset noup flag after last osd is deployed

### DIFF
--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -35,9 +35,7 @@
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items:
-        - "{{ groups['mons'] }}"
-        - "{{ groups['osds'] }}"
+      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
       run_once: True
       when:
         - delegate_facts_host | bool
@@ -65,9 +63,7 @@
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items:
-        - "{{ groups['mons'] }}"
-        - "{{ groups['osds'] }}"
+      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
       run_once: True
       when:
         - delegate_facts_host | bool
@@ -76,12 +72,6 @@
     - name: set_fact add_osd
       set_fact:
         add_osd: True
-
-    - name: set noup flag
-      command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd set noup"
-      delegate_to: "{{ groups['mons'][0] }}"
-      run_once: True
-      changed_when: False
 
   roles:
     - role: ceph-defaults
@@ -94,10 +84,3 @@
       when: not containerized_deployment | bool
     - role: ceph-config
     - role: ceph-osd
-
-  post_tasks:
-    - name: unset noup flag
-      command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd unset noup"
-      delegate_to: "{{ groups['mons'][0] }}"
-      run_once: True
-      changed_when: False

--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -15,36 +15,6 @@
 # you want to play the playbook on. So you need to comment already deployed OSD
 # and let uncommented the new OSDs.
 #
-- hosts:
-  - mons
-  - osds
-
-  gather_facts: False
-  become: true
-
-  vars:
-    delegate_facts_host: True
-
-  pre_tasks:
-    - name: gather facts
-      setup:
-      when:
-        - not delegate_facts_host | bool
-
-    - name: gather and delegate facts
-      setup:
-      delegate_to: "{{ item }}"
-      delegate_facts: True
-      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
-      run_once: True
-      when:
-        - delegate_facts_host | bool
-
-  roles:
-    - ceph-defaults
-    - ceph-facts
-    - ceph-validate
-
 - hosts: osds
   gather_facts: False
   become: True
@@ -75,11 +45,12 @@
 
   roles:
     - role: ceph-defaults
+    - role: ceph-facts
+    - role: ceph-validate
     - role: ceph-handler
     - role: ceph-infra
     - role: ceph-docker-common
       when: containerized_deployment | bool
-    - role: ceph-facts
     - role: ceph-common
       when: not containerized_deployment | bool
     - role: ceph-config

--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -5,6 +5,11 @@
   when:
     - ansible_os_family == 'Debian'
 
+- name: unset noup flag
+  command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd unset noup"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  changed_when: False
+
 # We only want to restart on hosts that have called the handler.
 # This var is set when he handler is called, and unset after the
 # restart to ensure only the correct hosts are restarted.

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -35,6 +35,13 @@
 - name: include_tasks common.yml
   include_tasks: common.yml
 
+- name: set noup flag
+  command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd set noup"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: True
+  changed_when: False
+  when: not rolling_update | default(False) | bool
+
 - name: include ceph_disk_cli_options_facts.yml
   include_tasks: ceph_disk_cli_options_facts.yml
 
@@ -89,6 +96,14 @@
 - name: include_tasks start_osds.yml
   include_tasks: start_osds.yml
 
+- name: unset noup flag
+  command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd unset noup"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  changed_when: False
+  when:
+    - not rolling_update | default(False) | bool
+    - inventory_hostname == ansible_play_hosts_all | last
+
 - name: wait for all osd to be up
   command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} -s -f json"
   register: wait_for_all_osds_up
@@ -100,6 +115,8 @@
   until:
     - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_osds"] | int > 0
     - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_up_osds"]
+  when:
+    - inventory_hostname == ansible_play_hosts_all | last
 
 - name: include crush_rules.yml
   include_tasks: crush_rules.yml


### PR DESCRIPTION
this commit fixes a bug when using `add-osd.yml` playbook.
`noup` flag is set early but it never got unset before the "wait for pgs
clean" check, so the playbook always fails because OSDs aren't never
seen UP.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1816023

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>