### PR TITLE
ceph-container-engine: add CentOS 8 support

### DIFF
--- a/roles/ceph-container-engine/vars/CentOS-8.yml
+++ b/roles/ceph-container-engine/vars/CentOS-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml


### PR DESCRIPTION
This adds CentOS 8 support for containerized deployment allowing podman
installation as the default container engine for this distribution.

Closes: #5130

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>