### PR TITLE
osd: fix monitor_name error when scaling out OSDs

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -26,7 +26,12 @@
 
 - name: set_fact monitor_name ansible_hostname
   set_fact:
-    monitor_name: "{{ ansible_hostname }}"
+    monitor_name: "{{ hostvars[item]['ansible_hostname'] }}"
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  with_items: "{{ groups.get(mon_group_name, []) }}"
+  run_once: true
+  when: groups.get(mon_group_name, []) | length > 0
 
 - name: find a running monitor
   when: groups.get(mon_group_name, []) | length > 0


### PR DESCRIPTION
This commit fixes a bug when trying to scale out osd nodes with
`crush_rule_config` is enabled.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1822599

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>