### PR TITLE
ceph-validate: update RHEL requirement for RHCS

### DIFF
--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -34,12 +34,12 @@
 - name: red hat based systems tasks
   when:
     - ceph_repository == 'rhcs'
-    - ansible_distribution == 'Red Hat Enterprise Linux'
+    - ansible_distribution == 'RedHat'
   block:
     - name: fail on unsupported distribution for red hat ceph storage
       fail:
-        msg: "Distribution not supported {{ ansible_distribution_version }} by Red Hat Ceph Storage, only RHEL >= 7.3"
-      when: ansible_distribution_version | version_compare('7.3', '<')
+        msg: "Distribution not supported {{ ansible_distribution_version }} by Red Hat Ceph Storage, only RHEL >= 8.2"
+      when: ansible_distribution_version | version_compare('8.2', '<')
 
     - name: subscription manager related tasks
       when: ceph_repository_type == 'cdn'


### PR DESCRIPTION
We were not testing the right ansible_distribution fact value for RHEL
distribution.
This commit also updates the minial RHEL version supported by RHCS.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>