### PR TITLE
osd: fix monitor_name error when scaling out OSDs (bp #5261)

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -30,13 +30,25 @@
 
 - name: set_fact monitor_name ansible_hostname
   set_fact:
-    monitor_name: "{{ ansible_hostname }}"
-  when: not mon_use_fqdn | bool
+    monitor_name: "{{ hostvars[item]['ansible_hostname'] }}"
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  with_items: "{{ groups.get(mon_group_name, []) }}"
+  run_once: true
+  when:
+    - groups.get(mon_group_name, []) | length > 0
+    - not mon_use_fqdn | bool
 
 - name: set_fact monitor_name ansible_fqdn
   set_fact:
-    monitor_name: "{{ ansible_fqdn }}"
-  when: mon_use_fqdn | bool
+    monitor_name: "{{ hostvars[item]['ansible_fqdn'] }}"
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  with_items: "{{ groups.get(mon_group_name, []) }}"
+  run_once: true
+  when:
+    - groups.get(mon_group_name, []) | length > 0
+    - mon_use_fqdn | bool
 
 - name: find a running monitor
   when: groups.get(mon_group_name, []) | length > 0


### PR DESCRIPTION
This is a manual backport of pull request #5261 done by Mergify
---


<details>
<summary>Mergify commands and options</summary>

<br />

More conditions and actions can be found in the [documentation](https://doc.mergify.io/).

You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR
- `@Mergifyio backport <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.io/) you can:

- look at your merge queues
- generate the Mergify configuration with the simulator.

Finally, you can contact us on https://mergify.io/
</details>
