### PR TITLE
nfs: create empty rados index object for nfs standalone

### DIFF
--- a/roles/ceph-nfs/tasks/main.yml
+++ b/roles/ceph-nfs/tasks/main.yml
@@ -33,24 +33,29 @@
   block:
     - name: create keyring directory
       file:
-        path: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}"
+        path: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ceph_nfs_ceph_user }}"
         state: directory
         owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         mode: "0755"
-      when:
+
+    - name: set_fact rgw_client_name
+      set_fact:
+        rgw_client_name: "client.rgw.{{ ceph_nfs_ceph_user }}"
 
     - name: get client cephx keys
       copy:
-        dest: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}/keyring"
-        content: "{{ item.content | b64decode }}"
-        mode: "{{ item.item.get('mode', '0600') }}"
+        dest: "{{ item.1 }}"
+        content: "{{ item.0.content | b64decode }}"
+        mode: "{{ item.0.item.get('mode', '0600') }}"
         owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
-      with_items: "{{ hostvars[groups['_filtered_clients'][0]]['slurp_client_keys']['results'] | default([]) }}"
+      with_nested:
+        - "{{ hostvars[groups['_filtered_clients'][0]]['slurp_client_keys']['results'] | default([]) }}"
+        - ['/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ceph_nfs_ceph_user }}/keyring', '/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}/keyring']
       when:
         - not item.get('skipped', False)
-        - item.item.name == 'client.' + ceph_nfs_ceph_user
+        - item.0.item.name == 'client.rgw.' + ceph_nfs_ceph_user
 
 - name: include start_nfs.yml
   import_tasks: start_nfs.yml

--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -2,27 +2,23 @@
 - block:
   - name: set_fact container_exec_cmd_nfs
     set_fact:
-      container_exec_cmd_nfs: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
-    when: containerized_deployment | bool
+      exec_cmd_nfs: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph/:/var/lib/ceph/:z -v /var/log/ceph/:/var/log/ceph/:z --entrypoint=rados ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else 'rados' }} -n client.{{ ceph_nfs_ceph_user if groups.get(mon_group_name, []) | length == 0 else '.rgw.' + ansible_hostname }} -k /var/lib/ceph/radosgw/{{ cluster + '-rgw.' +  ceph_nfs_ceph_user if groups.get(mon_group_name, []) | length == 0 else ansible_hostname }}"
 
   - name: check if rados index object exists
-    shell: "{{ container_exec_cmd_nfs | default('') }} rados -p {{ cephfs_data_pool.name }} --cluster {{ cluster }} ls|grep {{ ceph_nfs_rados_export_index }}"
+    shell: "{{ exec_cmd_nfs | default('') }} -p {{ cephfs_data_pool.name }} --cluster {{ cluster }} ls|grep {{ ceph_nfs_rados_export_index }}"
     changed_when: false
     failed_when: false
     register: rados_index_exists
     check_mode: no
     when: ceph_nfs_rados_backend | bool
-    delegate_to: "{{ groups[mon_group_name][0] }}"
     run_once: true
 
   - name: create an empty rados index object
-    command: "{{ container_exec_cmd_nfs | default('') }} rados -p {{ cephfs_data_pool.name }} --cluster {{ cluster }} put {{ ceph_nfs_rados_export_index }} /dev/null"
+    command: "{{ exec_cmd_nfs | default('') }} -p {{ cephfs_data_pool.name }} --cluster {{ cluster }} put {{ ceph_nfs_rados_export_index }} /dev/null"
     when:
       - ceph_nfs_rados_backend | bool
       - rados_index_exists.rc != 0
-    delegate_to: "{{ groups[mon_group_name][0] }}"
     run_once: true
-  when: groups.get(mon_group_name, []) | length > 0
 
 - name: create /etc/ganesha
   file:


### PR DESCRIPTION
This commit creates an empty rados index object even when deploying
standalone nfs-ganesha.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1822328

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>