### PR TITLE
docker2podman: pull images from docker daemon

### DIFF
--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -46,8 +46,9 @@
     - "{{ mgr_group_name | default('mgrs') }}"
     - "{{ iscsi_gw_group_name | default('iscsigws') }}"
     - "{{ rbdmirror_group_name | default('rbdmirrors') }}"
+  gather_facts: false
   become: true
-  pre_tasks:
+  tasks:
     - import_role:
         name: ceph-defaults
     - import_role:
@@ -55,15 +56,10 @@
     - import_role:
         name: ceph-handler
 
-
-  tasks:
-    - name: set_fact container_binary, container_binding_name, container_service_name, container_package_name
+    - name: set_fact docker2podman and container_binary
       set_fact:
         docker2podman: True
         container_binary: podman
-        container_binding_name: podman
-        container_service_name: podman
-        container_package_name: podman
 
     - name: install podman
       package:
@@ -71,9 +67,24 @@
         state: present
       register: result
       until: result is succeeded
-      tags:
-        - with_pkg
+      tags: with_pkg
       when: not is_atomic | bool
+
+    - name: "pulling {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} image from docker daemon"
+      command: "{{ timeout_command }} {{ container_binary }} pull docker-daemon:{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+      changed_when: false
+      register: pull_image
+      until: pull_image.rc == 0
+      retries: "{{ docker_pull_retry }}"
+      delay: 10
+      when: inventory_hostname in groups.get(mon_group_name, []) or
+            inventory_hostname in groups.get(osd_group_name, []) or
+            inventory_hostname in groups.get(mds_group_name, []) or
+            inventory_hostname in groups.get(rgw_group_name, []) or
+            inventory_hostname in groups.get(mgr_group_name, []) or
+            inventory_hostname in groups.get(rbdmirror_group_name, []) or
+            inventory_hostname in groups.get(iscsi_gw_group_name, []) or
+            inventory_hostname in groups.get(nfs_group_name, [])
 
     - import_role:
         name: ceph-mon
@@ -120,6 +131,6 @@
         tasks_from: systemd.yml
       when: inventory_hostname in groups.get(rgw_group_name, [])
 
-    - name: reload ceph monitor systemd unit
+    - name: reload systemd daemon
       systemd:
         daemon_reload: yes

--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -46,6 +46,7 @@
     - "{{ mgr_group_name | default('mgrs') }}"
     - "{{ iscsi_gw_group_name | default('iscsigws') }}"
     - "{{ rbdmirror_group_name | default('rbdmirrors') }}"
+    - "{{ grafana_server_group_name|default('grafana-server') }}"
   gather_facts: false
   become: true
   tasks:
@@ -85,6 +86,30 @@
             inventory_hostname in groups.get(rbdmirror_group_name, []) or
             inventory_hostname in groups.get(iscsi_gw_group_name, []) or
             inventory_hostname in groups.get(nfs_group_name, [])
+
+    - name: "pulling alertmanager/grafana/prometheus images from docker daemon"
+      command: "{{ timeout_command }} {{ container_binary }} pull docker-daemon:{{ item }}"
+      changed_when: false
+      register: pull_image
+      until: pull_image.rc == 0
+      retries: "{{ docker_pull_retry }}"
+      delay: 10
+      loop:
+        - "{{ alertmanager_container_image }}"
+        - "{{ grafana_container_image }}"
+        - "{{ prometheus_container_image }}"
+      when:
+        - dashboard_enabled | bool
+        - inventory_hostname in groups.get(grafana_server_group_name, [])
+
+    - name: "pulling {{ node_exporter_container_image }} image from docker daemon"
+      command: "{{ timeout_command }} {{ container_binary }} pull docker-daemon:{{ node_exporter_container_image }}"
+      changed_when: false
+      register: pull_image
+      until: pull_image.rc == 0
+      retries: "{{ docker_pull_retry }}"
+      delay: 10
+      when: dashboard_enabled | bool
 
     - import_role:
         name: ceph-mon
@@ -130,6 +155,28 @@
         name: ceph-rgw
         tasks_from: systemd.yml
       when: inventory_hostname in groups.get(rgw_group_name, [])
+
+    - name: dashboard configuration
+      when: dashboard_enabled | bool
+      block:
+        - import_role:
+            name: ceph-node-exporter
+            tasks_from: systemd.yml
+
+        - import_role:
+            name: ceph-facts
+            tasks_from: grafana.yml
+          when: inventory_hostname in groups.get(grafana_server_group_name, [])
+
+        - import_role:
+            name: ceph-grafana
+            tasks_from: systemd.yml
+          when: inventory_hostname in groups.get(grafana_server_group_name, [])
+
+        - import_role:
+            name: ceph-prometheus
+            tasks_from: systemd.yml
+          when: inventory_hostname in groups.get(grafana_server_group_name, [])
 
     - name: reload systemd daemon
       systemd:

--- a/roles/ceph-grafana/tasks/setup_container.yml
+++ b/roles/ceph-grafana/tasks/setup_container.yml
@@ -10,13 +10,8 @@
     - /etc/grafana
     - /var/lib/grafana
 
-- name: ship systemd service
-  template:
-    src: grafana-server.service.j2
-    dest: "/etc/systemd/system/grafana-server.service"
-    owner: root
-    group: root
-    mode: 0644
+- name: include_tasks systemd.yml
+  include_tasks: systemd.yml
 
 - name: start the grafana-server service
   systemd:

--- a/roles/ceph-grafana/tasks/systemd.yml
+++ b/roles/ceph-grafana/tasks/systemd.yml
@@ -1,0 +1,8 @@
+---
+- name: ship systemd service
+  template:
+    src: grafana-server.service.j2
+    dest: "/etc/systemd/system/grafana-server.service"
+    owner: root
+    group: root
+    mode: 0644

--- a/roles/ceph-node-exporter/tasks/setup_container.yml
+++ b/roles/ceph-node-exporter/tasks/setup_container.yml
@@ -1,11 +1,6 @@
 ---
-- name: ship systemd service
-  template:
-    src: node_exporter.service.j2
-    dest: "/etc/systemd/system/node_exporter.service"
-    owner: root
-    group: root
-    mode: 0644
+- name: include_tasks systemd.yml
+  include_tasks: systemd.yml
 
 - name: start the node_exporter service
   systemd:

--- a/roles/ceph-node-exporter/tasks/systemd.yml
+++ b/roles/ceph-node-exporter/tasks/systemd.yml
@@ -1,0 +1,8 @@
+---
+- name: ship systemd service
+  template:
+    src: node_exporter.service.j2
+    dest: "/etc/systemd/system/node_exporter.service"
+    owner: root
+    group: root
+    mode: 0644

--- a/roles/ceph-prometheus/handlers/main.yml
+++ b/roles/ceph-prometheus/handlers/main.yml
@@ -10,3 +10,4 @@
   with_items:
     - 'alertmanager'
     - 'prometheus'
+  when: not docker2podman | default(False) | bool

--- a/roles/ceph-prometheus/tasks/setup_container.yml
+++ b/roles/ceph-prometheus/tasks/setup_container.yml
@@ -1,15 +1,6 @@
 ---
-- name: ship systemd services
-  template:
-    src: "{{ item }}.j2"
-    dest: "/etc/systemd/system/{{ item }}"
-    owner: root
-    group: root
-    mode: 0644
-  with_items:
-    - 'alertmanager.service'
-    - 'prometheus.service'
-  notify: service handler
+- name: include_tasks systemd.yml
+  include_tasks: systemd.yml
 
 - name: start prometheus services
   systemd:

--- a/roles/ceph-prometheus/tasks/systemd.yml
+++ b/roles/ceph-prometheus/tasks/systemd.yml
@@ -1,0 +1,12 @@
+---
+- name: ship systemd services
+  template:
+    src: "{{ item }}.j2"
+    dest: "/etc/systemd/system/{{ item }}"
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - 'alertmanager.service'
+    - 'prometheus.service'
+  notify: service handler

--- a/tests/functional/docker2podman/group_vars/all
+++ b/tests/functional/docker2podman/group_vars/all
@@ -42,4 +42,5 @@ openstack_pools:
   - "{{ openstack_cinder_pool }}"
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
-dashboard_enabled: false
+dashboard_admin_password: $sX!cD$rYU6qR^B!
+grafana_admin_password: +xFRe+RES@7vg24n

--- a/tests/functional/docker2podman/hosts
+++ b/tests/functional/docker2podman/hosts
@@ -7,5 +7,5 @@ osd0
 [mgrs]
 mon0
 
-#[all:vars]
-#ansible_python_interpreter=/usr/bin/python3
+[grafana-server]
+mon0

--- a/tox-docker2podman.ini
+++ b/tox-docker2podman.ini
@@ -44,7 +44,13 @@ commands=
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
   "
 
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/infrastructure-playbooks/docker-to-podman.yml
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/infrastructure-playbooks/docker-to-podman.yml --extra-vars "\
+      delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
+      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+  "
 
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 


### PR DESCRIPTION
The docker2podman playbook only installs the podman package and updates
the systemd units with the right container_binary value.

We never pull the container image so if one service is restarted then
the container image will be pulled first before the service can start
which could cause longer downstream.

To avoid to download the container image from internet again we can just
pull it from the local docker daemon.

The container_{binding,package,service}_name variables are removed
because they are only used in the ceph-container-engine role which
isn't call in this playbook.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>