### PR TITLE
[skip ci] rolling_update: require_osd_release pacific

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -921,14 +921,14 @@
     - import_role:
         name: ceph-facts
 
-    - name: container | disallow pre-octopus OSDs and enable all new octopus-only functionality
-      command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph osd require-osd-release octopus"
+    - name: container | disallow pre-pacific OSDs and enable all new pacific-only functionality
+      command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph osd require-osd-release pacific"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
       when: containerized_deployment | bool
 
-    - name: non container | disallow pre-octopus OSDs and enable all new octopus-only functionality
-      command: "ceph --cluster {{ cluster }} osd require-osd-release octopus"
+    - name: non container | disallow pre-pacific OSDs and enable all new pacific-only functionality
+      command: "ceph --cluster {{ cluster }} osd require-osd-release pacific"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
       when: not containerized_deployment | bool


### PR DESCRIPTION
Since [1] we need to set pacific for the required OSD release during the
upgrade.

[1] https://github.com/ceph/ceph/commit/cc99c3bc

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>