### PR TITLE
Updated use of deprecated filter in check_system task

### DIFF
--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -39,7 +39,7 @@
     - name: fail on unsupported distribution for red hat ceph storage
       fail:
         msg: "Distribution not supported {{ ansible_distribution_version }} by Red Hat Ceph Storage, only RHEL >= 8.2"
-      when: ansible_distribution_version | version_compare('8.2', '<')
+      when: ansible_distribution_version is version('8.2', '<')
 
     - name: subscription manager related tasks
       when: ceph_repository_type == 'cdn'


### PR DESCRIPTION
In the check_system task as part of the ceph-validate role there is the use of a deprecated filter "version_compare" which has been removed from Ansible 2.9, the required version of Ansible for this version of Ceph.

This has been update to use the 'version' function instead.