### PR TITLE
Updated use of deprecated filter

### DIFF
--- a/roles/ceph-common/tasks/release-rhcs.yml
+++ b/roles/ceph-common/tasks/release-rhcs.yml
@@ -2,34 +2,34 @@
 - name: set_fact ceph_release jewel
   set_fact:
     ceph_release: jewel
-  when: ceph_version.split('.')[0] is version_compare('10', '==')
+  when: ceph_version.split('.')[0] is version('10', '==')
 
 - name: set_fact ceph_release kraken
   set_fact:
     ceph_release: kraken
-  when: ceph_version.split('.')[0] is version_compare('11', '==')
+  when: ceph_version.split('.')[0] is version('11', '==')
 
 - name: set_fact ceph_release luminous
   set_fact:
     ceph_release: luminous
-  when: ceph_version.split('.')[0] is version_compare('12', '==')
+  when: ceph_version.split('.')[0] is version('12', '==')
 
 - name: set_fact ceph_release mimic
   set_fact:
     ceph_release: mimic
-  when: ceph_version.split('.')[0] is version_compare('13', '==')
+  when: ceph_version.split('.')[0] is version('13', '==')
 
 - name: set_fact ceph_release nautilus
   set_fact:
     ceph_release: nautilus
-  when: ceph_version.split('.')[0] is version_compare('14', '==')
+  when: ceph_version.split('.')[0] is version('14', '==')
 
 - name: set_fact ceph_release octopus
   set_fact:
     ceph_release: octopus
-  when: ceph_version.split('.')[0] is version_compare('15', '==')
+  when: ceph_version.split('.')[0] is version('15', '==')
 
 - name: set_fact ceph_release pacific
   set_fact:
     ceph_release: pacific
-  when: ceph_version.split('.')[0] is version_compare('16', '==')
+  when: ceph_version.split('.')[0] is version('16', '==')

--- a/roles/ceph-container-common/tasks/release.yml
+++ b/roles/ceph-container-common/tasks/release.yml
@@ -2,34 +2,34 @@
 - name: set_fact ceph_release jewel
   set_fact:
     ceph_release: jewel
-  when: ceph_version.split('.')[0] is version_compare('10', '==')
+  when: ceph_version.split('.')[0] is version('10', '==')
 
 - name: set_fact ceph_release kraken
   set_fact:
     ceph_release: kraken
-  when: ceph_version.split('.')[0] is version_compare('11', '==')
+  when: ceph_version.split('.')[0] is version('11', '==')
 
 - name: set_fact ceph_release luminous
   set_fact:
     ceph_release: luminous
-  when: ceph_version.split('.')[0] is version_compare('12', '==')
+  when: ceph_version.split('.')[0] is version('12', '==')
 
 - name: set_fact ceph_release mimic
   set_fact:
     ceph_release: mimic
-  when: ceph_version.split('.')[0] is version_compare('13', '==')
+  when: ceph_version.split('.')[0] is version('13', '==')
 
 - name: set_fact ceph_release nautilus
   set_fact:
     ceph_release: nautilus
-  when: ceph_version.split('.')[0] is version_compare('14', '==')
+  when: ceph_version.split('.')[0] is version('14', '==')
 
 - name: set_fact ceph_release octopus
   set_fact:
     ceph_release: octopus
-  when: ceph_version.split('.')[0] is version_compare('15', '==')
+  when: ceph_version.split('.')[0] is version('15', '==')
 
 - name: set_fact ceph_release pacific
   set_fact:
     ceph_release: pacific
-  when: ceph_version.split('.')[0] is version_compare('16', '==')
+  when: ceph_version.split('.')[0] is version('16', '==')

--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -39,7 +39,7 @@
     - name: fail on unsupported distribution for red hat ceph storage
       fail:
         msg: "Distribution not supported {{ ansible_distribution_version }} by Red Hat Ceph Storage, only RHEL >= 8.2"
-      when: ansible_distribution_version | version_compare('8.2', '<')
+      when: ansible_distribution_version is version('8.2', '<')
 
     - name: subscription manager related tasks
       when: ceph_repository_type == 'cdn'


### PR DESCRIPTION
This was removed in Ansible 2.9.
```console
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of
using `result|version_compare` use `result is version_compare`. This
feature will be removed in version 2.9. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
```
Rename 'version_compare' to the function 'version'.

version_compose was renamed to version since ansible 2.5

Signed-off-by: abaird-rh <abaird@redhat.com>