### PR TITLE
Updated use of deprecated filter (bp #5284)

### DIFF
--- a/roles/ceph-common/tasks/release-rhcs.yml
+++ b/roles/ceph-common/tasks/release-rhcs.yml
@@ -2,24 +2,24 @@
 - name: set_fact ceph_release jewel
   set_fact:
     ceph_release: jewel
-  when: ceph_version.split('.')[0] is version_compare('10', '==')
+  when: ceph_version.split('.')[0] is version('10', '==')
 
 - name: set_fact ceph_release kraken
   set_fact:
     ceph_release: kraken
-  when: ceph_version.split('.')[0] is version_compare('11', '==')
+  when: ceph_version.split('.')[0] is version('11', '==')
 
 - name: set_fact ceph_release luminous
   set_fact:
     ceph_release: luminous
-  when: ceph_version.split('.')[0] is version_compare('12', '==')
+  when: ceph_version.split('.')[0] is version('12', '==')
 
 - name: set_fact ceph_release mimic
   set_fact:
     ceph_release: mimic
-  when: ceph_version.split('.')[0] is version_compare('13', '==')
+  when: ceph_version.split('.')[0] is version('13', '==')
 
 - name: set_fact ceph_release nautilus
   set_fact:
     ceph_release: nautilus
-  when: ceph_version.split('.')[0] is version_compare('14', '==')
+  when: ceph_version.split('.')[0] is version('14', '==')

--- a/roles/ceph-container-common/tasks/release.yml
+++ b/roles/ceph-container-common/tasks/release.yml
@@ -2,25 +2,25 @@
 - name: set_fact ceph_release jewel
   set_fact:
     ceph_release: jewel
-  when: ceph_version.split('.')[0] is version_compare('10', '==')
+  when: ceph_version.split('.')[0] is version('10', '==')
 
 - name: set_fact ceph_release kraken
   set_fact:
     ceph_release: kraken
-  when: ceph_version.split('.')[0] is version_compare('11', '==')
+  when: ceph_version.split('.')[0] is version('11', '==')
 
 - name: set_fact ceph_release luminous
   set_fact:
     ceph_release: luminous
-  when: ceph_version.split('.')[0] is version_compare('12', '==')
+  when: ceph_version.split('.')[0] is version('12', '==')
 
 - name: set_fact ceph_release mimic
   set_fact:
     ceph_release: mimic
-  when: ceph_version.split('.')[0] is version_compare('13', '==')
+  when: ceph_version.split('.')[0] is version('13', '==')
 
 - name: set_fact ceph_release nautilus
   set_fact:
     ceph_release: nautilus
-  when: ceph_version.split('.')[0] is version_compare('14', '==')
+  when: ceph_version.split('.')[0] is version('14', '==')
 

--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -12,7 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-api
 ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-api
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --memory={{ ceph_rbd_target_api_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
+  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_rbd_target_api_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_rbd_target_api_docker_cpu_limit * 100000 }} \

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -12,7 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-gw
 ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-gw
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --memory={{ ceph_rbd_target_gw_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
+  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_rbd_target_gw_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_rbd_target_gw_docker_cpu_limit * 100000 }} \

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -12,7 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop tcmu-runner
 ExecStartPre=-/usr/bin/{{ container_binary }} rm tcmu-runner
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
   --memory={{ ceph_tcmu_runner_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
+  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_tcmu_runner_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_tcmu_runner_docker_cpu_limit * 100000 }} \

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -13,7 +13,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mds-{{ ansible_hostname 
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mds-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_mds_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
+  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ cpu_limit }} \
   {% else -%}
   --cpu-quota={{ cpu_limit * 100000 }} \

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -12,7 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mgr-{{ ansible_hostname 
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mgr-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_mgr_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
+  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_mgr_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_mgr_docker_cpu_limit * 100000 }} \

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -12,7 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mon-%i
 ExecStartPre=/bin/sh -c '"$(command -v mkdir)" -p /etc/ceph /var/lib/ceph/mon'
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
   --memory={{ ceph_mon_docker_memory_limit }} \
-{% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
+{% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_mon_docker_cpu_limit }} \
 {% else -%}
   --cpu-quota={{ ceph_mon_docker_cpu_limit * 100000 }} \

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -20,7 +20,7 @@ numactl \
   {% if osd_objectstore == 'filestore' -%}
   --memory={{ ceph_osd_docker_memory_limit }} \
   {% endif -%}
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
+  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ cpu_limit }} \
   {% else -%}
   --cpu-quota={{ cpu_limit * 100000 }} \

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -12,7 +12,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rbd-mirror-{{ ansible_ho
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_rbd_mirror_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
+  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ ceph_rbd_mirror_docker_cpu_limit }} \
   {% else -%}
   --cpu-quota={{ ceph_rbd_mirror_docker_cpu_limit * 100000 }} \

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -13,7 +13,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rgw-{{ ansible_hostname 
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --memory={{ ceph_rgw_docker_memory_limit }} \
-  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version_compare('13', '>=')) or container_binary == 'podman' -%}
+  {% if (container_binary == 'docker' and ceph_docker_version.split('.')[0] is version('13', '>=')) or container_binary == 'podman' -%}
   --cpus={{ cpu_limit }} \
   {% else -%}
   --cpu-quota={{ cpu_limit * 100000 }} \

--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -34,8 +34,8 @@
     - name: fail on unsupported distribution for red hat ceph storage
       fail:
         msg: "Distribution not supported {{ ansible_distribution_version }} by Red Hat Ceph Storage, only RHEL 8 (>= 8.1) or RHEL 7 (>= 7.7)"
-      when: (ansible_distribution_major_version | int == 8 and ansible_distribution_version | version_compare('8.1', '<')) or
-            (ansible_distribution_major_version | int == 7 and ansible_distribution_version | version_compare('7.7', '<'))
+      when: (ansible_distribution_major_version | int == 8 and ansible_distribution_version is version('8.1', '<')) or
+            (ansible_distribution_major_version | int == 7 and ansible_distribution_version is version('7.7', '<'))
 
     - name: subscription manager related tasks
       when: ceph_repository_type == 'cdn'


### PR DESCRIPTION
This is a manual backport of pull request #5284 done by Mergify
---


<details>
<summary>Mergify commands and options</summary>

<br />

More conditions and actions can be found in the [documentation](https://doc.mergify.io/).

You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR on its base branch
- `@Mergifyio update` will merge the base branch into this PR
- `@Mergifyio backport <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.io/) you can:

- look at your merge queues
- generate the Mergify configuration with the simulator.

Finally, you can contact us on https://mergify.io/
</details>
