### PR TITLE
mds: don't enable application pool on cephfs pools

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -342,7 +342,6 @@ dummy:
 #    type: 1
 #    erasure_profile: ""
 #    expected_num_objects: ""
-#    application: "cephfs"
 #    size: "{{ osd_pool_default_size }}"
 #    min_size: "{{ osd_pool_default_min_size }}"
 #    pg_autoscale_mode: False
@@ -356,7 +355,6 @@ dummy:
 #  type: 1
 #  erasure_profile: ""
 #  expected_num_objects: ""
-#  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 #  pg_autoscale_mode: False
@@ -368,7 +366,6 @@ dummy:
 #  type: 1
 #  erasure_profile: ""
 #  expected_num_objects: ""
-#  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 #  pg_autoscale_mode: False

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -342,7 +342,6 @@ ceph_iscsi_config_dev: false
 #    type: 1
 #    erasure_profile: ""
 #    expected_num_objects: ""
-#    application: "cephfs"
 #    size: "{{ osd_pool_default_size }}"
 #    min_size: "{{ osd_pool_default_min_size }}"
 #    pg_autoscale_mode: False
@@ -356,7 +355,6 @@ ceph_iscsi_config_dev: false
 #  type: 1
 #  erasure_profile: ""
 #  expected_num_objects: ""
-#  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 #  pg_autoscale_mode: False
@@ -368,7 +366,6 @@ ceph_iscsi_config_dev: false
 #  type: 1
 #  erasure_profile: ""
 #  expected_num_objects: ""
-#  application: "cephfs"
 #  size: "{{ osd_pool_default_size }}"
 #  min_size: "{{ osd_pool_default_min_size }}"
 #  pg_autoscale_mode: False

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -334,7 +334,6 @@ mon_host_v2:
 #    type: 1
 #    erasure_profile: ""
 #    expected_num_objects: ""
-#    application: "cephfs"
 #    size: "{{ osd_pool_default_size }}"
 #    min_size: "{{ osd_pool_default_min_size }}"
 #    pg_autoscale_mode: False
@@ -348,7 +347,6 @@ cephfs_data_pool:
   type: 1
   erasure_profile: ""
   expected_num_objects: ""
-  application: "cephfs"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
   pg_autoscale_mode: False
@@ -360,7 +358,6 @@ cephfs_metadata_pool:
   type: 1
   erasure_profile: ""
   expected_num_objects: ""
-  application: "cephfs"
   size: "{{ osd_pool_default_size }}"
   min_size: "{{ osd_pool_default_min_size }}"
   pg_autoscale_mode: False

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -70,12 +70,6 @@
             - item.type | default(1) | int != 3
             - item.type | default('replicated') != 'erasure'
 
-        - name: assign application to cephfs pools
-          command: "{{ ceph_run_cmd }} --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"
-          with_items:
-            - "{{ cephfs_data_pool }}"
-            - "{{ cephfs_metadata_pool }}"
-          changed_when: false
 
 - name: check and create ceph filesystem
   delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
this commit removes the task which enable application on cephfs pools.

See: https://tracker.ceph.com/issues/43761

Fixes: #5278

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>