### PR TITLE
ceph-dashboard: fix mgr dashboard IPv6 fact

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard_backends.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard_backends.yml
@@ -6,7 +6,7 @@
 
 - name: get current mgr backend - ipv6
   set_fact:
-    mgr_server_addr: "{{ hostvars[dashboard_backend]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}"
+    mgr_server_addr: "{{ hostvars[dashboard_backend]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last }}"
   when: ip_version == 'ipv6'
 
 - name: config the current dashboard backend


### PR DESCRIPTION
15ed9ee introduced a regression for the mgr dashboard daemon using
IPv6 since the mgr dashboard configuration doesn't support brackets.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1827299

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>