### PR TITLE
config: consider dedicated devices when running batch report

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -45,6 +45,9 @@
           osds_per_device: "{{ osds_per_device | default(1) | int }}"
           journal_size: "{{ journal_size }}"
           block_db_size: "{{ block_db_size }}"
+          block_db_devices: "{{ dedicated_devices | unique if dedicated_devices | length > 0 else omit }}"
+          wal_devices: "{{ bluestore_wal_devices | unique if bluestore_wal_devices | length > 0 else omit }}"
+          journal_devices: "{{ dedicated_devices | unique if dedicated_devices | length > 0 else omit }}"
           report: true
           action: "batch"
         register: lvm_batch_report


### PR DESCRIPTION
We must pass these devices when running the ceph-volume lvm batch report
to reflect what will be run in ceph-osd role.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1827349

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>