### PR TITLE
dashboard: allow disabling grafana api ssl verify

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -749,6 +749,7 @@ dummy:
 # We only need this for SSL (https) connections
 #dashboard_crt: ''
 #dashboard_key: ''
+#dashboard_grafana_api_no_ssl_verify: False
 #dashboard_rgw_api_user_id: ceph-dashboard
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -749,6 +749,7 @@ ceph_docker_registry_auth: true
 # We only need this for SSL (https) connections
 #dashboard_crt: ''
 #dashboard_key: ''
+#dashboard_grafana_api_no_ssl_verify: False
 #dashboard_rgw_api_user_id: ceph-dashboard
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -107,6 +107,15 @@
   run_once: true
   changed_when: false
 
+- name: disable ssl verification for grafana
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-ssl-verify False"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  changed_when: false
+  when:
+    - dashboard_protocol == "https"
+    - dashboard_grafana_api_no_ssl_verify | bool
+
 - name: set alertmanager host
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-alertmanager-api-host http://{{ grafana_server_addrs | first }}:{{ alertmanager_port }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -741,6 +741,7 @@ dashboard_admin_user_ro: false
 # We only need this for SSL (https) connections
 dashboard_crt: ''
 dashboard_key: ''
+dashboard_grafana_api_no_ssl_verify: False
 dashboard_rgw_api_user_id: ceph-dashboard
 dashboard_rgw_api_admin_resource: ''
 dashboard_rgw_api_no_ssl_verify: False


### PR DESCRIPTION
When using an untrusted TLS certificate (like self-signed) on grafana
then the grafana dashboards update subcommand will fail.
One solution could be to trust the TLS certificate.
The other one is to disable the TLS verification on the grafana API.

Closes: #5324

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>