### PR TITLE
nfs: fix external ganesha keyring issues

### DIFF
--- a/roles/ceph-nfs/tasks/main.yml
+++ b/roles/ceph-nfs/tasks/main.yml
@@ -33,11 +33,14 @@
   block:
     - name: create keyring directory
       file:
-        path: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ceph_nfs_ceph_user }}"
+        path: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ item }}"
         state: directory
         owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         mode: "0755"
+      with_items:
+        - "{{ ceph_nfs_ceph_user }}"
+        - "{{ ansible_hostname }}"
 
     - name: set_fact rgw_client_name
       set_fact:
@@ -55,7 +58,7 @@
         - ['/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ceph_nfs_ceph_user }}/keyring', '/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}/keyring']
       when:
         - not item.0.get('skipped', False)
-        - item.0.item.name == 'client.rgw.' + ceph_nfs_ceph_user
+        - item.0.item.name == 'client.' + ceph_nfs_ceph_user or item.0.item.name == rgw_client_name
 
 - name: include start_nfs.yml
   import_tasks: start_nfs.yml

--- a/roles/ceph-nfs/tasks/main.yml
+++ b/roles/ceph-nfs/tasks/main.yml
@@ -54,7 +54,7 @@
         - "{{ hostvars[groups['_filtered_clients'][0]]['slurp_client_keys']['results'] | default([]) }}"
         - ['/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ceph_nfs_ceph_user }}/keyring', '/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}/keyring']
       when:
-        - not item.get('skipped', False)
+        - not item.0.get('skipped', False)
         - item.0.item.name == 'client.rgw.' + ceph_nfs_ceph_user
 
 - name: include start_nfs.yml

--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -2,7 +2,7 @@
 - block:
   - name: set_fact container_exec_cmd_nfs
     set_fact:
-      exec_cmd_nfs: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph/:/var/lib/ceph/:z -v /var/log/ceph/:/var/log/ceph/:z --entrypoint=rados ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else 'rados' }} -n client.{{ ceph_nfs_ceph_user if groups.get(mon_group_name, []) | length == 0 else '.rgw.' + ansible_hostname }} -k /var/lib/ceph/radosgw/{{ cluster + '-rgw.' +  ceph_nfs_ceph_user if groups.get(mon_group_name, []) | length == 0 else ansible_hostname }}"
+      exec_cmd_nfs: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph/:/var/lib/ceph/:z -v /var/log/ceph/:/var/log/ceph/:z --entrypoint=rados ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else 'rados' }} -n client.{{ ceph_nfs_ceph_user if groups.get(mon_group_name, []) | length == 0 else 'rgw.' + ansible_hostname }} -k /var/lib/ceph/radosgw/{{ cluster + '-rgw.' +  ceph_nfs_ceph_user if groups.get(mon_group_name, []) | length == 0 else ansible_hostname }}/keyring"
 
   - name: check if rados index object exists
     shell: "{{ exec_cmd_nfs | default('') }} -p {{ cephfs_data_pool.name }} --cluster {{ cluster }} ls|grep {{ ceph_nfs_rados_export_index }}"

--- a/roles/ceph-nfs/tasks/start_nfs.yml
+++ b/roles/ceph-nfs/tasks/start_nfs.yml
@@ -1,8 +1,16 @@
 ---
 - block:
-  - name: set_fact container_exec_cmd_nfs
+  - name: set_fact container_exec_cmd_nfs - external
     set_fact:
-      exec_cmd_nfs: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph/:/var/lib/ceph/:z -v /var/log/ceph/:/var/log/ceph/:z --entrypoint=rados ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else 'rados' }} -n client.{{ ceph_nfs_ceph_user if groups.get(mon_group_name, []) | length == 0 else 'rgw.' + ansible_hostname }} -k /var/lib/ceph/radosgw/{{ cluster + '-rgw.' +  ceph_nfs_ceph_user if groups.get(mon_group_name, []) | length == 0 else ansible_hostname }}/keyring"
+      exec_cmd_nfs: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph/:/var/lib/ceph/:z -v /var/log/ceph/:/var/log/ceph/:z --entrypoint=rados ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'rados' }} -n client.{{ ceph_nfs_ceph_user }} -k /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ceph_nfs_ceph_user }}/keyring"
+      delegate_node: "{{ inventory_hostname }}"
+    when: groups.get(mon_group_name, []) | length == 0
+
+  - name: set_fact container_exec_cmd_nfs - internal
+    set_fact:
+      exec_cmd_nfs: "{{ container_binary + ' exec ceph-mon-' + hostvars[groups[mon_group_name][0]]['ansible_hostname'] if containerized_deployment | bool else '' }} rados"
+      delegate_node: "{{ groups[mon_group_name][0] }}"
+    when: groups.get(mon_group_name, []) | length > 0
 
   - name: check if rados index object exists
     shell: "{{ exec_cmd_nfs | default('') }} -p {{ cephfs_data_pool.name }} --cluster {{ cluster }} ls|grep {{ ceph_nfs_rados_export_index }}"
@@ -11,6 +19,7 @@
     register: rados_index_exists
     check_mode: no
     when: ceph_nfs_rados_backend | bool
+    delegate_to: "{{ delegate_node }}"
     run_once: true
 
   - name: create an empty rados index object
@@ -18,6 +27,7 @@
     when:
       - ceph_nfs_rados_backend | bool
       - rados_index_exists.rc != 0
+    delegate_to: "{{ delegate_node }}"
     run_once: true
 
 - name: create /etc/ganesha


### PR DESCRIPTION
The condition is missing an index here which makes the playbook failing.

Typical error:
```
The conditional check 'not item.get('skipped', False)' failed. The error was: error while evaluating conditional (not item.get('skipped', False)): 'list object' has no attribute 'get'",
```

Also, adds the missing '/keyring' on the `exec_cmd_nfs` fact.

Fix the condition on the keyring copy task that prevent the ganesha
keyring to be created in the /var/lib/ceph directory.
Also ensure that the directory exists first.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1831342
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1831285

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>