### PR TITLE
tox-update: fix update container tag value

### DIFF
--- a/tox-update.ini
+++ b/tox-update.ini
@@ -31,9 +31,10 @@ setenv=
   container: PLAYBOOK = site-container.yml.sample
   non_container: PLAYBOOK = site.yml.sample
 
-  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
-  UPDATE_CEPH_DEV_BRANCH = master
-  UPDATE_CEPH_DEV_SHA1 = latest
+  CEPH_DOCKER_IMAGE_TAG = latest-octopus
+  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-octopus
+  CEPH_STABLE_RELEASE = octopus
+  UPDATE_CEPH_STABLE_RELEASE = octopus
   ROLLING_UPDATE = True
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
@@ -49,16 +50,16 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
-      ceph_stable_release=octopus \
+      ceph_stable_release={env:CEPH_STABLE_RELEASE:octopus} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
-      ceph_docker_image_tag=latest-octopus \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-octopus} \
   "
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/infrastructure-playbooks/rolling_update.yml --extra-vars "\
       ireallymeanit=yes \
       fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
-      ceph_stable_release=octopus \
+      ceph_stable_release={env:UPDATE_CEPH_STABLE_RELEASE:octopus} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:docker.io} \
       ceph_docker_image={env:UPDATE_CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:UPDATE_CEPH_DOCKER_IMAGE_TAG:latest-octopus} \


### PR DESCRIPTION
The update container tag value should be set to latest-octopus and not
latest-master.
Also we don't need the `UPDATE_CEPH_DEV_*` environment variables.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>