### PR TITLE
Explicitly set dashboard hosts

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: all:!ungrouped
   gather_facts: false
   become: true
   pre_tasks:


### PR DESCRIPTION
Until 43135840b1570d35314eee3115c2ec826cff4d8d, node-exporter was deployed only on specific host groups. Since the code has been moved to dashboard.yml, all hosts are being used for node-exporter deployment. This change explicitly sets the groups for deployment. While this has no impact on standalone ceph-ansible deployments, it has an impact when ceph-ansible is part of a bigger deployment, for example TripleO. This change prevents the node-exporter from  being deployed on unrelated hosts and potentially breaking stuff. I know this could be as well implemented in TripleO inventory generation for example, but it would involve a lot more work and potential implications. As this has no negative effect on ceph-ansible, it would be the preferred solution. It also prevents the described issue from happening with other tools that might use ceph-ansible, as it is not a TripleO-specific problem.

Any feedback is welcome, maybe a better solution comes up.