### PR TITLE
ceph-rgw: use match instead of equalto from jinja2

### DIFF
--- a/roles/ceph-rgw/tasks/multisite/create_realm_zonegroup_zone_lists.yml
+++ b/roles/ceph-rgw/tasks/multisite/create_realm_zonegroup_zone_lists.yml
@@ -34,6 +34,6 @@
 
 - name: create a list of zones and all their endpoints
   set_fact:
-    zone_endpoints_list: "{{ zone_endpoints_list | default([]) | union([{'zone': item.rgw_zone, 'zonegroup': item.rgw_zonegroup, 'realm': item.rgw_realm, 'is_master': item.rgw_zonemaster, 'endpoints': ','.join(zone_endpoint_pairs | selectattr('rgw_zone','==',item.rgw_zone) | selectattr('rgw_realm','==',item.rgw_realm) | selectattr('rgw_zonegroup', '==', item.rgw_zonegroup) | map(attribute='endpoint'))}]) }}"
+    zone_endpoints_list: "{{ zone_endpoints_list | default([]) | union([{'zone': item.rgw_zone, 'zonegroup': item.rgw_zonegroup, 'realm': item.rgw_realm, 'is_master': item.rgw_zonemaster, 'endpoints': ','.join(zone_endpoint_pairs | selectattr('rgw_zone','match','^'+item.rgw_zone+'$') | selectattr('rgw_realm','match','^'+item.rgw_realm+'$') | selectattr('rgw_zonegroup', 'match','^'+item.rgw_zonegroup+'$') | map(attribute='endpoint'))}]) }}"
   loop: "{{ zone_endpoint_pairs }}"
   run_once: true


### PR DESCRIPTION
The '==' jinja2 operator (or 'equalto') has been introduced in jinja2
2.8.
On EL7, jinja2 version is 2.7 so the operator isn't present creating
templating error like:

The error was: TemplateRuntimeError: no test named '=='

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1747206

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>