### PR TITLE
ceph-validate: Fix "fail on unsupported CentOS release"

### DIFF
--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -31,7 +31,7 @@
     - ansible_distribution == 'CentOS'
     - ansible_distribution_major_version | int == 7
     - not containerized_deployment | bool
-    - dashboard_enabled | true
+    - dashboard_enabled | bool
 
 - name: red hat based systems tasks
   when:


### PR DESCRIPTION
The `dashboard_enabled` condition used a `true` filter (which doesn't exist)
instead of the `bool` filter.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>