### PR TITLE
ceph-rgw: Make sure pool name templates are expanded

### DIFF
--- a/roles/ceph-rgw/tasks/rgw_create_pools.yml
+++ b/roles/ceph-rgw/tasks/rgw_create_pools.yml
@@ -1,7 +1,7 @@
 ---
 - name: remove ec profile
   command: "{{ container_exec_cmd }} ceph --connect-timeout 10 --cluster {{ cluster }} osd erasure-code-profile rm {{ item.value.ec_profile }}"
-  with_dict: "{{ rgw_create_pools }}"
+  loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   changed_when: false
   when:
@@ -11,7 +11,7 @@
 
 - name: set ec profile
   command: "{{ container_exec_cmd }} ceph --connect-timeout 10 --cluster {{ cluster }} osd erasure-code-profile set {{ item.value.ec_profile }} k={{ item.value.ec_k }} m={{ item.value.ec_m }}"
-  with_dict: "{{ rgw_create_pools }}"
+  loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   changed_when: false
   when:
@@ -20,7 +20,7 @@
 
 - name: set crush rule
   command: "{{ container_exec_cmd }} ceph --connect-timeout 10 --cluster {{ cluster }} osd crush rule create-erasure {{ item.key }} {{ item.value.ec_profile }}"
-  with_dict: "{{ rgw_create_pools }}"
+  loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   changed_when: false
   when:
@@ -29,7 +29,7 @@
 
 - name: create ec pools for rgw
   command: "{{ container_exec_cmd }} ceph --connect-timeout 10 --cluster {{ cluster }} osd pool create {{ item.key }} {{ item.value.pg_num | default(osd_pool_default_pg_num) }} erasure {{ item.value.ec_profile }}"
-  with_dict: "{{ rgw_create_pools }}"
+  loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   changed_when: false
   when:
@@ -43,7 +43,7 @@
   retries: 60
   delay: 3
   until: result is succeeded
-  with_dict: "{{ rgw_create_pools }}"
+  loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when: item.value.type is not defined or item.value.type == 'replicated'
 
@@ -53,7 +53,7 @@
   retries: 60
   delay: 3
   until: result is succeeded
-  with_dict: "{{ rgw_create_pools }}"
+  loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   changed_when: false
   when:
@@ -67,5 +67,5 @@
   delay: 3
   until: result is succeeded
   changed_when: false
-  with_dict: "{{ rgw_create_pools }}"
+  loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/roles/ceph-validate/tasks/check_rgw_pools.yml
+++ b/roles/ceph-validate/tasks/check_rgw_pools.yml
@@ -2,7 +2,7 @@
 - name: fail if ec_profile is not set for ec pools
   fail:
     msg: "ec_profile must be set for ec pools"
-  with_dict: "{{ rgw_create_pools }}"
+  loop: "{{ rgw_create_pools | dict2items }}"
   when:
     - item.value.type is defined
     - item.value.type == 'ec'
@@ -11,7 +11,7 @@
 - name: fail if ec_k is not set for ec pools
   fail:
     msg: "ec_k must be set for ec pools"
-  with_dict: "{{ rgw_create_pools }}"
+  loop: "{{ rgw_create_pools | dict2items }}"
   when:
     - item.value.type is defined
     - item.value.type == 'ec'
@@ -20,7 +20,7 @@
 - name: fail if ec_m is not set for ec pools
   fail:
     msg: "ec_m must be set for ec pools"
-  with_dict: "{{ rgw_create_pools }}"
+  loop: "{{ rgw_create_pools | dict2items }}"
   when:
     - item.value.type is defined
     - item.value.type == 'ec'


### PR DESCRIPTION
It is common to set templated pool names in `rgw_create_pools`, e.g.

```yaml
rgw_create_pools:
  "{{ rgw_zone }}.rgw.buckets.index":
    pg_num: 16
    size: 3
    type: replicated
```

This worked fine with Ansible 2.8, but broke in Ansible 2.9 due to a change in
the way `with_dict` works [1].

This commit replaces the use of `with_dict` with

```yaml
loop: "{{ rgw_create_pools | dict2items }}"
```

which works as intended and expands the template in the pool name.

[1]: https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.9.html#loops

Closes #5348

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>