### PR TITLE
docker-to-podman: conditional docker commands

### DIFF
--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -55,15 +55,18 @@
     - import_role:
         name: ceph-handler
 
-    - name: get docker version
-      command: docker --version
-      changed_when: false
-      check_mode: no
-      register: ceph_docker_version
+    - name: with docker configuration
+      when: container_binary == 'docker'
+      block:
+        - name: get docker version
+          command: docker --version
+          changed_when: false
+          check_mode: no
+          register: ceph_docker_version
 
-    - name: set_fact ceph_docker_version ceph_docker_version.stdout.split
-      set_fact:
-        ceph_docker_version: "{{ ceph_docker_version.stdout.split(' ')[2] }}"
+        - name: set_fact ceph_docker_version ceph_docker_version.stdout.split
+          set_fact:
+            ceph_docker_version: "{{ ceph_docker_version.stdout.split(' ')[2] }}"
 
 
   tasks:


### PR DESCRIPTION
The docker commands should be based on the container_binary variable
otherwise running the playbook on a host without docker (like podman
only) will failed.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1829985

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>