### PR TITLE
common: fix target_size_ratio task enablement

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -109,7 +109,9 @@
       command: "{{ ceph_admin_command | default('') }} --cluster {{ cluster }} osd pool set {{ item.name }} target_size_ratio {{ item.target_size_ratio }}"
       with_items: "{{ pools | unique }}"
       delegate_to: "{{ delegated_node }}"
-      when: item.pg_autoscale_mode | default(False) | bool
+      when:
+        - item.pg_autoscale_mode | default(False) | bool
+        - item.target_size_ratio is defined
 
     - name: set pg_autoscale_mode value on pool(s)
       command: "{{ ceph_admin_command | default('') }} --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -46,7 +46,9 @@
         - name: set the target ratio on pool(s)
           command: "{{ ceph_run_cmd }} --cluster {{ cluster }} osd pool set {{ item.name }} target_size_ratio {{ item.target_size_ratio }}"
           with_items: "{{ cephfs_pools | unique }}"
-          when: item.pg_autoscale_mode | default(False) | bool
+          when:
+            - item.pg_autoscale_mode | default(False) | bool
+            - item.target_size_ratio is defined
 
         - name: set pg_autoscale_mode value on pool(s)
           command: "{{ ceph_run_cmd }} --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -36,7 +36,9 @@
       command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} target_size_ratio {{ item.target_size_ratio }}"
       with_items: "{{ openstack_pools | unique }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
-      when: item.pg_autoscale_mode | default(False) | bool
+      when:
+        - item.pg_autoscale_mode | default(False) | bool
+        - item.target_size_ratio is defined
 
     - name: set pg_autoscale_mode value on pool(s)
       command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"


### PR DESCRIPTION
The condition on this task is wrong, we have to check whether
`target_size_ratio` is set in the pool definition instead.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>