### PR TITLE
test: set sitepackages=false in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -280,7 +280,7 @@ whitelist_externals =
     sleep
     rm
 passenv=*
-sitepackages=True
+sitepackages=False
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg


### PR DESCRIPTION
Otherwise it might try to use the system installed version of ansible
when there's one available.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>