### PR TITLE
tests: force using the more recent build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -315,7 +315,7 @@ setenv=
   UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
   CEPH_STABLE_RELEASE = pacific
 
-  switch_to_containers: CEPH_DOCKER_IMAGE_TAG = latest-master
+  switch_to_containers: CEPH_DOCKER_IMAGE_TAG = latest-master-devel
 
   ooo_collocation: CEPH_DOCKER_IMAGE_TAG = latest-master
 deps= -r{toxinidir}/tests/requirements.txt


### PR DESCRIPTION
We should use  `latest-master-devel` for switch_to_containers job.
Otherwise it might happen we actually downgrade the ceph version when
the image used is older than the rpm initially used for installing ceph.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>