### PR TITLE
facts: always set ceph_run_cmd and ceph_admin_command

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -373,7 +373,19 @@
 - name: set_fact ceph_run_cmd
   set_fact:
     ceph_run_cmd: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph/:/var/lib/ceph/:z -v /var/log/ceph/:/var/log/ceph/:z --entrypoint=ceph ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else 'ceph' }}"
+  delegate_to: "{{ item }}"
+  delegate_facts: True
+  run_once: True
+  with_items:
+    - "{{ groups[mon_group_name] if groups[mon_group_name] | default([]) | length > 0 else [] }}"
+    - "{{ inventory_hostname }}"
 
 - name: set_fact ceph_admin_command
   set_fact:
     ceph_admin_command: "{{ ceph_run_cmd }} -n client.admin -k /etc/ceph/{{ cluster }}.client.admin.keyring"
+  delegate_to: "{{ item }}"
+  delegate_facts: True
+  run_once: True
+  with_items:
+    - "{{ groups[mon_group_name] if groups[mon_group_name] | default([]) | length > 0 else [] }}"
+    - "{{ inventory_hostname }}"


### PR DESCRIPTION
always set these facts on monitor nodes whatever we run with `--limit`.
Otherwise, playbook will fail when using `--limit` on nodes where these
facts are used on a delegated task to monitor.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit e5e81843e918ed9aa57a5675af2888499700eac2)