### PR TITLE
ceph-osd/start_osds.yml: ensure wal and db partitions have proper owner

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -33,6 +33,15 @@
   include_tasks: systemd.yml
   when: containerized_deployment | bool
 
+- name: ensure files have correct owner
+  file:
+    path: /var/lib/ceph/osd/
+    state: directory
+    recurse: yes
+    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+  when: cephx | bool
+
 - name: systemd start osd
   systemd:
     name: ceph-osd@{{ item }}


### PR DESCRIPTION
OSD services fails to start due to permission denied error to access wal and db partitions (destination of block.wal and bock.db symlink).
I checked with ceph-deploy so ceph_volume works properly. This should be an ansible issue which this commit solves.
Also the problem might be from ceph_volume ansible module, but I could not find any problem on ceph_volume ansible module.
Note: I think it is a good idea to backport this to stable branch.

Signed-off-by: Siavash Sardari <siavash.sardari@gmail.com>