### PR TITLE
ceph-nfs: add stable noarch repository (bp #5377)

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
@@ -2,17 +2,30 @@
 - name: red hat based systems - repo handling
   when: ceph_origin == 'repository'
   block:
-    - name: add nfs-ganesha stable repository
-      yum_repository:
-        name: nfs_ganesha_stable
-        description: nfs-ganesha stable repo
-        gpgcheck: yes
-        state: present
-        gpgkey: "{{ ceph_stable_key }}"
-        baseurl: "{{ ceph_mirror }}/nfs-ganesha/rpm-{{ nfs_ganesha_stable_branch }}/{{ ceph_release }}/el$releasever/$basearch"
+    - name: red hat based systems - stable repo related tasks
       when:
         - nfs_ganesha_stable | bool
         - ceph_repository == 'community'
+      block:
+        - name: add nfs-ganesha stable repository
+          yum_repository:
+            name: nfs_ganesha_stable
+            description: nfs-ganesha stable repo
+            gpgcheck: yes
+            state: present
+            gpgkey: "{{ ceph_stable_key }}"
+            baseurl: "{{ ceph_mirror }}/nfs-ganesha/rpm-{{ nfs_ganesha_stable_branch }}/{{ ceph_release }}/el$releasever/$basearch"
+            file: nfs_ganesha_stable
+
+        - name: add nfs-ganesha stable noarch repository
+          yum_repository:
+            name: nfs_ganesha_stable_noarch
+            description: nfs-ganesha stable noarch repo
+            gpgcheck: yes
+            state: present
+            gpgkey: "{{ ceph_stable_key }}"
+            baseurl: "{{ ceph_mirror }}/nfs-ganesha/rpm-{{ nfs_ganesha_stable_branch }}/{{ ceph_release }}/el$releasever/noarch"
+            file: nfs_ganesha_stable
 
     - name: red hat based systems - dev repo related tasks
       block:


### PR DESCRIPTION
When using the stable nfs ganesha repository, we need have both arch
and noarch repositories enabled.
Currently the noarch repository is missing which cause the non
containerized deployment to fail.

Closes: #5375
Backport: #5377

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 44e1ebaaff61b5317bae0a3483f5d485c12bd18b)