### PR TITLE
common: quick fix in raw_install_python.yml

### DIFF
--- a/raw_install_python.yml
+++ b/raw_install_python.yml
@@ -65,5 +65,6 @@
   when:
     - stat_zypper.rc is defined
     - stat_zypper.rc == 0
+    - item.stat is defined
     - item.stat.exists | bool
     - item.stat.path == '/usr/bin/python'


### PR DESCRIPTION
Typical error:

```
  msg: |-
    The conditional check 'item.stat.exists | bool' failed. The error was: error while evaluating conditional (item.stat.exists | bool): 'dict object' has no attribute 'stat'

```

This can happen when none of the binaries was found.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>