### PR TITLE
library/ceph_pool: set name parameter as required

### DIFF
--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -456,7 +456,7 @@ def exit_module(module, out, rc, cmd, err, startd, changed=False):
 def run_module():
     module_args = dict(
         cluster=dict(type='str', required=False, default='ceph'),
-        name=dict(type='str', required=False),
+        name=dict(type='str', required=True),
         state=dict(type='str', required=True, choices=['present', 'absent', 'list']),
         details=dict(type='bool', required=False, default=False),
         size=dict(type='str', required=False),


### PR DESCRIPTION
The name parameter is required.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>