### PR TITLE
rgwloadbalancer undefined index variable

### DIFF
--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -19,8 +19,10 @@
 
 - name: set_fact vip to vrrp_instance
   set_fact:
-      vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item }]) }}"
+    vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item }]) }}"
   loop: "{{ virtual_ips | flatten(levels=1) }}"
+  loop_control:
+    index_var: index
 
 - name: "generate keepalived: configuration file: keepalived.conf"
   template:


### PR DESCRIPTION
The vrrp_instances variable is using a loop with index but the index_var
wasn't defined.
As a result, the fact task was failing on this undefined index variable.

The task includes an option with an undefined variable. The error was:
'index' is undefined

Closes: #5395

Signed-off-by: Florian Faltermeier <florian.faltermeier@uibk.ac.at>