### PR TITLE
Fix takeover-existing-cluster.yml

### DIFF
--- a/infrastructure-playbooks/take-over-existing-cluster.yml
+++ b/infrastructure-playbooks/take-over-existing-cluster.yml
@@ -33,6 +33,8 @@
   tasks:
     - import_role:
         name: ceph-defaults
+    - import_role:
+        name: ceph-facts
 
   post_tasks:
     - name: get the name of the existing ceph cluster
@@ -59,7 +61,7 @@
     - name: generate ceph configuration file
       action: config_template
       args:
-        src: "roles/ceph-config/templates/ceph.conf.j2"
+        src: "../roles/ceph-config/templates/ceph.conf.j2"
         dest: "/etc/ceph/{{ cluster_name.stdout }}.conf"
         owner: "{{ ceph_conf_stat.stat.pw_name }}"
         group: "{{ ceph_conf_stat.stat.gr_name }}"


### PR DESCRIPTION
Currently cluster takeover does not work, due to wrong path in templating out
ceph.conf and lack of variables (missing run of ceph-facts role).