### PR TITLE
ceph-rgw-loadbalancer: Fix keepalived master selection

### DIFF
--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -19,7 +19,7 @@
 
 - name: set_fact vip to vrrp_instance
   set_fact:
-    vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item }]) }}"
+    vrrp_instances: "{{ vrrp_instances | default([]) | union([{ 'name': 'VI_' + index|string , 'vip': item, 'master': groups[rgwloadbalancer_group_name][index] }]) }}"
   loop: "{{ virtual_ips | flatten(levels=1) }}"
   loop_control:
     index_var: index

--- a/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/keepalived.conf.j2
@@ -15,8 +15,8 @@ vrrp_script check_haproxy {
 
 {% for instance in vrrp_instances %}
 vrrp_instance {{ instance['name'] }} {
-    state {{ 'MASTER' if inventory_hostname == groups[rgwloadbalancer_group_name][0] else 'BACKUP' }}
-    priority {{ '100' if inventory_hostname == groups[rgwloadbalancer_group_name][0] else '90' }}
+    state {{ 'MASTER' if inventory_hostname == instance['master'] else 'BACKUP' }}
+    priority {{ '100' if inventory_hostname == instance['master'] else '90' }}
     interface {{ virtual_ip_interface }}
     virtual_router_id {{ 50 + loop.index }}
     advert_int 1

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -279,3 +279,18 @@
     - keys is defined
     - keys | length > 0
     - item.caps is not defined
+
+- name: check virtual_ips is defined
+  fail:
+    msg: "virtual_ips is not defined."
+  when:
+    - rgwloadbalancer_group_name in group_names
+    - groups[rgwloadbalancer_group_name] | length > 0
+    - virtual_ips is not defined
+
+- name: validate virtual_ips length
+  fail:
+    msg: "There are more virual_ips defined than rgwloadbalancer nodes"
+  when:
+    - rgwloadbalancer_group_name in group_names
+    - (virtual_ips | length) > (groups[rgwloadbalancer_group_name] | length)


### PR DESCRIPTION
While 2ca33641 fixed a bug in the way the `keepalived.conf.j2` template matched
hostnames to set the VRRP `MASTER`/`BACKUP` states, it also introduced a
regression in the case where `virtual_ips` is a list of more than one IP
address.

The previous behavior would result in each host in the `rgwloadbalancers` group
to be `MASTER` for one of the `virtual_ips`, but the new behavior caused the
first host to be `MASTER` for all the IP address in `virtual_ips`.

This commit restores the original behavior.