### PR TITLE
Readme: Link to release list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,3 +6,5 @@ Please refer to our hosted documentation here: http://docs.ceph.com/ceph-ansible
 
 You can view documentation for our ``stable-*`` branches by substituting ``master`` in the link
 above for the name of the branch. For example: http://docs.ceph.com/ceph-ansible/stable-3.0/ 
+
+For information about the available branches refer to https://docs.ceph.com/ceph-ansible/master/#releases.

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,6 @@ Ansible playbooks for Ceph, the distributed filesystem.
 Please refer to our hosted documentation here: http://docs.ceph.com/ceph-ansible/master/
 
 You can view documentation for our ``stable-*`` branches by substituting ``master`` in the link
-above for the name of the branch. For example: http://docs.ceph.com/ceph-ansible/stable-3.0/ 
+above for the name of the branch. For example: http://docs.ceph.com/ceph-ansible/stable-5.0/.
 
 For information about the available branches refer to https://docs.ceph.com/ceph-ansible/master/#releases.


### PR DESCRIPTION
Help new users to choose a branch by linking to the release list.

Updates the example link, too. Left this in a seprate commit for now, just in case you want really tiny scoped commits.