### PR TITLE
rgw: allow rgws can be run with or without multisite at the same

### DIFF
--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -73,4 +73,4 @@
   with_items: "{{ groups.get(rgw_group_name, []) }}"
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])
-    - rgw_multisite | bool
+    - hostvars[item]["rgw_multisite"] | default(False) | bool


### PR DESCRIPTION
Allows rgws in a ceph cluster to be run with multisite and without multisite at the same time.

Signed-off-by: Ali Maredia <amaredia@redhat.com>