### PR TITLE
container: inspect Id field instead of RepoDigests

### DIFF
--- a/roles/ceph-container-common/tasks/fetch_image.yml
+++ b/roles/ceph-container-common/tasks/fetch_image.yml
@@ -129,49 +129,49 @@
 
 - name: set_fact ceph_mon_image_repodigest_before_pulling
   set_fact:
-    ceph_mon_image_repodigest_before_pulling: "{{ (ceph_mon_container_inspect_before_pull.stdout | from_json)[0].RepoDigests[0].split('@')[1] }}"
+    ceph_mon_image_repodigest_before_pulling: "{{ (ceph_mon_container_inspect_before_pull.stdout | from_json)[0].Id }}"
   when:
     - mon_group_name in group_names
     - ceph_mon_container_inspect_before_pull.get('rc') == 0
 
 - name: set_fact ceph_osd_image_repodigest_before_pulling
   set_fact:
-    ceph_osd_image_repodigest_before_pulling: "{{ (ceph_osd_container_inspect_before_pull.stdout | from_json)[0].RepoDigests[0].split('@')[1] }}"
+    ceph_osd_image_repodigest_before_pulling: "{{ (ceph_osd_container_inspect_before_pull.stdout | from_json)[0].Id }}"
   when:
     - osd_group_name in group_names
     - ceph_osd_container_inspect_before_pull.get('rc') == 0
 
 - name: set_fact ceph_mds_image_repodigest_before_pulling
   set_fact:
-    ceph_mds_image_repodigest_before_pulling: "{{ (ceph_mds_container_inspect_before_pull.stdout | from_json)[0].RepoDigests[0].split('@')[1] }}"
+    ceph_mds_image_repodigest_before_pulling: "{{ (ceph_mds_container_inspect_before_pull.stdout | from_json)[0].Id }}"
   when:
     - mds_group_name in group_names
     - ceph_mds_container_inspect_before_pull.get('rc') == 0
 
 - name: set_fact ceph_rgw_image_repodigest_before_pulling
   set_fact:
-    ceph_rgw_image_repodigest_before_pulling: "{{ (ceph_rgw_container_inspect_before_pull.stdout | from_json)[0].RepoDigests[0].split('@')[1] }}"
+    ceph_rgw_image_repodigest_before_pulling: "{{ (ceph_rgw_container_inspect_before_pull.stdout | from_json)[0].Id }}"
   when:
     - rgw_group_name in group_names
     - ceph_rgw_container_inspect_before_pull.get('rc') == 0
 
 - name: set_fact ceph_mgr_image_repodigest_before_pulling
   set_fact:
-    ceph_mgr_image_repodigest_before_pulling: "{{ (ceph_mgr_container_inspect_before_pull.stdout | from_json)[0].RepoDigests[0].split('@')[1] }}"
+    ceph_mgr_image_repodigest_before_pulling: "{{ (ceph_mgr_container_inspect_before_pull.stdout | from_json)[0].Id }}"
   when:
     - mgr_group_name in group_names
     - ceph_mgr_container_inspect_before_pull.get('rc') == 0
 
 - name: set_fact ceph_rbd_mirror_image_repodigest_before_pulling
   set_fact:
-    ceph_rbd_mirror_image_repodigest_before_pulling: "{{ (ceph_rbd_mirror_container_inspect_before_pull.stdout | from_json)[0].RepoDigests[0].split('@')[1] }}"
+    ceph_rbd_mirror_image_repodigest_before_pulling: "{{ (ceph_rbd_mirror_container_inspect_before_pull.stdout | from_json)[0].Id }}"
   when:
     - rbdmirror_group_name in group_names
     - ceph_rbd_mirror_container_inspect_before_pull.get('rc') == 0
 
 - name: set_fact ceph_nfs_image_repodigest_before_pulling
   set_fact:
-    ceph_nfs_image_repodigest_before_pulling: "{{ (ceph_nfs_container_inspect_before_pull.stdout | from_json)[0].RepoDigests[0].split('@')[1] }}"
+    ceph_nfs_image_repodigest_before_pulling: "{{ (ceph_nfs_container_inspect_before_pull.stdout | from_json)[0].Id }}"
   when:
     - nfs_group_name in group_names
     - ceph_nfs_container_inspect_before_pull.get('rc') == 0
@@ -193,7 +193,7 @@
 
 - name: set_fact image_repodigest_after_pulling
   set_fact:
-    image_repodigest_after_pulling: "{{ (image_inspect_after_pull.stdout | from_json)[0].RepoDigests[0].split('@')[1] }}"
+    image_repodigest_after_pulling: "{{ (image_inspect_after_pull.stdout | from_json)[0].Id }}"
   when: image_inspect_after_pull.rc == 0
 
 - name: set_fact ceph_mon_image_updated


### PR DESCRIPTION
When a container image managed by podman isn't tag anymore then the
RepoDigests field when inspecting the image doesn't return any value.
This is different from docker workflow and it breaks the ceph-ansible
container upgrade when collocated multiple services and using a non
fix container tag (like latest or 4).

```console
$ podman images
REPOSITORY              TAG      IMAGE ID       CREATED        SIZE
docker.io/ceph/daemon   latest   680c9c0d38c3   8 days ago     957 MB
<none>                  <none>   011ee108bfc9   2 months ago   1.01 GB
```

```console
$ podman inspect 680c9c0d38c3 | jq .[0].RepoDigests[0]
"docker.io/ceph/daemon@sha256:20cf789235e23ddaf38e109b391d1496bb88011239d16862c4c106d0e05fea9e"
$ podman inspect 011ee108bfc9 | jq .[0].RepoDigests[0]
null
```

Because this field returns "null" then the ansible task trying to
determine this value is failing

```console
fatal: [foo]: FAILED! =>
  msg: |-
    The task includes an option with an undefined variable. The error
    was: None has no element 0

    The error appears to be in
    'roles/ceph-container-common/tasks/fetch_image.yml': line 137,
    column 3, but may be elsewhere in the file depending on the exact
    syntax problem.

    The offending line appears to be:

    - name: set_fact ceph_osd_image_repodigest_before_pulling
      ^ here
```

We don't have this behaviour with docker.

```console
$ docker images
REPOSITORY              TAG      IMAGE ID       CREATED        SIZE
docker.io/ceph/daemon   latest   680c9c0d38c3   8 days ago     928 MB
docker.io/ceph/daemon   <none>   011ee108bfc9   2 months ago   986 MB
```

```console
$ docker inspect 680c9c0d38c3 | jq .[0].RepoDigests[0]
"docker.io/ceph/daemon@sha256:45e6f28bb67c81b826acb64fad5c0da1cac3dffb41a88992fe4ca2be79575fa6"
$ docker inspect 011ee108bfc9 | jq .[0].RepoDigests[0]
"docker.io/ceph/daemon@sha256:b393a73309d72e43ca7d65cd3519036007947671e373eb59aa75a46185c52231"
```

Instead we should just get the Id field.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1844496

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>