### PR TITLE
rgw multisite: add master zone endpoints to zonegroup

### DIFF
--- a/roles/ceph-rgw/tasks/multisite/master.yml
+++ b/roles/ceph-rgw/tasks/multisite/master.yml
@@ -31,6 +31,15 @@
     - item.item.is_master | bool
     - "'No such file or directory' in item.stderr"
 
+- name: add endpoints to their zone groups(s)
+  command: "{{ container_exec_cmd }} radosgw-admin zonegroup modify --cluster={{ cluster }} --rgw-realm={{ item.realm }} --rgw-zonegroup={{ item.zonegroup }} --endpoints {{ item.endpoints }}"
+  loop: "{{ zone_endpoints_list }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  when:
+    - zone_endpoints_list is defined
+    - item.is_master | bool
+
 - name: add endpoints to their zone(s)
   command: "{{ container_exec_cmd }} radosgw-admin zone modify --cluster={{ cluster }} --rgw-realm={{ item.realm }} --rgw-zonegroup={{ item.zonegroup }} --rgw-zone={{ item.zone }} --endpoints {{ item.endpoints }}"
   loop: "{{ zone_endpoints_list }}"


### PR DESCRIPTION
We were only adding the endpoints to the master zone but not to the
zonegroup.
This patch fixes the issue.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1839228

Signed-off-by: Ali Maredia <amaredia@redhat.com>