### PR TITLE
mergify: remove merge on skip ci

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,16 +1,4 @@
 pull_request_rules:
-  - name: automatic merge on skip ci
-    conditions:
-      - label!=DNM
-      - title~=\[skip ci\]
-      - '#approved-reviews-by>=2'
-    actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
-      dismiss_reviews: {}
-      delete_head_branch: {}
 # Backports
   - actions:
       backport:


### PR DESCRIPTION
This rule will probably never be applyied and at the moment this is
creating a cancelled job in the CI status.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>