### PR TITLE
[skip ci] debian/uca: remove the handler notification

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_uca_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_uca_repository.yml
@@ -9,5 +9,4 @@
   apt_repository:
     repo: "deb {{ ceph_stable_repo_uca }} {{ ceph_stable_release_uca }} main"
     state: present
-    update_cache: no
-  notify: update apt cache if a repo was added
+    update_cache: yes

--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -4,13 +4,6 @@
      - not rolling_update | bool
      - not docker2podman | default(False) | bool
   block:
-    - name: update apt cache
-      apt:
-        update-cache: yes
-      when: ansible_os_family == 'Debian'
-      register: result
-      until: result is succeeded
-
     - name: make tempdir for scripts
       tempfile:
         state: directory


### PR DESCRIPTION
The "update apt cache" in the ceph-handler role was never called and the
handler trigger after adding the uca repository doesn't exist at all.
Instead of using a handler for that we can just set the update_cache
parameter to true like the other apt_repository tasks.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>