### PR TITLE
switch_to_containers: don't set noup flag

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -214,6 +214,7 @@
   vars:
     containerized_deployment: true
     osd_group_name: osds
+    switch_to_containers: True
 
   hosts: "{{ osd_group_name|default('osds') }}"
 

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -43,7 +43,9 @@
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: True
   changed_when: False
-  when: not rolling_update | default(False) | bool
+  when:
+    - not rolling_update | default(False) | bool
+    - not switch_to_containers | default(False) | bool
 
 - name: include container_options_facts.yml
   include_tasks: container_options_facts.yml
@@ -70,6 +72,7 @@
   changed_when: False
   when:
     - not rolling_update | default(False) | bool
+    - not switch_to_containers | default(False) | bool
     - inventory_hostname == ansible_play_hosts_all | last
 
 - name: wait for all osd to be up


### PR DESCRIPTION
We shouldn't set this flag when running switch_to_containers playbook.
Otherwise the playbook fails waiting for pgs to be clean.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1843569

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>