### PR TITLE
ceph_volume: make zap function idempotent

### DIFF
--- a/tests/library/test_ceph_volume.py
+++ b/tests/library/test_ceph_volume.py
@@ -75,6 +75,8 @@ class TestCephVolumeModule(object):
         fake_module.params = {'data': '/dev/sda'}
         fake_container_image = "docker.io/ceph/daemon:latest"
         expected_command_list = container_cmd + [fake_container_image,
+                                                 '--cluster',
+                                                 'ceph',
                                                  'lvm',
                                                  'zap',
                                                  '--destroy',
@@ -87,6 +89,8 @@ class TestCephVolumeModule(object):
         fake_module.params = {'data': '/dev/sda'}
         fake_container_image = None
         expected_command_list = ['ceph-volume',
+                                 '--cluster',
+                                 'ceph',
                                  'lvm',
                                  'zap',
                                  '--destroy',
@@ -99,6 +103,8 @@ class TestCephVolumeModule(object):
         fake_module.params = {'osd_fsid': 'a_uuid'}
         fake_container_image = None
         expected_command_list = ['ceph-volume',
+                                 '--cluster',
+                                 'ceph',
                                  'lvm',
                                  'zap',
                                  '--destroy',
@@ -109,6 +115,8 @@ class TestCephVolumeModule(object):
 
     def test_activate_osd(self):
         expected_command_list = ['ceph-volume',
+                                 '--cluster',
+                                 'ceph',
                                  'lvm',
                                  'activate',
                                  '--all']
@@ -147,6 +155,8 @@ class TestCephVolumeModule(object):
         fake_module = MagicMock()
         fake_container_image = None
         expected_command_list = ['ceph-volume',
+                                 '--cluster',
+                                 'ceph',
                                  'inventory',
                                  '--format=json',
                                  ]
@@ -157,6 +167,8 @@ class TestCephVolumeModule(object):
         fake_module = MagicMock()
         fake_container_image = "docker.io/ceph/daemon:latest"
         expected_command_list = container_cmd + [fake_container_image,
+                                                 '--cluster',
+                                                 'ceph',
                                                  'inventory',
                                                  '--format=json']
         result = ceph_volume.list_storage_inventory(fake_module, fake_container_image)


### PR DESCRIPTION
This commit makes the zap function idempotent, especially when using
lvm_volumes variable.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1845668

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>