### PR TITLE
requirements: exclude ansible 2.9.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # These are Python requirements needed to run ceph-ansible master
-ansible>=2.9,<2.10
+ansible>=2.9,<2.10,!=2.9.10
 netaddr

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ six==1.10.0
 testinfra>=3,<4
 pytest-xdist==1.28.0
 pytest>=4.6,<5.0
-ansible>=2.9,<2.10
+ansible>=2.9,<2.10,!=2.9.10
 Jinja2>=2.10
 netaddr
 mock


### PR DESCRIPTION
ansible 2.9.10 seems to have introduced a bug.

See https://github.com/ansible/ansible/issues/70168

This commit excludes this version from ceph-ansible requirements

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>