### PR TITLE
travis: use tests/requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/
 install:
-  - pip install -r requirements.txt
-  - pip install ansible-lint pytest pytest-cov
+  - pip install -r tests/requirements.txt
+  - pip install ansible-lint pytest-cov
 script:
   - if [[ -n $(grep --exclude-dir=.git -P "\xa0" -r .) ]]; then echo 'NBSP characters found'; exit 1; fi
   - pytest --cov=library/ --cov=plugins/filter/ -vvvv tests/library/ tests/plugins/filter/


### PR DESCRIPTION
Explicitly install ansible-lint pytest pytest-cov via pip results of a
specific pytest version (4.3.1) which is not supported for pytest-cov
(2.10).
Because we are already defining a specific pytest version in the tests
requirements then we can install all the python dependencies from that
file and remove this from the pip install command.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>