### PR TITLE
docker2podman: make images pulling optional

### DIFF
--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -71,45 +71,54 @@
       tags: with_pkg
       when: not is_atomic | bool
 
-    - name: "pulling {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} image from docker daemon"
-      command: "{{ timeout_command }} {{ container_binary }} pull docker-daemon:{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    - name: check podman presence
+      command: command -v podman
+      register: podman_presence
       changed_when: false
-      register: pull_image
-      until: pull_image.rc == 0
-      retries: "{{ docker_pull_retry }}"
-      delay: 10
-      when: inventory_hostname in groups.get(mon_group_name, []) or
-            inventory_hostname in groups.get(osd_group_name, []) or
-            inventory_hostname in groups.get(mds_group_name, []) or
-            inventory_hostname in groups.get(rgw_group_name, []) or
-            inventory_hostname in groups.get(mgr_group_name, []) or
-            inventory_hostname in groups.get(rbdmirror_group_name, []) or
-            inventory_hostname in groups.get(iscsi_gw_group_name, []) or
-            inventory_hostname in groups.get(nfs_group_name, [])
+      failed_when: false
 
-    - name: "pulling alertmanager/grafana/prometheus images from docker daemon"
-      command: "{{ timeout_command }} {{ container_binary }} pull docker-daemon:{{ item }}"
-      changed_when: false
-      register: pull_image
-      until: pull_image.rc == 0
-      retries: "{{ docker_pull_retry }}"
-      delay: 10
-      loop:
-        - "{{ alertmanager_container_image }}"
-        - "{{ grafana_container_image }}"
-        - "{{ prometheus_container_image }}"
-      when:
-        - dashboard_enabled | bool
-        - inventory_hostname in groups.get(grafana_server_group_name, [])
+    - name: pulling images from docker daemon
+      when: podman_presence.rc == 0
+      block:
+        - name: "pulling {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} image from docker daemon"
+          command: "{{ timeout_command }} {{ container_binary }} pull docker-daemon:{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+          changed_when: false
+          register: pull_image
+          until: pull_image.rc == 0
+          retries: "{{ docker_pull_retry }}"
+          delay: 10
+          when: inventory_hostname in groups.get(mon_group_name, []) or
+                inventory_hostname in groups.get(osd_group_name, []) or
+                inventory_hostname in groups.get(mds_group_name, []) or
+                inventory_hostname in groups.get(rgw_group_name, []) or
+                inventory_hostname in groups.get(mgr_group_name, []) or
+                inventory_hostname in groups.get(rbdmirror_group_name, []) or
+                inventory_hostname in groups.get(iscsi_gw_group_name, []) or
+                inventory_hostname in groups.get(nfs_group_name, [])
 
-    - name: "pulling {{ node_exporter_container_image }} image from docker daemon"
-      command: "{{ timeout_command }} {{ container_binary }} pull docker-daemon:{{ node_exporter_container_image }}"
-      changed_when: false
-      register: pull_image
-      until: pull_image.rc == 0
-      retries: "{{ docker_pull_retry }}"
-      delay: 10
-      when: dashboard_enabled | bool
+        - name: "pulling alertmanager/grafana/prometheus images from docker daemon"
+          command: "{{ timeout_command }} {{ container_binary }} pull docker-daemon:{{ item }}"
+          changed_when: false
+          register: pull_image
+          until: pull_image.rc == 0
+          retries: "{{ docker_pull_retry }}"
+          delay: 10
+          loop:
+            - "{{ alertmanager_container_image }}"
+            - "{{ grafana_container_image }}"
+            - "{{ prometheus_container_image }}"
+          when:
+            - dashboard_enabled | bool
+            - inventory_hostname in groups.get(grafana_server_group_name, [])
+
+        - name: "pulling {{ node_exporter_container_image }} image from docker daemon"
+          command: "{{ timeout_command }} {{ container_binary }} pull docker-daemon:{{ node_exporter_container_image }}"
+          changed_when: false
+          register: pull_image
+          until: pull_image.rc == 0
+          retries: "{{ docker_pull_retry }}"
+          delay: 10
+          when: dashboard_enabled | bool
 
     - import_role:
         name: ceph-mon


### PR DESCRIPTION
This commit makes the images pulling skipped if podman isn't installed
on the machine.

In OSP context, the podman installation is done later in the workflow,
it means all `podman pull` commands will fail.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1849559

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>