### PR TITLE
podman: Add Type and PIDFile value to unit files

### DIFF
--- a/roles/ceph-grafana/templates/grafana-server.service.j2
+++ b/roles/ceph-grafana/templates/grafana-server.service.j2
@@ -11,9 +11,16 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop grafana-server
 ExecStartPre=-/usr/bin/{{ container_binary }} rm grafana-server
+{% endif %}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=grafana-server \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   -v /etc/grafana:/etc/grafana:Z \
   -v /var/lib/grafana:/var/lib/grafana:Z \
   --net=host \
@@ -23,12 +30,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=grafana-server \
   --memory-swap={{ grafana_container_memory * 2 }}GB \
   -e GF_INSTALL_PLUGINS={{ grafana_plugins|join(',') }} \
   {{ grafana_container_image }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStop=-/usr/bin/{{ container_binary }} stop grafana-server
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -9,9 +9,16 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-api
 ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-api
+{% endif %}
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   --memory={{ ceph_rbd_target_api_docker_memory_limit }} \
   --cpus={{ ceph_rbd_target_api_docker_cpu_limit }} \
   -v /etc/localtime:/etc/localtime:ro \
@@ -28,12 +35,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   --name=rbd-target-api \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop rbd-target-api
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -9,9 +9,16 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-gw
 ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-gw
+{% endif %}
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   --memory={{ ceph_rbd_target_gw_docker_memory_limit }} \
   --cpus={{ ceph_rbd_target_gw_docker_cpu_limit }} \
   -v /etc/localtime:/etc/localtime:ro \
@@ -28,12 +35,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   --name=rbd-target-gw \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop rbd-target-gw
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -9,9 +9,16 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop tcmu-runner
 ExecStartPre=-/usr/bin/{{ container_binary }} rm tcmu-runner
+{% endif %}
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   --memory={{ ceph_tcmu_runner_docker_memory_limit }} \
   --cpus={{ ceph_tcmu_runner_docker_cpu_limit }} \
   -v /etc/localtime:/etc/localtime:ro \
@@ -27,12 +34,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   --name=tcmu-runner \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop tcmu-runner
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -10,9 +10,16 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mds-{{ ansible_hostname }}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mds-{{ ansible_hostname }}
+{% endif %}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   --memory={{ ceph_mds_docker_memory_limit }} \
   --cpus={{ cpu_limit }} \
   -v /var/lib/ceph:/var/lib/ceph:z \
@@ -26,12 +33,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   {{ ceph_mds_docker_extra_env }} \
   --name=ceph-mds-{{ ansible_hostname }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop ceph-mds-{{ ansible_hostname }}
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -9,9 +9,16 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mgr-{{ ansible_hostname }}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mgr-{{ ansible_hostname }}
+{% endif %}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   --memory={{ ceph_mgr_docker_memory_limit }} \
   --cpus={{ ceph_mgr_docker_cpu_limit }} \
   -v /var/lib/ceph:/var/lib/ceph:z \
@@ -25,12 +32,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   {{ ceph_mgr_docker_extra_env }} \
   --name=ceph-mgr-{{ ansible_hostname }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop ceph-mgr-{{ ansible_hostname }}
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -9,9 +9,16 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mon-%i
+{% endif %}
 ExecStartPre=/bin/sh -c '"$(command -v mkdir)" -p /etc/ceph /var/lib/ceph/mon'
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   --memory={{ ceph_mon_docker_memory_limit }} \
   --cpus={{ ceph_mon_docker_cpu_limit }} \
   -v /var/lib/ceph:/var/lib/ceph:z \
@@ -38,13 +45,21 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   {{ ceph_mon_docker_extra_env }} \
   {{ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStop=-/usr/bin/{{ container_binary }} stop ceph-mon-%i
+{% endif %}
 ExecStopPost=-/bin/rm -f /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -10,9 +10,16 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-nfs-%i
+{% endif %}
 ExecStartPre={{ '/bin/mkdir' if ansible_os_family == 'Debian' else '/usr/bin/mkdir' }} -p /etc/ceph /etc/ganesha /var/lib/nfs/ganesha /var/log/ganesha
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   -v /var/lib/ceph:/var/lib/ceph:z \
   -v /etc/ceph:/etc/ceph:z \
   -v /var/lib/nfs/ganesha:/var/lib/nfs/ganesha:z \
@@ -31,12 +38,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   {{ ceph_nfs_docker_extra_env }} \
   --name=ceph-nfs-{{ ceph_nfs_service_suffix | default(ansible_hostname) }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop ceph-nfs-%i
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -11,8 +11,15 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f node-exporter
+{% endif %}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   --privileged \
   -v /proc:/host/proc:ro -v /sys:/host/sys:ro \
   --net=host \
@@ -21,12 +28,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
   --path.sysfs=/host/sys \
   --no-collector.timex \
   --web.listen-address=:{{ node_exporter_port }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStop=-/usr/bin/{{ container_binary }} stop node-exporter
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -11,13 +11,20 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-osd-%i
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f ceph-osd-%i
+{% endif %}
 ExecStart={% if ceph_osd_numactl_opts != "" %}
 numactl \
 {{ ceph_osd_numactl_opts }} \
 {% endif %}
 /usr/bin/{{ container_binary }} run \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   --rm \
   --net=host \
   --privileged=true \
@@ -55,12 +62,20 @@ numactl \
   --name=ceph-osd-%i \
   {{ ceph_osd_docker_extra_env }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStop=-/usr/bin/{{ container_binary }} stop ceph-osd-%i
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -12,8 +12,15 @@ After=network.target
 [Service]
 WorkingDirectory={{ alertmanager_data_dir }}
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f alertmanager
+{% endif %}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=alertmanager \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   -v "{{ alertmanager_conf_dir }}:/etc/alertmanager:Z" \
   -v "{{ alertmanager_data_dir }}:/alertmanager:Z" \
   --net=host \
@@ -30,12 +37,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=alertmanager \
   --storage.path=/alertmanager \
   --web.external-url=http://{{ ansible_fqdn }}:{{ alertmanager_port }}/ \
   --web.listen-address={{ grafana_server_addr }}:{{ alertmanager_port }}
+{% if container_binary == 'podman' %}
+ExecStop=/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStop=/usr/bin/{{ container_binary }} stop alertmanager
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -11,8 +11,15 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f prometheus
+{% endif %}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=prometheus \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   -v "{{ prometheus_conf_dir }}:/etc/prometheus:Z" \
   -v "{{ prometheus_data_dir }}:/prometheus:Z" \
   --net=host \
@@ -26,12 +33,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=prometheus \
   --storage.tsdb.path=/prometheus \
   --web.external-url=http://{{ ansible_fqdn }}:{{ prometheus_port }}/ \
   --web.listen-address={{ grafana_server_addr }}:{{ prometheus_port }}
+{% if container_binary == 'podman' %}
+ExecStop=/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStop=/usr/bin/{{ container_binary }} stop prometheus
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -9,9 +9,16 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/environment
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rbd-mirror-{{ ansible_hostname }}
+{% endif %}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   --memory={{ ceph_rbd_mirror_docker_memory_limit }} \
   --cpus={{ ceph_rbd_mirror_docker_cpu_limit }} \
   -v /var/lib/ceph:/var/lib/ceph:z \
@@ -25,12 +32,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --name=ceph-rbd-mirror-{{ ansible_hostname }} \
   {{ ceph_rbd_mirror_docker_extra_env }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop ceph-rbd-mirror-{{ ansible_hostname }}
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -10,9 +10,16 @@ After=network.target
 
 [Service]
 EnvironmentFile=/var/lib/ceph/radosgw/{{ cluster }}-%i/EnvironmentFile
+{% if container_binary == 'podman' %}
+ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+{% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
+{% endif %}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
+{% if container_binary == 'podman' %}
+  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+{% endif %}
   --memory={{ ceph_rgw_docker_memory_limit }} \
   --cpus={{ cpu_limit }} \
   {% if ceph_rgw_docker_cpuset_cpus is defined -%}
@@ -40,12 +47,20 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --name=ceph-rgw-{{ ansible_hostname }}-${INST_NAME} \
   {{ ceph_rgw_docker_extra_env }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+{% if container_binary == 'podman' %}
+ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"
+{% else %}
 ExecStopPost=-/usr/bin/{{ container_binary }} stop ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
+{% endif %}
 KillMode=none
 Restart=always
 RestartSec=10s
 TimeoutStartSec=120
 TimeoutStopSec=15
+{% if container_binary == 'podman' %}
+Type=forking
+PIDFile=/%t/%n-pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This changes the way we are running the podman containers via systemd.
They are now in dettached mode and Type/PIDFile set.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1834974

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>