### PR TITLE
[skip ci] docker: Add Requires on docker service

### DIFF
--- a/roles/ceph-grafana/templates/grafana-server.service.j2
+++ b/roles/ceph-grafana/templates/grafana-server.service.j2
@@ -4,6 +4,7 @@
 Description=grafana-server
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -2,6 +2,7 @@
 Description=RBD Target API Service
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -2,6 +2,7 @@
 Description=RBD Target Gateway Service
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -2,6 +2,7 @@
 Description=TCMU Runner
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -2,6 +2,7 @@
 Description=Ceph MDS
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -2,6 +2,7 @@
 Description=Ceph Manager
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -2,6 +2,7 @@
 Description=Ceph Monitor
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -3,6 +3,7 @@ Description=NFS-Ganesha file server
 Documentation=http://github.com/nfs-ganesha/nfs-ganesha/wiki
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -4,6 +4,7 @@
 Description=Node Exporter
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -3,6 +3,7 @@
 Description=Ceph OSD
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -4,6 +4,7 @@
 Description=alertmanager
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -4,6 +4,7 @@
 Description=prometheus
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -2,6 +2,7 @@
 Description=Ceph RBD mirror
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -2,6 +2,7 @@
 Description=Ceph RGW
 {% if container_binary == 'docker' %}
 After=docker.service
+Requires=docker.service
 {% else %}
 After=network.target
 {% endif %}


### PR DESCRIPTION
When using docker container engine then the systemd unit scripts only
use a dependency on the docker daemon via the After parameter.
But if docker is restarted on a live system then the ceph systemd units
should wait for the docker daemon to be fully restarted.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1846830

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>