### PR TITLE
dashboard: copy self-signed generated crt to mons

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -36,11 +36,36 @@
         mode: 0440
       when: dashboard_key | length > 0
 
-    - name: generate a Self Signed OpenSSL certificate for dashboard
-      shell: |
-        test -f /etc/ceph/ceph-dashboard.key -a -f /etc/ceph/ceph-dashboard.crt || \
-        openssl req -new -nodes -x509 -subj '/O=IT/CN=ceph-dashboard' -days 3650 -keyout /etc/ceph/ceph-dashboard.key -out /etc/ceph/ceph-dashboard.crt -extensions v3_ca
+    - name: generate and copy self-signed certificate
       when: dashboard_key | length == 0 or dashboard_crt | length == 0
+      block:
+        - name: generate a Self Signed OpenSSL certificate for dashboard
+          shell: |
+            test -f /etc/ceph/ceph-dashboard.key -a -f /etc/ceph/ceph-dashboard.crt || \
+            openssl req -new -nodes -x509 -subj '/O=IT/CN=ceph-dashboard' -days 3650 -keyout /etc/ceph/ceph-dashboard.key -out /etc/ceph/ceph-dashboard.crt -extensions v3_ca
+          run_once: True
+
+        - name: slurp self-signed generated certificate for dashboard
+          slurp:
+            src: "/etc/ceph/{{ item }}"
+          run_once: True
+          with_items:
+            - 'ceph-dashboard.key'
+            - 'ceph-dashboard.crt'
+          register: slurp_self_signed_crt
+
+        - name: copy self-signed generated certificate on mons
+          copy:
+            dest: "{{ item.0.source }}"
+            content: "{{ item.0.content | b64decode }}"
+            owner: "{{ ceph_uid }}"
+            group: "{{ ceph_uid }}"
+            mode: "{{ '0600' if item.0.source.split('.')[-1] == 'key' else '0664' }}"
+          delegate_to: "{{ item.1 }}"
+          run_once: True
+          with_nested:
+            - "{{ slurp_self_signed_crt.results }}"
+            - "{{ groups[mon_group_name] }}"
 
     - name: import dashboard certificate file
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} config-key set mgr/dashboard/crt -i /etc/ceph/ceph-dashboard.crt"


### PR DESCRIPTION
This commit makes the playbook copying self-signed generated certificate
to monitors.
When mons and mgrs are deployed on dedicated nodes the playbook will
fail when trying to import certificate and key files since they are
generated on mgrs whereas we try to import them from a monitor.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1846995

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>