### PR TITLE
switch-to-containers: set and unset osd flags

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -212,6 +212,7 @@
     health_osd_check_delay: 15
     containerized_deployment: true
     osd_group_name: osds
+    switch_to_containers: True
 
   hosts:
     - "{{ osd_group_name|default('osds') }}"

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -192,6 +192,19 @@
     - ceph-mgr
 
 
+- name: set osd flags
+  hosts: "{{ mon_group_name | default('mons') }}[0]"
+  become: True
+  roles:
+    - ceph-defaults
+  post_tasks:
+    - name: set osd flags
+      command: "docker exec ceph-mon-{{ ansible_hostname }} ceph --cluster {{ cluster }} osd set {{ item }}"
+      with_items:
+        - noout
+        - nodeep-scrub
+
+
 - name: switching from non-containerized to containerized ceph osd
 
   vars:
@@ -343,6 +356,18 @@
       when:
         - (ceph_pgs.stdout | from_json).pgmap.num_pgs != 0
 
+
+- name: unset osd flags
+  hosts: "{{ mon_group_name | default('mons') }}[0]"
+  become: True
+  roles:
+    - ceph-defaults
+  post_tasks:
+    - name: set osd flags
+      command: "docker exec ceph-mon-{{ ansible_hostname }} ceph --cluster {{ cluster }} osd unset {{ item }}"
+      with_items:
+        - noout
+        - nodeep-scrub
 
 - name: switching from non-containerized to containerized ceph mds
 

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -40,7 +40,9 @@
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: True
   changed_when: False
-  when: not rolling_update | default(False) | bool
+  when:
+    - not rolling_update | default(False) | bool
+    - not switch_to_containers | default(False) | bool
 
 - name: include ceph_disk_cli_options_facts.yml
   include_tasks: ceph_disk_cli_options_facts.yml
@@ -102,6 +104,7 @@
   changed_when: False
   when:
     - not rolling_update | default(False) | bool
+    - not switch_to_containers | default(False) | bool
     - inventory_hostname == ansible_play_hosts_all | last
 
 - name: wait for all osd to be up


### PR DESCRIPTION
The workflow in this playbook should be the same than in rolling_update,
we should first set noout and nodeep-scrub flags before migrating the
first osd and unset osd flags after the last osd is migrated.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1848134

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 2cfaa05)