### PR TITLE
Exclude Ubuntu focal from python-routes installation.

### DIFF
--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -43,3 +43,4 @@
   when:
     - ansible_os_family == 'Debian'
     - "'ceph-mgr-dashboard' in ceph_mgr_packages"
+    - ansible_distribution_release != 'focal'


### PR DESCRIPTION
python-routes is not available in Focal and it's not needed for
Octopus ceph-mgr-dashboards module.

Fixes: #5463

I'm not sure if it need to be more inclusive, but it fixes Ubuntu Focal issue here.