### PR TITLE
dashboard: configure mgr backend before restart

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -92,6 +92,11 @@
   changed_when: false
   failed_when: false # Do not fail if the option does not exist, it only exists post-14.2.0
 
+- include_tasks: configure_dashboard_backends.yml
+  with_items: '{{ groups[mgr_group_name] | default(groups[mon_group_name]) }}'
+  vars:
+    dashboard_backend: '{{ item }}'
+
 - name: disable mgr dashboard module (restart)
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} mgr module disable dashboard"
   delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -164,11 +169,6 @@
   run_once: true
   changed_when: false
   when: dashboard_frontend_vip is defined and dashboard_frontend_vip |length > 0
-
-- include_tasks: configure_dashboard_backends.yml
-  with_items: '{{ groups[mgr_group_name] | default(groups[mon_group_name]) }}'
-  vars:
-    dashboard_backend: '{{ item }}'
 
 - name: dashboard object gateway management frontend
   when: groups.get(rgw_group_name, []) | length > 0


### PR DESCRIPTION
We need to set the mgr dashboard server ip address before restarting the
dashboard module otherwise we can try to bind the dashboard module on an
already used address.
We already do this configuration for the dashboard port value and ssl
setup so we should do the same for server address too.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1851455

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>