### PR TITLE
rolling_update: add any_errors_fatal

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -51,6 +51,7 @@
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
     - "{{ grafana_server_group_name|default('grafana-server') }}"
 
+  any_errors_fatal: True
   become: True
   gather_facts: False
   vars:


### PR DESCRIPTION
If a failure occurs in ceph-validate, the upgrade playbook keeps running
where we expect it to fail.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>