### PR TITLE
facts: explicitly disable facter and ohai

### DIFF
--- a/infrastructure-playbooks/add-mon.yml
+++ b/infrastructure-playbooks/add-mon.yml
@@ -16,12 +16,20 @@
 
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
     - import_role:
         name: ceph-defaults
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: true
       with_items: "{{ groups[mon_group_name] }}"

--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -30,6 +30,10 @@
 
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when: not delegate_facts_host | bool
 
     - import_role:
@@ -37,6 +41,10 @@
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items:
@@ -63,6 +71,10 @@
 
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when: not delegate_facts_host | bool
 
     - import_role:
@@ -70,6 +82,10 @@
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items:

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -44,10 +44,18 @@
 
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: true
       with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"

--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -27,10 +27,18 @@
     # pre-tasks for following import -
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['all'] | difference(groups.get(client_group_name | default('clients'), [])) }}"

--- a/infrastructure-playbooks/filestore-to-bluestore.yml
+++ b/infrastructure-playbooks/filestore-to-bluestore.yml
@@ -12,6 +12,10 @@
   tasks:
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups[mon_group_name] }}"
@@ -279,6 +283,10 @@
 
         - name: refresh ansible devices fact
           setup:
+            gather_subset:
+              - 'all'
+              - '!facter'
+              - '!ohai'
             filter: ansible_devices
           when: osd_auto_discovery | bool
 

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -61,6 +61,10 @@
     - block:
         - name: get nfs nodes ansible facts
           setup:
+            gather_subset:
+              - 'all'
+              - '!facter'
+              - '!ohai'
           delegate_to: "{{ item }}"
           delegate_facts: True
           with_items: "{{ groups[nfs_group_name] }}"

--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -45,6 +45,10 @@
     - block:
         - name: get nfs nodes ansible facts
           setup:
+            gather_subset:
+              - 'all'
+              - '!facter'
+              - '!ohai'
           delegate_to: "{{ item }}"
           delegate_facts: True
           with_items: "{{ groups[nfs_group_name] }}"
@@ -249,6 +253,10 @@
 
   - name: gather monitors facts
     setup:
+      gather_subset:
+        - 'all'
+        - '!facter'
+        - '!ohai'
     delegate_to: "{{ item }}"
     delegate_facts: True
     with_items: "{{ groups.get(mon_group_name | default('mons')) }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -64,10 +64,18 @@
 
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"

--- a/infrastructure-playbooks/shrink-rgw.yml
+++ b/infrastructure-playbooks/shrink-rgw.yml
@@ -47,6 +47,10 @@
   gather_facts: false
   tasks:
     - setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
 
 - hosts: mons[0]
   become: true

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -47,6 +47,10 @@
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['all'] | difference(groups.get(client_group_name, [])) }}"

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -28,11 +28,19 @@
     # pre-tasks for following import -
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
       tags: always
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -32,11 +32,19 @@
 
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when:
         - not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"


### PR DESCRIPTION
By default, ansible gathers facts from facter and ohai if installed on
the remote nodes, given we don't need them, let's exclude these facts
from our facts gathering

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>