### PR TITLE
tests: enforce pytest-rerunfailures version

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,4 +8,4 @@ Jinja2>=2.10
 netaddr
 mock
 jmespath
-pytest-rerunfailures
+pytest-rerunfailures<9.0


### PR DESCRIPTION
This commit enforces the pytest-rerunfailures installed so it's <9.0

This is to avoid the following error:

```
ERROR: pytest-rerunfailures 9.0 has requirement pytest>=5.0, but you'll have pytest 4.6.11 which is incompatible.
```

latest version of pytest-rerunfailures isn't compatible with the version
of pytest we are using.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>