### PR TITLE
radosgw: remove INST_PORT environment variable

### DIFF
--- a/roles/ceph-config/tasks/rgw_systemd_environment_file.yml
+++ b/roles/ceph-config/tasks/rgw_systemd_environment_file.yml
@@ -16,7 +16,6 @@
     mode: "0644"
     content: |
       INST_NAME={{ item.instance_name }}
-      INST_PORT={{ item.radosgw_frontend_port }}
   with_items: "{{ rgw_instances }}"
   when:
     - containerized_deployment | bool

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -42,7 +42,6 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -e CEPH_DAEMON=RGW \
   -e CLUSTER={{ cluster }} \
   -e RGW_NAME={{ ansible_hostname }}.${INST_NAME} \
-  -e RGW_CIVETWEB_PORT=${INST_PORT} \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
   --name=ceph-rgw-{{ ansible_hostname }}-${INST_NAME} \
   {{ ceph_rgw_docker_extra_env }} \


### PR DESCRIPTION
This variable isn't consumed by the container so we can remove it.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>