### PR TITLE
doc: fix warning treated as an error

### DIFF
--- a/docs/source/day-2/upgrade.rst
+++ b/docs/source/day-2/upgrade.rst
@@ -1,5 +1,5 @@
 Upgrading the ceph cluster
--------------------
+--------------------------
 
 ceph-ansible provides a playbook in ``infrastructure-playbooks`` for upgrading a Ceph cluster: ``rolling_update.yml``.
 


### PR DESCRIPTION
Typical error:

```
Warning, treated as error:
/home/jenkins-build/build/workspace/ceph-ansible-docs-pull-requests/docs/source/day-2/upgrade.rst:2:Title underline too short.
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>