### PR TITLE
[skip ci] tests: update nfs-ganesha to V3.3-stable

### DIFF
--- a/tests/functional/all_daemons/group_vars/nfss
+++ b/tests/functional/all_daemons/group_vars/nfss
@@ -8,4 +8,4 @@ ganesha_conf_overrides: |
 nfs_ganesha_stable: true
 nfs_ganesha_dev: false
 nfs_ganesha_flavor: "ceph_master"
-nfs_ganesha_stable_branch: "V2.7-stable"
+nfs_ganesha_stable_branch: "V3.3-stable"


### PR DESCRIPTION
not really needed in master, commit intended to be backported in octopus
branch.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>