### PR TITLE
[skip ci] tests: remove nfs_ganesha_stable_branch variable

### DIFF
--- a/tests/functional/all_daemons/group_vars/nfss
+++ b/tests/functional/all_daemons/group_vars/nfss
@@ -8,4 +8,3 @@ ganesha_conf_overrides: |
 nfs_ganesha_stable: true
 nfs_ganesha_dev: false
 nfs_ganesha_flavor: "ceph_master"
-nfs_ganesha_stable_branch: "V3.3-stable"


### PR DESCRIPTION
We don't need to override this variable in the group_vars but use the
default value instead.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>