### PR TITLE
[skip ci] tests: reenable nfs-ganesha testing

### DIFF
--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -23,8 +23,8 @@ rgw0
 client0
 client1
 
-#[nfss]
-#nfs0
+[nfss]
+nfs0
 
 [rbdmirrors]
 rbd-mirror0

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -8,7 +8,7 @@ mon_vms: 3
 osd_vms: 3
 mds_vms: 3
 rgw_vms: 1
-nfs_vms: 0
+nfs_vms: 1
 grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2


### PR DESCRIPTION
This re-adds the nfs-ganesha testing in non containerized deployment.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>