### PR TITLE
doc: add stable-5.0 note in release section

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -79,6 +79,8 @@ The ``master`` branch should be considered experimental and used with caution.
 
 - ``stable-4.0`` Supports Ceph version ``nautilus``. This branch requires Ansible version ``2.8``.
 
+- ``stable-5.0`` Supports Ceph version ``octopus``. This branch requires Ansible version ``2.9``.
+
 - ``master`` Supports the master branch of Ceph. This branch requires Ansible version ``2.8``.
 
 .. NOTE:: ``stable-3.0`` and ``stable-3.1`` branches of ceph-ansible are deprecated and no longer maintained.


### PR DESCRIPTION
This commit adds the missing stable-5.0 details about what it is
supported in this branch regarding ceph/ansible.

Fixes: #5519

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>