### PR TITLE
facts: explicitly disable facter and ohai (bp #5486)

### DIFF
--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -26,11 +26,19 @@
 
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when:
         - not delegate_facts_host | bool
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -59,6 +59,10 @@
     - block:
         - name: get nfs nodes ansible facts
           setup:
+            gather_subset:
+              - 'all'
+              - '!facter'
+              - '!ohai'
           delegate_to: "{{ item }}"
           delegate_facts: True
           with_items: "{{ groups[nfs_group_name] }}"

--- a/infrastructure-playbooks/purge-docker-cluster.yml
+++ b/infrastructure-playbooks/purge-docker-cluster.yml
@@ -46,6 +46,10 @@
     - block:
         - name: get nfs nodes ansible facts
           setup:
+            gather_subset:
+              - 'all'
+              - '!facter'
+              - '!ohai'
           delegate_to: "{{ item }}"
           delegate_facts: True
           with_items: "{{ groups[nfs_group_name] }}"
@@ -367,6 +371,10 @@
   post_tasks:
     - name: gather monitors facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups.get(mon_group_name | default('mons')) }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -66,10 +66,18 @@
 
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -48,6 +48,10 @@
   post_tasks:
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['all'] | difference(groups.get(client_group_name, [])) }}"

--- a/site-docker.yml.sample
+++ b/site-docker.yml.sample
@@ -24,11 +24,19 @@
   pre_tasks:
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when: not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
       tags: always
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -53,11 +53,19 @@
 
     - name: gather facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       when:
         - not delegate_facts_host | bool or inventory_hostname in groups.get(client_group_name, [])
 
     - name: gather and delegate facts
       setup:
+        gather_subset:
+          - 'all'
+          - '!facter'
+          - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
       with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"


### PR DESCRIPTION
By default, ansible gathers facts from facter and ohai if installed on
the remote nodes, given we don't need them, let's exclude these facts
from our facts gathering

Backport: #5486

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit c95adc564b8be6f9f9b1ba8568072daf39da7a2c)