### PR TITLE
play: remove backward compatibility group name

### DIFF
--- a/infrastructure-playbooks/gather-ceph-logs.yml
+++ b/infrastructure-playbooks/gather-ceph-logs.yml
@@ -7,7 +7,6 @@
   - rbdmirrors
   - clients
   - mgrs
-  - iscsi-gws
   - iscsigws
 
   gather_facts: false

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -10,7 +10,6 @@
   - rbdmirrors
   - clients
   - iscsigws
-  - iscsi-gws # for backward compatibility only!
   - mgrs
   - grafana-server
 

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -11,7 +11,6 @@
   - clients
   - mgrs
   - iscsigws
-  - iscsi-gws # for backward compatibility only!
   - grafana-server
   - rgwloadbalancers
 


### PR DESCRIPTION
It's time to remove this old group name.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>