### PR TITLE
rgw: set container memory limit to 4g

### DIFF
--- a/group_vars/rgws.yml.sample
+++ b/group_vars/rgws.yml.sample
@@ -84,7 +84,7 @@ dummy:
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_rgw_docker_extra_env' variable.
-#ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
+#ceph_rgw_docker_memory_limit: "4096m"
 #ceph_rgw_docker_cpu_limit: 8
 #ceph_rgw_docker_cpuset_cpus: "0,2,4,6,8,10,12,14,16"
 #ceph_rgw_docker_cpuset_mems: "0"

--- a/roles/ceph-rgw/defaults/main.yml
+++ b/roles/ceph-rgw/defaults/main.yml
@@ -76,7 +76,7 @@ copy_admin_key: false
 # For the whole list of limits you can apply see: docs.docker.com/engine/admin/resource_constraints
 # Default values are based from: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/2/html/red_hat_ceph_storage_hardware_guide/minimum_recommendations
 # These options can be passed using the 'ceph_rgw_docker_extra_env' variable.
-ceph_rgw_docker_memory_limit: "{{ ansible_memtotal_mb }}m"
+ceph_rgw_docker_memory_limit: "4096m"
 ceph_rgw_docker_cpu_limit: 8
 #ceph_rgw_docker_cpuset_cpus: "0,2,4,6,8,10,12,14,16"
 #ceph_rgw_docker_cpuset_mems: "0"


### PR DESCRIPTION
This commit changes the container memory limit for rgw daemons.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1707488

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>