### PR TITLE
defaults: remove legacy

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -486,9 +486,14 @@ dummy:
 ###############
 # NFS-GANESHA #
 ###############
-
-# Confiure the type of NFS gatway access.  At least one must be enabled for an
-# NFS role to be useful
+#
+# Access type options
+#
+# Enable NFS File access
+# If set to true, then ganesha is set up to export the root of the
+# Ceph filesystem, and ganesha's attribute and directory caching is disabled
+# as much as possible since libcephfs clients also caches the same
+# information.
 #
 # Set this to true to enable File access via NFS.  Requires an MDS role.
 #nfs_file_gw: false

--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -31,19 +31,6 @@ dummy:
 # can be set by 'ceph_nfs_service_suffix'
 # ceph_nfs_service_suffix: ansible_hostname
 
-#######################
-# Access type options #
-#######################
-# These are currently in ceph-common defaults because nfs_obj_gw shared with ceph-rgw
-# Enable NFS File access
-# If set to true, then ganesha is set up to export the root of the
-# Ceph filesystem, and ganesha's attribute and directory caching is disabled
-# as much as possible since libcephfs clients also caches the same
-# information.
-#nfs_file_gw: false
-# Enable NFS Object access
-#nfs_obj_gw: true
-
 ######################
 # NFS Ganesha Config #
 ######################

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -486,9 +486,14 @@ ceph_iscsi_config_dev: false
 ###############
 # NFS-GANESHA #
 ###############
-
-# Confiure the type of NFS gatway access.  At least one must be enabled for an
-# NFS role to be useful
+#
+# Access type options
+#
+# Enable NFS File access
+# If set to true, then ganesha is set up to export the root of the
+# Ceph filesystem, and ganesha's attribute and directory caching is disabled
+# as much as possible since libcephfs clients also caches the same
+# information.
 #
 # Set this to true to enable File access via NFS.  Requires an MDS role.
 #nfs_file_gw: false

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -478,9 +478,14 @@ health_osd_check_delay: 10
 ###############
 # NFS-GANESHA #
 ###############
-
-# Confiure the type of NFS gatway access.  At least one must be enabled for an
-# NFS role to be useful
+#
+# Access type options
+#
+# Enable NFS File access
+# If set to true, then ganesha is set up to export the root of the
+# Ceph filesystem, and ganesha's attribute and directory caching is disabled
+# as much as possible since libcephfs clients also caches the same
+# information.
 #
 # Set this to true to enable File access via NFS.  Requires an MDS role.
 nfs_file_gw: false

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -23,19 +23,6 @@ ceph_nfs_enable_service: true
 # can be set by 'ceph_nfs_service_suffix'
 # ceph_nfs_service_suffix: ansible_hostname
 
-#######################
-# Access type options #
-#######################
-# These are currently in ceph-common defaults because nfs_obj_gw shared with ceph-rgw
-# Enable NFS File access
-# If set to true, then ganesha is set up to export the root of the
-# Ceph filesystem, and ganesha's attribute and directory caching is disabled
-# as much as possible since libcephfs clients also caches the same
-# information.
-nfs_file_gw: false
-# Enable NFS Object access
-nfs_obj_gw: true
-
 ######################
 # NFS Ganesha Config #
 ######################


### PR DESCRIPTION
These variables aren't consummed anywhere else than in ceph-nfs role so
there is no need to have them in `ceph-defaults`'s defaults

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>