### PR TITLE
[skip ci] rhcs: default to containerized deployment

### DIFF
--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -122,14 +122,14 @@ fetch_directory: ~/ceph-ansible-keys
 # - 'distro' means that no separate repo file will be added
 #  you will get whatever version of Ceph is included in your Linux distro.
 # 'local' means that the ceph binaries will be copied over from the local machine
-ceph_origin: repository
+#ceph_origin: dummy
 #valid_ceph_origins:
 #  - repository
 #  - distro
 #  - local
 
 
-ceph_repository: rhcs
+#ceph_repository: dummy
 #valid_ceph_repository:
 #  - community
 #  - rhcs
@@ -165,7 +165,7 @@ ceph_repository: rhcs
 #
 # This version is supported on RHEL 8
 #
-ceph_rhcs_version: 5
+#ceph_rhcs_version: "{{ ceph_stable_rh_storage_version | default(5) }}"
 #valid_ceph_repository_type:
 #  - cdn
 #  - iso
@@ -209,7 +209,7 @@ ceph_rhcs_version: 5
 # flavors so far include: ceph_master, ceph_jewel, ceph_kraken, ceph_luminous
 #nfs_ganesha_flavor: "ceph_master"
 
-ceph_iscsi_config_dev: false
+#ceph_iscsi_config_dev: true # special repo for deploying iSCSI gateways
 
 
 # REPOSITORY: CUSTOM
@@ -590,7 +590,7 @@ ceph_docker_registry_auth: true
 #ceph_client_docker_registry: "{{ ceph_docker_registry }}"
 #ceph_docker_enable_centos_extra_repo: false
 #ceph_docker_on_openstack: false
-#containerized_deployment: False
+containerized_deployment: true
 #container_binary:
 #timeout_command: "{{ 'timeout --foreground -s KILL ' ~ docker_pull_timeout if (docker_pull_timeout != '0') and (ceph_docker_dev_image is undefined or not ceph_docker_dev_image) else '' }}"
 

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -1,8 +1,5 @@
-ceph_repository: rhcs
-ceph_origin: repository
-ceph_iscsi_config_dev: false
 fetch_directory: ~/ceph-ansible-keys
-ceph_rhcs_version: 5
+containerized_deployment: true
 ceph_docker_image: "rhceph/rhceph-5-rhel8"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"


### PR DESCRIPTION
Starting RHCS 5, only containerized deployment is available.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>