### PR TITLE
ceph-dashboard: copy TLS cert/key on monitor

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -25,6 +25,7 @@
         owner: root
         group: root
         mode: 0440
+      delegate_to: "{{ groups[mon_group_name][0] }}"
       when: dashboard_crt | length > 0
 
     - name: copy dashboard SSL certificate key
@@ -34,6 +35,7 @@
         owner: root
         group: root
         mode: 0440
+      delegate_to: "{{ groups[mon_group_name][0] }}"
       when: dashboard_key | length > 0
 
     - name: generate and copy self-signed certificate


### PR DESCRIPTION
The ceph-dashboard role is executed on the mgr nodes so the TLS cert/key
files are copied to those nodes.
But we are running importing the cert/key files into the ceph
configuration on the monitor.

Closes: #5557

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>