### PR TITLE
facts: fix broken facts when using --limit (bp #5544)

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -378,14 +378,16 @@
   run_once: True
   with_items:
     - "{{ groups[mon_group_name] if groups[mon_group_name] | default([]) | length > 0 else [] }}"
-    - "{{ inventory_hostname }}"
+    - "{{ groups[mds_group_name] if groups[mds_group_name] | default([]) | length > 0 else [] }}"
+    - "{{ groups[client_group_name] if groups[client_group_name] | default([]) | length > 0 else [] }}"
 
 - name: set_fact ceph_admin_command
   set_fact:
-    ceph_admin_command: "{{ ceph_run_cmd }} -n client.admin -k /etc/ceph/{{ cluster }}.client.admin.keyring"
+    ceph_admin_command: "{{ hostvars[item]['ceph_run_cmd'] }} -n client.admin -k /etc/ceph/{{ cluster }}.client.admin.keyring"
   delegate_to: "{{ item }}"
   delegate_facts: True
   run_once: True
   with_items:
     - "{{ groups[mon_group_name] if groups[mon_group_name] | default([]) | length > 0 else [] }}"
-    - "{{ inventory_hostname }}"
+    - "{{ groups[mds_group_name] if groups[mds_group_name] | default([]) | length > 0 else [] }}"
+    - "{{ groups[client_group_name] if groups[client_group_name] | default([]) | length > 0 else [] }}"


### PR DESCRIPTION
This commit fixes these tasks when --limit is used.

It makes sure the fact is set on right nodes even when the playbook is
run with `--limit`

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit f8a951f50c6a64ab3d60a1bf66ca9d2db2f6bc35)