### PR TITLE
podman: always remove container on start

### DIFF
--- a/roles/ceph-grafana/templates/grafana-server.service.j2
+++ b/roles/ceph-grafana/templates/grafana-server.service.j2
@@ -15,8 +15,8 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop grafana-server
-ExecStartPre=-/usr/bin/{{ container_binary }} rm grafana-server
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm grafana-server
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=grafana-server \
 {% if container_binary == 'podman' %}
   -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \

--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -13,8 +13,8 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-api
-ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-api
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-api
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
 {% if container_binary == 'podman' %}
   -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -13,8 +13,8 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-gw
-ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-gw
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-gw
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
 {% if container_binary == 'podman' %}
   -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -13,8 +13,8 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop tcmu-runner
-ExecStartPre=-/usr/bin/{{ container_binary }} rm tcmu-runner
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm tcmu-runner
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
 {% if container_binary == 'podman' %}
   -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -14,8 +14,8 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mds-{{ ansible_hostname }}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mds-{{ ansible_hostname }}
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mds-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
   -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -13,8 +13,8 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mgr-{{ ansible_hostname }}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mgr-{{ ansible_hostname }}
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mgr-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
   -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -11,9 +11,8 @@ After=network.target
 EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
-{% else %}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mon-%i
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mon-%i
 ExecStartPre=/bin/sh -c '"$(command -v mkdir)" -p /etc/ceph /var/lib/ceph/mon'
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
 {% if container_binary == 'podman' %}

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -12,9 +12,8 @@ After=network.target
 EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
-{% else %}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-nfs-%i
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-nfs-%i
 ExecStartPre={{ '/bin/mkdir' if ansible_os_family == 'Debian' else '/usr/bin/mkdir' }} -p /etc/ceph /etc/ganesha /var/lib/nfs/ganesha /var/log/ganesha
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}

--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -13,9 +13,8 @@ After=network.target
 EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
-{% else %}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm -f node-exporter
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm -f node-exporter
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
 {% if container_binary == 'podman' %}
   -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -15,8 +15,8 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-osd-%i
-ExecStartPre=-/usr/bin/{{ container_binary }} rm -f ceph-osd-%i
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm -f ceph-osd-%i
 ExecStart={% if ceph_osd_numactl_opts != "" %}
 numactl \
 {{ ceph_osd_numactl_opts }} \

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -14,9 +14,8 @@ WorkingDirectory={{ alertmanager_data_dir }}
 EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
-{% else %}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm -f alertmanager
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm -f alertmanager
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=alertmanager \
 {% if container_binary == 'podman' %}
   -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -13,9 +13,8 @@ After=network.target
 EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
-{% else %}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm -f prometheus
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm -f prometheus
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=prometheus \
 {% if container_binary == 'podman' %}
   -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -13,8 +13,8 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rbd-mirror-{{ ansible_hostname }}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rbd-mirror-{{ ansible_hostname }}
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
   -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -14,8 +14,8 @@ EnvironmentFile=/var/lib/ceph/radosgw/{{ cluster }}-%i/EnvironmentFile
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
-ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
   -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \


### PR DESCRIPTION
In case of failure, the systemd ExecStop isn't executed so the container
isn't removed. After a reboot of a failed node, the container doesn't
start because the old container is still present in created state.
We should always try to remove the container in ExecStartPre for this
situation.
A normal reboot doesn't trigger this issue and this also doesn't affect
nodes running containers via docker.
This behaviour was introduced by d43769d.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1858865

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>