### PR TITLE
[skip ci] crash: rm container in ExecPreStart even with docker

### DIFF
--- a/roles/ceph-crash/templates/ceph-crash.service.j2
+++ b/roles/ceph-crash/templates/ceph-crash.service.j2
@@ -10,8 +10,8 @@ After=network.target
 [Service]
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
-ExecStartPre=-/usr/bin/{{ container_binary }} rm -f ceph-crash-%i
 {% endif %}
+ExecStartPre=-/usr/bin/{{ container_binary }} rm -f ceph-crash-%i
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-crash-%i \
 {% if container_binary == 'podman' %}
 -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \


### PR DESCRIPTION
We should ensure the container is removed in `ExecPreStart` even when
`{{ container_binary }}` is docker.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>