### PR TITLE
ceph-handler: add missing condition on ceph-crash

### DIFF
--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -69,6 +69,13 @@
     - name: ceph crash handler
       include_tasks: handler_crash.yml
       listen: "restart ceph crash"
+      when:
+        - inventory_hostname in groups.get(mon_group_name, [])
+          or inventory_hostname in groups.get(mgr_group_name, [])
+          or inventory_hostname in groups.get(osd_group_name, [])
+          or inventory_hostname in groups.get(mds_group_name, [])
+          or inventory_hostname in groups.get(rgw_group_name, [])
+          or inventory_hostname in groups.get(rbdmirror_group_name, [])
 
     - name: remove tempdir for scripts
       file:

--- a/roles/ceph-handler/tasks/check_running_containers.yml
+++ b/roles/ceph-handler/tasks/check_running_containers.yml
@@ -85,3 +85,10 @@
   changed_when: false
   failed_when: false
   check_mode: no
+  when:
+    - inventory_hostname in groups.get(mon_group_name, [])
+      or inventory_hostname in groups.get(mgr_group_name, [])
+      or inventory_hostname in groups.get(osd_group_name, [])
+      or inventory_hostname in groups.get(mds_group_name, [])
+      or inventory_hostname in groups.get(rgw_group_name, [])
+      or inventory_hostname in groups.get(rbdmirror_group_name, [])

--- a/roles/ceph-handler/tasks/check_socket_non_container.yml
+++ b/roles/ceph-handler/tasks/check_socket_non_container.yml
@@ -223,3 +223,10 @@
   failed_when: false
   check_mode: no
   register: crash_process
+  when:
+    - inventory_hostname in groups.get(mon_group_name, [])
+      or inventory_hostname in groups.get(mgr_group_name, [])
+      or inventory_hostname in groups.get(osd_group_name, [])
+      or inventory_hostname in groups.get(mds_group_name, [])
+      or inventory_hostname in groups.get(rgw_group_name, [])
+      or inventory_hostname in groups.get(rbdmirror_group_name, [])


### PR DESCRIPTION
The ceph-crash tasks present in the ceph-handler role don't need to be
executed on all nodes.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>