### PR TITLE
ceph-handler: remove iscsigws restart scripts

### DIFF
--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -16,8 +16,6 @@
         - "restart ceph nfss"
         - "restart ceph rbdmirrors"
         - "restart ceph mgrs"
-        - "restart ceph tcmu-runner"
-        - "restart ceph rbd-target-api-gw"
       register: tmpdirpath
       when: tmpdirpath is not defined or tmpdirpath.path is not defined or tmpdirpath.state=="absent"
 
@@ -82,7 +80,5 @@
         - "restart ceph nfss"
         - "restart ceph rbdmirrors"
         - "restart ceph mgrs"
-        - "restart ceph tcmu-runner"
-        - "restart ceph rbd-target-api-gw"
       register: tmpdirpath
       when: tmpdirpath is defined

--- a/roles/ceph-handler/tasks/handler_rbd_target_api_gw.yml
+++ b/roles/ceph-handler/tasks/handler_rbd_target_api_gw.yml
@@ -3,16 +3,10 @@
   set_fact:
     _rbd_target_api_handler_called: True
 
-- name: copy rbd-target-api restart script
-  template:
-    src: restart_rbd_target_api.sh.j2
-    dest: "{{ tmpdirpath.path }}/restart_rbd_target_api.sh"
-    owner: root
-    group: root
-    mode: 0750
-
 - name: restart rbd-target-api
-  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_rbd_target_api.sh
+  service:
+    name: rbd-target-api
+    state: restarted
   when:
     - ceph_rbd_target_api_stat.get('rc') == 0
     - hostvars[item]['_rbd_target_api_handler_called'] | default(False) | bool
@@ -29,16 +23,10 @@
   set_fact:
     _rbd_target_gw_handler_called: True
 
-- name: copy rbd-target-gw restart script
-  template:
-    src: restart_rbd_target_gw.sh.j2
-    dest: "{{ tmpdirpath.path }}/restart_rbd_target_gw.sh"
-    owner: root
-    group: root
-    mode: 0750
-
 - name: restart rbd-target-gw
-  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_rbd_target_gw.sh
+  service:
+    name: rbd-target-gw
+    state: restarted
   when:
     - ceph_rbd_target_gw_stat.get('rc') == 0
     - hostvars[item]['_rbd_target_gw_handler_called'] | default(False) | bool

--- a/roles/ceph-handler/tasks/handler_tcmu_runner.yml
+++ b/roles/ceph-handler/tasks/handler_tcmu_runner.yml
@@ -3,16 +3,10 @@
   set_fact:
     _tcmu_runner_handler_called: True
 
-- name: copy tcmu-runner restart script
-  template:
-    src: restart_tcmu_runner.sh.j2
-    dest: "{{ tmpdirpath.path }}/restart_tcmu_runner.sh"
-    owner: root
-    group: root
-    mode: 0750
-
 - name: restart tcmu-runner
-  command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_tcmu_runner.sh
+  service:
+    name: tcmu-runner
+    state: restarted
   when:
     - ceph_tcmu_runner_stat.get('rc') == 0
     - hostvars[item]['_tcmu_runner_handler_called'] | default(False) | bool

--- a/roles/ceph-handler/templates/restart_rbd_target_api.sh.j2
+++ b/roles/ceph-handler/templates/restart_rbd_target_api.sh.j2
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-systemctl restart rbd-target-api

--- a/roles/ceph-handler/templates/restart_rbd_target_gw.sh.j2
+++ b/roles/ceph-handler/templates/restart_rbd_target_gw.sh.j2
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-systemctl restart rbd-target-gw

--- a/roles/ceph-handler/templates/restart_tcmu_runner.sh.j2
+++ b/roles/ceph-handler/templates/restart_tcmu_runner.sh.j2
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-systemctl restart tcmu-runner


### PR DESCRIPTION
The iscsigws restart scripts for tcmu-runner and rbd-target-{api,gw}
services only call the systemctl restart command.
We don't really need to copy a shell script to do it when we can use
the ansible service module instead.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>