### PR TITLE
[skip ci] ceph-facts: remove mds_name fact

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -172,10 +172,6 @@
     set_fact:
       fsid: "{{ cluster_uuid.stdout }}"
 
-- name: set_fact mds_name ansible_hostname
-  set_fact:
-    mds_name: "{{ ansible_hostname }}"
-
 - name: resolve device link(s)
   command: readlink -f {{ item }}
   changed_when: false

--- a/roles/ceph-handler/templates/restart_mds_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_mds_daemon.sh.j2
@@ -2,7 +2,7 @@
 
 RETRIES="{{ handler_health_mds_check_retries }}"
 DELAY="{{ handler_health_mds_check_delay }}"
-MDS_NAME="{{ mds_name }}"
+MDS_NAME="{{ ansible_hostname }}"
 {% if containerized_deployment %}
 DOCKER_EXEC="{{ container_binary }} exec ceph-mds-{{ ansible_hostname }}"
 {% endif %}

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -8,7 +8,7 @@
     mode: "{{ ceph_directories_mode }}"
   with_items:
     - /var/lib/ceph/bootstrap-mds/
-    - /var/lib/ceph/mds/{{ cluster }}-{{ mds_name }}
+    - /var/lib/ceph/mds/{{ cluster }}-{{ ansible_hostname }}
 
 - name: get keys from monitors
   command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"

--- a/roles/ceph-mds/tasks/non_containerized.yml
+++ b/roles/ceph-mds/tasks/non_containerized.yml
@@ -21,15 +21,15 @@
     - ansible_os_family in ['Suse', 'RedHat']
 
 - name: create mds keyring
-  command: ceph --cluster {{ cluster }} --name client.bootstrap-mds --keyring /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring auth get-or-create mds.{{ mds_name }} osd 'allow rwx' mds 'allow' mon 'allow profile mds' -o /var/lib/ceph/mds/{{ cluster }}-{{ mds_name }}/keyring
+  command: ceph --cluster {{ cluster }} --name client.bootstrap-mds --keyring /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring auth get-or-create mds.{{ ansible_hostname }} osd 'allow rwx' mds 'allow' mon 'allow profile mds' -o /var/lib/ceph/mds/{{ cluster }}-{{ ansible_hostname }}/keyring
   args:
-    creates: /var/lib/ceph/mds/{{ cluster }}-{{ mds_name }}/keyring
+    creates: /var/lib/ceph/mds/{{ cluster }}-{{ ansible_hostname }}/keyring
   changed_when: false
   when: cephx
 
 - name: set mds key permissions
   file:
-    path: /var/lib/ceph/mds/{{ cluster }}-{{ mds_name }}/keyring
+    path: /var/lib/ceph/mds/{{ cluster }}-{{ ansible_hostname }}/keyring
     owner: "ceph"
     group: "ceph"
     mode: "0600"
@@ -55,7 +55,7 @@
 
 - name: start and add that the metadata service to the init sequence
   service:
-    name: ceph-mds@{{ mds_name }}
+    name: ceph-mds@{{ ansible_hostname }}
     state: started
     enabled: yes
     masked: no


### PR DESCRIPTION
The mds_name fact always gets the ansible_hostname value so we don't
need to have a dedicated fact for this and use the ansible_hostname fact
instead.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>