### PR TITLE
tests: (lvm_setup.yml), don't shrink lvol

### DIFF
--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -14,10 +14,12 @@
         path: /run/ostree-booted
       register: stat_ostree
       tags: always
+
     - name: set_fact is_atomic
       set_fact:
         is_atomic: '{{ stat_ostree.stat.exists }}'
       tags: always
+
     # Some images may not have lvm2 installed
     - name: install lvm2
       package:
@@ -26,22 +28,26 @@
       register: result
       until: result is succeeded
       when: not is_atomic | bool
+
     - name: create volume group
       lvg:
         vg: test_group
         pvs: "{{ pv_devices[0] | default('/dev/sdb') }}"
+
     - name: create logical volume 1
       lvol:
         vg: test_group
         lv: data-lv1
         size: 50%FREE
         shrink: false
+
     - name: create logical volume 2
       lvol:
         vg: test_group
         lv: data-lv2
         size: 100%FREE
         shrink: false
+
     - name: partition  "{{ pv_devices[1] | default('/dev/sdc') }}"for journals
       parted:
         device: "{{ pv_devices[1] | default('/dev/sdc') }}"
@@ -52,6 +58,7 @@
         label: gpt
         state: present
       tags: partitions
+
     - name: partition  "{{ pv_devices[1] | default('/dev/sdc') }}"for journals
       parted:
         device: "{{ pv_devices[1] | default('/dev/sdc') }}"
@@ -62,10 +69,12 @@
         state: present
         label: gpt
       tags: partitions
+
     - name: create journals vg from  "{{ pv_devices[1] | default('/dev/sdc') }}2"
       lvg:
         vg: journals
         pvs: "{{ pv_devices[1] | default('/dev/sdc') }}2"
+
     - name: create journal1 lv
       lvol:
         vg: journals

--- a/tests/functional/lvm_setup.yml
+++ b/tests/functional/lvm_setup.yml
@@ -35,11 +35,13 @@
         vg: test_group
         lv: data-lv1
         size: 50%FREE
+        shrink: false
     - name: create logical volume 2
       lvol:
         vg: test_group
         lv: data-lv2
         size: 100%FREE
+        shrink: false
     - name: partition  "{{ pv_devices[1] | default('/dev/sdc') }}"for journals
       parted:
         device: "{{ pv_devices[1] | default('/dev/sdc') }}"
@@ -69,3 +71,4 @@
         vg: journals
         lv: journal1
         size: 100%FREE
+        shrink: false


### PR DESCRIPTION
when rerunning lvm_setup.yml on existing cluster with OSDs already
deployed, it fails like following:

```
fatal: [osd0]: FAILED! => changed=false
  msg: Sorry, no shrinking of data-lv2 to 0 permitted.
```

because we are asking `lvol` module to create a volume on an empty VG
with size extents = `100%FREE`.

The default behavior of `lvol` is to shrink the volume if the LV's current
size is greater than the requested size.

Given the requested size is calculated like this:

`size_requested = size_percent * this_vg['free'] / 100`

in our case, it is similar to:

`size_requested = 100 * 0 / 100` which basically means `0`

So the current LV size is well greater than the requested size which
leads the module to attempt to shrink it to 0 which isn't obviously now
allowed.

Adding `shrink: false` to the module calls fixes this issue.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>