### PR TITLE
tox: remove ubuntu references

### DIFF
--- a/tox-external_clients.ini
+++ b/tox-external_clients.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {centos,ubuntu}-{container,non_container}-external_clients
+envlist = centos-{container,non_container}-external_clients
 
 skipsdist = True
 

--- a/tox-filestore_to_bluestore.ini
+++ b/tox-filestore_to_bluestore.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {centos,ubuntu}-{container,non_container}-filestore_to_bluestore
+envlist = centos-{container,non_container}-filestore_to_bluestore
 
 skipsdist = True
 
@@ -22,10 +22,8 @@ setenv=
   # Set the vagrant box image to use
   centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
   centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
-  ubuntu: CEPH_ANSIBLE_VAGRANT_BOX = guits/ubuntu-bionic64
 
   # Set the ansible inventory host file to be used according to which distrib we are running on
-  ubuntu: _INVENTORY = hosts-ubuntu
   INVENTORY = {env:_INVENTORY:hosts}
   container: CONTAINER_DIR = /container
   container: PLAYBOOK = site-container.yml.sample

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {centos,ubuntu}-{container,non_container}-update
+envlist = centos-{container,non_container}-update
 
 skipsdist = True
 
@@ -22,10 +22,7 @@ setenv=
   # Set the vagrant box image to use
   centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
   centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
-  ubuntu: CEPH_ANSIBLE_VAGRANT_BOX = guits/ubuntu-bionic64
 
-  # Set the ansible inventory host file to be used according to which distrib we are running on
-  ubuntu: _INVENTORY = hosts-ubuntu
   INVENTORY = {env:_INVENTORY:hosts}
   container: CONTAINER_DIR = /container
   container: PLAYBOOK = site-container.yml.sample

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = {centos,ubuntu}-{container,non_container}-{all_daemons,collocation,lvm_osds,shrink_mon,shrink_osd,shrink_mgr,shrink_mds,shrink_rbdmirror,shrink_rgw,lvm_batch,add_mons,add_osds,add_mgrs,add_mdss,add_rbdmirrors,add_rgws,rgw_multisite,purge,storage_inventory,lvm_auto_discovery,all_in_one,cephadm_adopt}
-  {centos,ubuntu}-container-{ooo_collocation}
-  {centos,ubuntu}-non_container-{switch_to_containers}
+envlist = centos-{container,non_container}-{all_daemons,collocation,lvm_osds,shrink_mon,shrink_osd,shrink_mgr,shrink_mds,shrink_rbdmirror,shrink_rgw,lvm_batch,add_mons,add_osds,add_mgrs,add_mdss,add_rbdmirrors,add_rgws,rgw_multisite,purge,storage_inventory,lvm_auto_discovery,all_in_one,cephadm_adopt}
+  centos-container-{ooo_collocation}
+  centos-non_container-{switch_to_containers}
   infra_lv_create
   migrate_ceph_disk_to_ceph_volume
 
@@ -332,10 +332,6 @@ setenv=
   # Set the vagrant box image to use
   centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
   centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
-  ubuntu: CEPH_ANSIBLE_VAGRANT_BOX = guits/ubuntu-bionic64
-
-  # Set the ansible inventory host file to be used according to which distrib we are running on
-  ubuntu: _INVENTORY = hosts-ubuntu
   INVENTORY = {env:_INVENTORY:hosts}
   container: CONTAINER_DIR = /container
   container: PLAYBOOK = site-container.yml.sample


### PR DESCRIPTION
since we've dropped ubuntu testing on PRs and nightlies, we don't need
these references anymore in tox files.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>