### PR TITLE
[skip ci] rolling_update: restart active mds after the upgrade

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -563,6 +563,7 @@
         name: ceph-mds@{{ ansible_hostname }}
         enabled: no
         masked: yes
+      when: not containerized_deployment | bool
 
     - import_role:
         name: ceph-handler
@@ -577,6 +578,18 @@
     - import_role:
         name: ceph-mds
 
+    - name: restart ceph mds
+      systemd:
+        name: ceph-mds@{{ ansible_hostname }}
+        state: restarted
+        enabled: yes
+        masked: no
+      when: not containerized_deployment | bool
+
+    - name: restart active mds
+      command: "{{ container_binary }} stop ceph-mds-{{ ansible_hostname }}"
+      changed_when: false
+      when: containerized_deployment | bool
 
 - name: upgrade standbys ceph mdss cluster
   vars:
@@ -596,6 +609,7 @@
         name: ceph-mds@{{ ansible_hostname }}
         enabled: no
         masked: yes
+      when: not containerized_deployment | bool
 
     - import_role:
         name: ceph-handler


### PR DESCRIPTION
In addition of 155e2a2, the active mds daemons isn't stop/start
correctly as opposed as the other services so that daemon doesn't come
back after the upgrade.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1861688

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>