### PR TITLE
tests: pin pytest-forked to 1.2.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,7 @@
 # These are Python requirements needed to run the functional tests
 six==1.10.0
 testinfra==3.4.0
+pytest-forked==1.2.0
 pytest-xdist==1.27.0
 pytest==3.6.1
 ansible~=2.6,<2.7


### PR DESCRIPTION
The pytest-forked 1.3.0 release isn't compatible with the pytest release
we are using in that branch.

-----------------------
pytest-forked 1.3.0 requires pytest>=3.10, but you'll have pytest 3.6.1
which is incompatible.
-----------------------

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>