### PR TITLE
tests: install pyyaml on osd nodes

### DIFF
--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -74,3 +74,15 @@
         size: +100%FREE
         resizefs: yes
       when: is_atomic | bool
+
+    # https://tracker.ceph.com/issues/46759
+    - name: install pyyaml for ceph-volume
+      package:
+        name: "{{ 'python3-pyyaml' if ansible_distribution_major_version | int == 8 else 'python36-PyYAML' }}"
+      register: result
+      until: result is succeeded
+      when:
+        - not is_atomic | bool
+        - ansible_distribution == 'CentOS'
+        - inventory_hostname in groups.get('osds', [])
+        - not containerized_deployment | default(false) | bool


### PR DESCRIPTION
Due to [1], ceph-volume has now a dependency on pyyaml but it's not
installed by default via the package dependency.
This patch only add the required package on non containerized
deployment and as temporary workaround for the CI.

[1] https://tracker.ceph.com/issues/46759

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>