### PR TITLE
Use the parameters from the vars file instead

### DIFF
--- a/roles/ceph-container-common/tasks/fetch_image.yml
+++ b/roles/ceph-container-common/tasks/fetch_image.yml
@@ -82,13 +82,12 @@
     - ceph_mon_inspect.get('rc') == 0
 
 - name: "inspecting ceph osd container image before pulling"
-  command: "{{ container_binary }} inspect {{ (ceph_osd_inspect.stdout | from_json)[0].Image }}"
+  command: "{{ container_binary }} inspect {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
   changed_when: false
   failed_when: false
   register: ceph_osd_container_inspect_before_pull
   when:
     - osd_group_name in group_names
-    - ceph_osd_inspect.get('rc') == 0
 
 - name: "inspecting ceph rgw container image before pulling"
   command: "{{ container_binary }} inspect {{ (ceph_rgw_inspect.stdout | from_json)[0].Image }}"


### PR DESCRIPTION
Use the parameters from the vars file instead, this will fix:

https://bugzilla.redhat.com/show_bug.cgi?id=1844496

Signed-off-by: raul <rmahique@redhat.com>