### PR TITLE
dashboard: allow remote TLS cert/key copy

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -754,6 +754,7 @@ dummy:
 # We only need this for SSL (https) connections
 #dashboard_crt: ''
 #dashboard_key: ''
+#dashboard_tls_external: false
 #dashboard_grafana_api_no_ssl_verify: False
 #dashboard_rgw_api_user_id: ceph-dashboard
 #dashboard_rgw_api_admin_resource: ''

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -754,6 +754,7 @@ ceph_docker_registry_auth: true
 # We only need this for SSL (https) connections
 #dashboard_crt: ''
 #dashboard_key: ''
+#dashboard_tls_external: false
 #dashboard_grafana_api_no_ssl_verify: False
 #dashboard_rgw_api_user_id: ceph-dashboard
 #dashboard_rgw_api_admin_resource: ''

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -25,6 +25,7 @@
         owner: root
         group: root
         mode: 0440
+        remote_src: "{{ dashboard_tls_external | bool }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       when: dashboard_crt | length > 0
 
@@ -35,6 +36,7 @@
         owner: root
         group: root
         mode: 0440
+        remote_src: "{{ dashboard_tls_external | bool }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       when: dashboard_key | length > 0
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -746,6 +746,7 @@ dashboard_admin_user_ro: false
 # We only need this for SSL (https) connections
 dashboard_crt: ''
 dashboard_key: ''
+dashboard_tls_external: false
 dashboard_grafana_api_no_ssl_verify: False
 dashboard_rgw_api_user_id: ceph-dashboard
 dashboard_rgw_api_admin_resource: ''

--- a/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -75,6 +75,7 @@
     owner: "{{ grafana_uid }}"
     group: "{{ grafana_uid }}"
     mode: 0640
+    remote_src: "{{ dashboard_tls_external | bool }}"
   when:
     - grafana_crt | length > 0
     - dashboard_protocol == "https"
@@ -86,6 +87,7 @@
     owner: "{{ grafana_uid }}"
     group: "{{ grafana_uid }}"
     mode: 0440
+    remote_src: "{{ dashboard_tls_external | bool }}"
   when:
     - grafana_key | length > 0
     - dashboard_protocol == "https"


### PR DESCRIPTION
When using TLS on the ceph dashboard or grafana services, we can provide
the TLS certificate and key.
Those files should be present on the ansible controller and they will be
copyied to the right node(s).
In some situation, the TLS certificate and key could be already present
on the target node and not on the ansible controller.
For this scenario, we just need to copy the files locally (on each remote
host).

This patch adds the dashboard_tls_external variable (with default to
false) to allow users to achieve this scenario when configuring this
variable to true.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1860815

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>