### PR TITLE
purge-cluster: check if rbdmap exists

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -88,8 +88,15 @@
     - name: ensure cephfs mountpoint(s) are unmounted
       command: umount -a -t ceph
 
+    - name: check if rbdmap is still installed
+      command: command -v rbdmap
+      register: command_rbdmap
+      failed_when: false
+      changed_when: false
+
     - name: ensure rbd devices are unmapped
       command: rbdmap unmap-all
+      when: command_rbdmap.rc == 0
 
     - name: unload ceph kernel modules
       modprobe:


### PR DESCRIPTION
When running `infrastructure-playbooks/purge-cluster.yml` twice, it fails the
second time on the `ensure rbd devices are unmapped` task, because `rbdmap`
isn't installed anymore at that point.

This commit adds a check that ensures `rbdmap` is available, and skips the
`ensure rbd devices are unmapped` task if it isn't.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>