### PR TITLE
shrink_osd: add missing default value

### DIFF
--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -189,7 +189,7 @@
       until: result is succeeded
       when:
         - item.2 not in _lvm_list.keys()
-        - ceph_osd_data_json[item.2]['encrypted'] | bool
+        - ceph_osd_data_json[item.2]['encrypted'] | default(False) | bool
         - ceph_osd_data_json[item.2][item.3] is defined
 
     - name: use ceph-volume lvm zap to destroy all partitions


### PR DESCRIPTION
This commit adds a missing `| default(False)` needed to avoid error like
following :

```
fatal: [ceph01]: FAILED! =>
  msg: |-
    The conditional check 'ceph_osd_data_json[item.2]['encrypted'] | bool' failed. The error was: error while evaluating conditional (ceph_osd_data_json[item.2]['encrypted'] | bool): 'dict object' has no attribute 'encrypted'
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1862416

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>