### PR TITLE
purge-cluster: replace shell by command in a task

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -476,7 +476,7 @@
     register: ceph_lockbox_partition_to_erase_path
 
   - name: see if ceph-volume is installed
-    shell: "command -v ceph-volume"
+    command: command -v ceph-volume
     failed_when: false
     register: ceph_volume_present
 


### PR DESCRIPTION
There is no need to use `shell` here.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>