### PR TITLE
infra: add log rotation support (containers)

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -324,6 +324,8 @@ dummy:
 #mon_host_v2:
 #  suffix: ':3300'
 
+#enable_ceph_volume_debug: False
+
 ##########
 # CEPHFS #
 ##########
@@ -889,4 +891,4 @@ dummy:
 
 #container_exec_cmd:
 #docker: false
-
+#ceph_volume_debug: "{{ enable_ceph_volume_debug | ternary(1, 0)  }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -324,6 +324,8 @@ ceph_iscsi_config_dev: false
 #mon_host_v2:
 #  suffix: ':3300'
 
+#enable_ceph_volume_debug: False
+
 ##########
 # CEPHFS #
 ##########
@@ -889,4 +891,4 @@ alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alert
 
 #container_exec_cmd:
 #docker: false
-
+#ceph_volume_debug: "{{ enable_ceph_volume_debug | ternary(1, 0)  }}"

--- a/infrastructure-playbooks/filestore-to-bluestore.yml
+++ b/infrastructure-playbooks/filestore-to-bluestore.yml
@@ -217,7 +217,7 @@
                 osd_fsid: "{{ item.osd_fsid }}"
                 destroy: false
               environment:
-                CEPH_VOLUME_DEBUG: 1
+                CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
                 CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
                 CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               loop: "{{ osd_fsid_list }}"
@@ -229,7 +229,7 @@
                 data: "{{ item.device }}"
                 destroy: true
               environment:
-                CEPH_VOLUME_DEBUG: 1
+                CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
                 CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
                 CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               loop: "{{ osd_fsid_list }}"

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -492,7 +492,7 @@
       wal_vg: "{{ item.wal_vg|default(omit) }}"
       action: "zap"
     environment:
-      CEPH_VOLUME_DEBUG: 1
+      CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
     with_items: "{{ lvm_volumes }}"
     when:
       - lvm_volumes | default([]) | length > 0
@@ -503,7 +503,7 @@
       data: "{{ item }}"
       action: "zap"
     environment:
-      CEPH_VOLUME_DEBUG: 1
+      CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
     with_items: "{{ devices | default([]) }}"
     when:
       - devices | default([]) | length > 0

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -370,6 +370,9 @@
 
   tasks:
 
+  - import_role:
+      name: ceph-defaults
+
   - name: default lvm_volumes if not defined
     set_fact:
       lvm_volumes: []

--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -300,7 +300,7 @@
       wal_vg: "{{ item.wal_vg|default(omit) }}"
       action: "zap"
     environment:
-      CEPH_VOLUME_DEBUG: 1
+      CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
       CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     with_items: "{{ lvm_volumes }}"
@@ -311,7 +311,7 @@
       data: "{{ item }}"
       action: "zap"
     environment:
-      CEPH_VOLUME_DEBUG: 1
+      CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
       CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     with_items: "{{ devices | default([]) }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -408,7 +408,7 @@
     - name: scan ceph-disk osds with ceph-volume if deploying nautilus
       command: "ceph-volume --cluster={{ cluster }} simple scan --force"
       environment:
-        CEPH_VOLUME_DEBUG: 1
+        CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
       when:
         - ceph_release in ["nautilus", "octopus"]
         - not containerized_deployment | bool
@@ -416,7 +416,7 @@
     - name: activate scanned ceph-disk osds and migrate to ceph-volume if deploying nautilus
       command: "ceph-volume --cluster={{ cluster }} simple activate --all"
       environment:
-        CEPH_VOLUME_DEBUG: 1
+        CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
       when:
         - ceph_release in ["nautilus", "octopus"]
         - not containerized_deployment | bool

--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -211,7 +211,7 @@
         action: "zap"
         osd_fsid: "{{ item.1 }}"
       environment:
-        CEPH_VOLUME_DEBUG: 1
+        CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
         CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       delegate_to: "{{ item.0 }}"

--- a/infrastructure-playbooks/storage-inventory.yml
+++ b/infrastructure-playbooks/storage-inventory.yml
@@ -28,6 +28,6 @@
       ceph_volume:
         action: "inventory"
       environment:
-        CEPH_VOLUME_DEBUG: 1
+        CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
         CEPH_CONTAINER_BINARY: "{{ container_binary }}"

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -26,7 +26,7 @@
           action: "inventory"
         register: rejected_devices
         environment:
-          CEPH_VOLUME_DEBUG: 1
+          CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
           CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
           CEPH_CONTAINER_BINARY: "{{ container_binary }}"
           PYTHONIOENCODING: utf-8
@@ -53,7 +53,7 @@
           action: "batch"
         register: lvm_batch_report
         environment:
-          CEPH_VOLUME_DEBUG: 1
+          CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
           CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
           CEPH_CONTAINER_BINARY: "{{ container_binary }}"
           PYTHONIOENCODING: utf-8
@@ -73,7 +73,7 @@
       action: "list"
     register: lvm_list
     environment:
-      CEPH_VOLUME_DEBUG: 1
+      CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
       CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
       CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       PYTHONIOENCODING: utf-8

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -316,6 +316,8 @@ mon_host_v1:
 mon_host_v2:
   suffix: ':3300'
 
+enable_ceph_volume_debug: False
+
 ##########
 # CEPHFS #
 ##########
@@ -881,3 +883,4 @@ client_connections: {}
 
 container_exec_cmd:
 docker: false
+ceph_volume_debug: "{{ enable_ceph_volume_debug | ternary(1, 0)  }}"

--- a/roles/ceph-infra/tasks/main.yml
+++ b/roles/ceph-infra/tasks/main.yml
@@ -17,3 +17,20 @@
   include_tasks: setup_ntp.yml
   when: ntp_service_enabled | bool
   tags: configure_ntp
+
+- name: ensure logrotate is installed
+  package:
+    name: logrotate
+    state: present
+  register: result
+  until: result is succeeded
+  when: not is_atomic | bool
+
+- name: add logrotate configuration
+  template:
+    src: logrotate.conf.j2
+    dest: /etc/logrotate.d/ceph
+    mode: "0644"
+    owner: root
+    group: root
+  when: containerized_deployment | bool

--- a/roles/ceph-infra/templates/logrotate.conf.j2
+++ b/roles/ceph-infra/templates/logrotate.conf.j2
@@ -1,0 +1,12 @@
+/var/log/ceph/*.log {
+    rotate 7
+    daily
+    compress
+    sharedscripts
+    postrotate
+        killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw rbd-mirror || pkill -1 -x "ceph-mon|ceph-mgr|ceph-mds|ceph-osd|ceph-fuse|radosgw|rbd-mirror" || true
+    endscript
+    missingok
+    notifempty
+    su root root
+}

--- a/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
@@ -15,7 +15,7 @@
     journal_devices: "{{ dedicated_devices | unique if dedicated_devices | length > 0 else omit }}"
     action: "batch"
   environment:
-    CEPH_VOLUME_DEBUG: 1
+    CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     PYTHONIOENCODING: utf-8

--- a/roles/ceph-osd/tasks/scenarios/lvm.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm.yml
@@ -15,7 +15,7 @@
     dmcrypt: "{{ dmcrypt|default(omit) }}"
     action: "{{ 'prepare' if containerized_deployment else 'create' }}"
   environment:
-    CEPH_VOLUME_DEBUG: 1
+    CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     PYTHONIOENCODING: utf-8


### PR DESCRIPTION
This commit adds the log rotation support via logrotate in containerized
deployments.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1848388

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>