### PR TITLE
[skip ci] pytest: register ceph_crash mark

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -2,6 +2,7 @@
 # dir really is. 
 [pytest]
 markers =
+  ceph_crash: environment with ceph crash enabled
   dashboard: environment with dashboard enabled
   no_docker: environment without containers
   docker: environment with containers


### PR DESCRIPTION
Otherwise we see some pytest warning.

PytestUnknownMarkWarning: Unknown pytest.mark.ceph_crash - is this a typo?
You can register custom marks to avoid this warning - for details,
see https://docs.pytest.org/en/latest/mark.html

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>