### PR TITLE
tox: only wait 30sec for right jobs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -418,7 +418,7 @@ commands=
   all_daemons: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/reboot.yml
 
   # wait 30sec for services to be ready
-  sleep 30
+  all_daemons,all_in_one: sleep 30
   # retest to ensure cluster came back up correctly after rebooting
   all_daemons: py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 


### PR DESCRIPTION
There's no need to call `sleep 30` for other job than `all_daemons` and
`all_in_one`.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>