### PR TITLE
switch_to_containers: Fix cluster config file permissions to match the ceph-config role

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -129,6 +129,9 @@
         name: ceph-container-common
 
     - import_role:
+        name: ceph-config
+
+    - import_role:
         name: ceph-mon
 
   post_tasks:
@@ -191,6 +194,9 @@
 
     - import_role:
         name: ceph-container-common
+
+    - import_role:
+        name: ceph-config
 
     - import_role:
         name: ceph-mgr
@@ -308,6 +314,9 @@
         name: ceph-container-common
 
     - import_role:
+        name: ceph-config
+
+    - import_role:
         name: ceph-osd
 
   post_tasks:
@@ -390,6 +399,9 @@
         name: ceph-container-common
 
     - import_role:
+        name: ceph-config
+
+    - import_role:
          name: ceph-mds
 
 
@@ -447,6 +459,9 @@
         name: ceph-container-common
 
     - import_role:
+        name: ceph-config
+
+    - import_role:
         name: ceph-rgw
 
 
@@ -499,6 +514,9 @@
         name: ceph-container-common
 
     - import_role:
+        name: ceph-config
+
+    - import_role:
         name: ceph-rbd-mirror
 
 
@@ -546,6 +564,9 @@
 
     - import_role:
         name: ceph-container-common
+
+    - import_role:
+        name: ceph-config
 
     - import_role:
         name: ceph-nfs


### PR DESCRIPTION
switch_to_containers changes the ownership of /etc/ceph/* to ceph:ceph using
the find command multiple times. The "generate {{ cluster }}.conf configuration
file" task under the "config file operations for containerized scenarios" block
in the ceph-config role sets the ownership of
"{{ ceph_conf_key_directory }}/{{ cluster }}.conf" to root:root. After running
the switch_to_containers playbook, the ownership of {{ cluster }}.conf is
ceph:ceph. The next time the ceph-ansible playbook (site.yml) is ran, the
ownership is changed to root:root and the handler restarts all ceph services.
For large clusters, this is a time consuming and unnecessary process. This fix
runs the ceph-config role prior to running the service role in order to sync
the ownership of {{ cluster }}.conf so the service only needs to be restarted
once when running switch_to_containers. Also, by importing the ceph-config role
the ownership of {{ cluster }}.conf will remain synced with the ceph-config
role should the "generate {{ cluster }}.conf configuration file" task change.
Alternatively, a task can be added to switch_to_containers after the find
command to change the ownership of
"{{ ceph_conf_key_directory }}/{{ cluster }}.conf" to root:root. This would
results in fewer service restarts when running the switch_to_containers,
however it could result in the ownership of
"{{ ceph_conf_key_directory }}/{{ cluster }}.conf" to not be in sync with the
ceph-config role, should the role be changed.

Signed-off-by: Kevin Coakley <kcoakley@sdsc.edu>