### PR TITLE
[ceph-osd][main] Fix key when retrieving osdmap

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -83,8 +83,8 @@
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   until:
-    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] | int > 0
-    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_up_osds"]
+    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_osds"] | int > 0
+    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_up_osds"]
   when:
     - inventory_hostname == ansible_play_hosts_all | last
 


### PR DESCRIPTION
For the nautilus version of ceph, osdmap is a nested dict with another
osdmap dict inside:

```
root@mon1:~# ceph --cluster ceph -s -f json | jq '.osdmap'
{
  "osdmap": {
    "epoch": 13,
    "num_osds": 3,
    "num_up_osds": 3,
    "num_in_osds": 3,
    "num_remapped_pgs": 0
  }
}
root@mon1:~# ceph --version
ceph version 14.2.11 (f7fdb2f52131f54b891a2ec99d8205561242cdaf) nautilus (stable)
```

We were only extracting the first one and ended up failing to check
the number of registered osds when setting them up.


Before the fix:

```
TASK [ceph-osd : wait for all osd to be up] *************************************************************
Tuesday 11 August 2020  22:20:29 +0000 (0:00:00.558)       0:01:39.088 ******** 
skipping: [osd1]
skipping: [osd2]
fatal: [osd3]: FAILED! => 
  msg: 'The conditional check ''(wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] | int > 0'' failed. The error was: error while evaluating conditional ((wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] | int > 0): ''dict object'' has no attribute ''num_osds'''
```


After:
```
TASK [ceph-osd : wait for all osd to be up] *************************************************************
Tuesday 11 August 2020  22:24:21 +0000 (0:00:00.672)       0:01:38.898 ******** 
skipping: [osd1]
skipping: [osd2]
ok: [osd3 -> mon1]
```