### PR TITLE
tests: test iscsigw against stable build

### DIFF
--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -32,7 +32,7 @@ client1
 rbd-mirror0
 
 [iscsigws]
-iscsi-gw0 ceph_repository="dev"
+iscsi-gw0
 
 [grafana-server]
 mon0


### PR DESCRIPTION
This commit makes the ci using stable build for testing iscsigw in
stable-5.0

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>