### PR TITLE
tests: test iscsigw against stable

### DIFF
--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -32,7 +32,7 @@ client1
 rbd-mirror0
 
 [iscsigws]
-iscsi-gw0 ceph_repository="dev"
+iscsi-gw0 ceph_repository="community" ceph_stable_release="octopus"
 
 [grafana-server]
 mon0


### PR DESCRIPTION
Since it is broken at the moment with dev repos, let's test against
stable builds so the CI is unlocked.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>