### PR TITLE
[skip ci] infra: add missing tag

### DIFF
--- a/roles/ceph-infra/tasks/main.yml
+++ b/roles/ceph-infra/tasks/main.yml
@@ -25,6 +25,7 @@
   register: result
   until: result is succeeded
   when: not is_atomic | bool
+  tags: with_pkg
 
 - name: add logrotate configuration
   template:
@@ -33,4 +34,11 @@
     mode: "0644"
     owner: root
     group: root
-  when: containerized_deployment | bool
+  when:
+    - containerized_deployment | bool
+    - inventory_hostname in groups.get(mon_group_name, []) or
+      inventory_hostname in groups.get(osd_group_name, []) or
+      inventory_hostname in groups.get(mds_group_name, []) or
+      inventory_hostname in groups.get(rgw_group_name, []) or
+      inventory_hostname in groups.get(mgr_group_name, []) or
+      inventory_hostname in groups.get(rbdmirror_group_name, [])


### PR DESCRIPTION
This commit adds the missing `with_pkg` tag on the logrotate
installation task.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>