### PR TITLE
[skip ci] container: don't install the engine on all clients

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -61,6 +61,7 @@
     - import_role:
         name: ceph-container-engine
       tags: with_pkg
+      when: (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
     - import_role:
         name: ceph-container-common
       tags: fetch_container_image


### PR DESCRIPTION
We only need the container engine to be installed on the first clients
node in order to execute the pools/keys operation. We already do the
same worflow with the ceph-container-common role which pull the ceph
container image.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>