### PR TITLE
Allow updating crush rule on existing pool

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -144,6 +144,18 @@
         - item.type | default(1) | int != 3
         - item.type | default('replicated') != 'erasure'
 
+    - name: customize pool crush_rule
+      command: >
+        {{ ceph_admin_command | default('') }} --cluster {{ cluster }}
+        osd pool set {{ item.name }} crush_rule {{ item.rule_name | default(ceph_osd_pool_default_crush_rule_name) }}
+      with_items: "{{ pools | unique }}"
+      delegate_to: "{{ delegated_node }}"
+      changed_when: false
+      when:
+        - item.rule_name | default(ceph_osd_pool_default_crush_rule_name)
+        - item.type | default(1) | int != 3
+        - item.type | default('replicated') != 'erasure'
+
     - name: assign application to pool(s)
       command: "{{ ceph_admin_command | default('') }} --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"
       with_items: "{{ pools | unique }}"

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -72,6 +72,14 @@
             - item.type | default(1) | int != 3
             - item.type | default('replicated') != 'erasure'
 
+        - name: customize pool crush_rule
+          command: "{{ ceph_run_cmd }} --cluster {{ cluster }} osd pool set {{ item.name }} crush_rule {{ item.rule_name | default(ceph_osd_pool_default_crush_rule_name) }}"
+          with_items: "{{ cephfs_pools | unique }}"
+          changed_when: false
+          when:
+            - item.rule_name | default(ceph_osd_pool_default_crush_rule_name)
+            - item.type | default(1) | int != 3
+            - item.type | default('replicated') != 'erasure'
 
 - name: check and create ceph filesystem
   delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -69,6 +69,18 @@
         - item.type | default(1) | int != 3
         - item.type | default('replicated') != 'erasure'
 
+    - name: customize pool crush_rule
+      command: >
+        {{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }}
+        osd pool set {{ item.name }} crush_rule {{ item.rule_name | default(ceph_osd_pool_default_crush_rule_name) }}
+      with_items: "{{ openstack_pools | unique }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      changed_when: false
+      when:
+        - item.rule_name | default(ceph_osd_pool_default_crush_rule_name)
+        - item.type | default(1) | int != 3
+        - item.type | default('replicated') != 'erasure'
+
     - name: assign application to pool(s)
       command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool application enable {{ item.name }} {{ item.application }}"
       with_items: "{{ openstack_pools | unique }}"


### PR DESCRIPTION
The crush rule value was only set once during the pool creation. It was
not possible to update the crush rule value by updating the value in the
configuration.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1847166

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>