### PR TITLE
mgr: enable pg_autoscaler by default

### DIFF
--- a/roles/ceph-mgr/tasks/mgr_modules.yml
+++ b/roles/ceph-mgr/tasks/mgr_modules.yml
@@ -1,8 +1,12 @@
 ---
 - name: append dashboard modules to ceph_mgr_modules
   set_fact:
-    ceph_mgr_modules: "{{ (ceph_mgr_modules + [ 'dashboard', 'prometheus' ]) | unique }}"
+    ceph_mgr_modules: "{{ ceph_mgr_modules | union(['dashboard', 'prometheus']) }}"
   when: dashboard_enabled | bool
+
+- name: append pg_autoscaler module to ceph_mgr_modules
+  set_fact:
+    ceph_mgr_modules: "{{ ceph_mgr_modules | union(['pg_autoscaler']) }}"
 
 - name: wait for all mgr to be up
   command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} mgr dump -f json"


### PR DESCRIPTION
Otherwise, even though we set the pg autoscaler attribute on a pool, the
feature won't be working as expected.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1836431

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>