### PR TITLE
[skip ci] travis: enforce ansible-lint 4.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/
 install:
   - pip install -r tests/requirements.txt
-  - pip install ansible-lint pytest-cov
+  - pip install ansible-lint==4.2.0 pytest-cov
 script:
   - if [[ -n $(grep --exclude-dir=.git -P "\xa0" -r .) ]]; then echo 'NBSP characters found'; exit 1; fi
   - pytest --cov=library/ --cov=plugins/filter/ -vvvv tests/library/ tests/plugins/filter/


### PR DESCRIPTION
Let's pin to 4.2.0

(because of ansible/ansible-lint/issues/966)

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>