### PR TITLE
[skip ci] travis: enforce ansible-lint 4.2.0 (bp #5676)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/
 install:
   - pip install -r requirements.txt
-  - pip install ansible-lint pytest
+  - pip install ansible-lint==4.2.0 pytest
 script:
   - if [[ -n $(grep --exclude-dir=.git -P "\xa0" -r .) ]]; then echo 'NBSP characters found'; exit 1; fi
   - pytest -vvvv tests/library/ tests/plugins/filter/


### PR DESCRIPTION
Let's pin to 4.2.0

(because of ansible/ansible-lint/issues/966)

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 04d77dcaebb52734a1c6d1838ecfa669bf8f3c67)