### PR TITLE
[skip ci] Set default permission for prometheus config files

### DIFF
--- a/roles/ceph-prometheus/tasks/main.yml
+++ b/roles/ceph-prometheus/tasks/main.yml
@@ -13,6 +13,7 @@
     src: prometheus.yml.j2
     dest: "{{ prometheus_conf_dir }}/prometheus.yml"
     owner: "{{ prometheus_user_id }}"
+    mode: 0640
   notify: service handler
 
 - name: make sure the alerting rules directory exists
@@ -42,7 +43,8 @@
   template:
     src: alertmanager.yml.j2
     dest: "{{ alertmanager_conf_dir }}/alertmanager.yml"
-    owner: "root"
+    owner: "{{ prometheus_user_id }}"
+    mode: 0640
   notify: service handler
 
 - name: include setup_container.yml


### PR DESCRIPTION
Regardless of the outcome of Ansible 2.9.12 issue 71200
we can set a default permission for these files.

Closes: https://github.com/ceph/ceph-ansible/issues/5677

Signed-off-by: John Fulton <fulton@redhat.com>