### PR TITLE
[skip ci] shrink-mds: use mds_to_kill_hostname instead

### DIFF
--- a/infrastructure-playbooks/shrink-mds.yml
+++ b/infrastructure-playbooks/shrink-mds.yml
@@ -78,9 +78,9 @@
   tasks:
     # get rid of this as soon as "systemctl stop ceph-msd@$HOSTNAME" also
     # removes the MDS from the FS map.
-    - name: exit mds if it the deployment is containerized
+    - name: exit mds when containerized deployment
+      command: "{{ container_exec_cmd | default('') }} ceph tell mds.{{ mds_to_kill_hostname }} exit"
       when: containerized_deployment | bool
-      command: "{{ container_exec_cmd | default('') }} ceph tell mds.{{ mds_to_kill }} exit"
 
     - name: get ceph status
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json"


### PR DESCRIPTION
When using fqdn in inventory host file, this task will fail because the
mds is registered with its shortname.

It means we must use `mds_to_kill_hostname` in this task.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1869837

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>