### PR TITLE
osd: move systemd rendering task

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -83,19 +83,6 @@
   register: ceph_volume_osd_ids
   when: osd_scenario == 'lvm'
 
-- name: generate systemd unit file
-  become: true
-  template:
-    src: "{{ role_path }}/templates/ceph-osd.service.j2"
-    dest: /etc/systemd/system/ceph-osd@.service
-    owner: "root"
-    group: "root"
-    mode: "0644"
-  notify:
-    - restart ceph osds
-  when:
-    - containerized_deployment
-
 - name: device to id migration
   when:
     - containerized_deployment | bool

--- a/roles/ceph-osd/tasks/systemd.yml
+++ b/roles/ceph-osd/tasks/systemd.yml
@@ -9,3 +9,14 @@
     mode: "0744"
   notify:
     - restart ceph osds
+
+- name: generate systemd unit file
+  become: true
+  template:
+    src: "{{ role_path }}/templates/ceph-osd.service.j2"
+    dest: /etc/systemd/system/ceph-osd@.service
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  notify:
+    - restart ceph osds


### PR DESCRIPTION
This commit moves the systemd rendering task into `systemd.yml` file.
Otherwise, when running docker to podman playbook, the systemd unit file
isn't updated as it should be.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1870141

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>