### PR TITLE
[skip ci] Comment out ceph_custom_key

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -220,7 +220,7 @@ dummy:
 # a URL to the .repo file to be installed on the targets.  For deb,
 # ceph_custom_repo should be the URL to the repo base.
 #
-#ceph_custom_key: https://server.domain.com/ceph-custom-repo-key.asc
+#ceph_custom_key: https://server.domain.com/ceph-custom-repo/key.asc
 #ceph_custom_repo: https://server.domain.com/ceph-custom-repo
 
 

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -220,7 +220,7 @@ ceph_iscsi_config_dev: false
 # a URL to the .repo file to be installed on the targets.  For deb,
 # ceph_custom_repo should be the URL to the repo base.
 #
-#ceph_custom_key: https://server.domain.com/ceph-custom-repo-key.asc
+#ceph_custom_key: https://server.domain.com/ceph-custom-repo/key.asc
 #ceph_custom_repo: https://server.domain.com/ceph-custom-repo
 
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -212,7 +212,7 @@ ceph_iscsi_config_dev: true # special repo for deploying iSCSI gateways
 # a URL to the .repo file to be installed on the targets.  For deb,
 # ceph_custom_repo should be the URL to the repo base.
 #
-ceph_custom_key: https://server.domain.com/ceph-custom-repo-key.asc
+#ceph_custom_key: https://server.domain.com/ceph-custom-repo/key.asc
 ceph_custom_repo: https://server.domain.com/ceph-custom-repo
 
 


### PR DESCRIPTION
Since there is a check if ceph_custom_key is defined, there is no reason
to define it by default.

Signed-off-by: Rafał Wądołowski <rwadolowski@cloudferro.com>