### PR TITLE
Remove 'run_once: true' from wait 'for all osd to be up' task in ceph…

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -114,7 +114,6 @@
   delay: "{{ delay_wait_osd_up }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  run_once: true
   until:
     - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_osds"] | int > 0
     - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_up_osds"]


### PR DESCRIPTION
…-osd/tasks/main.yml role.

This together with condition 'ansible_play_hosts_all | last' causes skipping that task if nr of hosts in `osds` group is higher than one.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1871035

To maintainers: This was fixed previously in the master few months ago, but there were few other changes in that PR and I do not think it can be backported right now (details in the bugzilla issue).

Signed-off-by: RPietrzak <rp.pietrzak@gmail.com>