### PR TITLE
[skip ci] rolling_update: remove 'ignore_errors'

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -184,23 +184,15 @@
 
     # NOTE: we mask the service so the RPM can't restart it
     # after the package gets upgraded
-    - name: stop ceph mon - shortname
+    - name: stop ceph mon
       systemd:
-        name: ceph-mon@{{ ansible_hostname }}
+        name: ceph-mon@{{ item }}
         state: stopped
         enabled: no
         masked: yes
-      ignore_errors: True
-
-    # NOTE: we mask the service so the RPM can't restart it
-    # after the package gets upgraded
-    - name: stop ceph mon - fqdn
-      systemd:
-        name: ceph-mon@{{ ansible_fqdn }}
-        state: stopped
-        enabled: no
-        masked: yes
-      ignore_errors: True
+      with_items:
+        - "{{ ansible_hostname }}"
+        - "{{ ansible_fqdn }}"
 
     # only mask the service for mgr because it must be upgraded
     # after ALL monitors, even when collocated
@@ -229,7 +221,8 @@
         name: ceph-mgr@{{ ansible_hostname }}
         state: started
         enabled: yes
-      ignore_errors: True # if no mgr collocated with mons
+      when: inventory_hostname in groups[mgr_group_name] | default([])
+            or groups[mgr_group_name] | default([]) | length == 0
 
     - name: non container | waiting for the monitor to join the quorum...
       command: ceph --cluster "{{ cluster }}" -m "{{ hostvars[groups[mon_group_name][0]]['_current_monitor_address'] }}" -s --format json


### PR DESCRIPTION
There's no need to use `ignore_errors: true` on these tasks.

Using a loop on the task stopping mon daemons allows us to avoid
duplicating this task, the `ignore_errors` isn't needed here because it
won't fail the playbook if one of the ID doesn't exist (shortname vs. fqdn)

Using the right condition on the task starting the mgr daemon allows us
to avoid using an `ignore_errors: true` as well.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>