### PR TITLE
ansible: bump to ansible 2.9

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -16,8 +16,8 @@ Obsoletes:      ceph-iscsi-ansible <= 1.5
 
 BuildArch:      noarch
 
-BuildRequires: ansible >= 2.8
-Requires: ansible >= 2.8
+BuildRequires: ansible >= 2.9
+Requires: ansible >= 2.9
 
 %if 0%{?rhel} == 7
 BuildRequires: python2-devel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # These are Python requirements needed to run ceph-ansible master
-ansible>=2.8.8,<2.9
+ansible>=2.9,<2.10,!=2.9.10
 netaddr

--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -6,10 +6,10 @@
 
 - name: fail on unsupported ansible version
   fail:
-    msg: "Ansible version must be 2.8 or 2.9!"
+    msg: "Ansible version must be 2.9!"
   when:
     - ansible_version.major|int == 2
-    - ansible_version.minor|int not in [8, 9]
+    - ansible_version.minor|int != 9
 
 - name: fail on unsupported system
   fail:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ six==1.10.0
 testinfra>=3,<4
 pytest-xdist==1.28.0
 pytest>=4.6,<5.0
-ansible>=2.8.8,<2.9
+ansible>=2.9,<2.10,!=2.9.10
 Jinja2>=2.10
 netaddr
 mock


### PR DESCRIPTION
Prior this commit we were supporting both ansible 2.8 and 2.9.
Let's drop 2.8 now.

Closes: #5459
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1879178

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>