### PR TITLE
tests: reenable ceph-iscsi testing

### DIFF
--- a/tests/functional/all_daemons/container/hosts
+++ b/tests/functional/all_daemons/container/hosts
@@ -29,8 +29,8 @@ client1
 [rbdmirrors]
 rbd-mirror0
 
-#[iscsigws]
-#iscsi-gw0
+[iscsigws]
+iscsi-gw0
 
 [grafana-server]
 mon0

--- a/tests/functional/all_daemons/container/vagrant_variables.yml
+++ b/tests/functional/all_daemons/container/vagrant_variables.yml
@@ -12,7 +12,7 @@ nfs_vms: 1
 grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2
-iscsi_gw_vms: 0
+iscsi_gw_vms: 1
 mgr_vms: 1
 
 # SUBNETS TO USE FOR THE VMS

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -30,7 +30,7 @@ nfs0
 rbd-mirror0
 
 [iscsigws]
-iscsi-gw0 ceph_repository="community" ceph_stable_release="octopus"
+iscsi-gw0
 
 [grafana-server]
 mon0


### PR DESCRIPTION
This re-adds the ceph-iscsi testing for both non containerized and
containerized deployment since the rados connection error on ceph
dev has been fixed [1].

[1] https://tracker.ceph.com/issues/47002

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>