### PR TITLE
library: Fix new-style modules check mode

### DIFF
--- a/library/ceph_crush.py
+++ b/library/ceph_crush.py
@@ -169,14 +169,14 @@ def run_module():
         changed=False,
         stdout='',
         stderr='',
-        rc='',
+        rc=0,
         start='',
         end='',
         delta='',
     )
 
     if module.check_mode:
-        return result
+        module.exit_json(**result)
 
     startd = datetime.datetime.now()
 

--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -528,14 +528,15 @@ def run_module():
         changed=changed,
         stdout='',
         stderr='',
-        rc='',
+        rc=0,
         start='',
         end='',
         delta='',
     )
 
     if module.check_mode:
-        return result
+        module.exit_json(**result)
+
     startd = datetime.datetime.now()
 
     # will return either the image name or None

--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -527,11 +527,11 @@ def run_module():
     }
 
     if module.check_mode:
-        return dict(
+        module.exit_json(
             changed=False,
             stdout='',
             stderr='',
-            rc='',
+            rc=0,
             start='',
             end='',
             delta='',
@@ -609,4 +609,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -574,14 +574,14 @@ def run_module():
         changed=False,
         stdout='',
         stderr='',
-        rc='',
+        rc=0,
         start='',
         end='',
         delta='',
     )
 
     if module.check_mode:
-        return result
+        module.exit_json(**result)
 
     # start execution
     startd = datetime.datetime.now()


### PR DESCRIPTION
Running the `ceph_crush.py`, `ceph_key.py` or `ceph_volume.py` modules in check
mode resulted in the following error:

```
New-style module did not handle its own exit
```

This was due to the fact that they simply returned a `dict` in that case,
instead of calling `module.exit_json()`.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>