### PR TITLE
Fix Ansible check mode for site.yml.sample playbook

### DIFF
--- a/roles/ceph-crash/tasks/main.yml
+++ b/roles/ceph-crash/tasks/main.yml
@@ -46,6 +46,7 @@
       with_items: "{{ list_target_node }}"
       delegate_to: "{{ item }}"
       run_once: True
+      when: _crash_keys is not skipped
 
 - name: start ceph-crash daemon
   when: containerized_deployment | bool

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -72,6 +72,7 @@
       with_items: "{{ _mgr_keys.results }}"
       when:
         - cephx | bool
+        - item is not skipped
         - item.item.copy_key | bool
 
 - name: set mgr key permissions

--- a/roles/ceph-mgr/tasks/mgr_modules.yml
+++ b/roles/ceph-mgr/tasks/mgr_modules.yml
@@ -14,6 +14,7 @@
   until:
     - mgr_dump.rc == 0
     - (mgr_dump.stdout | from_json).available | bool
+  when: not ansible_check_mode
 
 - name: get enabled modules from ceph-mgr
   command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} --format json mgr module ls"

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -14,6 +14,7 @@
   retries: "{{ handler_health_mon_check_retries }}"
   delay: "{{ handler_health_mon_check_delay }}"
   changed_when: false
+  when: not ansible_check_mode
 
 - name: fetch ceph initial keys
   ceph_key:

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -33,4 +33,5 @@
   with_items: "{{ _osd_keys.results }}"
   when:
     - cephx | bool
+    - item is not skipped
     - item.item.copy_key | bool

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -86,6 +86,7 @@
     - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] | int > 0
     - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_up_osds"]
   when:
+    - not ansible_check_mode
     - inventory_hostname == ansible_play_hosts_all | last
 
 - name: include crush_rules.yml

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -30,6 +30,7 @@
   with_items: "{{ _rgw_keys.results }}"
   when:
     - cephx | bool
+    - item is not skipped
     - item.item.copy_key | bool
 
 - name: copy SSL certificate & key data to certificate path

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -488,4 +488,6 @@
         msg: "{{ ceph_status.stdout_lines }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
-      when: not ceph_status.failed
+      when:
+        - ceph_status is not skipped
+        - ceph_status is successful


### PR DESCRIPTION
Make sure the `site.yml.sample` playbook can be run in check mode by skipping
tasks that try to read the output of commands that have been skipped.

Requires #5717.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>