### PR TITLE
[skip ci] Add CentOS 8 support for rpm deployment

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -84,7 +84,7 @@ dummy:
 
 #centos_package_dependencies:
 #  - epel-release
-#  - libselinux-python
+#  - "{{ 'python3-libselinux' if ansible_distribution_major_version | int >= 8 else 'libselinux-python' }}"
 
 #redhat_package_dependencies: []
 
@@ -155,10 +155,6 @@ dummy:
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/
 # for more info read: https://github.com/ceph/ceph-ansible/issues/305
 #ceph_stable_distro_source: "{{ ansible_distribution_release }}"
-
-# This option is needed for _both_ stable and dev version, so please always fill the right version
-# # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
-#ceph_stable_redhat_distro: el7
 
 
 # REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -84,7 +84,7 @@ fetch_directory: ~/ceph-ansible-keys
 
 #centos_package_dependencies:
 #  - epel-release
-#  - libselinux-python
+#  - "{{ 'python3-libselinux' if ansible_distribution_major_version | int >= 8 else 'libselinux-python' }}"
 
 #redhat_package_dependencies: []
 
@@ -155,10 +155,6 @@ ceph_repository: rhcs
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/
 # for more info read: https://github.com/ceph/ceph-ansible/issues/305
 #ceph_stable_distro_source: "{{ ansible_distribution_release }}"
-
-# This option is needed for _both_ stable and dev version, so please always fill the right version
-# # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
-#ceph_stable_redhat_distro: el7
 
 
 # REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)

--- a/roles/ceph-common/tasks/installs/redhat_community_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_community_repository.yml
@@ -5,6 +5,7 @@
   register: result
   until: result is succeeded
   tags: with_pkg
+  when: ansible_distribution_major_version | int == 7
 
 - name: configure red hat ceph community repository stable key
   rpm_key:
@@ -20,7 +21,7 @@
     gpgcheck: yes
     state: present
     gpgkey: "{{ ceph_stable_key }}"
-    baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_stable_release }}/{{ ceph_stable_redhat_distro }}/$basearch"
+    baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_stable_release }}/el{{ ansible_distribution_major_version }}/$basearch"
     file: ceph_stable
     priority: 2
   register: result
@@ -33,7 +34,7 @@
     gpgcheck: yes
     state: present
     gpgkey: "{{ ceph_stable_key }}"
-    baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_stable_release }}/{{ ceph_stable_redhat_distro }}/noarch"
+    baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_stable_release }}/el{{ ansible_distribution_major_version }}/noarch"
     file: ceph_stable
     priority: 2
   register: result

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -76,7 +76,7 @@ debian_package_dependencies: []
 
 centos_package_dependencies:
   - epel-release
-  - libselinux-python
+  - "{{ 'python3-libselinux' if ansible_distribution_major_version | int >= 8 else 'libselinux-python' }}"
 
 redhat_package_dependencies: []
 
@@ -147,10 +147,6 @@ nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_s
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/
 # for more info read: https://github.com/ceph/ceph-ansible/issues/305
 #ceph_stable_distro_source: "{{ ansible_distribution_release }}"
-
-# This option is needed for _both_ stable and dev version, so please always fill the right version
-# # for supported distros, see http://download.ceph.com/rpm-{{ ceph_stable_release }}/
-ceph_stable_redhat_distro: el7
 
 
 # REPOSITORY: RHCS VERSION RED HAT STORAGE (from 4.0)

--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -9,7 +9,6 @@
           - targetcli
         common_repos:
           - tcmu-runner
-          - python-rtslib
 
     - name: set_fact base iscsi pkgs if new style ceph-iscsi
       set_fact:

--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -51,6 +51,7 @@
             state: absent
       when:
         - ansible_distribution == 'CentOS'
+        - ansible_distribution_major_version | int == 7
         - not is_atomic | bool
 
     - name: resize logical volume for root partition to fill remaining free space


### PR DESCRIPTION
We were only supporting CentOS 8 for containerized deployment.
Since Nautilus 14.2.10 we now have el8 rpm packages so we should be
able to deploy a nautilus ceph cluster with el8.
Note that the nfs-ganesha isn't supported because there's no el8 rpm
packages for nfs-ganesha V2.8.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>