### PR TITLE
[skip ci] tests: disable nfs testing

### DIFF
--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -23,8 +23,8 @@ rgw0
 client0
 client1
 
-[nfss]
-nfs0
+#[nfss]
+#nfs0
 
 [rbdmirrors]
 rbd-mirror0

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -8,7 +8,7 @@ mon_vms: 3
 osd_vms: 3
 mds_vms: 3
 rgw_vms: 1
-nfs_vms: 1
+nfs_vms: 0
 grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2


### PR DESCRIPTION
Due to [1], we don't have any nfs-ganesha el8 build available on
shaman so the nfs testing in non containerized all_daemons scenario
is currently failing.

```console
fatal: [nfs0]: FAILED! => changed=false
  dest: /etc/yum.repos.d/nfs-ganesha-dev.repo
  elapsed: 0
  msg: Request failed
  response: 'HTTP Error 504: Gateway Timeout'
  status_code: 504
  url: https://shaman.ceph.com/api/repos/nfs-ganesha/next/latest/centos/8/flavors/ceph_master/repo
```

[1] https://github.com/nfs-ganesha/nfs-ganesha/issues/631

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>