### PR TITLE
[skip ci] Fix hosts field in rolling_update playbook when mds are processed

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -454,7 +454,7 @@
         - nodeep-scrub
 
 - name: upgrade ceph mdss cluster, deactivate all rank > 0
-  hosts: "{{ groups[mon_group_name|default('mons')][0] }}"
+  hosts: "{{ mon_group_name | default('mons') }}[0]"
   become: true
   tasks:
     - name: deactivate all mds rank > 0


### PR DESCRIPTION
In the OSP context, during the rolling update the playbook fails
with the following error:

'''
ERROR! The field 'hosts' has an invalid value, which includes an
undefined variable. The error was: list object has no element 0
'''

This PR just change the hosts field providing a valid mons group
value.

Closes: https://bugzilla.redhat.com/1876803
Signed-off-by: Francesco Pantano <fpantano@redhat.com>