### PR TITLE
tests: use grafana from quay.io

### DIFF
--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -48,3 +48,4 @@ ceph_docker_image_tag: latest-master
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/app-sre/grafana:5.4.3"

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -39,3 +39,4 @@ ceph_docker_registry: quay.ceph.io
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/app-sre/grafana:5.4.3"

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -30,3 +30,4 @@ ceph_docker_image_tag: latest-master
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/app-sre/grafana:5.4.3"

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -24,3 +24,4 @@ grafana_admin_password: +xFRe+RES@7vg24n
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/app-sre/grafana:5.4.3"

--- a/tests/functional/docker2podman/group_vars/all
+++ b/tests/functional/docker2podman/group_vars/all
@@ -47,3 +47,7 @@ grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
 ceph_docker_image_tag: latest-master
+node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/app-sre/grafana:5.4.3"

--- a/tests/functional/podman/group_vars/all
+++ b/tests/functional/podman/group_vars/all
@@ -46,3 +46,7 @@ grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
 ceph_docker_image_tag: latest-master
+node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/app-sre/grafana:5.4.3"


### PR DESCRIPTION
This changes the grafana container image regitry from docker.io to
quay.io to avoid rate limit.
This also adds the missing container image values for docker2podman
and podman scenarios.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>