### PR TITLE
ceph-rgw: use ceph_pool module

### DIFF
--- a/roles/ceph-rgw/tasks/rgw_create_pools.yml
+++ b/roles/ceph-rgw/tasks/rgw_create_pools.yml
@@ -28,57 +28,38 @@
     - item.value.type == 'ec'
 
 - name: create ec pools for rgw
-  command: "{{ container_exec_cmd }} ceph --connect-timeout 10 --cluster {{ cluster }} osd pool create {{ item.key }} {{ item.value.pg_num | default(osd_pool_default_pg_num) }} erasure {{ item.value.ec_profile }}"
+  ceph_pool:
+    name: "{{ item.key }}"
+    state: present
+    cluster: "{{ cluster }}"
+    pg_num: "{{ item.value.pg_num | default(osd_pool_default_pg_num) }}"
+    pgp_num: "{{ item.value.pg_num | default(osd_pool_default_pg_num) }}"
+    pool_type: erasure
+    erasure_profile: "{{ item.value.ec_profile }}"
+    application: rgw
   loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  changed_when: false
   when:
     - item.value.type is defined
     - item.value.type == 'ec'
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: create replicated pools for rgw
-  command: "{{ container_exec_cmd }} ceph --connect-timeout 10 --cluster {{ cluster }} osd pool create {{ item.key }} {{ item.value.pg_num | default(osd_pool_default_pg_num) }} replicated {{ item.value.rule_name | default(ceph_osd_pool_default_crush_rule_name) }}"
-  changed_when: false
-  register: result
-  retries: 60
-  delay: 3
-  until: result is succeeded
+  ceph_pool:
+    name: "{{ item.key }}"
+    state: present
+    cluster: "{{ cluster }}"
+    pg_num: "{{ item.value.pg_num | default(osd_pool_default_pg_num) }}"
+    pgp_num: "{{ item.value.pg_num | default(osd_pool_default_pg_num) }}"
+    size: "{{ item.value.size | default(osd_pool_default_size) }}"
+    pool_type: replicated
+    rule_name: "{{ item.value.rule_name | default(ceph_osd_pool_default_crush_rule_name) }}"
+    application: rgw
   loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when: item.value.type is not defined or item.value.type == 'replicated'
-
-- name: customize replicated pool size
-  command: "{{ container_exec_cmd }} ceph --connect-timeout 10 --cluster {{ cluster }} osd pool set {{ item.key }} size {{ item.value.size | default(osd_pool_default_size) }} {{ '--yes-i-really-mean-it' if item.value.size | default(osd_pool_default_size) | int == 1 else '' }}"
-  register: result
-  retries: 60
-  delay: 3
-  until: result is succeeded
-  loop: "{{ rgw_create_pools | dict2items }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  changed_when: false
-  when:
-    - item.value.type is not defined or item.value.type == 'replicated'
-    - item.value.size | default(osd_pool_default_size) != ceph_osd_pool_default_size
-
-- name: customize replicated pool crush_rule
-  command: "{{ container_exec_cmd }} ceph --connect-timeout 10 --cluster {{ cluster }} osd pool set {{ item.key }} crush_rule {{ item.value.rule_name | default(ceph_osd_pool_default_crush_rule_name) }}"
-  register: result
-  retries: 60
-  delay: 3
-  until: result is succeeded
-  loop: "{{ rgw_create_pools | dict2items }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  changed_when: false
-  when:
-    - item.value.type is not defined or item.value.type == 'replicated'
-    - item.value.rule_name | default(ceph_osd_pool_default_crush_rule_name)
-
-- name: set the rgw_create_pools pools application to rgw
-  command: "{{ container_exec_cmd }} ceph --connect-timeout 10 --cluster {{ cluster }} osd pool application enable {{ item.key }} rgw"
-  register: result
-  retries: 60
-  delay: 3
-  until: result is succeeded
-  changed_when: false
-  loop: "{{ rgw_create_pools | dict2items }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"


### PR DESCRIPTION
Since [1] we can use the ceph_pool module instead of using the command
module combined with ceph osd pool commands.

[1] bddcb439ce1b46735946e9fd5d147bc6604bcda3

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>