### PR TITLE
[skip ci] ceph_pool: set state as optional

### DIFF
--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -457,7 +457,7 @@ def run_module():
     module_args = dict(
         cluster=dict(type='str', required=False, default='ceph'),
         name=dict(type='str', required=True),
-        state=dict(type='str', required=True, choices=['present', 'absent', 'list']),
+        state=dict(type='str', required=False, default='present', choices=['present', 'absent', 'list']),
         details=dict(type='bool', required=False, default=False),
         size=dict(type='str', required=False),
         min_size=dict(type='str', required=False),

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -32,7 +32,6 @@
 
 - name: create cephx key(s)
   ceph_key:
-    state: present
     name: "{{ item.name }}"
     caps: "{{ item.caps }}"
     secret: "{{ item.key | default('') }}"

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -55,7 +55,6 @@
 - name: create iscsi pool
   ceph_pool:
     name: "{{ iscsi_pool_name }}"
-    state: present
     cluster: "{{ cluster }}"
     pg_num: "{{ osd_pool_default_pg_num }}"
     size: "{{ iscsi_pool_size | default(osd_pool_default_size) }}"

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -12,7 +12,6 @@
         - name: create filesystem pools
           ceph_pool:
             name: "{{ item.name }}"
-            state: present
             cluster: "{{ cluster }}"
             pg_num: "{{ item.pg_num | default(osd_pool_default_pg_num) if not item.0.pg_autoscale_mode | default(False) | bool else 16 }}"
             pgp_num: "{{ item.pgp_num | default(item.pg_num) | default(osd_pool_default_pg_num) if not item.pg_autoscale_mode | default(False) | bool else omit }}"

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -4,7 +4,6 @@
     - name: create openstack pool(s)
       ceph_pool:
         name: "{{ item.name }}"
-        state: present
         cluster: "{{ cluster }}"
         pg_num: "{{ item.pg_num | default(osd_pool_default_pg_num) if not item.0.pg_autoscale_mode | default(False) | bool else 16 }}"
         pgp_num: "{{ item.pgp_num | default(item.pg_num) | default(osd_pool_default_pg_num) if not item.pg_autoscale_mode | default(False) | bool else omit }}"


### PR DESCRIPTION
Most ansible module using a state parameter default to the present
value (when available) instead of using it as a mandatory option.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>