### PR TITLE
Fix delegation when facts are computed in rolling_update context

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -133,9 +133,9 @@
   when: cephx | bool or generate_fsid | bool
 
 - name: get current fsid
-  command: "{{ timeout_command }} {{ container_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ hostvars[mon_host | default(groups[mon_group_name][0])]['ansible_hostname'] }}.asok config get fsid"
+  command: "{{ timeout_command }} {{ _container_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ hostvars[mon_host | default(groups[mon_group_name][0])]['ansible_hostname'] }}.asok config get fsid"
   register: rolling_update_fsid
-  delegate_to: "{{ mon_host | default(groups[mon_group_name][0]) }}"
+  delegate_to: "{{ groups[mon_group_name][0] if running_mon is undefined else running_mon }}"
   until: rolling_update_fsid is succeeded
   when: rolling_update | bool
 


### PR DESCRIPTION
This change is trying to fix an issue that occurs when rolling_update
playbook is run: in particular the following error is reported:

 FAILED! => {"msg": "list object has no element 0"}

and this patch is just an attempt to fix it.
The change also make the playbook and the delegation consistent with
the rest of the playbook.

Closes: https://bugzilla.redhat.com/1877426
Signed-off-by: Francesco Pantano <fpantano@redhat.com>