### PR TITLE
purge: add osd_auto_discovery scenario support

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -380,6 +380,10 @@
   - import_role:
       name: ceph-defaults
 
+  - import_role:
+      name: ceph-facts
+      tasks_from: devices.yml
+
   - name: default lvm_volumes if not defined
     set_fact:
       lvm_volumes: []

--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -251,6 +251,10 @@
   - import_role:
       name: ceph-defaults
 
+  - import_role:
+      name: ceph-facts
+      tasks_from: devices.yml
+
   - name: gather monitors facts
     setup:
       gather_subset:

--- a/roles/ceph-facts/tasks/devices.yml
+++ b/roles/ceph-facts/tasks/devices.yml
@@ -1,0 +1,38 @@
+---
+- name: resolve device link(s)
+  command: readlink -f {{ item }}
+  changed_when: false
+  check_mode: no
+  with_items: "{{ devices }}"
+  register: devices_prepare_canonicalize
+  when:
+    - devices is defined
+    - not osd_auto_discovery | default(False) | bool
+
+- name: set_fact build devices from resolved symlinks
+  set_fact:
+    devices: "{{ devices | default([]) + [ item.stdout ] }}"
+  with_items: "{{ devices_prepare_canonicalize.results }}"
+  when:
+    - devices is defined
+    - not osd_auto_discovery | default(False) | bool
+
+- name: set_fact build final devices list
+  set_fact:
+    devices: "{{ devices | reject('search','/dev/disk') | list | unique }}"
+  when:
+    - devices is defined
+    - not osd_auto_discovery | default(False) | bool
+
+- name: set_fact devices generate device list when osd_auto_discovery
+  set_fact:
+    devices: "{{ (devices | default([]) + [ item.key | regex_replace('^', '/dev/') ]) | unique }}"
+  with_dict: "{{ ansible_devices }}"
+  when:
+    - osd_auto_discovery | default(False) | bool
+    - ansible_devices is defined
+    - item.value.removable == "0"
+    - item.value.sectors != "0"
+    - item.value.partitions|count == 0
+    - item.value.holders|count == 0
+    - item.key is not match osd_auto_discovery_exclude

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -166,47 +166,9 @@
       set_fact:
         fsid: "{{ cluster_uuid.stdout }}"
 
-- name: resolve device link(s)
-  command: readlink -f {{ item }}
-  changed_when: false
-  check_mode: no
-  with_items: "{{ devices }}"
-  register: devices_prepare_canonicalize
-  when:
-    - devices is defined
-    - inventory_hostname in groups.get(osd_group_name, [])
-    - not osd_auto_discovery | default(False) | bool
-
-- name: set_fact build devices from resolved symlinks
-  set_fact:
-    devices: "{{ devices | default([]) + [ item.stdout ] }}"
-  with_items: "{{ devices_prepare_canonicalize.results }}"
-  when:
-    - devices is defined
-    - inventory_hostname in groups.get(osd_group_name, [])
-    - not osd_auto_discovery | default(False) | bool
-
-- name: set_fact build final devices list
-  set_fact:
-    devices: "{{ devices | reject('search','/dev/disk') | list | unique }}"
-  when:
-    - devices is defined
-    - inventory_hostname in groups.get(osd_group_name, [])
-    - not osd_auto_discovery | default(False) | bool
-
-- name: set_fact devices generate device list when osd_auto_discovery
-  set_fact:
-    devices: "{{ (devices | default([]) + [ item.key | regex_replace('^', '/dev/') ]) | unique }}"
-  with_dict: "{{ ansible_devices }}"
-  when:
-    - osd_auto_discovery | default(False) | bool
-    - inventory_hostname in groups.get(osd_group_name, [])
-    - ansible_devices is defined
-    - item.value.removable == "0"
-    - item.value.sectors != "0"
-    - item.value.partitions|count == 0
-    - item.value.holders|count == 0
-    - item.key is not match osd_auto_discovery_exclude
+- name: import_tasks devices.yml
+  import_tasks: devices.yml
+  when: inventory_hostname in groups.get(osd_group_name, [])
 
 - name: backward compatibility tasks related
   when:


### PR DESCRIPTION
This commit adds the osd_auto_discovery purge support.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1876860

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>