### PR TITLE
ceph-facts: only get fsid when monitor are present

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -20,10 +20,12 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-container-engine
+      when: (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
     - import_role:
         name: ceph-container-common
         tasks_from: registry
       when:
+        - (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
         - not containerized_deployment | bool
         - ceph_docker_registry_auth | bool
     - import_role:

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -89,14 +89,15 @@
         name: ceph-infra
 
     - import_role:
+        name: ceph-validate
+
+    - import_role:
         name: ceph-container-common
         tasks_from: registry
       when:
+        - (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
         - containerized_deployment | bool
         - ceph_docker_registry_auth | bool
-
-    - import_role:
-        name: ceph-validate
 
     - set_fact: rolling_update=true
 
@@ -806,7 +807,9 @@
       when: not containerized_deployment | bool
     - import_role:
         name: ceph-container-common
-      when: containerized_deployment | bool
+      when:
+        - (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
+        - containerized_deployment | bool
     - import_role:
         name: ceph-config
     - import_role:

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -861,25 +861,33 @@
       command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph --cluster {{ cluster }} osd require-osd-release pacific"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
-      when: containerized_deployment | bool
+      when:
+        - containerized_deployment | bool
+        - groups.get(mon_group_name, []) | length > 0
 
     - name: non container | disallow pre-pacific OSDs and enable all new pacific-only functionality
       command: "ceph --cluster {{ cluster }} osd require-osd-release pacific"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
-      when: not containerized_deployment | bool
+      when:
+        - not containerized_deployment | bool
+        - groups.get(mon_group_name, []) | length > 0
 
     - name: container | enable msgr2 protocol
       command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph --cluster {{ cluster }} mon enable-msgr2"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
-      when: containerized_deployment | bool
+      when:
+        - containerized_deployment | bool
+        - groups.get(mon_group_name, []) | length > 0
 
     - name: non container | enable msgr2 protocol
       command: "ceph --cluster {{ cluster }} mon enable-msgr2"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True
-      when: not containerized_deployment | bool
+      when:
+        - not containerized_deployment | bool
+        - groups.get(mon_group_name, []) | length > 0
 
     - import_role:
         name: ceph-handler

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -137,12 +137,16 @@
   register: rolling_update_fsid
   delegate_to: "{{ mon_host | default(groups[mon_group_name][0]) }}"
   until: rolling_update_fsid is succeeded
-  when: rolling_update | bool
+  when:
+    - rolling_update | bool
+    - groups.get(mon_group_name, []) | length > 0
 
 - name: set_fact fsid
   set_fact:
     fsid: "{{ (rolling_update_fsid.stdout | from_json).fsid }}"
-  when: rolling_update | bool
+  when:
+    - rolling_update | bool
+    - groups.get(mon_group_name, []) | length > 0
 
 - name: set_fact fsid from current_fsid
   set_fact:

--- a/tox-external_clients.ini
+++ b/tox-external_clients.ini
@@ -66,4 +66,19 @@ commands=
 
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/inventory/external_clients-hosts --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests/test_install.py::TestCephConf
 
+  ansible-playbook -vv -i {changedir}/inventory/external_clients-hosts {toxinidir}/infrastructure-playbooks/rolling_update.yml --extra-vars "\
+      ireallymeanit=yes \
+      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
+      fsid=40358a87-ab6e-4bdc-83db-1d909147861c \
+      external_cluster_mon_ips=192.168.31.10,192.168.31.11,192.168.31.12 \
+      generate_fsid=false \
+      ceph_dev_branch=master \
+      ceph_dev_sha1=latest \
+      ceph_docker_registry_auth=True \
+      ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
+      ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
+  "
+
+  py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/inventory/external_clients-hosts --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests/test_install.py::TestCephConf
+
   vagrant destroy --force


### PR DESCRIPTION
When running the rolling_update playbook with an inventory without
monitor nodes defined (like external scenario) then we can't retrieve
the cluster fsid from the running monitor.
In this scenario we have to pass this information manually (group_vars
or host_vars).

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1877426

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>