### PR TITLE
tests: add quay registry for collocation baremetal

### DIFF
--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -21,6 +21,7 @@ handler_health_osd_check_delay: 10
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 dashboard_admin_user_ro: true
 grafana_admin_password: +xFRe+RES@7vg24n
+ceph_docker_registry: quay.ceph.io
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"


### PR DESCRIPTION
Even if the non containerized collocation scenario deploys ceph with
RPMs then we also deploy the dashboard/monitoring but with containers.
This requires to set the registry variable to ceph's quay.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>