### PR TITLE
dashboard: use entity with ceph config get mgr

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -10,7 +10,7 @@
   block:
    - name: get SSL status for dashboard
      run_once: true
-     command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} config get mgr mgr/dashboard/ssl"
+     command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} config get mgr.{{ hostvars[groups[mgr_group_name][0]]['ansible_hostname'] }} mgr/dashboard/ssl"
      changed_when: false
      register: current_ssl_for_dashboard
 


### PR DESCRIPTION
That commit [1] introduced a regression in the dashboard configuration
because the `ceph config get mgr xxxx` command doesn't work with
nautilus.
In that release the get operation needs an entity.

[1] f607857f2a58b2ed14faf49f2b10d056a7f96b30

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>