### PR TITLE
ceph_key: set state as optional

### DIFF
--- a/infrastructure-playbooks/ceph-keys.yml
+++ b/infrastructure-playbooks/ceph-keys.yml
@@ -25,7 +25,6 @@
     - name: create ceph key(s) module
       ceph_key:
         name: "{{ item.name }}"
-        state: present
         caps: "{{ item.caps }}"
         cluster: "{{ cluster }}"
         secret: "{{ item.key | default('') }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -167,7 +167,6 @@
     - name: create potentially missing keys (rbd and rbd-mirror)
       ceph_key:
         name: "client.{{ item.0 }}"
-        state: present
         dest: "/var/lib/ceph/{{ item.0 }}/"
         caps:
           mon: "allow profile {{ item.0 }}"

--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -59,9 +59,9 @@ options:
             return a json output.
             If 'info' is used, the module will return in a json format the
             description of a given keyring.
-        required: true
-        choices: ['present', 'absent', 'list', 'info']
-        default: list
+        required: false
+        choices: ['present', 'update', 'absent', 'list', 'info', 'fetch_initial_keys']
+        default: present
     caps:
         description:
             - CephX key capabilities
@@ -498,7 +498,7 @@ def run_module():
     module_args = dict(
         cluster=dict(type='str', required=False, default='ceph'),
         name=dict(type='str', required=False),
-        state=dict(type='str', required=True),
+        state=dict(type='str', required=False, default='present', choices=['present', 'update', 'absent', 'list', 'info', 'fetch_initial_keys']),
         caps=dict(type='dict', required=False, default=None),
         secret=dict(type='str', required=False, default=None),
         import_key=dict(type='bool', required=False, default=True),

--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -52,9 +52,9 @@ options:
             If 'absent' is used, the module will simply delete the pool.
             If 'list' is used, the module will return all details about the existing pools
             (json formatted).
-        required: true
+        required: false
         choices: ['present', 'absent', 'list']
-        default: list
+        default: present
     size:
         description:
             - set the replica size of the pool.

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -75,7 +75,6 @@
     - name: create ceph pool(s)
       ceph_pool:
         name: "{{ item.name }}"
-        state: present
         cluster: "{{ cluster }}"
         pg_num: "{{ item.pg_num | default(osd_pool_default_pg_num) if not item.0.pg_autoscale_mode | default(False) | bool else 16 }}"
         pgp_num: "{{ item.pgp_num | default(item.pg_num) | default(osd_pool_default_pg_num) if not item.pg_autoscale_mode | default(False) | bool else omit }}"

--- a/roles/ceph-crash/tasks/main.yml
+++ b/roles/ceph-crash/tasks/main.yml
@@ -4,7 +4,6 @@
   block:
     - name: create client.crash keyring
       ceph_key:
-        state: present
         name: "client.crash"
         caps: "{{ {'mon': 'allow profile crash', 'mgr': 'allow profile crash'} }}"
         cluster: "{{ cluster }}"

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -10,7 +10,6 @@
 - name: fetch ceph mgr keyring
   ceph_key:
     name: "mgr.{{ ansible_hostname }}"
-    state: present
     caps:
       mon: allow profile mgr
       osd: allow *
@@ -32,7 +31,6 @@
     - name: create ceph mgr keyring(s) on a mon node
       ceph_key:
         name: "mgr.{{ hostvars[item]['ansible_hostname'] }}"
-        state: present
         caps:
           mon: allow profile mgr
           osd: allow *

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -29,7 +29,6 @@
 - name: create monitor initial keyring
   ceph_key:
     name: mon.
-    state: present
     dest: "/var/lib/ceph/tmp/"
     secret: "{{ monitor_keyring }}"
     cluster: "{{ cluster }}"
@@ -62,7 +61,6 @@
 - name: create custom admin keyring
   ceph_key:
     name: client.admin
-    state: present
     secret: "{{ admin_secret }}"
     caps: "{{ client_admin_ceph_authtool_cap }}"
     import_key: False

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -25,7 +25,6 @@
   block:
     - name: generate keys
       ceph_key:
-        state: present
         name: "{{ item.name }}"
         caps: "{{ item.caps }}"
         secret: "{{ item.key | default('') }}"


### PR DESCRIPTION
Most ansible module using a state parameter default to the present
value (when available) instead of using it as a mandatory option.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>