### PR TITLE
[skip ci] purge: remove potential socket leftover

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -781,7 +781,7 @@
       - ansible_pkg_mgr == 'apt'
       - purge_all_packages == true
 
-  - name: remove config
+  - name: remove config and any ceph socket left
     file:
       path: "{{ item }}"
       state: absent
@@ -789,6 +789,7 @@
       - /etc/ceph
       - /etc/keepalived
       - /etc/haproxy
+      - /run/ceph
 
   - name: remove logs
     file:

--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -656,13 +656,15 @@
   become: true
 
   tasks:
-  - name: purge ceph directories for "{{ ansible_hostname }}"
+  - name: purge ceph directories for "{{ ansible_hostname }}" and ceph socket
     file:
       path: "{{ item }}"
       state: absent
     with_items:
       - /etc/ceph
       - /var/log/ceph
+      - /run/ceph
+      - "{{ ceph_osd_docker_run_script_path | default('/usr/share') }}/ceph-osd-run.sh"
 
   - name: remove ceph data
     shell: rm -rf /var/lib/ceph/*


### PR DESCRIPTION
This commit ensure we remove any socket left by ceph and the
`ceph-osd-run.sh` script.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1861755

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>