### PR TITLE
[skip ci] node-exporter: exclude client nodes

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -1,5 +1,14 @@
 ---
-- hosts: all
+- hosts:
+    - "{{ mon_group_name|default('mons') }}"
+    - "{{ osd_group_name|default('osds') }}"
+    - "{{ mds_group_name|default('mdss') }}"
+    - "{{ rgw_group_name|default('rgws') }}"
+    - "{{ mgr_group_name|default('mgrs') }}"
+    - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
+    - "{{ nfs_group_name|default('nfss') }}"
+    - "{{ iscsi_gw_group_name|default('iscsigws') }}"
+    - "{{ grafana_server_group_name|default('grafana-server') }}"
   gather_facts: false
   become: true
   pre_tasks:
@@ -20,12 +29,10 @@
       tags: ['ceph_update_config']
     - import_role:
         name: ceph-container-engine
-      when: (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
     - import_role:
         name: ceph-container-common
         tasks_from: registry
       when:
-        - (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
         - not containerized_deployment | bool
         - ceph_docker_registry_auth | bool
     - import_role:

--- a/roles/ceph-prometheus/templates/prometheus.yml.j2
+++ b/roles/ceph-prometheus/templates/prometheus.yml.j2
@@ -12,15 +12,14 @@ scrape_configs:
   - job_name: 'ceph'
     honor_labels: true
     static_configs:
-{% for host in groups['mgrs'] | default(groups['mons']) %}
+{% for host in groups[mgr_group_name] | default(groups[mon_group_name]) %}
       - targets: ['{{ host }}:9283']
         labels:
           instance: 'ceph_cluster'
 {% endfor %}
   - job_name: 'node'
     static_configs:
-{% if grafana_server_group_name in groups %}
-{% for host in (groups['all'] | difference(groups[grafana_server_group_name])) %}
+{% for host in (groups['all'] | difference(groups[grafana_server_group_name]|union(groups.get(client_group_name, [])))) %}
       - targets: ['{{ host }}:{{ node_exporter_port }}']
         labels:
           instance: "{{ hostvars[host]['ansible_nodename'] }}"
@@ -32,17 +31,10 @@ scrape_configs:
         labels:
           instance: "{{ hostvars[host]['ansible_nodename'] }}"
 {% endfor %}
-{% else %}
-{% for host in groups['all'] %}
-      - targets: ['{{ host }}:{{ node_exporter_port }}']
-        labels:
-          instance: "{{ hostvars[host]['ansible_nodename'] }}"
-{% endfor %}
-{% endif %}
-{% if 'iscsigws' in groups %}
+{% if iscsi_gw_group_name in groups %}
   - job_name: 'iscsi-gws'
     static_configs:
-{% for host in groups['iscsigws'] %}
+{% for host in groups[iscsi_gw_group_name] %}
       - targets: ['{{ host }}:9287']
         labels:
           instance: "{{ hostvars[host]['ansible_nodename'] }}"


### PR DESCRIPTION
We don't need to install node-exporter on client node because there's
no ceph services running on them.
This also makes sure we use the group name variables in the prometheus
service template instead of hardcoding the values.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>