### PR TITLE
[skip ci] ceph-rgw: remove ceph_pool state and default value

### DIFF
--- a/roles/ceph-rgw/tasks/rgw_create_pools.yml
+++ b/roles/ceph-rgw/tasks/rgw_create_pools.yml
@@ -30,7 +30,6 @@
 - name: create ec pools for rgw
   ceph_pool:
     name: "{{ item.key }}"
-    state: present
     cluster: "{{ cluster }}"
     pg_num: "{{ item.value.pg_num | default(osd_pool_default_pg_num) }}"
     pgp_num: "{{ item.value.pg_num | default(osd_pool_default_pg_num) }}"
@@ -49,13 +48,12 @@
 - name: create replicated pools for rgw
   ceph_pool:
     name: "{{ item.key }}"
-    state: present
     cluster: "{{ cluster }}"
     pg_num: "{{ item.value.pg_num | default(osd_pool_default_pg_num) }}"
     pgp_num: "{{ item.value.pg_num | default(osd_pool_default_pg_num) }}"
-    size: "{{ item.value.size | default(osd_pool_default_size) }}"
+    size: "{{ item.value.size | default(omit) }}"
     pool_type: replicated
-    rule_name: "{{ item.value.rule_name | default(ceph_osd_pool_default_crush_rule_name) }}"
+    rule_name: "{{ item.value.rule_name | default(omit) }}"
     application: rgw
   loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
Since the state is now optional and default values are handled in the
ceph_pool module itself.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>