### PR TITLE
Revert "tests: disable nfs-ganesha testing"

### DIFF
--- a/tests/functional/all_daemons/container/hosts
+++ b/tests/functional/all_daemons/container/hosts
@@ -19,8 +19,8 @@ mds2
 [rgws]
 rgw0
 
-#[nfss]
-#nfs0
+[nfss]
+nfs0
 
 [clients]
 client0

--- a/tests/functional/all_daemons/container/vagrant_variables.yml
+++ b/tests/functional/all_daemons/container/vagrant_variables.yml
@@ -8,7 +8,7 @@ mon_vms: 3
 osd_vms: 3
 mds_vms: 3
 rgw_vms: 1
-nfs_vms: 0
+nfs_vms: 1
 grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -23,8 +23,8 @@ rgw0
 client0
 client1
 
-#[nfss]
-#nfs0
+[nfss]
+nfs0
 
 [rbdmirrors]
 rbd-mirror0

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -8,7 +8,7 @@ mon_vms: 3
 osd_vms: 3
 mds_vms: 3
 rgw_vms: 1
-nfs_vms: 0
+nfs_vms: 1
 grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2


### PR DESCRIPTION
This reverts commit 7348e9a253518904724b05565c97fa1f35c47006.

Since the nfs-ganesha rpm build for CentOS 8 has been fixed.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>