### PR TITLE
[skip ci] tests/library: rename ceph_dashboard_user class

### DIFF
--- a/tests/library/test_ceph_dashboard_user.py
+++ b/tests/library/test_ceph_dashboard_user.py
@@ -31,7 +31,7 @@ fake_params = {'cluster': fake_cluster,
                'roles': fake_roles}
 
 
-class TestRadosgwRealmModule(object):
+class TestCephDashboardUserModule(object):
 
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
     def test_container_exec(self):


### PR DESCRIPTION
Rename the test class with the right information.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>