### PR TITLE
[skip ci] infra: support log rotation for tcmu-runner

### DIFF
--- a/roles/ceph-infra/templates/logrotate.conf.j2
+++ b/roles/ceph-infra/templates/logrotate.conf.j2
@@ -10,3 +10,16 @@
     notifempty
     su root root
 }
+
+/var/log/tcmu-runner/*.log {
+    rotate 7
+    daily
+    compress
+    sharedscripts
+    postrotate
+        killall -q -1 tcmu-runner || pkill -1 -x "tcmu-runner"
+    endscript
+    missingok
+    notifempty
+    su root root
+}

--- a/roles/ceph-iscsi-gw/tasks/containerized.yml
+++ b/roles/ceph-iscsi-gw/tasks/containerized.yml
@@ -6,6 +6,7 @@
   with_items:
     - rbd-target-api
     - rbd-target-gw
+    - tcmu-runner
 
 - name: include_tasks systemd.yml
   include_tasks: systemd.yml

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -28,7 +28,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
   -v /dev:/dev \
   -v /lib/modules:/lib/modules \
   -v /etc/ceph:/etc/ceph \
-  -v /var/log/ceph:/var/log/ceph:z \
+  -v /var/log/tcmu-runner:/var/log/tcmu-runner:z \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=TCMU_RUNNER \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \


### PR DESCRIPTION
This commit adds the log rotation support for tcmu-runner.

ceph-container related PR: ceph/ceph-container#1726

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1873915

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>