### PR TITLE
[skip ci] ceph-prometheus: update pool stat counter

### DIFF
--- a/roles/ceph-prometheus/files/ceph_dashboard.yml
+++ b/roles/ceph-prometheus/files/ceph_dashboard.yml
@@ -74,7 +74,7 @@ groups:
       summary: "Network Errors"
       description: "This indicates that more than 10 dropped/error packets are seen in a 5m interval"
   - alert: Pool Capacity Low
-    expr: (ceph_pool_bytes_used / (ceph_pool_bytes_used + ceph_pool_max_avail) * 100 + on (pool_id) group_left (name) (ceph_pool_metadata*0)) > 85
+    expr: (ceph_pool_stored / (ceph_pool_stored + ceph_pool_max_avail) * 100 + on (pool_id) group_left (name) (ceph_pool_metadata*0)) > 85
     for: 1m
     labels:
       severity: page


### PR DESCRIPTION
Since [1] The bytes_used pool counter in prometheus has been renamed
to stored.

Closes: #5781

[1] https://github.com/ceph/ceph/commit/71fe9149

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>