### PR TITLE
[skip ci] switch2container: fixes for running containers on Debian based host

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -267,7 +267,7 @@
     # The file module has to run checks on current ownership of all directories and files. This is unnecessary
     # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      command: "find /var/lib/ceph /etc/ceph -not -( -user {{ ceph_uid }} -or -group {{ ceph_uid }} -) -execdir chown {{ ceph_uid }}:{{ ceph_uid }} {} +"
+      command: "find /var/lib/ceph /etc/ceph -not -( -user {{ ceph_uid }} -or -group {{ ceph_uid }} -) -execdir chown -h {{ ceph_uid }}:{{ ceph_uid }} {} +"
       changed_when: false
 
     - name: check for existing old leveldb file extension (ldb)

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -80,11 +80,13 @@
 
     - name: remove old systemd unit files
       file:
-        path: /usr/lib/systemd/system/{{ item }}
+        path: "{{ item }}"
         state: absent
       with_items:
-        - ceph-mon@.service
-        - ceph-mon.target
+        - /usr/lib/systemd/system/ceph-mon@.service
+        - /usr/lib/systemd/system/ceph-mon.target
+        - /lib/systemd/system/ceph-mon@.service
+        - /lib/systemd/system/ceph-mon.target
 
     - import_role:
         name: ceph-defaults
@@ -163,11 +165,13 @@
 
     - name: remove old systemd unit files
       file:
-        path: /usr/lib/systemd/system/{{ item }}
+        path: "{{ item }}"
         state: absent
       with_items:
-        - ceph-mgr@.service
-        - ceph-mgr.target
+        - /usr/lib/systemd/system/ceph-mgr@.service
+        - /usr/lib/systemd/system/ceph-mgr.target
+        - /lib/systemd/system/ceph-mgr@.service
+        - /lib/systemd/system/ceph-mgr.target
 
     - import_role:
         name: ceph-defaults
@@ -252,6 +256,9 @@
         - /usr/lib/systemd/system/ceph-osd.target
         - /usr/lib/systemd/system/ceph-osd@.service
         - /usr/lib/systemd/system/ceph-volume@.service
+        - /lib/systemd/system/ceph-osd.target
+        - /lib/systemd/system/ceph-osd@.service
+        - /lib/systemd/system/ceph-volume@.service
 
     - import_role:
         name: ceph-facts
@@ -360,11 +367,13 @@
 
     - name: remove old systemd unit files
       file:
-        path: /usr/lib/systemd/system/{{ item }}
+        path: "{{ item }}"
         state: absent
       with_items:
-        - ceph-mds@.service
-        - ceph-mds.target
+        - /usr/lib/systemd/system/ceph-mds@.service
+        - /usr/lib/systemd/system/ceph-mds.target
+        - /lib/systemd/system/ceph-mds@.service
+        - /lib/systemd/system/ceph-mds.target
 
     - import_role:
         name: ceph-defaults
@@ -431,11 +440,13 @@
 
     - name: remove old systemd unit files
       file:
-        path: /usr/lib/systemd/system/{{ item }}
+        path: "{{ item }}"
         state: absent
       with_items:
-        - ceph-radosgw@.service
-        - ceph-radosgw.target
+        - /usr/lib/systemd/system/ceph-radosgw@.service
+        - /usr/lib/systemd/system/ceph-radosgw.target
+        - /lib/systemd/system/ceph-radosgw@.service
+        - /lib/systemd/system/ceph-radosgw.target
 
     - import_role:
         name: ceph-handler
@@ -469,11 +480,13 @@
 
     - name: remove old systemd unit files
       file:
-        path: /usr/lib/systemd/system/{{ item }}
+        path: "{{ item }}"
         state: absent
       with_items:
-        - ceph-rbd-mirror@.service
-        - ceph-rbd-mirror.target
+        - /usr/lib/systemd/system/ceph-rbd-mirror@.service
+        - /usr/lib/systemd/system/ceph-rbd-mirror.target
+        - /lib/systemd/system/ceph-rbd-mirror@.service
+        - /lib/systemd/system/ceph-rbd-mirror.target
 
     - import_role:
         name: ceph-defaults


### PR DESCRIPTION
The `switch-from-non-containerized-to-containerized-ceph-daemons.yml` playbook is currently only used for switching from a RPM based deployment to containerized deployment.
When using a DEB based system then there's some differences in the packaging (systemd unit path) and other thing to fix.