### PR TITLE
switch2container: fixes for running containers on Debian based host (bp #5785)

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -249,6 +249,9 @@
         - /usr/lib/systemd/system/ceph-osd.target
         - /usr/lib/systemd/system/ceph-osd@.service
         - /usr/lib/systemd/system/ceph-volume@.service
+        - /lib/systemd/system/ceph-osd.target
+        - /lib/systemd/system/ceph-osd@.service
+        - /lib/systemd/system/ceph-volume@.service
         - /etc/systemd/system/ceph.target.wants
 
     - name: dmcrypt extra operations

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -299,7 +299,7 @@
     # The file module has to run checks on current ownership of all directories and files. This is unnecessary
     # as in this case we know we want all owned by ceph user
     - name: set proper ownership on ceph directories
-      command: "find /var/lib/ceph /etc/ceph -not -( -user {{ ceph_uid }} -or -group {{ ceph_uid }} -) -execdir chown {{ ceph_uid }}:{{ ceph_uid }} {} +"
+      command: "find /var/lib/ceph /etc/ceph -not -( -user {{ ceph_uid }} -or -group {{ ceph_uid }} -) -execdir chown -h {{ ceph_uid }}:{{ ceph_uid }} {} +"
       changed_when: false
 
     - name: check for existing old leveldb file extension (ldb)


### PR DESCRIPTION
The switch-from-non-containerized-to-containerized-ceph-daemons.yml playbook is currently only used for switching from a RPM based deployment to containerized deployment.
When using a DEB based system then there's some differences in the packaging (systemd unit path) and other thing to fix.

Backport: #5785