### PR TITLE
container: add optional http(s) proxy option (bp #5786)

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -586,6 +586,9 @@ dummy:
 #ceph_docker_registry_auth: false
 #ceph_docker_registry_username:
 #ceph_docker_registry_password:
+#ceph_docker_http_proxy:
+#ceph_docker_https_proxy:
+#ceph_docker_no_proxy: "localhost,127.0.0.1"
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -586,6 +586,9 @@ ceph_docker_registry: "registry.redhat.io"
 ceph_docker_registry_auth: true
 #ceph_docker_registry_username:
 #ceph_docker_registry_password:
+#ceph_docker_http_proxy:
+#ceph_docker_https_proxy:
+#ceph_docker_no_proxy: "localhost,127.0.0.1"
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"

--- a/roles/ceph-container-common/tasks/fetch_image.yml
+++ b/roles/ceph-container-common/tasks/fetch_image.yml
@@ -204,6 +204,10 @@
   retries: "{{ docker_pull_retry }}"
   delay: 10
   when: (ceph_docker_dev_image is undefined or not ceph_docker_dev_image | bool)
+  environment:
+    HTTP_PROXY: "{{ ceph_docker_http_proxy | default('') }}"
+    HTTPS_PROXY: "{{ ceph_docker_https_proxy | default('') }}"
+    NO_PROXY: "{{ ceph_docker_no_proxy }}"
 
 - name: "inspecting {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} image after pulling"
   command: "{{ container_binary }} inspect {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"

--- a/roles/ceph-container-common/tasks/registry.yml
+++ b/roles/ceph-container-common/tasks/registry.yml
@@ -3,3 +3,7 @@
   command: '{{ container_binary }} login -u {{ ceph_docker_registry_username }} -p {{ ceph_docker_registry_password }} {{ ceph_docker_registry }}'
   changed_when: false
   no_log: true
+  environment:
+    HTTP_PROXY: "{{ ceph_docker_http_proxy | default('') }}"
+    HTTPS_PROXY: "{{ ceph_docker_https_proxy | default('') }}"
+    NO_PROXY: "{{ ceph_docker_no_proxy }}"

--- a/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
@@ -39,11 +39,49 @@
   tags: with_pkg
   when: inventory_hostname in groups.get(osd_group_name, [])
 
-- name: start container service
-  service:
-    name: '{{ container_service_name }}'
-    state: started
-    enabled: yes
-  tags:
-    with_pkg
+- name: extra configuration for docker
   when: container_service_name == 'docker'
+  block:
+    - name: create the systemd docker override directory
+      file:
+        path: /etc/systemd/system/docker.service.d
+        state: directory
+      when: ceph_docker_http_proxy is defined or ceph_docker_https_proxy is defined
+
+    - name: create the systemd docker override file
+      template:
+        src: docker-proxy.conf.j2
+        dest: /etc/systemd/system/docker.service.d/proxy.conf
+        mode: 0600
+        owner: root
+        group: root
+      register: proxy_created
+      when: ceph_docker_http_proxy is defined or ceph_docker_https_proxy is defined
+
+    - name: remove docker proxy configuration
+      file:
+        path: /etc/systemd/system/docker.service.d/proxy.conf
+        state: absent
+      register: proxy_removed
+      when:
+        - ceph_docker_http_proxy is not defined
+        - ceph_docker_https_proxy is not defined
+
+    # using xxx.changed here instead of an ansible handler because we need to
+    # have an immediate effect and not wait the end of the play.
+    # using flush_handlers via the meta action plugin isn't enough too because
+    # it flushes all handlers and not only the one notified in this role.
+    - name: restart docker
+      systemd:
+        name: "{{ container_service_name }}"
+        state: restarted
+        daemon_reload: yes
+      when: proxy_created.changed | bool or proxy_removed.changed | bool
+
+    - name: start container service
+      service:
+        name: '{{ container_service_name }}'
+        state: started
+        enabled: yes
+      tags:
+        with_pkg

--- a/roles/ceph-container-engine/templates/docker-proxy.conf.j2
+++ b/roles/ceph-container-engine/templates/docker-proxy.conf.j2
@@ -1,0 +1,8 @@
+[Service]
+{% if ceph_docker_http_proxy is defined %}
+Environment="HTTP_PROXY={{ ceph_docker_http_proxy }}"
+{% endif %}
+{% if ceph_docker_https_proxy is defined %}
+Environment="HTTPS_PROXY={{ ceph_docker_https_proxy }}"
+{% endif %}
+Environment="NO_PROXY={{ ceph_docker_no_proxy }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -578,6 +578,9 @@ ceph_docker_registry: docker.io
 ceph_docker_registry_auth: false
 #ceph_docker_registry_username:
 #ceph_docker_registry_password:
+#ceph_docker_http_proxy:
+#ceph_docker_https_proxy:
+ceph_docker_no_proxy: "localhost,127.0.0.1"
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 ceph_client_docker_image: "{{ ceph_docker_image }}"
 ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"


### PR DESCRIPTION
When using a http(s) proxy with either docker or podman we can rely on
the HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables.
But with ansible, even if those variables are defined in a source file
then they aren't loaded during the container pull/login tasks.
This implements the http(s) proxy support with docker/podman.
Both implementations are different:
  1/ docker doesn't rely en the environment variables with the CLI.
Thos are needed by the docker daemon via systemd.
  2/ podman uses the environment variables so we need to add them to
the login/pull tasks.

Backport: #5786
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1876692

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit bda3581294c8f29eda598522c331a4c009243884)