### PR TITLE
rgw multisite: check connection for realm endpoint

### DIFF
--- a/roles/ceph-rgw/tasks/multisite/secondary.yml
+++ b/roles/ceph-rgw/tasks/multisite/secondary.yml
@@ -1,4 +1,17 @@
 ---
+- name: ensure connection to primary cluster from mon
+  uri:
+    url: "{{ item.endpoint }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  loop: "{{ secondary_realms }}"
+  when: secondary_realms is defined
+
+- name: ensure connection to primary cluster from rgw
+  uri:
+    url: "{{ item.endpoint }}"
+  loop: "{{ rgw_instances }}"
+
 - name: fetch the realm(s)
   command: "{{ container_exec_cmd }} radosgw-admin realm pull --cluster={{ cluster }} --rgw-realm={{ item.realm }} --url={{ item.endpoint }} --access-key={{ item.system_access_key }} --secret={{ item.system_secret_key }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
Add a check that ensures a connection to the
endpoint the realm is being pulled from.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1731158

Signed-off-by: Ali Maredia <amaredia@redhat.com>