### PR TITLE
ceph-dashboard: increase radosgw-admin timeout

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -183,7 +183,7 @@
   run_once: true
   block:
     - name: get radosgw system user
-      command: "timeout --foreground -s KILL 20 {{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} user info --uid={{ dashboard_rgw_api_user_id }}"
+      command: "timeout --foreground -s KILL 60 {{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} user info --uid={{ dashboard_rgw_api_user_id }}"
       register: get_rgw_user
       until: get_rgw_user.rc == 0
       retries: 3
@@ -192,7 +192,7 @@
       changed_when: false
 
     - name: create radosgw system user
-      command: "timeout --foreground -s KILL 20 {{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} user create --uid={{ dashboard_rgw_api_user_id }} --display-name='Ceph dashboard' --system"
+      command: "timeout --foreground -s KILL 60 {{ container_exec_cmd }} radosgw-admin --cluster {{ cluster }} user create --uid={{ dashboard_rgw_api_user_id }} --display-name='Ceph dashboard' --system"
       register: create_rgw_user
       until: create_rgw_user.rc == 0
       retries: 3


### PR DESCRIPTION
20s could be too short in some case so raising this to 60s.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>