### PR TITLE
[skip ci] facts: fix 'set_fact rgw_instances with rgw multisite'

### DIFF
--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -50,14 +50,21 @@
     - inventory_hostname in groups.get(rgw_group_name, [])
     - not rgw_multisite | bool
 
+- name: set_fact is_rgw_instances_defined
+  set_fact:
+    is_rgw_instances_defined: "{{ rgw_instances is defined }}"
+  when:
+    - inventory_hostname in groups.get(rgw_group_name, [])
+    - rgw_multisite | bool
+
 - name: set_fact rgw_instances with rgw multisite
   set_fact:
     rgw_instances: "{{ rgw_instances|default([]) | union([{ 'instance_name': 'rgw' + item | string, 'radosgw_address': _radosgw_address, 'radosgw_frontend_port': radosgw_frontend_port | int + item|int, 'rgw_realm': rgw_realm | string, 'rgw_zonegroup': rgw_zonegroup | string, 'rgw_zone': rgw_zone | string, 'system_access_key': system_access_key, 'system_secret_key': system_secret_key, 'rgw_zone_user': rgw_zone_user, 'rgw_zone_user_display_name': rgw_zone_user_display_name, 'endpoint': (rgw_pull_proto + '://' + rgw_pullhost + ':' + rgw_pull_port | string) if not rgw_zonemaster | bool and rgw_zonesecondary | bool else omit }]) }}"
   with_sequence: start=0 end={{ radosgw_num_instances|int - 1 }}
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])
-    - rgw_instances is undefined
     - rgw_multisite | bool
+    - not is_rgw_instances_defined | default(False) | bool
 
 - name: set_fact rgw_instances_host
   set_fact:


### PR DESCRIPTION
the current condition doesn't work, as soon as the first iteration is
done the condition makes next iterations skip since `rgw_instances` got
set with the first iteration.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1859872

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>