### PR TITLE
[skip ci] container: quote registry password

### DIFF
--- a/roles/ceph-container-common/tasks/registry.yml
+++ b/roles/ceph-container-common/tasks/registry.yml
@@ -1,6 +1,6 @@
 ---
 - name: container registry authentication
-  command: '{{ container_binary }} login -u {{ ceph_docker_registry_username }} -p {{ ceph_docker_registry_password }} {{ ceph_docker_registry }}'
+  command: '{{ container_binary }} login -u {{ ceph_docker_registry_username }} -p {{ ceph_docker_registry_password | quote }} {{ ceph_docker_registry }}'
   changed_when: false
   no_log: true
   environment:


### PR DESCRIPTION
When using a quote in the registry password then we have the following
error:

The error was: ValueError: No closing quotation

To fix this we need to use the quote filter.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1880252

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>