### PR TITLE
grafana-server - Invalid characters were found in group names

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,7 +60,7 @@ ansible_provision = proc do |ansible|
     'clients'          => (0..CLIENTS - 1).map { |j| "#{LABEL_PREFIX}client#{j}" },
     'iscsigws'         => (0..NISCSI_GWS - 1).map { |j| "#{LABEL_PREFIX}iscsi_gw#{j}" },
     'mgrs'             => (0..MGRS - 1).map { |j| "#{LABEL_PREFIX}mgr#{j}" },
-    'grafana-server'   => (0..GRAFANA - 1).map { |j| "#{LABEL_PREFIX}grafana#{j}" }
+    'grafana_server'   => (0..GRAFANA - 1).map { |j| "#{LABEL_PREFIX}grafana#{j}" }
   }
 
   ansible.extra_vars = {

--- a/dashboard.yml
+++ b/dashboard.yml
@@ -8,7 +8,7 @@
     - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
-    - "{{ grafana_server_group_name|default('grafana-server') }}"
+    - "{{ grafana_server_group_name|default('grafana_server') }}"
   gather_facts: false
   become: true
   pre_tasks:

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -57,7 +57,7 @@ dummy:
 #iscsi_gw_group_name: iscsigws
 #mgr_group_name: mgrs
 #rgwloadbalancer_group_name: rgwloadbalancers
-#grafana_server_group_name: grafana-server
+#grafana_server_group_name: grafana_server
 
 # If configure_firewall is true, then ansible will try to configure the
 # appropriate firewalling rules so that Ceph daemons can communicate

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -57,7 +57,7 @@ fetch_directory: ~/ceph-ansible-keys
 #iscsi_gw_group_name: iscsigws
 #mgr_group_name: mgrs
 #rgwloadbalancer_group_name: rgwloadbalancers
-#grafana_server_group_name: grafana-server
+#grafana_server_group_name: grafana_server
 
 # If configure_firewall is true, then ansible will try to configure the
 # appropriate firewalling rules so that Ceph daemons can communicate

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -33,7 +33,7 @@
     - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
-    - "{{ grafana_server_group_name|default('grafana-server') }}"
+    - "{{ grafana_server_group_name|default('grafana_server') }}"
   become: true
   gather_facts: false
   vars:
@@ -818,7 +818,7 @@
         CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
 - name: redeploy alertmanager/grafana/prometheus daemons
-  hosts: "{{ grafana_server_group_name|default('grafana-server') }}"
+  hosts: "{{ grafana_server_group_name|default('grafana_server') }}"
   serial: 1
   become: true
   gather_facts: false
@@ -961,7 +961,7 @@
     - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
-    - "{{ grafana_server_group_name|default('grafana-server') }}"
+    - "{{ grafana_server_group_name|default('grafana_server') }}"
   become: true
   gather_facts: false
   tasks:

--- a/infrastructure-playbooks/cephadm.yml
+++ b/infrastructure-playbooks/cephadm.yml
@@ -9,7 +9,7 @@
     - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
-    - "{{ grafana_server_group_name|default('grafana-server') }}"
+    - "{{ grafana_server_group_name|default('grafana_server') }}"
   become: true
   gather_facts: false
   vars:
@@ -43,9 +43,9 @@
       when: dashboard_enabled | bool
       run_once: true
       block:
-        - name: fail if [grafana-server] group doesn't exist or empty
+        - name: fail if [grafana_server] group doesn't exist or empty
           fail:
-            msg: "you must add a [grafana-server] group and add at least one node."
+            msg: "you must add a [grafana_server] group and add at least one node."
           when: groups[grafana_server_group_name] is undefined or groups[grafana_server_group_name] | length == 0
 
         - name: fail when dashboard_admin_password is not set
@@ -197,7 +197,7 @@
     - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
-    - "{{ grafana_server_group_name|default('grafana-server') }}"
+    - "{{ grafana_server_group_name|default('grafana_server') }}"
   become: true
   gather_facts: false
   tasks:
@@ -285,7 +285,7 @@
         CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
 - name: adjust monitoring service placement
-  hosts: "{{ grafana_server_group_name|default('grafana-server') }}"
+  hosts: "{{ grafana_server_group_name|default('grafana_server') }}"
   become: true
   gather_facts: false
   tasks:

--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -8,7 +8,7 @@
   - clients
   - iscsigws
   - mgrs
-  - grafana-server
+  - grafana_server
 
   gather_facts: false
   become: True
@@ -54,7 +54,7 @@
     - "{{ mgr_group_name | default('mgrs') }}"
     - "{{ iscsi_gw_group_name | default('iscsigws') }}"
     - "{{ rbdmirror_group_name | default('rbdmirrors') }}"
-    - "{{ grafana_server_group_name|default('grafana-server') }}"
+    - "{{ grafana_server_group_name|default('grafana_server') }}"
   gather_facts: false
   become: true
   tasks:

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -42,7 +42,7 @@
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ client_group_name|default('clients') }}"
     - "{{ mgr_group_name|default('mgrs') }}"
-    - grafana-server
+    - grafana_server
 
   become: true
 
@@ -137,7 +137,7 @@
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ client_group_name|default('clients') }}"
     - "{{ mgr_group_name|default('mgrs') }}"
-    - grafana-server
+    - grafana_server
     - clients
     - iscsigws
 
@@ -173,7 +173,7 @@
 
 
 - name: purge ceph grafana-server
-  hosts: grafana-server
+  hosts: grafana_server
   become: true
   vars:
     grafana_services:
@@ -690,7 +690,7 @@
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ client_group_name|default('clients') }}"
     - "{{ mgr_group_name|default('mgrs') }}"
-    - grafana-server
+    - grafana_server
 
   gather_facts: false # Already gathered previously
 

--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -369,7 +369,7 @@
     - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ mgr_group_name|default('mgrs') }}"
-    - grafana-server
+    - grafana_server
     - iscsigws
     - clients
 
@@ -407,7 +407,7 @@
 
 - name: purge ceph-grafana
 
-  hosts: grafana-server
+  hosts: grafana_server
 
   gather_facts: false
 

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -49,7 +49,7 @@
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ client_group_name|default('clients') }}"
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
-    - "{{ grafana_server_group_name|default('grafana-server') }}"
+    - "{{ grafana_server_group_name|default('grafana_server') }}"
 
   any_errors_fatal: True
   become: True

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -49,7 +49,7 @@ client_group_name: clients
 iscsi_gw_group_name: iscsigws
 mgr_group_name: mgrs
 rgwloadbalancer_group_name: rgwloadbalancers
-grafana_server_group_name: grafana-server
+grafana_server_group_name: grafana_server
 
 # If configure_firewall is true, then ansible will try to configure the
 # appropriate firewalling rules so that Ceph daemons can communicate

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -212,14 +212,14 @@
     - ceph_rbd_mirror_configure | default(false) | bool
 
 - block:
-    - name: fail if [grafana-server] group doesn't exist
+    - name: fail if [grafana_server] group doesn't exist
       fail:
-        msg: "you must add a [grafana-server] group and add at least one node."
+        msg: "you must add a [grafana_server] group and add at least one node."
       when: groups[grafana_server_group_name] is undefined
 
-    - name: fail when [grafana-server] doesn't contain at least one node.
+    - name: fail when [grafana_server] doesn't contain at least one node.
       fail:
-        msg: "you must add at least one node in the [grafana-server] hosts group"
+        msg: "you must add at least one node in the [grafana_server] hosts group"
       when: groups[grafana_server_group_name] | length < 1
 
     - name: fail when dashboard_admin_password and/or grafana_admin_password are not set

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -11,7 +11,7 @@
   - clients
   - iscsigws
   - mgrs
-  - grafana-server
+  - grafana_server
 
   gather_facts: false
   become: True

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -11,7 +11,7 @@
   - clients
   - mgrs
   - iscsigws
-  - grafana-server
+  - grafana_server
   - rgwloadbalancers
 
   gather_facts: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,7 @@ def node(host, request):
             request.function, group_names)
         pytest.skip(reason)
 
-    if request.node.get_closest_marker('ceph_crash') and group_names in [['nfss'], ['iscsigws'], ['clients'], ['grafana-server']]:
+    if request.node.get_closest_marker('ceph_crash') and group_names in [['nfss'], ['iscsigws'], ['clients'], ['grafana_server']]:
         pytest.skip('Not a valid test for nfs, client or iscsigw nodes')
 
     if request.node.get_closest_marker("no_docker") and docker:

--- a/tests/functional/all_daemons/container/hosts
+++ b/tests/functional/all_daemons/container/hosts
@@ -32,5 +32,5 @@ rbd-mirror0
 [iscsigws]
 iscsi-gw0
 
-[grafana-server]
+[grafana_server]
 mon0

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -32,5 +32,5 @@ rbd-mirror0
 [iscsigws]
 iscsi-gw0
 
-[grafana-server]
+[grafana_server]
 mon0

--- a/tests/functional/all_daemons/hosts-switch-to-containers
+++ b/tests/functional/all_daemons/hosts-switch-to-containers
@@ -23,5 +23,5 @@ rgw0
 [clients]
 client0
 
-[grafana-server]
+[grafana_server]
 mon0

--- a/tests/functional/cephadm/hosts
+++ b/tests/functional/cephadm/hosts
@@ -27,5 +27,5 @@ rbd-mirror0
 [iscsigws]
 iscsi-gw0
 
-[grafana-server]
+[grafana_server]
 mon0

--- a/tests/functional/collocation/container/hosts
+++ b/tests/functional/collocation/container/hosts
@@ -22,5 +22,5 @@ mds0
 #rgw0
 #mds0
 
-[grafana-server]
+[grafana_server]
 mon0

--- a/tests/functional/collocation/hosts
+++ b/tests/functional/collocation/hosts
@@ -22,5 +22,5 @@ mds0
 #rgw0
 #mds0
 
-[grafana-server]
+[grafana_server]
 mon0

--- a/tests/functional/docker2podman/hosts
+++ b/tests/functional/docker2podman/hosts
@@ -7,5 +7,5 @@ osd0
 [mgrs]
 mon0
 
-[grafana-server]
+[grafana_server]
 mon0

--- a/tests/functional/podman/hosts
+++ b/tests/functional/podman/hosts
@@ -26,7 +26,7 @@ rbd-mirror0
 [iscsigws]
 iscsi-gw0
 
-[grafana-server]
+[grafana_server]
 mon0
 
 #[all:vars]


### PR DESCRIPTION
In the upcoming release of ansible 2.10, grafana-server group will no longer
be viable to use by default, it will fail instead of give a warning.

To fix this we'll need to convert all the references to the group from '-' to '_'.

I _believe_ I got all the exceptions like grafana_services vars to stay grafana-server instead of grafana_server, and I believe I changed the tests/vagrantfiles to be correct too, but someone definitely needs to double check that.