### PR TITLE
facts: refact `ceph_uid` fact (bp #5526)

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -257,7 +257,7 @@ dummy:
 
 #ceph_conf_key_directory: /etc/ceph
 
-#ceph_uid: 167
+#ceph_uid: "{{ '64045' if not containerized_deployment | bool and ansible_os_family == 'Debian' else '167' }}"
 
 # Permissions for keyring files in /etc/ceph
 #ceph_keyring_permissions: '0600'

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -257,7 +257,7 @@ ceph_iscsi_config_dev: false
 
 #ceph_conf_key_directory: /etc/ceph
 
-#ceph_uid: 167
+#ceph_uid: "{{ '64045' if not containerized_deployment | bool and ansible_os_family == 'Debian' else '167' }}"
 
 # Permissions for keyring files in /etc/ceph
 #ceph_keyring_permissions: '0600'

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -249,7 +249,7 @@ generate_fsid: true
 
 ceph_conf_key_directory: /etc/ceph
 
-ceph_uid: 167
+ceph_uid: "{{ '64045' if not containerized_deployment | bool and ansible_os_family == 'Debian' else '167' }}"
 
 # Permissions for keyring files in /etc/ceph
 ceph_keyring_permissions: '0600'

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -212,13 +212,6 @@
     - item.value.holders|count == 0
     - item.key is not match osd_auto_discovery_exclude
 
-- name: set_fact ceph_uid for debian based system - non container
-  set_fact:
-    ceph_uid: 64045
-  when:
-    - not containerized_deployment | bool
-    - ansible_os_family == 'Debian'
-
 - name: backward compatibility tasks related
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])


### PR DESCRIPTION
There's no need to set this fact with a `set_fact`
We can achieve this in `ceph-defaults`

Backport: #5526

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit bcc673f66c22364766beb4b5ebb971bd3f517693)