### PR TITLE
facts: refact `ceph_uid` fact (bp #4948,#5526)

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -255,7 +255,7 @@ dummy:
 
 #ceph_conf_key_directory: /etc/ceph
 
-#ceph_uid: 167
+#ceph_uid: "{{ '64045' if not containerized_deployment | bool and ansible_os_family == 'Debian' else '167' }}"
 
 # Permissions for keyring files in /etc/ceph
 #ceph_keyring_permissions: '0600'

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -255,6 +255,8 @@ dummy:
 
 #ceph_conf_key_directory: /etc/ceph
 
+#ceph_uid: 167
+
 # Permissions for keyring files in /etc/ceph
 #ceph_keyring_permissions: '0600'
 
@@ -294,9 +296,9 @@ dummy:
 # 'rbd_client_directory_mode: "0755"', *not*
 # 'rbd_client_directory_mode: 0755', or Ansible will complain: mode
 # must be in octal or symbolic form
-#rbd_client_directory_owner: null
-#rbd_client_directory_group: null
-#rbd_client_directory_mode: null
+#rbd_client_directory_owner: ceph
+#rbd_client_directory_group: ceph
+#rbd_client_directory_mode: "0770"
 
 #rbd_client_log_path: /var/log/ceph
 #rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -255,6 +255,8 @@ ceph_iscsi_config_dev: false
 
 #ceph_conf_key_directory: /etc/ceph
 
+#ceph_uid: 167
+
 # Permissions for keyring files in /etc/ceph
 #ceph_keyring_permissions: '0600'
 
@@ -294,9 +296,9 @@ ceph_iscsi_config_dev: false
 # 'rbd_client_directory_mode: "0755"', *not*
 # 'rbd_client_directory_mode: 0755', or Ansible will complain: mode
 # must be in octal or symbolic form
-#rbd_client_directory_owner: null
-#rbd_client_directory_group: null
-#rbd_client_directory_mode: null
+#rbd_client_directory_owner: ceph
+#rbd_client_directory_group: ceph
+#rbd_client_directory_mode: "0770"
 
 #rbd_client_log_path: /var/log/ceph
 #rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -255,7 +255,7 @@ ceph_iscsi_config_dev: false
 
 #ceph_conf_key_directory: /etc/ceph
 
-#ceph_uid: 167
+#ceph_uid: "{{ '64045' if not containerized_deployment | bool and ansible_os_family == 'Debian' else '167' }}"
 
 # Permissions for keyring files in /etc/ceph
 #ceph_keyring_permissions: '0600'

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -247,6 +247,8 @@ generate_fsid: true
 
 ceph_conf_key_directory: /etc/ceph
 
+ceph_uid: 167
+
 # Permissions for keyring files in /etc/ceph
 ceph_keyring_permissions: '0600'
 
@@ -286,9 +288,9 @@ rbd_client_directories: true # this will create rbd_client_log_path and rbd_clie
 # 'rbd_client_directory_mode: "0755"', *not*
 # 'rbd_client_directory_mode: 0755', or Ansible will complain: mode
 # must be in octal or symbolic form
-rbd_client_directory_owner: null
-rbd_client_directory_group: null
-rbd_client_directory_mode: null
+rbd_client_directory_owner: ceph
+rbd_client_directory_group: ceph
+rbd_client_directory_mode: "0770"
 
 rbd_client_log_path: /var/log/ceph
 rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -247,7 +247,7 @@ generate_fsid: true
 
 ceph_conf_key_directory: /etc/ceph
 
-ceph_uid: 167
+ceph_uid: "{{ '64045' if not containerized_deployment | bool and ansible_os_family == 'Debian' else '167' }}"
 
 # Permissions for keyring files in /etc/ceph
 ceph_keyring_permissions: '0600'

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -238,13 +238,6 @@
     - item.value.holders|count == 0
     - item.key is not match osd_auto_discovery_exclude
 
-- name: set_fact ceph_uid for debian based system - non container
-  set_fact:
-    ceph_uid: 64045
-  when:
-    - not containerized_deployment | bool
-    - ansible_os_family == 'Debian'
-
 - name: backward compatibility tasks related
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -197,24 +197,6 @@
     mds_name: "{{ ansible_fqdn }}"
   when: mds_use_fqdn | bool
 
-- name: set_fact rbd_client_directory_owner ceph
-  set_fact:
-    rbd_client_directory_owner: ceph
-  when: rbd_client_directory_owner is not defined
-      or not rbd_client_directory_owner
-
-- name: set_fact rbd_client_directory_group rbd_client_directory_group
-  set_fact:
-    rbd_client_directory_group: ceph
-  when: rbd_client_directory_group is not defined
-      or not rbd_client_directory_group
-
-- name: set_fact rbd_client_directory_mode 0770
-  set_fact:
-    rbd_client_directory_mode: "0770"
-  when: rbd_client_directory_mode is not defined
-      or not rbd_client_directory_mode
-
 - name: resolve device link(s)
   command: readlink -f {{ item }}
   changed_when: false
@@ -262,31 +244,6 @@
   when:
     - not containerized_deployment | bool
     - ansible_os_family == 'Debian'
-
-- name: set_fact ceph_uid for red hat or suse based system - non container
-  set_fact:
-    ceph_uid: 167
-  when:
-    - not containerized_deployment | bool
-    - ansible_os_family in ['RedHat', 'Suse']
-
-- name: set_fact ceph_uid for debian based system - container
-  set_fact:
-    ceph_uid: 64045
-  when:
-    - containerized_deployment | bool
-    - ceph_docker_image_tag | string is search("ubuntu")
-
-- name: set_fact ceph_uid for red hat based system - container
-  set_fact:
-    ceph_uid: 167
-  when:
-    - containerized_deployment | bool
-    - (ceph_docker_image_tag | string is search("latest")
-      or ceph_docker_image_tag | string is search("centos")
-      or ceph_docker_image_tag | string is search("fedora")
-      or ceph_docker_image_tag | string is search("rhceph")
-      or (ansible_distribution == 'RedHat'))
 
 - name: backward compatibility tasks related
   when:


### PR DESCRIPTION
There's no need to set this fact with a set_fact
We can achieve this in ceph-defaults

Backport: #4948
Backport: #5526

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1875058

Signed-off-by: Guillaume Abrioux gabrioux@redhat.com
(cherry picked from commit bcc673f)