### PR TITLE
ceph-volume: remove useless condition

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -435,10 +435,9 @@ def list_osd(module, container_image):
     data = get_data(data, data_vg)
 
     # Build the CLI
-    action = ['lvm', 'list']
+    action = ['lvm', 'list', data]
     cmd = build_cmd(action, container_image, cluster)
-    if data:
-        cmd.append(data)
+
     cmd.append('--format=json')
 
     return cmd


### PR DESCRIPTION
whatever we pass a 'vg/lv' or a root device, the function `get_data()`
always returns a non-empty string.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>