### PR TITLE
[skip ci] Remove libjemalloc1 installation task

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_debian.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_debian.yml
@@ -49,13 +49,6 @@
         - (ceph_origin == 'repository' or ceph_origin == 'distro')
         - ceph_repository != 'rhcs'
       block:
-        - name: install jemalloc for debian
-          apt:
-            name: libjemalloc1
-            state: "{{ (upgrade_ceph_packages|bool) | ternary('latest','present') }}"
-            update_cache: yes
-          register: result
-          until: result is succeeded
         - name: install nfs rgw/cephfs gateway - debian
           apt:
             name: ['nfs-ganesha-rgw', 'radosgw']


### PR DESCRIPTION
libjemalloc1 package is not required neither for ganesha dependency nor
for the package build process. So this task can be simply dropped.

Signed-Off-By: Dmitriy Rabotyagov <noonedeadpunk@ya.ru>