### PR TITLE
rgw: fix multi instances scaleout in baremetal

### DIFF
--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -47,6 +47,16 @@ options:
         description:
             - name of the CephX key
         required: true
+    user:
+        description:
+            - entity used to perform operation.
+            It corresponds to the -n option (--name)
+        required: false
+    user_key:
+        description:
+            - the path to the keyring corresponding to the
+            user being used.
+            It corresponds to the -k option (--keyring)
     state:
         description:
             - If 'present' is used, the module creates a keyring
@@ -131,6 +141,8 @@ caps:
 - name: create cephx key
   ceph_key:
     name: "{{ keys_to_create }}"
+    user: client.bootstrap-rgw
+    user_key: /var/lib/ceph/bootstrap-rgw/ceph.keyring
     state: present
     caps: "{{ caps }}"
 
@@ -244,10 +256,12 @@ def generate_secret():
     return secret
 
 
-def generate_caps(cmd, _type, caps):
+def generate_caps(_type, caps):
     '''
     Generate CephX capabilities list
     '''
+
+    caps_cli = []
 
     for k, v in caps.items():
         # makes sure someone didn't pass an empty var,
@@ -255,13 +269,13 @@ def generate_caps(cmd, _type, caps):
         if len(k) == 0:
             continue
         if _type == "ceph-authtool":
-            cmd.extend(["--cap"])
-        cmd.extend([k, v])
+            caps_cli.extend(["--cap"])
+        caps_cli.extend([k, v])
 
-    return cmd
+    return caps_cli
 
 
-def generate_ceph_cmd(cluster, args, user, user_key, container_image=None):
+def generate_ceph_cmd(cluster, args, user, user_key_path, container_image=None):
     '''
     Generate 'ceph' command line to execute
     '''
@@ -278,7 +292,7 @@ def generate_ceph_cmd(cluster, args, user, user_key, container_image=None):
         '-n',
         user,
         '-k',
-        user_key,
+        user_key_path,
         '--cluster',
         cluster,
         'auth',
@@ -312,40 +326,38 @@ def generate_ceph_authtool_cmd(cluster, name, secret, caps, dest, container_imag
     ]
 
     cmd.extend(base_cmd)
-    cmd = generate_caps(cmd, "ceph-authtool", caps)
+    cmd.extend(generate_caps("ceph-authtool", caps))
 
     return cmd
 
 
-def create_key(module, result, cluster, name, secret, caps, import_key, dest, container_image=None):  # noqa E501
+def create_key(module, result, cluster, user, user_key_path, name, secret, caps, import_key, dest, container_image=None):  # noqa E501
     '''
     Create a CephX key
     '''
 
-    args = [
-        'import',
-        '-i',
-        dest,
-    ]
     cmd_list = []
-
     if not secret:
         secret = generate_secret()
+
+    if user == 'client.admin':
+        args = ['import', '-i', dest]
+    else:
+        args = ['get-or-create', name]
+        args.extend(generate_caps(None, caps))
+        args.extend(['-o', dest])
 
     cmd_list.append(generate_ceph_authtool_cmd(
         cluster, name, secret, caps, dest, container_image))
 
-    if import_key:
-        user = "client.admin"
-        keyring_filename = cluster + "." + user + ".keyring"
-        user_key = os.path.join("/etc/ceph/", keyring_filename)
+    if import_key or user != 'client.admin':
         cmd_list.append(generate_ceph_cmd(
-            cluster, args, user, user_key, container_image))
+            cluster, args, user, user_key_path, container_image))
 
     return cmd_list
 
 
-def delete_key(cluster, name, container_image=None):
+def delete_key(cluster, user, user_key_path, name, container_image=None):
     '''
     Delete a CephX key
     '''
@@ -357,16 +369,13 @@ def delete_key(cluster, name, container_image=None):
         name,
     ]
 
-    user = "client.admin"
-    keyring_filename = cluster + "." + user + ".keyring"
-    user_key = os.path.join("/etc/ceph/", keyring_filename)
     cmd_list.append(generate_ceph_cmd(
-        cluster, args, user, user_key, container_image))
+        cluster, args, user, user_key_path, container_image))
 
     return cmd_list
 
 
-def get_key(cluster, name, dest, container_image=None):
+def get_key(cluster, user, user_key_path, name, dest, container_image=None):
     '''
     Get a CephX key (write on the filesystem)
     '''
@@ -380,16 +389,13 @@ def get_key(cluster, name, dest, container_image=None):
         dest,
     ]
 
-    user = "client.admin"
-    keyring_filename = cluster + "." + user + ".keyring"
-    user_key = os.path.join("/etc/ceph/", keyring_filename)
     cmd_list.append(generate_ceph_cmd(
-        cluster, args, user, user_key, container_image))
+        cluster, args, user, user_key_path, container_image))
 
     return cmd_list
 
 
-def info_key(cluster, name, user, user_key, output_format, container_image=None):  # noqa E501
+def info_key(cluster, name, user, user_key_path, output_format, container_image=None):  # noqa E501
     '''
     Get information about a CephX key
     '''
@@ -404,12 +410,12 @@ def info_key(cluster, name, user, user_key, output_format, container_image=None)
     ]
 
     cmd_list.append(generate_ceph_cmd(
-        cluster, args, user, user_key, container_image))
+        cluster, args, user, user_key_path, container_image))
 
     return cmd_list
 
 
-def list_keys(cluster, user, user_key, container_image=None):
+def list_keys(cluster, user, user_key_path, container_image=None):
     '''
     List all CephX keys
     '''
@@ -423,7 +429,7 @@ def list_keys(cluster, user, user_key, container_image=None):
     ]
 
     cmd_list.append(generate_ceph_cmd(
-        cluster, args, user, user_key, container_image))
+        cluster, args, user, user_key_path, container_image))
 
     return cmd_list
 
@@ -505,6 +511,8 @@ def run_module():
         secret=dict(type='str', required=False, default=None, no_log=True),
         import_key=dict(type='bool', required=False, default=True),
         dest=dict(type='str', required=False, default='/etc/ceph/'),
+        user=dict(type='str', required=False, default='client.admin'),
+        user_key=dict(type='str', required=False, default=None)
     )
 
     module = AnsibleModule(
@@ -523,6 +531,8 @@ def run_module():
     secret = module.params.get('secret')
     import_key = module.params.get('import_key')
     dest = module.params.get('dest')
+    user = module.params.get('user')
+    user_key = module.params.get('user_key')
 
     changed = False
 
@@ -551,9 +561,13 @@ def run_module():
     _caps = caps
     key_exist = 1
 
-    user = "client.admin"
-    keyring_filename = cluster + '.' + user + '.keyring'
-    user_key = os.path.join("/etc/ceph/", keyring_filename)
+    if not user_key:
+        user_key_filename = '{}.{}.keyring'.format(cluster, user)
+        user_key_dir = '/etc/ceph'
+        user_key_path = os.path.join(user_key_dir, user_key_filename)
+    else:
+        user_key_path = user_key
+
     output_format = "json"
 
     if (state in ["present", "update"]):
@@ -575,7 +589,7 @@ def run_module():
         if import_key:
             _info_key = []
             rc, cmd, out, err = exec_commands(
-                module, info_key(cluster, name, user, user_key, output_format, container_image))  # noqa E501
+                module, info_key(cluster, name, user, user_key_path, output_format, container_image))  # noqa E501
             key_exist = rc
             if not caps and key_exist != 0:
                 fatal("Capabilities must be provided when state is 'present'", module)  # noqa E501
@@ -591,7 +605,7 @@ def run_module():
                 _caps = _info_key[0]['caps']
                 if secret == _secret and caps == _caps:
                     if not os.path.isfile(file_path):
-                        rc, cmd, out, err = exec_commands(module, get_key(cluster, name, file_path, container_image))  # noqa E501
+                        rc, cmd, out, err = exec_commands(module, get_key(cluster, user, user_key_path, name, file_path, container_image))  # noqa E501
                         result["rc"] = rc
                         if rc != 0:
                             result["stdout"] = "Couldn't fetch the key {0} at {1}.".format(name, file_path) # noqa E501
@@ -609,7 +623,7 @@ def run_module():
                 module.exit_json(**result)
         if (key_exist == 0 and (secret != _secret or caps != _caps)) or key_exist != 0:  # noqa E501
             rc, cmd, out, err = exec_commands(module, create_key(
-                module, result, cluster, name, secret, caps, import_key, file_path, container_image))  # noqa E501
+                module, result, cluster, user, user_key_path, name, secret, caps, import_key, file_path, container_image))  # noqa E501
             if rc != 0:
                 result["stdout"] = "Couldn't create or update {0}".format(name)
                 result["stderr"] = err
@@ -620,7 +634,7 @@ def run_module():
     elif state == "absent":
         if key_exist == 0:
             rc, cmd, out, err = exec_commands(
-                module, delete_key(cluster, name, container_image))
+                module, delete_key(cluster, user, user_key_path, name, container_image))
             if rc == 0:
                 changed = True
         else:
@@ -628,7 +642,7 @@ def run_module():
 
     elif state == "info":
         rc, cmd, out, err = exec_commands(
-            module, info_key(cluster, name, user, user_key, output_format, container_image))  # noqa E501
+            module, info_key(cluster, name, user, user_key_path, output_format, container_image))  # noqa E501
         if rc != 0:
             result["stdout"] = "skipped, since {0} does not exist".format(name)
             result['rc'] = 0
@@ -636,15 +650,15 @@ def run_module():
 
     elif state == "list":
         rc, cmd, out, err = exec_commands(
-            module, list_keys(cluster, user, user_key, container_image))
+            module, list_keys(cluster, user, user_key_path, container_image))
 
     elif state == "fetch_initial_keys":
         hostname = socket.gethostname().split('.', 1)[0]
         user = "mon."
         keyring_filename = cluster + "-" + hostname + "/keyring"
-        user_key = os.path.join("/var/lib/ceph/mon/", keyring_filename)
+        user_key_path = os.path.join("/var/lib/ceph/mon/", keyring_filename)
         rc, cmd, out, err = exec_commands(
-            module, list_keys(cluster, user, user_key, container_image))
+            module, list_keys(cluster, user, user_key_path, container_image))
         if rc != 0:
             result["stdout"] = "failed to retrieve ceph keys"
             result["sdterr"] = err
@@ -669,7 +683,7 @@ def run_module():
             ]
 
             info_cmd = info_key(cluster, entity, user,
-                                user_key, output_format, container_image)
+                                user_key_path, output_format, container_image)
             # we use info_cmd[0] because info_cmd is an array made of an array
             info_cmd[0].extend(extra_args)
             rc, cmd, out, err = exec_commands(

--- a/roles/ceph-handler/tasks/main.yml
+++ b/roles/ceph-handler/tasks/main.yml
@@ -48,3 +48,18 @@
       or inventory_hostname in groups.get(mds_group_name, [])
       or inventory_hostname in groups.get(rgw_group_name, [])
       or inventory_hostname in groups.get(rbdmirror_group_name, [])
+
+- name: rgw multi-instances related tasks
+  when:
+    - inventory_hostname in groups.get(rgw_group_name, [])
+    - handler_rgw_status | bool
+  block:
+    - name: import_role ceph-config
+      import_role:
+        name: ceph-config
+
+    - name: import_role ceph-rgw
+      import_role:
+        name: ceph-rgw
+        tasks_from: pre_requisite.yml
+      when: not containerized_deployment | bool

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -1,17 +1,20 @@
 ---
-- name: create rados gateway instance keyring
-  command: ceph --cluster {{ cluster }} --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring auth get-or-create client.rgw.{{ ansible_hostname }}.{{ item.instance_name }} osd 'allow rwx' mon 'allow rw' -o /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}.{{ item.instance_name }}/keyring
-  args:
-    creates: /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}.{{ item.instance_name }}/keyring
-  changed_when: false
-  with_items: "{{ rgw_instances }}"
-  when: cephx | bool
-
-- name: set rados gateway instance key permissions
-  file:
-    path: /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}.{{ item.instance_name }}/keyring
+- name: create rgw keyrings
+  ceph_key:
+    name: "client.rgw.{{ ansible_hostname }}.{{ item.instance_name }}"
+    cluster: "{{ cluster }}"
+    user: "client.bootstrap-rgw"
+    user_key: /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring
+    dest: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}.{{ item.instance_name }}/keyring"
+    caps:
+      osd: 'allow rwx'
+      mon: 'allow rw'
+    import_key: False
     owner: "ceph"
     group: "ceph"
     mode: "0600"
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   with_items: "{{ rgw_instances }}"
   when: cephx | bool

--- a/tests/functional/all_daemons/ceph-override.json
+++ b/tests/functional/all_daemons/ceph-override.json
@@ -33,5 +33,6 @@
       "min_size": 0
     }
   ],
-  "ceph_mon_docker_memory_limit": "2g"
+  "ceph_mon_docker_memory_limit": "2g",
+  "radosgw_num_instances": 2
 }

--- a/tox.ini
+++ b/tox.ini
@@ -369,13 +369,13 @@ commands=
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 
   # reboot all vms
-  all_daemons: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/reboot.yml
+  all_daemons,collocation: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/reboot.yml
 
   # retest to ensure cluster came back up correctly after rebooting
-  all_daemons: py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
+  all_daemons,collocation: py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 
   # handlers/idempotency test
-  all_daemons,all_in_one: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "delegate_facts_host={env:DELEGATE_FACTS_HOST:True} fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-bis-master} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --extra-vars @ceph-override.json
+  all_daemons,all_in_one,collocation: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "delegate_facts_host={env:DELEGATE_FACTS_HOST:True} fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-bis-master} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --extra-vars @ceph-override.json
 
   purge: {[purge]commands}
   switch_to_containers: {[switch-to-containers]commands}


### PR DESCRIPTION
When rgw and osd are collocated, the current workflow prevents from
scaling out the radosgw_num_instances parameter when rerunning the
playbook in baremetal deployments.

When ceph-osd notifies handlers, it means rgw handlers are triggered
too. The issue with this is that they are triggered before the role
ceph-rgw is run.
In the case a scaleout operation is expected on `radosgw_num_instances`
it causes an issue because keyrings haven't been created yet so the new
instances won't start.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1881313

- [x] modify the `ceph-override.json` to scaleout `radosgw_num_instances`

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>