### PR TITLE
ansible.cfg: set force_valid_group_names param

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -20,6 +20,7 @@ fact_caching_timeout = 7200
 nocows = 1
 callback_whitelist = profile_tasks
 stdout_callback = yaml
+force_valid_group_names = ignore
 
 # Disable them in the context of https://review.openstack.org/#/c/469644
 retry_files_enabled = False

--- a/infrastructure-playbooks/ansible.cfg
+++ b/infrastructure-playbooks/ansible.cfg
@@ -1,6 +1,0 @@
-[defaults]
-ansible_managed = Please do not change this file directly since it is managed by Ansible and will be overwritten
-action_plugins = ../plugins/actions
-callback_plugins = ../plugins/callback
-roles_path = ../roles
-force_valid_group_names = ignore

--- a/infrastructure-playbooks/ansible.cfg
+++ b/infrastructure-playbooks/ansible.cfg
@@ -3,3 +3,4 @@ ansible_managed = Please do not change this file directly since it is managed by
 action_plugins = ../plugins/actions
 callback_plugins = ../plugins/callback
 roles_path = ../roles
+force_valid_group_names = ignore


### PR DESCRIPTION
As of 2.10, group names containing a dash are invalid.
However, setting this option makes it still possible to use a dash in
group names and prevent this warning to show up.
It might need to be definitely addressed in a future ansible release.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1880476

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>