### PR TITLE
[skip ci] ceph-config: remove ceph_release from ceph.conf.j2

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -20,7 +20,6 @@ osd crush chooseleaf type = 0
 {% set nb_client = groups.get(client_group_name, []) | length | int %}
 {% set nb_osd = groups.get(osd_group_name, []) | length | int %}
 {% if inventory_hostname in groups.get(client_group_name, []) and not inventory_hostname == groups.get(client_group_name, []) | first %}
-{% set ceph_release = hostvars[groups[client_group_name][0]]['ceph_release'] %}
 {% endif %}
 
 {% if nb_mon > 0 and inventory_hostname in groups.get(mon_group_name, []) %}


### PR DESCRIPTION
We don't use ceph_release variable in the ceph.conf jinja template.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>