### PR TITLE
Remove unused centos docker tasks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,7 +76,6 @@ ansible_provision = proc do |ansible|
       monitor_interface: ETH,
       ceph_mon_docker_subnet: "#{PUBLIC_SUBNET}.0/24",
       devices: settings['disks'],
-      ceph_docker_on_openstack: BOX == 'openstack',
       radosgw_interface: ETH,
       generate_fsid: 'true',
     })

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -598,8 +598,6 @@ dummy:
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
 #ceph_client_docker_registry: "{{ ceph_docker_registry }}"
-#ceph_docker_enable_centos_extra_repo: false
-#ceph_docker_on_openstack: false
 #containerized_deployment: False
 #container_binary:
 #timeout_command: "{{ 'timeout --foreground -s KILL ' ~ docker_pull_timeout if (docker_pull_timeout != '0') and (ceph_docker_dev_image is undefined or not ceph_docker_dev_image) else '' }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -598,8 +598,6 @@ ceph_docker_registry_auth: true
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
 #ceph_client_docker_registry: "{{ ceph_docker_registry }}"
-#ceph_docker_enable_centos_extra_repo: false
-#ceph_docker_on_openstack: false
 #containerized_deployment: False
 #container_binary:
 #timeout_command: "{{ 'timeout --foreground -s KILL ' ~ docker_pull_timeout if (docker_pull_timeout != '0') and (ceph_docker_dev_image is undefined or not ceph_docker_dev_image) else '' }}"

--- a/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
@@ -11,18 +11,6 @@
     - ansible_os_family == 'Debian'
   tags: with_pkg
 
-# ensure extras enabled for docker
-- name: enable extras on centos
-  yum_repository:
-    name: extras
-    state: present
-    enabled: yes
-  when:
-    - ansible_distribution == 'CentOS'
-    - ceph_docker_enable_centos_extra_repo | bool
-  tags:
-    with_pkg
-
 - name: install container packages
   package:
     name: ['{{ container_package_name }}', '{{ container_binding_name }}']

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -590,8 +590,6 @@ ceph_docker_no_proxy: "localhost,127.0.0.1"
 ceph_client_docker_image: "{{ ceph_docker_image }}"
 ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
 ceph_client_docker_registry: "{{ ceph_docker_registry }}"
-ceph_docker_enable_centos_extra_repo: false
-ceph_docker_on_openstack: false
 containerized_deployment: False
 container_binary:
 timeout_command: "{{ 'timeout --foreground -s KILL ' ~ docker_pull_timeout if (docker_pull_timeout != '0') and (ceph_docker_dev_image is undefined or not ceph_docker_dev_image) else '' }}"

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -1,14 +1,4 @@
 ---
-- name: umount ceph disk (if on openstack)
-  mount:
-    name: /mnt
-    src: /dev/vdb
-    fstype: ext3
-    state: unmounted
-  when:
-    - ceph_docker_on_openstack | bool
-    - containerized_deployment | bool
-
 # this is for ceph-disk, the ceph-disk command is gone so we have to list /var/lib/ceph
 - name: get osd ids
   shell: |

--- a/tests/functional/all-in-one/container/group_vars/all
+++ b/tests/functional/all-in-one/container/group_vars/all
@@ -8,7 +8,6 @@ monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_num_instances: 2
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 public_network: "192.168.19.0/24"
 cluster_network: "192.168.20.0/24"
 rgw_override_bucket_index_max_shards: 16

--- a/tests/functional/all-in-one/group_vars/all
+++ b/tests/functional/all-in-one/group_vars/all
@@ -5,7 +5,6 @@ ceph_repository: community
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 openstack_config: True
 dashboard_enabled: False
 public_network: "192.168.17.0/24"

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -7,7 +7,6 @@ containerized_deployment: True
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 public_network: "192.168.17.0/24"
 cluster_network: "192.168.18.0/24"
 rgw_override_bucket_index_max_shards: 16

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -8,7 +8,6 @@ monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_num_instances: 2
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 public_network: "192.168.15.0/24"
 cluster_network: "192.168.16.0/24"
 rgw_override_bucket_index_max_shards: 16

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -5,7 +5,6 @@ ceph_repository: community
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 public_network: "192.168.15.0/24"
 cluster_network: "192.168.16.0/24"
 rgw_override_bucket_index_max_shards: 16

--- a/tests/functional/docker2podman/group_vars/all
+++ b/tests/functional/docker2podman/group_vars/all
@@ -8,7 +8,6 @@ containerized_deployment: True
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 public_network: "192.168.58.0/24"
 cluster_network: "192.168.59.0/24"
 rgw_override_bucket_index_max_shards: 16

--- a/tests/functional/external_clients/container/inventory/group_vars/all
+++ b/tests/functional/external_clients/container/inventory/group_vars/all
@@ -8,7 +8,6 @@ monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_num_instances: 2
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 public_network: "192.168.31.0/24"
 cluster_network: "192.168.32.0/24"
 rgw_override_bucket_index_max_shards: 16

--- a/tests/functional/external_clients/inventory/group_vars/all
+++ b/tests/functional/external_clients/inventory/group_vars/all
@@ -5,7 +5,6 @@ ceph_repository: community
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 openstack_config: True
 dashboard_enabled: False
 public_network: "192.168.31.0/24"

--- a/tests/functional/podman/group_vars/all
+++ b/tests/functional/podman/group_vars/all
@@ -7,7 +7,6 @@ containerized_deployment: True
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 public_network: "192.168.30.0/24"
 cluster_network: "192.168.31.0/24"
 rgw_override_bucket_index_max_shards: 16

--- a/tests/functional/shrink_mds/container/group_vars/all
+++ b/tests/functional/shrink_mds/container/group_vars/all
@@ -6,7 +6,6 @@ docker: True
 containerized_deployment: True
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 public_network: "192.168.79.0/24"
 cluster_network: "192.168.80.0/24"
 ceph_conf_overrides:

--- a/tests/functional/shrink_mgr/container/group_vars/all
+++ b/tests/functional/shrink_mgr/container/group_vars/all
@@ -6,7 +6,6 @@ docker: True
 containerized_deployment: True
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 public_network: "192.168.83.0/24"
 cluster_network: "192.168.84.0/24"
 ceph_conf_overrides:

--- a/tests/functional/shrink_mon/container/group_vars/all
+++ b/tests/functional/shrink_mon/container/group_vars/all
@@ -6,7 +6,6 @@ docker: True
 containerized_deployment: True
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 public_network: "192.168.17.0/24"
 cluster_network: "192.168.18.0/24"
 ceph_conf_overrides:

--- a/tests/functional/shrink_osd/container/group_vars/all
+++ b/tests/functional/shrink_osd/container/group_vars/all
@@ -6,7 +6,6 @@ docker: True
 containerized_deployment: True
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 public_network: "192.168.73.0/24"
 cluster_network: "192.168.74.0/24"
 ceph_conf_overrides:

--- a/tests/functional/shrink_rbdmirror/container/group_vars/all
+++ b/tests/functional/shrink_rbdmirror/container/group_vars/all
@@ -7,7 +7,6 @@ cluster_network: "192.168.88.0/24"
 containerized_deployment: True
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 ceph_conf_overrides:
   global:
     mon_allow_pool_size_one: true

--- a/tests/functional/shrink_rgw/container/group_vars/all
+++ b/tests/functional/shrink_rgw/container/group_vars/all
@@ -9,7 +9,6 @@ cluster_network: "192.168.92.0/24"
 monitor_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 radosgw_interface: "{{ 'eth1' if ansible_distribution == 'CentOS' else 'ens6' }}"
 ceph_mon_docker_subnet: "{{ public_network }}"
-ceph_docker_on_openstack: False
 ceph_conf_overrides:
   global:
     mon_allow_pool_size_one: true


### PR DESCRIPTION
The `enable extras on centos` task just doesn't work when using the
variable ceph_docker_enable_centos_extra_repo to true.

fatal: [xxx]; FAILED! => {"changed": false, "msg": "Parameter
'baseurl', 'metalink' or 'mirrorlist' is required."}

The CentOS extras repository is enabled by default so it's pretty
safe to remove this task and the associated variable.

This also removes the ceph_docker_on_openstack variable as it's a
leftover and it is unused.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>