### PR TITLE
library/ceph_pool: use ceph config show command

### DIFF
--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -137,6 +137,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa E402
 import datetime  # noqa E402
 import json  # noqa E402
 import os  # noqa E402
+import platform  # noqa E402
 import stat  # noqa E402
 import time  # noqa E402
 
@@ -237,8 +238,8 @@ def generate_get_config_cmd(param, cluster, user, user_key, container_image=None
         '--cluster',
         cluster,
         'config',
-        'get',
-        'mon.*',
+        'show',
+        'mon.{}'.format(platform.node().split('.')[0]),
         param
     ]
     cmd = _cmd + args

--- a/tests/library/test_ceph_pool.py
+++ b/tests/library/test_ceph_pool.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import sys
 sys.path.append('./library')
 import ceph_pool
@@ -194,8 +195,8 @@ class TestCephPoolModule(object):
                 '--cluster',
                 'ceph',
                 'config',
-                'get',
-                'mon.*',
+                'show',
+                'mon.{}'.format(platform.node().split('.')[0]),
                 param
             ])
             cmd_list.append(ceph_pool.generate_get_config_cmd(param, fake_cluster_name, fake_user, fake_user_key, container_image=fake_container_image_name))


### PR DESCRIPTION
The `ceph config get` command doesn't return the running configuration
but only the configuration option(s) with default ceph values.
That means that even if we set osd_pool_default_size to 1 or 2 in the
ceph configuration file then the ceph config get command will always
return 3 because that's the ceph default value but not the running
value.
Instead we need to use the `ceph config show` command which uses the
existing mon entity (wildcard isn't allowed).

```console
-----
config get <who> [<key>] :  Show configuration option(s) for an entity
config show <who> [<key>] :  Show running configuration
-----
```

```console
$ grep 'osd pool default size' /etc/ceph/ceph.conf
osd pool default size = 1
$ ceph config get mon.* osd_pool_default_size
3
$ ceph config show mon.mon0 osd_pool_default_size
1
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>