### PR TITLE
ceph-iscsi: create pool once from monitor

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -59,6 +59,8 @@
     pg_num: "{{ osd_pool_default_pg_num }}"
     size: "{{ iscsi_pool_size | default(osd_pool_default_size) }}"
     application: "rbd"
+  run_once: true
+  delegate_to: "{{ groups[mon_group_name][0] }}"
   environment:
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"


### PR DESCRIPTION
af9f6684 introduced a regression on the ceph iscsi pool creation
because it was delegated to the first monitor node before that change.
This patch restores the initial worflow.
When the iscsi node doesn't have the admin keyring then the pool
creation fails.
This commit also ensures that the pool creation is only executed once
when having multiple iscsi nodes.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>