### PR TITLE
ceph-facts: check for mon socket in its own host

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -71,6 +71,7 @@
       check_mode: no
       register: mon_socket
       run_once: true
+      delegate_to: "{{ hostvars[item.item]['inventory_hostname'] }}"
       with_items: "{{ mon_socket_stat.results }}"
       when:
         - not containerized_deployment | bool


### PR DESCRIPTION
delegate to its own host after checking mon socket to findout if mon socket is in-use or not.

Signed-off-by: Seena Fallah <seenafallah@gmail.com>