### PR TITLE
tests: remove sleep commands from tox ini files

### DIFF
--- a/tox-cephadm.ini
+++ b/tox-cephadm.ini
@@ -8,7 +8,6 @@ whitelist_externals =
     vagrant
     bash
     pip
-    sleep
     rm
 passenv=*
 sitepackages=True

--- a/tox-docker2podman.ini
+++ b/tox-docker2podman.ini
@@ -8,7 +8,6 @@ whitelist_externals =
     vagrant
     bash
     pip
-    sleep
     rm
 passenv=*
 sitepackages=True

--- a/tox-podman.ini
+++ b/tox-podman.ini
@@ -8,7 +8,6 @@ whitelist_externals =
     vagrant
     bash
     pip
-    sleep
     rm
 passenv=*
 sitepackages=True
@@ -49,16 +48,12 @@ commands=
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
   "
 
-  # wait 30sec for services to be ready
-  sleep 30
   # test cluster state using ceph-ansible tests
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
-  # wait 30sec for services to be ready
 
   # reboot all vms
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/reboot.yml
 
-  # wait 30sec for services to be ready
   # retest to ensure cluster came back up correctly after rebooting
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 

--- a/tox-shrink_osd.ini
+++ b/tox-shrink_osd.ini
@@ -48,7 +48,6 @@ commands=
 whitelist_externals =
     vagrant
     bash
-    sleep
 passenv=*
 sitepackages=False
 setenv=
@@ -102,8 +101,6 @@ commands=
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
   "
 
-  # wait 30sec for services to be ready
-  sleep 30
   # test cluster state using ceph-ansible tests
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
   

--- a/tox.ini
+++ b/tox.ini
@@ -277,7 +277,6 @@ whitelist_externals =
     vagrant
     bash
     pip
-    sleep
     rm
 passenv=*
 sitepackages=False
@@ -366,16 +365,12 @@ commands=
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
   "
 
-  # wait 30sec for services to be ready
-  sleep 30
   # test cluster state using ceph-ansible tests
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 
   # reboot all vms
   all_daemons: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/reboot.yml
 
-  # wait 30sec for services to be ready
-  all_daemons,all_in_one: sleep 30
   # retest to ensure cluster came back up correctly after rebooting
   all_daemons: py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 


### PR DESCRIPTION
Since we use the rerun plugin in tox, we shouldn't need to add these
`sleep` commands.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>