### PR TITLE
[skip ci] library: remove legacy file

### DIFF
--- a/library/validate
+++ b/library/validate
@@ -1,4 +1,0 @@
-# This is a placeholder file so that the ``validate`` action plugin can work.
-# An action plugin is prefered because that gets executed on the master. If at
-# some point the validation engine needs to run on remote nodes, then this
-# placeholder can implement the ``module`` part of the plugin.


### PR DESCRIPTION
This file is a leftover and should have been removed when we dropped the
validate module.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>