### PR TITLE
ceph-osd: refact `docker_exec_start_osd`

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -9,12 +9,12 @@
   changed_when: false
   register: osd_ids_non_container
 
-- name: set_fact docker_exec_start_osd
+- name: set_fact container_exec_start_osd
   set_fact:
-    docker_exec_start_osd: "{{ '{{ container_binary }} run --rm --net=host --privileged=true -v /var/run/udev/:/var/run/udev/:z -v /run/lvm/:/run/lvm/ -v /etc/ceph:/etc/ceph:z -v /dev:/dev --entrypoint=ceph-volume ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph-volume' }}"
+    container_exec_start_osd: "{{ container_binary + ' run --rm --net=host --privileged=true -v /var/run/udev/:/var/run/udev/:z -v /run/lvm/:/run/lvm/ -v /etc/ceph:/etc/ceph:z -v /dev:/dev --entrypoint=ceph-volume ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph-volume' }}"
 
 - name: collect osd ids
-  command: "{{ docker_exec_start_osd }} lvm list --format json"
+  command: "{{ container_exec_start_osd }} lvm list --format json"
   changed_when: false
   failed_when: false
   register: ceph_osd_ids


### PR DESCRIPTION
This commit drops nested jinja construction in this set_fact task.
It also rename it to `container_exec_start_osd`

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>