### PR TITLE
Disable redirect mechanism in a ssl+haproxy context

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -91,6 +91,12 @@
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
 
+    - name: disable redirect mechanism of the dashboard
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} config set mgr mgr/dashboard/standby_behaviour error"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
+      when: dashboard_frontend_vip is defined and dashboard_frontend_vip |length > 0
+
 - name: "set the dashboard port ({{ dashboard_port }})"
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} config set mgr mgr/dashboard/server_port {{ dashboard_port }}"
   changed_when: false


### PR DESCRIPTION
When ssl is enabled and haproxy is configured (because the vip is
provided only when we have haproxy entries), according to the doc
[1][2] we want to disable the redirection behaviour to prevent
situations when internal (unresolvable) URL’s are published to the
frontend client.
By doing this haproxy is able to respond with a HTTP error (503),
sending the user to the active instance.

[1] https://docs.ceph.com/en/latest/mgr/dashboard/#disable-the-redirection
[2] https://docs.ceph.com/en/latest/mgr/dashboard/#haproxy-example-configuration

Signed-off-by: fmount <fpantano@redhat.com>