### PR TITLE
ceph-volume: dirty hack

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -691,6 +691,8 @@ def run_module():
         rc, cmd, out, err = exec_command(
             module, batch_report_cmd)
         try:
+            if not out:
+                out = '{}'
             report_result = json.loads(out)
         except ValueError:
             strategy_changed_in_out = "strategy changed" in out

--- a/tests/functional/collocation/hosts
+++ b/tests/functional/collocation/hosts
@@ -11,6 +11,7 @@ mds0
 rgw0
 
 [rgws]
+osd0
 rgw0
 mds0
 

--- a/tests/functional/dev_setup.yml
+++ b/tests/functional/dev_setup.yml
@@ -9,7 +9,7 @@
     - block:
         - name: set_fact group_vars_path
           set_fact:
-            group_vars_path: "{{ change_dir + '/hosts' if 'ooo-collocation' in change_dir.split('/') else change_dir + '/inventory/group_vars' if 'external_clients' in change_dir.split('/') else change_dir + '/group_vars' }}"
+            group_vars_path: "{{ change_dir + '/inventory/group_vars' if 'external_clients' in change_dir.split('/') else change_dir + '/group_vars' }}"
 
         - block:
             - name: change ceph_repository to 'dev'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = centos-{container,non_container}-{all_daemons,collocation,lvm_osds,shrink_mon,shrink_osd,shrink_mgr,shrink_mds,shrink_rbdmirror,shrink_rgw,lvm_batch,add_mons,add_osds,add_mgrs,add_mdss,add_rbdmirrors,add_rgws,rgw_multisite,purge,storage_inventory,lvm_auto_discovery,all_in_one,cephadm_adopt}
-  centos-container-{ooo_collocation}
   centos-non_container-{switch_to_containers}
   infra_lv_create
   migrate_ceph_disk_to_ceph_volume
@@ -312,7 +311,6 @@ setenv=
 
   switch_to_containers: CEPH_DOCKER_IMAGE_TAG = latest-master-devel
 
-  ooo_collocation: CEPH_DOCKER_IMAGE_TAG = latest-master
 deps= -r{toxinidir}/tests/requirements.txt
 changedir=
   all_daemons: {toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
@@ -330,7 +328,6 @@ changedir=
   switch_to_containers: {toxinidir}/tests/functional/all_daemons
   lvm_osds: {toxinidir}/tests/functional/lvm-osds{env:CONTAINER_DIR:}
   lvm_batch: {toxinidir}/tests/functional/lvm-batch{env:CONTAINER_DIR:}
-  ooo_collocation: {toxinidir}/tests/functional/ooo-collocation
   add_mons: {toxinidir}/tests/functional/add-mons{env:CONTAINER_DIR:}
   add_osds: {toxinidir}/tests/functional/add-osds{env:CONTAINER_DIR:}
   add_mgrs: {toxinidir}/tests/functional/add-mgrs{env:CONTAINER_DIR:}
@@ -351,7 +348,7 @@ commands=
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   # configure lvm
-  !lvm_batch-!lvm_auto_discovery-!ooo_collocation: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml
+  !lvm_batch-!lvm_auto_discovery: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml
 
   rhcs: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.ceph.io} repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
 


### PR DESCRIPTION
ceph-volume recently introduced a breaking change because of a `lvm
batch` refactor.
when rerunning `lvm batch --report --format json` on existing OSDs, it
doesn't output a valid json on stdout.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>