### PR TITLE
[skip ci] flake8: fix pep8 syntax on tests/functional/tests/

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -11,4 +11,4 @@ jobs:
           python-version: 3.8
           architecture: x64
       - run: pip install flake8
-      - run: flake8 --max-line-length 160 ./library/ ./tests/library/
+      - run: flake8 --max-line-length 160 ./library/ ./tests/library/ ./tests/conftest.py ./tests/functional/tests/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ def str_to_bool(val):
     else:
         raise ValueError("Invalid input value: %s" % val)
 
+
 @pytest.fixture(scope="module")
 def setup(host):
     cluster_address = ""
@@ -27,7 +28,6 @@ def setup(host):
     container_binary = ansible_vars.get("container_binary", "")
     osd_auto_discovery = ansible_vars.get("osd_auto_discovery")
     group_names = ansible_vars["group_names"]
-    fsid = ansible_vars.get("fsid")
 
     ansible_distribution = ansible_facts["ansible_facts"]["ansible_distribution"]
 
@@ -81,6 +81,7 @@ def setup(host):
         container_binary=container_binary)
 
     return data
+
 
 @pytest.fixture()
 def node(host, request):

--- a/tests/functional/tests/test_install.py
+++ b/tests/functional/tests/test_install.py
@@ -30,6 +30,7 @@ class TestCephConf(object):
                 result = False
             assert result
 
+
 class TestCephCrash(object):
     @pytest.mark.no_docker
     @pytest.mark.ceph_crash


### PR DESCRIPTION
tests/conftest.py and tests present in tests/functional/tests/ has been
missed from previous commit

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>