### PR TITLE
ceph_key: remove backward compatibility

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -1,15 +1,4 @@
 ---
-- name: set_fact keys_tmp - preserve backward compatibility after the introduction of the ceph_keys module
-  set_fact:
-    keys_tmp: "{{ keys_tmp|default([]) + [ { 'key': item.key, 'name': item.name, 'caps': { 'mon': item.mon_cap, 'osd': item.osd_cap|default(''), 'mds': item.mds_cap|default(''), 'mgr': item.mgr_cap|default('') } , 'mode': item.mode } ] }}"
-  when: item.get('mon_cap', None) # it's enough to assume we are running an old-fashionned syntax simply by checking the presence of mon_cap since every key needs this cap
-  with_items: "{{ keys }}"
-
-- name: set_fact keys - override keys_tmp with keys
-  set_fact:
-    keys: "{{ keys_tmp }}"
-  when: keys_tmp is defined
-
 # dummy container setup is only supported on x86_64
 # when running with containerized_deployment: true this task
 # creates a group that contains only x86_64 hosts.

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -92,23 +92,6 @@
   include_tasks: crush_rules.yml
   when: hostvars[groups[mon_group_name][0]]['crush_rule_config'] | default(crush_rule_config) | bool
 
-- name: set_fact openstack_keys_tmp - preserve backward compatibility after the introduction of the ceph_keys module
-  set_fact:
-    openstack_keys_tmp: "{{ openstack_keys_tmp|default([]) + [ { 'key': item.key, 'name': item.name, 'caps': { 'mon': item.mon_cap, 'osd': item.osd_cap|default(''), 'mds': item.mds_cap|default(''), 'mgr': item.mgr_cap|default('') } , 'mode': item.mode } ] }}"
-  with_items: "{{ openstack_keys }}"
-  when:
-    - not add_osd | bool
-    - openstack_config | bool
-    - item.get('mon_cap', None)
-    # it's enough to assume we are running an old-fashionned syntax simply by checking the presence of mon_cap since every key needs this cap
-
-- name: set_fact keys - override keys_tmp with keys
-  set_fact:
-    openstack_keys: "{{ openstack_keys_tmp }}"
-  when:
-    - not add_osd | bool
-    - openstack_keys_tmp is defined
-
 # Create the pools listed in openstack_pools
 - name: include openstack_config.yml
   include_tasks: openstack_config.yml

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -259,3 +259,23 @@
     - keys | length > 0
     - item.key is defined
     - item.key is not match("^[a-zA-Z0-9+/]{38}==$")
+
+- name: validate openstack_keys caps
+  fail:
+    msg: '{{ item.name }} key has no caps defined'
+  with_items: '{{ openstack_keys }}'
+  when:
+    - osd_group_name in group_names
+    - openstack_keys is defined
+    - openstack_keys | length > 0
+    - item.caps is not defined
+
+- name: validate clients keys caps
+  fail:
+    msg: '{{ item.name }} key has no caps defined'
+  with_items: '{{ keys }}'
+  when:
+    - client_group_name in group_names
+    - keys is defined
+    - keys | length > 0
+    - item.caps is not defined


### PR DESCRIPTION
It's time to remove this backward compatibility. Users had enough time
to convert their openstack_keys and key values.
We now fail in ceph-validate if the caps key isn't set.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>