### PR TITLE
ceph-config: ceph.conf rendering refactor

### DIFF
--- a/docs/source/testing/tox.rst
+++ b/docs/source/testing/tox.rst
@@ -21,9 +21,6 @@ runs of ``ceph-ansible``.
 
 The following environent variables are available for use:
 
-* ``FETCH_DIRECTORY`` : (default: ``changedir``) This would configure the ``ceph-ansible`` variable ``fetch_directory``. This defaults to
-  the ``changedir`` of the given scenario and should not need to be changed.
-
 * ``CEPH_STABLE_RELEASE``: (default: ``jewel``) This would configure the ``ceph-ansible`` variable ``ceph_stable_relese``. This is set
   automatically when using the ``jewel-*`` or ``kraken-*`` testing scenarios.
 

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -76,8 +76,6 @@ dummy:
 #ceph_dashboard_firewall_zone: public
 #ceph_rgwloadbalancer_firewall_zone: public
 
-# Generate local ceph.conf in fetch directory
-#ceph_conf_local: false
 
 ############
 # PACKAGES #

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -32,8 +32,6 @@ dummy:
 #  pacific: 16
 #  dev: 99
 
-# Directory to fetch cluster fsid, keys etc...
-#fetch_directory: fetch/
 
 # The 'cluster' variable determines the name of the cluster.
 # Changing the default value to something else means that you will
@@ -244,8 +242,8 @@ dummy:
 ## Ceph options
 #
 # Each cluster requires a unique, consistent filesystem ID. By
-# default, the playbook generates one for you and stores it in a file
-# in `fetch_directory`. If you want to customize how the fsid is
+# default, the playbook generates one for you.
+# If you want to customize how the fsid is
 # generated, you may find it useful to disable fsid generation to
 # avoid cluttering up your ansible repo. If you set `generate_fsid` to
 # false, you *must* generate `fsid` in another way.

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -32,8 +32,6 @@ dummy:
 #  pacific: 16
 #  dev: 99
 
-# Directory to fetch cluster fsid, keys etc...
-fetch_directory: ~/ceph-ansible-keys
 
 # The 'cluster' variable determines the name of the cluster.
 # Changing the default value to something else means that you will
@@ -244,8 +242,8 @@ ceph_iscsi_config_dev: false
 ## Ceph options
 #
 # Each cluster requires a unique, consistent filesystem ID. By
-# default, the playbook generates one for you and stores it in a file
-# in `fetch_directory`. If you want to customize how the fsid is
+# default, the playbook generates one for you.
+# If you want to customize how the fsid is
 # generated, you may find it useful to disable fsid generation to
 # avoid cluttering up your ansible repo. If you set `generate_fsid` to
 # false, you *must* generate `fsid` in another way.

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -76,8 +76,6 @@ fetch_directory: ~/ceph-ansible-keys
 #ceph_dashboard_firewall_zone: public
 #ceph_rgwloadbalancer_firewall_zone: public
 
-# Generate local ceph.conf in fetch directory
-#ceph_conf_local: false
 
 ############
 # PACKAGES #

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -862,5 +862,5 @@
 
   - name: purge fetch directory for localhost
     file:
-      path: "{{ fetch_directory }}"
+      path: "{{ fetch_directory | default('fetch/') }}"
       state: absent

--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -690,5 +690,5 @@
 
   - name: purge fetch directory for localhost
     file:
-      path: "{{ fetch_directory }}/"
+      path: "{{ fetch_directory | default('fetch/') }}/"
       state: absent

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -89,92 +89,30 @@
       - devices | default([]) | length > 0
       - not (lvm_batch_report.stdout | default('{}') | from_json).changed | default(false) | bool
 
-# ceph-common
-- name: config file operation for non-containerized scenarios
+- name: create ceph conf directory
+  file:
+    path: "/etc/ceph"
+    state: directory
+    owner: "ceph"
+    group: "ceph"
+    mode: "{{ ceph_directories_mode }}"
   when: not containerized_deployment | bool
-  block:
-  - name: create ceph conf directory
-    file:
-      path: "/etc/ceph"
-      state: directory
-      owner: "ceph"
-      group: "ceph"
-      mode: "{{ ceph_directories_mode }}"
 
-  - name: "generate ceph configuration file: {{ cluster }}.conf"
-    action: config_template
-    args:
-      src: ceph.conf.j2
-      dest: /etc/ceph/{{ cluster }}.conf
-      owner: "ceph"
-      group: "ceph"
-      mode: "0644"
-      config_overrides: "{{ ceph_conf_overrides }}"
-      config_type: ini
-    notify:
-      - restart ceph mons
-      - restart ceph osds
-      - restart ceph mdss
-      - restart ceph rgws
-      - restart ceph mgrs
-      - restart ceph rbdmirrors
-      - restart ceph rbd-target-api-gw
-
-  - name: "ensure fetch directory exists"
-    run_once: true
-    become: false
-    file:
-      path: "{{ fetch_directory }}/{{ fsid }}/etc/ceph"
-      state: directory
-      mode: "{{ ceph_directories_mode }}"
-    delegate_to: localhost
-    when: ceph_conf_local | bool
-
-  - name: "generate {{ cluster }}.conf configuration file locally"
-    config_template:
-    become: false
-    run_once: true
-    delegate_to: localhost
-    args:
-      src: "ceph.conf.j2"
-      dest: "{{ fetch_directory }}/{{ fsid }}/etc/ceph/{{ cluster }}.conf"
-      config_overrides: "{{ ceph_conf_overrides }}"
-      config_type: ini
-    when:
-      - inventory_hostname in groups.get(mon_group_name, [])
-      - ceph_conf_local | bool
-
-- name: config file operations for containerized scenarios
-  when: containerized_deployment | bool
-  block:
-  - name: create a local fetch directory if it does not exist
-    file:
-      path: "{{ fetch_directory }}"
-      state: directory
-    delegate_to: localhost
-    changed_when: false
-    become: false
-    run_once: true
-    when:
-      - (cephx or generate_fsid) | bool
-      - ((inventory_hostname in groups.get(mon_group_name, [])) or
-        (groups.get(nfs_group_name, []) | length > 0) and inventory_hostname == groups.get(nfs_group_name, [])[0])
-
-  - name: "generate {{ cluster }}.conf configuration file"
-    action: config_template
-    args:
-      src: "ceph.conf.j2"
-      dest: "{{ ceph_conf_key_directory }}/{{ cluster }}.conf"
-      owner: "root"
-      group: "root"
-      mode: "0644"
-      config_overrides: "{{ ceph_conf_overrides }}"
-      config_type: ini
-    notify:
-      - restart ceph mons
-      - restart ceph osds
-      - restart ceph mdss
-      - restart ceph rgws
-      - restart ceph mgrs
-      - restart ceph rbdmirrors
-      - restart ceph rbd-target-api-gw
+- name: "generate {{ cluster }}.conf configuration file"
+  action: config_template
+  args:
+    src: "ceph.conf.j2"
+    dest: "{{ ceph_conf_key_directory }}/{{ cluster }}.conf"
+    owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
+    group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
+    mode: "0644"
+    config_overrides: "{{ ceph_conf_overrides }}"
+    config_type: ini
+  notify:
+    - restart ceph mons
+    - restart ceph osds
+    - restart ceph mdss
+    - restart ceph rgws
+    - restart ceph mgrs
+    - restart ceph rbdmirrors
+    - restart ceph rbd-target-api-gw

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -24,8 +24,6 @@ ceph_release_num:
   pacific: 16
   dev: 99
 
-# Directory to fetch cluster fsid, keys etc...
-fetch_directory: fetch/
 
 # The 'cluster' variable determines the name of the cluster.
 # Changing the default value to something else means that you will
@@ -236,8 +234,8 @@ ceph_custom_repo: https://server.domain.com/ceph-custom-repo
 ## Ceph options
 #
 # Each cluster requires a unique, consistent filesystem ID. By
-# default, the playbook generates one for you and stores it in a file
-# in `fetch_directory`. If you want to customize how the fsid is
+# default, the playbook generates one for you.
+# If you want to customize how the fsid is
 # generated, you may find it useful to disable fsid generation to
 # avoid cluttering up your ansible repo. If you set `generate_fsid` to
 # false, you *must* generate `fsid` in another way.

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -68,8 +68,6 @@ ceph_iscsi_firewall_zone: public
 ceph_dashboard_firewall_zone: public
 ceph_rgwloadbalancer_firewall_zone: public
 
-# Generate local ceph.conf in fetch directory
-ceph_conf_local: false
 
 ############
 # PACKAGES #

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -124,15 +124,6 @@
       rc: 1
   when: rolling_update | bool or groups.get(mon_group_name, []) | length == 0
 
-- name: create a local fetch directory if it does not exist
-  file:
-    path: "{{ fetch_directory }}"
-    state: directory
-  delegate_to: localhost
-  changed_when: false
-  become: false
-  when: cephx | bool or generate_fsid | bool
-
 - name: get current fsid
   command: "{{ timeout_command }} {{ container_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ hostvars[mon_host | default(groups[mon_group_name][0])]['ansible_hostname'] }}.asok config get fsid"
   register: rolling_update_fsid

--- a/roles/ceph-fetch-keys/tasks/main.yml
+++ b/roles/ceph-fetch-keys/tasks/main.yml
@@ -4,6 +4,12 @@
   changed_when: false
   register: ceph_keys
 
+- name: create a local fetch directory if it does not exist
+  file:
+    path: "{{ fetch_directory | default('fetch/') }}"
+    state: directory
+  delegate_to: localhost
+  become: false
 
 - name: "copy ceph user and bootstrap keys to the ansible server in {{ fetch_directory }}/{{ fsid }}/"
   fetch:

--- a/tox-docker2podman.ini
+++ b/tox-docker2podman.ini
@@ -37,7 +37,6 @@ commands=
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/site-container.yml.sample --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -45,7 +44,6 @@ commands=
 
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/infrastructure-playbooks/docker-to-podman.yml --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
   "
 
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests

--- a/tox-external_clients.ini
+++ b/tox-external_clients.ini
@@ -41,7 +41,6 @@ commands=
   non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup=True change_dir={changedir} ceph_dev_branch=master ceph_dev_sha1=latest" --tags "vagrant_setup"
   ansible-playbook -vv -i {changedir}/inventory/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --limit 'all:!clients' --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch=master \
       ceph_dev_sha1=latest \
       ceph_docker_registry_auth=True \
@@ -53,7 +52,6 @@ commands=
 
   ansible-playbook -vv -i {changedir}/inventory/external_clients-hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       fsid=40358a87-ab6e-4bdc-83db-1d909147861c \
       external_cluster_mon_ips=192.168.31.10,192.168.31.11,192.168.31.12 \
       generate_fsid=false \
@@ -68,7 +66,6 @@ commands=
 
   ansible-playbook -vv -i {changedir}/inventory/external_clients-hosts {toxinidir}/infrastructure-playbooks/rolling_update.yml --extra-vars "\
       ireallymeanit=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       fsid=40358a87-ab6e-4bdc-83db-1d909147861c \
       external_cluster_mon_ips=192.168.31.10,192.168.31.11,192.168.31.12 \
       generate_fsid=false \

--- a/tox-filestore_to_bluestore.ini
+++ b/tox-filestore_to_bluestore.ini
@@ -49,7 +49,6 @@ commands=
   # deploy the cluster
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_stable_release={env:CEPH_STABLE_RELEASE:octopus} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
@@ -59,7 +58,6 @@ commands=
   "
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/filestore-to-bluestore.yml --limit osds --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_stable_release={env:CEPH_STABLE_RELEASE:octopus} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \

--- a/tox-podman.ini
+++ b/tox-podman.ini
@@ -42,7 +42,6 @@ commands=
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \

--- a/tox-shrink_osd.ini
+++ b/tox-shrink_osd.ini
@@ -93,7 +93,6 @@ commands=
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
@@ -111,7 +110,6 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --limit osds --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -46,7 +46,6 @@ commands=
   non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup=True change_dir={changedir} ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
@@ -56,7 +55,6 @@ commands=
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --extra-vars "\
       ireallymeanit=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,6 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
       ireallymeanit=yes \
       remove_packages=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.ceph.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph-ci/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
@@ -62,7 +61,6 @@ commands=
 
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars @ceph-override.json --extra-vars "\
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
@@ -77,7 +75,6 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
       ireallymeanit=yes \
       remove_packages=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -87,7 +84,6 @@ commands=
 
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
@@ -139,7 +135,6 @@ commands=
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml --extra-vars "\
       ireallymeanit=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_docker_image_tag=latest-master-devel \
       ceph_docker_registry=quay.ceph.io \
       ceph_docker_image=ceph-ci/daemon \
@@ -155,7 +150,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts-2 --limit mon1 {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i {changedir}/hosts-2 {toxinidir}/infrastructure-playbooks/add-mon.yml --extra-vars "\
       ireallymeanit=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       "
@@ -166,7 +160,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts-2 --limit mgrs {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i {changedir}/hosts-2 --limit mgrs {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
@@ -180,7 +173,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts-2 --limit mdss {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i {changedir}/hosts-2 --limit mdss {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
@@ -194,7 +186,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts-2 --limit rbdmirrors {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i {changedir}/hosts-2 --limit rbdmirrors {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
@@ -208,7 +199,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts-2 --limit rgws {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i {changedir}/hosts-2 --limit rgws {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
@@ -229,7 +219,6 @@ commands=
   ansible -i localhost, all -c local -b -m iptables -a 'chain=FORWARD protocol=tcp source=192.168.0.0/16 destination=192.168.0.0/16 jump=ACCEPT action=insert rule_num=1 state=present'
   ansible-playbook --ssh-common-args='-F {changedir}/secondary/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey' -vv -i {changedir}/secondary/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/secondary/fetch} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
@@ -253,7 +242,6 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/cephadm-adopt.yml --extra-vars "\
       ireallymeanit=yes \
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} \
   "
 
 [testenv]
@@ -356,7 +344,7 @@ commands=
   all_daemons,collocation: py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 
   # handlers/idempotency test
-  all_daemons,all_in_one,collocation: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "delegate_facts_host={env:DELEGATE_FACTS_HOST:True} fetch_directory={env:FETCH_DIRECTORY:{changedir}/fetch} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-bis-master} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --extra-vars @ceph-override.json
+  all_daemons,all_in_one,collocation: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "delegate_facts_host={env:DELEGATE_FACTS_HOST:True} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-bis-master} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --extra-vars @ceph-override.json
 
   purge: {[purge]commands}
   switch_to_containers: {[switch-to-containers]commands}


### PR DESCRIPTION
This commit cleans up the `main.yml` task file of `ceph-config`.
It drops the local ceph.conf generation.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>