### PR TITLE
tests: change cephfs pool size

### DIFF
--- a/tests/functional/all_daemons/ceph-override.json
+++ b/tests/functional/all_daemons/ceph-override.json
@@ -17,7 +17,7 @@
       "erasure_profile": "",
       "expected_num_objects": "",
       "application": "cephfs",
-      "size": 3,
+      "size": 2,
       "min_size": 0
     },
     {
@@ -29,7 +29,7 @@
       "erasure_profile": "",
       "expected_num_objects": "",
       "application": "cephfs",
-      "size": 3,
+      "size": 2,
       "min_size": 0
     }
   ],


### PR DESCRIPTION
`all_daemons` scenario can't handle pools with `size: 3` because we have
1 osd node in root=HDD and two nodes in root=default.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>