### PR TITLE
handler: refact check_socket_non_container

### DIFF
--- a/roles/ceph-handler/tasks/check_socket_non_container.yml
+++ b/roles/ceph-handler/tasks/check_socket_non_container.yml
@@ -1,197 +1,209 @@
 ---
-- name: check for a ceph mon socket
-  shell: stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-mon*.asok
-  changed_when: false
-  failed_when: false
-  check_mode: no
+- name: find ceph mon socket
+  find:
+    paths: ["{{ rbd_client_admin_socket_path }}"]
+    recurse: yes
+    file_type: any
+    patterns: "{{ cluster }}-mon*.asok"
+    use_regex: no
   register: mon_socket_stat
   when: inventory_hostname in groups.get(mon_group_name, [])
 
 - name: check if the ceph mon socket is in-use
-  command: grep -q {{ mon_socket_stat.stdout }} /proc/net/unix
+  command: grep -q {{ item.path }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
   register: mon_socket
+  with_items: "{{ mon_socket_stat.files }}"
   when:
     - inventory_hostname in groups.get(mon_group_name, [])
-    - mon_socket_stat.rc == 0
+    - mon_socket_stat.files | length > 0
 
 - name: remove ceph mon socket if exists and not used by a process
   file:
-    name: "{{ mon_socket_stat.stdout }}"
+    name: "{{ item.0.path }}"
     state: absent
+  with_together:
+    - "{{ mon_socket_stat.files }}"
+    - "{{ mon_socket.results }}"
   when:
     - inventory_hostname in groups.get(mon_group_name, [])
-    - mon_socket_stat.rc == 0
-    - mon_socket.rc == 1
+    - mon_socket_stat.files | length > 0
+    - item.1.rc == 1
 
-- name: check for a ceph osd socket
-  shell: |
-    stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-osd*.asok
-  changed_when: false
-  failed_when: false
-  check_mode: no
+- name: find ceph osd socket
+  find:
+    paths: ["{{ rbd_client_admin_socket_path }}"]
+    recurse: yes
+    file_type: any
+    patterns: "{{ cluster }}-osd.*.asok"
+    use_regex: no
   register: osd_socket_stat
   when: inventory_hostname in groups.get(osd_group_name, [])
 
 - name: check if the ceph osd socket is in-use
-  command: grep -q {{ osd_socket_stat.stdout }} /proc/net/unix
+  command: grep -q {{ item.path }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
   register: osd_socket
+  with_items: "{{ osd_socket_stat.files }}"
   when:
     - inventory_hostname in groups.get(osd_group_name, [])
-    - osd_socket_stat.rc == 0
+    - osd_socket_stat.files | length > 0
 
 - name: remove ceph osd socket if exists and not used by a process
   file:
-    name: "{{ osd_socket_stat.stdout }}"
+    name: "{{ item.0.path }}"
     state: absent
+  with_together:
+    - "{{ osd_socket_stat.files }}"
+    - "{{ osd_socket.results }}"
   when:
     - inventory_hostname in groups.get(osd_group_name, [])
-    - osd_socket_stat.rc == 0
-    - osd_socket.rc == 1
+    - osd_socket_stat.files | length > 0
+    - item.1.rc == 1
 
-- name: check for a ceph mds socket
-  shell: |
-    stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-mds*.asok
-  changed_when: false
-  failed_when: false
-  check_mode: no
+- name: find ceph osd socket
+  find:
+    paths: ["{{ rbd_client_admin_socket_path }}"]
+    recurse: yes
+    file_type: any
+    patterns: "{{ cluster }}-mds*.asok"
+    use_regex: no
   register: mds_socket_stat
   when: inventory_hostname in groups.get(mds_group_name, [])
 
 - name: check if the ceph mds socket is in-use
-  command: grep -q {{ mds_socket_stat.stdout }} /proc/net/unix
+  command: grep -q {{ item.path }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
   register: mds_socket
+  with_items: "{{ mds_socket_stat.files }}"
   when:
     - inventory_hostname in groups.get(mds_group_name, [])
-    - mds_socket_stat.rc == 0
+    - mds_socket_stat.files | length > 0
 
 - name: remove ceph mds socket if exists and not used by a process
   file:
-    name: "{{ mds_socket_stat.stdout }}"
+    name: "{{ item.0.path }}"
     state: absent
+  with_together:
+    - "{{ mds_socket_stat.files }}"
+    - "{{ mds_socket.results }}"
   when:
     - inventory_hostname in groups.get(mds_group_name, [])
-    - mds_socket_stat.rc == 0
-    - mds_socket.rc == 1
+    - mds_socket_stat.files | length > 0
+    - item.1.rc == 1
 
-- name: check for a ceph rgw socket
-  shell: |
-    stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-client.rgw*.asok
-  changed_when: false
-  failed_when: false
-  check_mode: no
+- name: find ceph rgw socket
+  find:
+    paths: ["{{ rbd_client_admin_socket_path }}"]
+    recurse: yes
+    file_type: any
+    patterns: "{{ cluster }}-client.rgw*.asok"
+    use_regex: no
   register: rgw_socket_stat
   when: inventory_hostname in groups.get(rgw_group_name, [])
 
 - name: check if the ceph rgw socket is in-use
-  command: grep -q {{ rgw_socket_stat.stdout }} /proc/net/unix
+  command: grep -q {{ item.path }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
   register: rgw_socket
+  with_items: "{{ rgw_socket_stat.files }}"
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])
-    - rgw_socket_stat.rc == 0
+    - rgw_socket_stat.files | length > 0
 
 - name: remove ceph rgw socket if exists and not used by a process
   file:
-    name: "{{ rgw_socket_stat.stdout }}"
+    name: "{{ item.0.path }}"
     state: absent
+  with_together:
+    - "{{ rgw_socket_stat.files }}"
+    - "{{ rgw_socket.results }}"
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])
-    - rgw_socket_stat.rc == 0
-    - rgw_socket.rc == 1
+    - rgw_socket_stat.files | length > 0
+    - item.1.rc == 1
 
-- name: check for a ceph mgr socket
-  shell: |
-    stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-mgr*.asok
-  changed_when: false
-  failed_when: false
-  check_mode: no
+- name: find ceph mgr socket
+  find:
+    paths: ["{{ rbd_client_admin_socket_path }}"]
+    recurse: yes
+    file_type: any
+    patterns: "{{ cluster }}-mgr*.asok"
+    use_regex: no
   register: mgr_socket_stat
   when: inventory_hostname in groups.get(mgr_group_name, [])
 
 - name: check if the ceph mgr socket is in-use
-  command: grep -q {{ mgr_socket_stat.stdout }} /proc/net/unix
+  command: grep -q {{ item.path }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
   register: mgr_socket
+  with_items: "{{ mgr_socket_stat.files }}"
   when:
     - inventory_hostname in groups.get(mgr_group_name, [])
-    - mgr_socket_stat.rc == 0
+    - mgr_socket_stat.files | length > 0
 
 - name: remove ceph mgr socket if exists and not used by a process
   file:
-    name: "{{ mgr_socket_stat.stdout }}"
+    name: "{{ item.0.path }}"
     state: absent
+  with_together:
+    - "{{ mgr_socket_stat.files }}"
+    - "{{ mgr_socket.results }}"
   when:
     - inventory_hostname in groups.get(mgr_group_name, [])
-    - mgr_socket_stat.rc == 0
-    - mgr_socket.rc == 1
+    - mgr_socket_stat.files | length > 0
+    - item.1.rc == 1
 
-- name: check for a ceph rbd mirror socket
-  shell: |
-    stat --printf=%n {{ rbd_client_admin_socket_path }}/{{ cluster }}-client.rbd-mirror*.asok
-  changed_when: false
-  failed_when: false
-  check_mode: no
+- name: find ceph rbd mirror socket
+  find:
+    paths: ["{{ rbd_client_admin_socket_path }}"]
+    recurse: yes
+    file_type: any
+    patterns: "{{ cluster }}-client.rbd-mirror*.asok"
+    use_regex: no
   register: rbd_mirror_socket_stat
   when: inventory_hostname in groups.get(rbdmirror_group_name, [])
 
 - name: check if the ceph rbd mirror socket is in-use
-  command: grep -q {{ rbd_mirror_socket_stat.stdout }} /proc/net/unix
+  command: grep -q {{ item.path }} /proc/net/unix
   changed_when: false
   failed_when: false
   check_mode: no
   register: rbd_mirror_socket
+  with_items: "{{ rbd_mirror_socket_stat.files }}"
   when:
     - inventory_hostname in groups.get(rbdmirror_group_name, [])
-    - rbd_mirror_socket_stat.rc == 0
+    - rbd_mirror_socket_stat.files | length > 0
 
 - name: remove ceph rbd mirror socket if exists and not used by a process
   file:
-    name: "{{ rbd_mirror_socket_stat.stdout }}"
+    name: "{{ item.0.path }}"
     state: absent
+  with_together:
+    - "{{ rbd_mirror_socket_stat.files }}"
+    - "{{ rbd_mirror_socket.results }}"
   when:
     - inventory_hostname in groups.get(rbdmirror_group_name, [])
-    - rbd_mirror_socket_stat.rc == 0
-    - rbd_mirror_socket.rc == 1
+    - rbd_mirror_socket_stat.files | length > 0
+    - item.1.rc == 1
 
-- name: check for a ceph nfs ganesha socket
-  command: stat --printf=%n /var/run/ganesha.pid
+- name: check for a nfs ganesha pid
+  command: "pgrep ganesha.nfsd"
+  register: nfs_process
   changed_when: false
   failed_when: false
   check_mode: no
-  register: nfs_socket_stat
   when: inventory_hostname in groups.get(nfs_group_name, [])
-
-- name: check if the ceph nfs ganesha socket is in-use
-  command: grep -q {{ nfs_socket_stat.stdout }} /proc/net/unix
-  changed_when: false
-  failed_when: false
-  check_mode: no
-  register: nfs_socket
-  when:
-    - inventory_hostname in groups.get(nfs_group_name, [])
-    - nfs_socket_stat.rc == 0
-
-- name: remove ceph nfs ganesha socket if exists and not used by a process
-  file:
-    name: "{{ nfs_socket_stat.stdout }}"
-    state: absent
-  when:
-    - inventory_hostname in groups.get(nfs_group_name, [])
-    - nfs_socket_stat.rc == 0
-    - nfs_socket.rc == 1
 
 - name: check for a tcmu-runner
   command: "pgrep tcmu-runner"

--- a/roles/ceph-handler/tasks/main.yml
+++ b/roles/ceph-handler/tasks/main.yml
@@ -5,37 +5,37 @@
 # We do not want to run these checks on initial deployment (`socket.rc == 0`)
 - name: set_fact handler_mon_status
   set_fact:
-    handler_mon_status: "{{ (mon_socket.get('rc') == 0) if not containerized_deployment | bool else (ceph_mon_container_stat.get('rc') == 0 and ceph_mon_container_stat.get('stdout_lines', []) | length != 0) }}"
+    handler_mon_status: "{{ 0 in (mon_socket.results | map(attribute='rc') | list) if not containerized_deployment | bool else (ceph_mon_container_stat.get('rc') == 0 and ceph_mon_container_stat.get('stdout_lines', []) | length != 0) }}"
   when: inventory_hostname in groups.get(mon_group_name, [])
 
 - name: set_fact handler_osd_status
   set_fact:
-    handler_osd_status: "{{ (osd_socket.get('rc') == 0 and ceph_current_status.fsid is defined) if not containerized_deployment | bool else (ceph_osd_container_stat.get('rc') == 0 and ceph_osd_container_stat.get('stdout_lines', []) | length != 0) }}"
+    handler_osd_status: "{{ 0 in (osd_socket.results | map(attribute='rc') | list) if not containerized_deployment | bool else (ceph_osd_container_stat.get('rc') == 0 and ceph_osd_container_stat.get('stdout_lines', []) | length != 0) }}"
   when: inventory_hostname in groups.get(osd_group_name, [])
 
 - name: set_fact handler_mds_status
   set_fact:
-    handler_mds_status: "{{ (mds_socket.get('rc') == 0) if not containerized_deployment | bool else (ceph_mds_container_stat.get('rc') == 0 and ceph_mds_container_stat.get('stdout_lines', []) | length != 0) }}"
+    handler_mds_status: "{{ 0 in (mds_socket.results | map(attribute='rc') | list) if not containerized_deployment | bool else (ceph_mds_container_stat.get('rc') == 0 and ceph_mds_container_stat.get('stdout_lines', []) | length != 0) }}"
   when: inventory_hostname in groups.get(mds_group_name, [])
 
 - name: set_fact handler_rgw_status
   set_fact:
-    handler_rgw_status: "{{ (rgw_socket.get('rc') == 0) if not containerized_deployment | bool else (ceph_rgw_container_stat.get('rc') == 0 and ceph_rgw_container_stat.get('stdout_lines', []) | length != 0) }}"
+    handler_rgw_status: "{{ 0 in (rgw_socket.results | map(attribute='rc') | list) if not containerized_deployment | bool else (ceph_rgw_container_stat.get('rc') == 0 and ceph_rgw_container_stat.get('stdout_lines', []) | length != 0) }}"
   when: inventory_hostname in groups.get(rgw_group_name, [])
 
 - name: set_fact handler_nfs_status
   set_fact:
-    handler_nfs_status: "{{ (nfs_socket.get('rc') == 0) if not containerized_deployment | bool else (ceph_nfs_container_stat.get('rc') == 0 and ceph_nfs_container_stat.get('stdout_lines', []) | length != 0) }}"
+    handler_nfs_status: "{{ (nfs_process.get('rc') == 0) if not containerized_deployment | bool else (ceph_nfs_container_stat.get('rc') == 0 and ceph_nfs_container_stat.get('stdout_lines', []) | length != 0) }}"
   when: inventory_hostname in groups.get(nfs_group_name, [])
 
 - name: set_fact handler_rbd_status
   set_fact:
-    handler_rbd_mirror_status: "{{ (rbd_mirror_socket.get('rc') == 0) if not containerized_deployment | bool else (ceph_rbd_mirror_container_stat.get('rc') == 0 and ceph_rbd_mirror_container_stat.get('stdout_lines', []) | length != 0) }}"
+    handler_rbd_mirror_status: "{{ 0 in (rbd_mirror_socket.results | map(attribute='rc') | list) if not containerized_deployment | bool else (ceph_rbd_mirror_container_stat.get('rc') == 0 and ceph_rbd_mirror_container_stat.get('stdout_lines', []) | length != 0) }}"
   when: inventory_hostname in groups.get(rbdmirror_group_name, [])
 
 - name: set_fact handler_mgr_status
   set_fact:
-    handler_mgr_status: "{{ (mgr_socket.get('rc') == 0) if not containerized_deployment | bool else (ceph_mgr_container_stat.get('rc') == 0 and ceph_mgr_container_stat.get('stdout_lines', []) | length != 0) }}"
+    handler_mgr_status: "{{ 0 in (mgr_socket.results | map(attribute='rc') | list) if not containerized_deployment | bool else (ceph_mgr_container_stat.get('rc') == 0 and ceph_mgr_container_stat.get('stdout_lines', []) | length != 0) }}"
   when: inventory_hostname in groups.get(mgr_group_name, [])
 
 - name: set_fact handler_crash_status


### PR DESCRIPTION
the `stat --printf=%n` returns something like following:

```
ok: [osd0] => changed=false
  cmd: |-
    stat --printf=%n /var/run/ceph/ceph-osd*.asok
  delta: '0:00:00.009388'
  end: '2020-10-06 06:18:28.109500'
  failed_when_result: false
  rc: 0
  start: '2020-10-06 06:18:28.100112'
  stderr: ''
  stderr_lines: <omitted>
  stdout: /var/run/ceph/ceph-osd.2.asok/var/run/ceph/ceph-osd.5.asok
  stdout_lines: <omitted>
```

it makes the next task "check if the ceph osd socket is in-use" grep
like this:

```
ok: [osd0] => changed=false
  cmd:
  - grep
  - -q
  - /var/run/ceph/ceph-osd.2.asok/var/run/ceph/ceph-osd.5.asok
  - /proc/net/unix
```

which will obviously fail because this path never exists. It makes the
OSD handler broken.

Let's use `find` module instead.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
