### PR TITLE
ceph-facts: Fix osd_pool_default_crush_rule fact

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -308,29 +308,35 @@
     path: '/etc/ceph/{{ cluster }}.conf'
   register: ceph_conf
 
+- name: set default osd_pool_default_crush_rule fact
+  set_fact:
+    osd_pool_default_crush_rule: "{{ ceph_osd_pool_default_crush_rule }}"
+
 - name: get default crush rule value from ceph configuration
-  command: grep 'osd pool default crush rule' /etc/ceph/{{ cluster }}.conf
-  register: crush_rule_variable
-  changed_when: false
-  check_mode: no
-  failed_when: false
+  block:
+    - &read-osd-pool-default-crush-rule
+      name: read osd pool default crush rule
+      command: grep 'osd pool default crush rule' /etc/ceph/{{ cluster }}.conf
+      register: crush_rule_variable
+      changed_when: false
+      check_mode: no
+      failed_when: crush_rule_variable.rc not in (0, 1)
+    - &set-osd-pool-default-crush-rule-fact
+      name: set osd_pool_default_crush_rule fact
+      set_fact:
+        osd_pool_default_crush_rule: "{{ crush_rule_variable.stdout.split(' = ')[1] }}"
+      when: crush_rule_variable.rc == 0
   when: ceph_conf.stat.exists | bool
 
 - name: get default crush rule value from running monitor ceph configuration
-  command: grep 'osd pool default crush rule' /etc/ceph/{{ cluster }}.conf
-  register: crush_rule_variable
-  changed_when: false
-  check_mode: no
-  failed_when: false
-  run_once: true
-  delegate_to: "{{ running_mon }}"
+  block:
+    - <<: *read-osd-pool-default-crush-rule
+      run_once: true
+      delegate_to: "{{ running_mon }}"
+    - *set-osd-pool-default-crush-rule-fact
   when:
     - running_mon is defined
     - not ceph_conf.stat.exists | bool
-
-- name: set_fact osd_pool_default_crush_rule
-  set_fact:
-    osd_pool_default_crush_rule: "{{ crush_rule_variable.stdout.split(' = ')[1] if crush_rule_variable.get('rc', 1) | int == 0 else ceph_osd_pool_default_crush_rule }}"
 
 - name: import_tasks set_monitor_address.yml
   import_tasks: set_monitor_address.yml


### PR DESCRIPTION
The `osd_pool_default_crush_rule` is set based on `crush_rule_variable`, which
is the output of a `grep` command.

However, two consecutive tasks can set that variable, and if the second task is
skipped, it still overwrites the `crush_rule_variable`, leading the
`osd_pool_default_crush_rule` to be set to `ceph_osd_pool_default_crush_rule`
instead of the output of the first task.

This commit ensures that the fact is set right after the `crush_rule_variable`
is assigned, before it can be overwritten.

Closes #5912

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>