### PR TITLE
library: add ceph_dashboard_rgw module

### DIFF
--- a/library/ceph_dashboard_rgw.py
+++ b/library/ceph_dashboard_rgw.py
@@ -1,0 +1,468 @@
+# Copyright 2021, Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible.module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized, exec_command
+except ImportError:
+    from module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized, exec_command
+import datetime
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ceph_dashboard_rgw
+
+short_description: Manage Ceph Dashboard RGW API
+
+version_added: "2.8"
+
+description:
+    - Manage Ceph Dashboard rgw api configuration.
+options:
+    cluster:
+        description:
+            - The ceph cluster name.
+        required: false
+        default: ceph
+    user:
+        description:
+            - user of the Ceph Rados Gateway API.
+        required: true
+    access_key:
+        description:
+            - access key of the Ceph Rados Gateway API.
+        required: true
+    secret_key:
+        description:
+            - secret key of the Ceph Rados Gateway API.
+        required: true
+    host:
+        description:
+            - host of the Ceph Rados Gateway API.
+        required: true
+    port:
+        description:
+            - port of the Ceph Rados Gateway API.
+        required: false
+    scheme:
+        description:
+            - scheme of the Ceph Rados Gateway API.
+        required: false
+    admin_resource:
+        description:
+            - admin resource of the Ceph Rados Gateway API.
+        required: false
+    tls_verify:
+        description:
+            - verify the TLS certificate of the Ceph Rados Gateway API.
+        required: false
+
+author:
+    - Dimitri Savineau <dsavinea@redhat.com>
+'''
+
+EXAMPLES = '''
+- name: enabling the Ceph Dashboard RGW frontend
+  ceph_dashboard_rgw:
+    user: foo
+    access_key: LbwDPp2BBo2Sdlts89Um
+    secret_key: FavL6ueQWcWuWn0YXyQ3TnJ3mT3Uj5SGVHCUXC5K
+    host: 192.168.100.1
+    port: 8080
+    scheme: https
+    admin_resource: admin
+    tls_verify: false
+'''
+
+RETURN = '''#  '''
+
+
+def get_rgw_api_user(module, container_image=None):
+    '''
+    Get rgw api user
+    '''
+
+    cluster = module.params.get('cluster')
+
+    args = ['get-rgw-api-user-id']
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def set_rgw_api_user(module, container_image=None):
+    '''
+    Set rgw api user
+    '''
+
+    cluster = module.params.get('cluster')
+    user = module.params.get('user')
+
+    args = ['set-rgw-api-user-id', user]
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def get_rgw_api_access_key(module, container_image=None):
+    '''
+    Get rgw api access key
+    '''
+
+    cluster = module.params.get('cluster')
+
+    args = ['get-rgw-api-access-key']
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def set_rgw_api_access_key(module, container_image=None):
+    '''
+    Set rgw api access key
+    '''
+
+    cluster = module.params.get('cluster')
+
+    args = ['set-rgw-api-access-key', '-i', '-']
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image, interactive=True)
+
+    return cmd
+
+
+def get_rgw_api_secret_key(module, container_image=None):
+    '''
+    Get rgw api secret key
+    '''
+
+    cluster = module.params.get('cluster')
+
+    args = ['get-rgw-api-secret-key']
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def set_rgw_api_secret_key(module, container_image=None):
+    '''
+    Set rgw api secret key
+    '''
+
+    cluster = module.params.get('cluster')
+
+    args = ['set-rgw-api-secret-key', '-i', '-']
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image, interactive=True)
+
+    return cmd
+
+
+def get_rgw_api_host(module, container_image=None):
+    '''
+    Get rgw api host
+    '''
+
+    cluster = module.params.get('cluster')
+
+    args = ['get-rgw-api-host']
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def set_rgw_api_host(module, container_image=None):
+    '''
+    Set rgw api host
+    '''
+
+    cluster = module.params.get('cluster')
+    host = module.params.get('host')
+
+    args = ['set-rgw-api-host', host]
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def get_rgw_api_port(module, container_image=None):
+    '''
+    Get rgw api port
+    '''
+
+    cluster = module.params.get('cluster')
+
+    args = ['get-rgw-api-port']
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def set_rgw_api_port(module, container_image=None):
+    '''
+    Set rgw api port
+    '''
+
+    cluster = module.params.get('cluster')
+    port = module.params.get('port')
+
+    args = ['set-rgw-api-port', str(port)]
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def get_rgw_api_scheme(module, container_image=None):
+    '''
+    Get rgw api scheme
+    '''
+
+    cluster = module.params.get('cluster')
+
+    args = ['get-rgw-api-scheme']
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def set_rgw_api_scheme(module, container_image=None):
+    '''
+    Set rgw api scheme
+    '''
+
+    cluster = module.params.get('cluster')
+    scheme = module.params.get('scheme')
+
+    args = ['set-rgw-api-scheme', scheme]
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def get_rgw_api_admin_resource(module, container_image=None):
+    '''
+    Get rgw api admin resource
+    '''
+
+    cluster = module.params.get('cluster')
+
+    args = ['get-rgw-api-admin-resource']
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def set_rgw_api_admin_resource(module, container_image=None):
+    '''
+    Set rgw api admin resource
+    '''
+
+    cluster = module.params.get('cluster')
+    admin_resource = module.params.get('admin_resource')
+
+    args = ['set-rgw-api-admin-resource', admin_resource]
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def get_rgw_api_tls_verify(module, container_image=None):
+    '''
+    Get rgw api tls verify
+    '''
+
+    cluster = module.params.get('cluster')
+
+    args = ['get-rgw-api-ssl-verify']
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def set_rgw_api_tls_verify(module, container_image=None):
+    '''
+    Set rgw api tls verify
+    '''
+
+    cluster = module.params.get('cluster')
+    tls_verify = module.params.get('tls_verify')
+
+    args = ['set-rgw-api-ssl-verify', str(tls_verify)]
+
+    cmd = generate_ceph_cmd(['dashboard'], args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            cluster=dict(type='str', required=False, default='ceph'),
+            user=dict(type='str', required=True),
+            access_key=dict(type='str', required=True, no_log=True),
+            secret_key=dict(type='str', required=True, no_log=True),
+            host=dict(type='str', required=True),
+            port=dict(type='int', required=False),
+            scheme=dict(type='str', required=False, choices=['http', 'https']),
+            admin_resource=dict(type='str', required=False),
+            tls_verify=dict(type='bool', required=False),
+        ),
+        supports_check_mode=True,
+    )
+
+    user = module.params.get('user')
+    access_key = module.params.get('access_key')
+    secret_key = module.params.get('secret_key')
+    host = module.params.get('host')
+    port = str(module.params.get('port'))
+    scheme = module.params.get('scheme')
+    admin_resource = module.params.get('admin_resource')
+    tls_verify = str(module.params.get('tls_verify'))
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            stdout='',
+            stderr='',
+            rc=0,
+            start='',
+            end='',
+            delta='',
+        )
+
+    startd = datetime.datetime.now()
+    changed = False
+
+    # will return either the image name or None
+    container_image = is_containerized()
+
+    cmds = []
+    outs = ''
+    errs = ''
+
+    rc, cmd, out, err = exec_command(module, get_rgw_api_user(module, container_image=container_image))
+    if user != out.rstrip("\r\n"):
+        rc, cmd, out, err = exec_command(module, set_rgw_api_user(module, container_image=container_image))
+        if rc != 0:
+            exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=False)
+        changed = True
+        outs += out
+        errs += err
+    cmds.append(' '.join(cmd))
+
+    rc, cmd, out, err = exec_command(module, get_rgw_api_access_key(module, container_image=container_image))
+    if access_key != out.rstrip("\r\n"):
+        rc, cmd, out, err = exec_command(module, set_rgw_api_access_key(module, container_image=container_image), stdin=access_key)
+        if rc != 0:
+            exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=False)
+        changed = True
+        outs += out
+        errs += err
+    cmds.append(' '.join(cmd))
+
+    rc, cmd, out, err = exec_command(module, get_rgw_api_secret_key(module, container_image=container_image))
+    if secret_key != out.rstrip("\r\n"):
+        rc, cmd, out, err = exec_command(module, set_rgw_api_secret_key(module, container_image=container_image), stdin=secret_key)
+        if rc != 0:
+            exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=False)
+        changed = True
+        outs += out
+        errs += err
+    cmds.append(' '.join(cmd))
+
+    rc, cmd, out, err = exec_command(module, get_rgw_api_host(module, container_image=container_image))
+    if host != out.rstrip("\r\n"):
+        rc, cmd, out, err = exec_command(module, set_rgw_api_host(module, container_image=container_image))
+        if rc != 0:
+            exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=False)
+        changed = True
+        outs += out
+        errs += err
+    cmds.append(' '.join(cmd))
+
+    if port:
+        rc, cmd, out, err = exec_command(module, get_rgw_api_port(module, container_image=container_image))
+        if port != out.rstrip("\r\n"):
+            rc, cmd, out, err = exec_command(module, set_rgw_api_port(module, container_image=container_image))
+            if rc != 0:
+                exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=False)
+            changed = True
+            outs += out
+            errs += err
+        cmds.append(' '.join(cmd))
+
+    if scheme:
+        rc, cmd, out, err = exec_command(module, get_rgw_api_scheme(module, container_image=container_image))
+        if scheme != out.rstrip("\r\n"):
+            rc, cmd, out, err = exec_command(module, set_rgw_api_scheme(module, container_image=container_image))
+            if rc != 0:
+                exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=False)
+            changed = True
+            outs += out
+            errs += err
+        cmds.append(' '.join(cmd))
+
+    if admin_resource:
+        rc, cmd, out, err = exec_command(module, get_rgw_api_admin_resource(module, container_image=container_image))
+        if admin_resource != out.rstrip("\r\n"):
+            rc, cmd, out, err = exec_command(module, set_rgw_api_admin_resource(module, container_image=container_image))
+            if rc != 0:
+                exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=False)
+            changed = True
+            outs += out
+            errs += err
+        cmds.append(' '.join(cmd))
+
+    if tls_verify:
+        rc, cmd, out, err = exec_command(module, get_rgw_api_tls_verify(module, container_image=container_image))
+        if tls_verify != out.rstrip("\r\n"):
+            rc, cmd, out, err = exec_command(module, set_rgw_api_tls_verify(module, container_image=container_image))
+            if rc != 0:
+                exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=False)
+            changed = True
+            outs += out
+            errs += err
+        cmds.append(' '.join(cmd))
+
+    if not changed:
+        outs = 'Nothing to update'
+
+    exit_module(module=module, out=outs, rc=rc, cmd=cmds, err=errs, startd=startd, changed=changed)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -216,55 +216,21 @@
         rgw_access_key: "{{ (rgw_dashboard_user.stdout | from_json)['keys'][0]['access_key'] }}"
         rgw_secret_key: "{{ (rgw_dashboard_user.stdout | from_json)['keys'][0]['secret_key'] }}"
 
-    - name: set the rgw user
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-user-id {{ dashboard_rgw_api_user_id }}"
+    - name: configure the rgw frontend
+      ceph_dashboard_rgw:
+        cluster: "{{ cluster }}"
+        user: "{{ dashboard_rgw_api_user_id }}"
+        access_key: "{{ rgw_access_key }}"
+        secret_key: "{{ rgw_secret_key }}"
+        host: "{{ hostvars[groups[rgw_group_name][0]]['rgw_instances'][0]['radosgw_address'] }}"
+        port: "{{ hostvars[groups[rgw_group_name][0]]['rgw_instances'][0]['radosgw_frontend_port'] }}"
+        scheme: "{{ 'https' if radosgw_frontend_ssl_certificate else 'http' }}"
+        admin_resource: "{{ dashboard_rgw_api_admin_resource }}"
+        tls_verify: "{{ false if dashboard_rgw_api_no_ssl_verify | bool and radosgw_frontend_ssl_certificate | length > 0 else true }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
-      changed_when: false
-
-    - name: set the rgw access key
-      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard set-rgw-api-access-key -i -"
-      args:
-        stdin: "{{ rgw_access_key }}"
-        stdin_add_newline: no
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-      changed_when: false
-
-    - name: set the rgw secret key
-      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard set-rgw-api-secret-key -i -"
-      args:
-        stdin: "{{ rgw_secret_key }}"
-        stdin_add_newline: no
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-      changed_when: false
-
-    - name: set the rgw host
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-host {{ hostvars[groups[rgw_group_name][0]]['rgw_instances'][0]['radosgw_address'] }}"
-      changed_when: false
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-
-    - name: set the rgw port
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-port {{ hostvars[groups[rgw_group_name][0]]['rgw_instances'][0]['radosgw_frontend_port'] }}"
-      changed_when: false
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-
-    - name: set the rgw scheme
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-scheme {{ 'https' if radosgw_frontend_ssl_certificate else 'http' }}"
-      changed_when: false
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-
-    - name: set the rgw admin resource
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-admin-resource {{ dashboard_rgw_api_admin_resource }}"
-      changed_when: false
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-      when: dashboard_rgw_api_admin_resource | length > 0
-
-    - name: disable ssl verification for rgw
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-ssl-verify False"
-      changed_when: false
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-      when:
-        - dashboard_rgw_api_no_ssl_verify | bool
-        - radosgw_frontend_ssl_certificate | length > 0
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: dashboard iscsi management
   when: groups.get(iscsi_gw_group_name, []) | length > 0

--- a/tests/library/test_ceph_dashboard_rgw.py
+++ b/tests/library/test_ceph_dashboard_rgw.py
@@ -1,0 +1,210 @@
+from mock.mock import patch
+import os
+import pytest
+import ca_test_common
+import ceph_dashboard_rgw
+
+fake_binary = 'ceph'
+fake_cluster = 'ceph'
+fake_container_binary = 'podman'
+fake_container_image = 'quay.ceph.io/ceph/daemon:latest'
+fake_user_key = 'client.admin'
+fake_keyring = '/etc/ceph/{}.{}.keyring'.format(fake_cluster, fake_user_key)
+ceph_common = '-n {} -k {} --cluster {} dashboard'.format(fake_user_key, fake_keyring, fake_cluster)
+container_common = '--rm --net=host -v /etc/ceph:/etc/ceph:z' \
+                   ' -v /var/lib/ceph/:/var/lib/ceph/:z -v /var/log/ceph/:/var/log/ceph/:z' \
+                   ' --entrypoint={} {} {} '.format(fake_binary, fake_container_image, ceph_common)
+fake_container_cmd = '{} run {}'.format(fake_container_binary, container_common)
+fake_container_cmd_stdin = '{} run --interactive {}'.format(fake_container_binary, container_common)
+fake_cmd = '{} {} '.format(fake_binary, ceph_common)
+fake_user = 'foo'
+fake_access_key = 'PC7NPg87QWhOzXTkXIhX'
+fake_secret_key = 'jV64v39lVTjEx1ZJN6ocopnhvwMp1mXCD4kzBiPz'
+fake_host = '192.168.100.1'
+fake_port = 10080
+fake_scheme = 'https'
+fake_admin_resource = 'admin'
+fake_tls_verify = False
+fake_user_key = 'client.admin'
+fake_keyring = '/etc/ceph/{}.{}.keyring'.format(fake_cluster, fake_user_key)
+
+
+class TestCephDashboardRGWModule(object):
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    def test_with_check_mode(self, m_exit_json):
+        ca_test_common.set_module_args({
+            'user': fake_user,
+            'access_key': fake_access_key,
+            'secret_key': fake_secret_key,
+            'host': fake_host,
+            '_ansible_check_mode': True
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_dashboard_rgw.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['rc'] == 0
+        assert not result['stdout']
+        assert not result['stderr']
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_all_options(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'user': fake_user,
+            'access_key': fake_access_key,
+            'secret_key': fake_secret_key,
+            'host': fake_host,
+            'port': fake_port,
+            'scheme': fake_scheme,
+            'admin_resource': fake_admin_resource,
+            'tls_verify': fake_tls_verify
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        m_run_command.side_effect = [
+            (0, '', ''),
+            (0, 'Option RGW_API_USER_ID updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_ACCESS_KEY updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_SECRET_KEY updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_HOST updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_PORT updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_SCHEME updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_ADMIN_RESOURCE updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_SSL_VERIFY updated', ''),
+        ]
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_dashboard_rgw.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == [fake_cmd + 'set-rgw-api-user-id {}'.format(fake_user),
+                                 fake_cmd + 'set-rgw-api-access-key -i -',
+                                 fake_cmd + 'set-rgw-api-secret-key -i -',
+                                 fake_cmd + 'set-rgw-api-host {}'.format(fake_host),
+                                 fake_cmd + 'set-rgw-api-port {}'.format(fake_port),
+                                 fake_cmd + 'set-rgw-api-scheme {}'.format(fake_scheme),
+                                 fake_cmd + 'set-rgw-api-admin-resource {}'.format(fake_admin_resource),
+                                 fake_cmd + 'set-rgw-api-ssl-verify {}'.format(fake_tls_verify)]
+        assert result['rc'] == 0
+        assert result['stderr'] == ''
+        assert result['stdout'] == 'Option RGW_API_USER_ID updated' \
+                                   'Option RGW_API_ACCESS_KEY updated' \
+                                   'Option RGW_SECRET_KEY updated' \
+                                   'Option RGW_API_HOST updated' \
+                                   'Option RGW_API_PORT updated' \
+                                   'Option RGW_API_SCHEME updated' \
+                                   'Option RGW_API_ADMIN_RESOURCE updated' \
+                                   'Option RGW_API_SSL_VERIFY updated'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_options_already_set(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'user': fake_user,
+            'access_key': fake_access_key,
+            'secret_key': fake_secret_key,
+            'host': fake_host,
+            'port': fake_port,
+            'scheme': fake_scheme,
+            'admin_resource': fake_admin_resource,
+            'tls_verify': fake_tls_verify
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        m_run_command.side_effect = [
+            (0, fake_user, ''),
+            (0, fake_access_key, ''),
+            (0, fake_secret_key, ''),
+            (0, fake_host, ''),
+            (0, str(fake_port), ''),
+            (0, fake_scheme, ''),
+            (0, fake_admin_resource, ''),
+            (0, str(fake_tls_verify), ''),
+        ]
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_dashboard_rgw.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['cmd'] == [fake_cmd + 'get-rgw-api-user-id',
+                                 fake_cmd + 'get-rgw-api-access-key',
+                                 fake_cmd + 'get-rgw-api-secret-key',
+                                 fake_cmd + 'get-rgw-api-host',
+                                 fake_cmd + 'get-rgw-api-port',
+                                 fake_cmd + 'get-rgw-api-scheme',
+                                 fake_cmd + 'get-rgw-api-admin-resource',
+                                 fake_cmd + 'get-rgw-api-ssl-verify']
+        assert result['rc'] == 0
+        assert result['stderr'] == ''
+        assert result['stdout'] == 'Nothing to update'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
+    @patch.dict(os.environ, {'CEPH_CONTAINER_IMAGE': fake_container_image})
+    def test_with_containers(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'user': fake_user,
+            'access_key': fake_access_key,
+            'secret_key': fake_secret_key,
+            'host': fake_host,
+            'port': fake_port,
+            'scheme': fake_scheme,
+            'admin_resource': fake_admin_resource,
+            'tls_verify': fake_tls_verify
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        m_run_command.side_effect = [
+            (0, '', ''),
+            (0, 'Option RGW_API_USER_ID updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_ACCESS_KEY updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_SECRET_KEY updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_HOST updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_PORT updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_SCHEME updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_ADMIN_RESOURCE updated', ''),
+            (0, '', ''),
+            (0, 'Option RGW_API_SSL_VERIFY updated', ''),
+        ]
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_dashboard_rgw.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == [fake_container_cmd + 'set-rgw-api-user-id {}'.format(fake_user),
+                                 fake_container_cmd_stdin + 'set-rgw-api-access-key -i -',
+                                 fake_container_cmd_stdin + 'set-rgw-api-secret-key -i -',
+                                 fake_container_cmd + 'set-rgw-api-host {}'.format(fake_host),
+                                 fake_container_cmd + 'set-rgw-api-port {}'.format(fake_port),
+                                 fake_container_cmd + 'set-rgw-api-scheme {}'.format(fake_scheme),
+                                 fake_container_cmd + 'set-rgw-api-admin-resource {}'.format(fake_admin_resource),
+                                 fake_container_cmd + 'set-rgw-api-ssl-verify {}'.format(fake_tls_verify)]
+        assert result['rc'] == 0
+        assert result['stderr'] == ''
+        assert result['stdout'] == 'Option RGW_API_USER_ID updated' \
+                                   'Option RGW_API_ACCESS_KEY updated' \
+                                   'Option RGW_SECRET_KEY updated' \
+                                   'Option RGW_API_HOST updated' \
+                                   'Option RGW_API_PORT updated' \
+                                   'Option RGW_API_SCHEME updated' \
+                                   'Option RGW_API_ADMIN_RESOURCE updated' \
+                                   'Option RGW_API_SSL_VERIFY updated'


### PR DESCRIPTION
This adds the ceph_dashboard_rgw ansible module for replacing the
command module usage with the ceph dashboard set-rgw-api-xxx command.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>