### PR TITLE
[skip ci] rhcs: default to containerized deployment

### DIFF
--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -571,7 +571,7 @@ ceph_docker_registry_auth: true
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
 #ceph_client_docker_registry: "{{ ceph_docker_registry }}"
-#containerized_deployment: False
+containerized_deployment: true
 #container_binary:
 #timeout_command: "{{ 'timeout --foreground -s KILL ' ~ docker_pull_timeout if (docker_pull_timeout != '0') and (ceph_docker_dev_image is undefined or not ceph_docker_dev_image) else '' }}"
 

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -3,6 +3,7 @@ ceph_origin: repository
 ceph_iscsi_config_dev: false
 fetch_directory: ~/ceph-ansible-keys
 ceph_rhcs_version: 5
+containerized_deployment: true
 ceph_docker_image: "rhceph/rhceph-5-rhel8"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"


### PR DESCRIPTION
Starting RHCS 5, only containerized deployment is available.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>