### PR TITLE
container: remove container_binding_name variable

### DIFF
--- a/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
+++ b/roles/ceph-container-engine/tasks/pre_requisites/prerequisites.yml
@@ -13,7 +13,7 @@
 
 - name: install container packages
   package:
-    name: ['{{ container_package_name }}', '{{ container_binding_name }}']
+    name: '{{ container_package_name }}'
     update_cache: true
   register: result
   until: result is succeeded

--- a/roles/ceph-container-engine/vars/Debian.yml
+++ b/roles/ceph-container-engine/vars/Debian.yml
@@ -1,4 +1,3 @@
 ---
 container_package_name: docker-ce
 container_service_name: docker
-container_binding_name: python-docker

--- a/roles/ceph-container-engine/vars/RedHat-8.yml
+++ b/roles/ceph-container-engine/vars/RedHat-8.yml
@@ -1,4 +1,3 @@
 ---
 container_package_name: podman
 container_service_name: podman
-container_binding_name: podman

--- a/roles/ceph-container-engine/vars/RedHat.yml
+++ b/roles/ceph-container-engine/vars/RedHat.yml
@@ -1,4 +1,3 @@
 ---
 container_package_name: docker
 container_service_name: docker
-container_binding_name: python-docker-py

--- a/roles/ceph-container-engine/vars/Ubuntu-16.yml
+++ b/roles/ceph-container-engine/vars/Ubuntu-16.yml
@@ -1,4 +1,3 @@
 ---
 container_package_name: docker.io
 container_service_name: docker
-container_binding_name: python-docker

--- a/roles/ceph-container-engine/vars/Ubuntu-18.yml
+++ b/roles/ceph-container-engine/vars/Ubuntu-18.yml
@@ -1,4 +1,3 @@
 ---
 container_package_name: docker.io
 container_service_name: docker
-container_binding_name: python3-docker

--- a/roles/ceph-container-engine/vars/Ubuntu-20.yml
+++ b/roles/ceph-container-engine/vars/Ubuntu-20.yml
@@ -1,4 +1,3 @@
 ---
 container_package_name: docker.io
 container_service_name: docker
-container_binding_name: python3-docker


### PR DESCRIPTION
The container_binding_name package was only mandatory when we were
using the docker modules (docker_image and docker_container) but since
we manage both docker and podman containers without using the dedicated
module then we can remove it.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>