### PR TITLE
mon: fix force peer addition task

### DIFF
--- a/roles/ceph-mon/tasks/docker/main.yml
+++ b/roles/ceph-mon/tasks/docker/main.yml
@@ -17,7 +17,7 @@
   until: monitor_socket.rc == 0
 
 - name: ipv4 - force peer addition as potential bootstrap peer for cluster bringup - monitor_interface
-  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[groups[mon_group_name][0]]['ansible_' + monitor_interface].ipv4.address }}"
+  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint {{ hostvars[groups[mon_group_name][0]]['ansible_' + hostvars[groups[mon_group_name][0]]['monitor_interface']].ipv4.address }}"
   changed_when: false
   failed_when: false
   when:
@@ -47,7 +47,7 @@
     - hostvars[groups[mon_group_name][0]]['monitor_address_block'] != 'subnet'
 
 - name: ipv6 - force peer addition as potential bootstrap peer for cluster bringup - monitor_interface
-  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['ansible_' + monitor_interface].ipv6[0].address }}]"
+  command: "{{ docker_exec_cmd }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ monitor_name }}.asok add_bootstrap_peer_hint [{{ hostvars[groups[mon_group_name][0]]['ansible_' + hostvars[groups[mon_group_name][0]]['monitor_interface']].ipv6[0].address }}]"
   changed_when: false
   failed_when: false
   when:


### PR DESCRIPTION
when using `monitor_interface`, if nodes don't have same interface names
this task will fail like following:

```
fatal: [argo010]: FAILED! => {
    "msg": "The task includes an option with an undefined variable. The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute u'ansible_enp1s0f0'\n\nThe error appears to have been in '/usr/share/ceph-ansible/roles/ceph-mon/tasks/docker/main.yml': line 19, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: ipv4 - force peer addition as potential bootstrap peer for cluster bringup - monitor_interface\n  ^ here\n"
}

```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1876551

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>