### PR TITLE
ceph-osd: don't start the OSD services twice

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -30,7 +30,7 @@
     enabled: yes
     masked: no
     daemon_reload: yes
-  with_items: "{{ ((ceph_osd_ids.stdout | default('{}') | from_json).keys() | list) + osd_ids_non_container.stdout_lines | default([]) }}"
+  with_items: "{{ ((ceph_osd_ids.stdout | default('{}') | from_json).keys() | list) | union(osd_ids_non_container.stdout_lines) | default([]) }}"
 
 - name: ensure systemd service override directory exists
   file:


### PR DESCRIPTION
Using the + operation on two lists doesn't filter out the duplicate
keys.
Currently each OSDs is started (via systemd) twice.
Instead we could use the union filter.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>