### PR TITLE
ceph-osd: start osd after systemd overrides

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -23,15 +23,6 @@
   include_tasks: systemd.yml
   when: containerized_deployment | bool
 
-- name: systemd start osd
-  systemd:
-    name: ceph-osd@{{ item }}
-    state: started
-    enabled: yes
-    masked: no
-    daemon_reload: yes
-  with_items: "{{ ((ceph_osd_ids.stdout | default('{}') | from_json).keys() | list) | union(osd_ids_non_container.stdout_lines) | default([]) }}"
-
 - name: ensure systemd service override directory exists
   file:
     state: directory
@@ -49,3 +40,12 @@
   when:
     - ceph_osd_systemd_overrides is defined
     - ansible_service_mgr == 'systemd'
+
+- name: systemd start osd
+  systemd:
+    name: ceph-osd@{{ item }}
+    state: started
+    enabled: yes
+    masked: no
+    daemon_reload: yes
+  with_items: "{{ ((ceph_osd_ids.stdout | default('{}') | from_json).keys() | list) | union(osd_ids_non_container.stdout_lines) | default([]) }}"


### PR DESCRIPTION
The service should be started after the ceph-osd systemd overrides has
been added, otherwise, the latter isn't considered.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1860739

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>