### PR TITLE
ceph-osd: allow to use ceph_tcmalloc_max_total_thread_cache for bluestore

### DIFF
--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -55,5 +55,4 @@
   include_tasks: configure_memory_allocator.yml
   when:
     - (ceph_tcmalloc_max_total_thread_cache | int) > 0
-    - osd_objectstore == 'filestore'
     - (ceph_origin == 'repository' or ceph_origin == 'distro')

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -53,7 +53,7 @@ numactl \
   {% endif -%}
   {{ container_env_args }} \
   -e CLUSTER={{ cluster }} \
-  {% if (ceph_tcmalloc_max_total_thread_cache | int) > 0 and osd_objectstore == 'filestore' -%}
+  {% if (ceph_tcmalloc_max_total_thread_cache | int) > 0 -%}
   -e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }} \
   {% endif -%}
   -v /run/lvm/:/run/lvm/ \


### PR DESCRIPTION
`TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES` is for both bluestore and filestore

Signed-off-by: Seena Fallah <seenafallah@gmail.com>