### PR TITLE
library: add cephadm_bootstrap module

### DIFF
--- a/infrastructure-playbooks/cephadm.yml
+++ b/infrastructure-playbooks/cephadm.yml
@@ -143,10 +143,16 @@
         state: directory
 
     - name: bootstrap the new cluster
-      command: "{{ cephadm_cmd }} bootstrap --mon-ip {{ _current_monitor_address }} --skip-pull --skip-monitoring-stack {{ '--initial-dashboard-user ' + dashboard_admin_user + ' --initial-dashboard-password ' + dashboard_admin_password if dashboard_enabled | bool else '--skip-dashboard' }}"
-      changed_when: false
-      environment:
-        CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+      cephadm_bootstrap:
+        mon_ip: "{{ _current_monitor_address }}"
+        image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+        docker: "{{ true if container_binary == 'docker' else false }}"
+        pull: false
+        dashboard: "{{ dashboard_enabled }}"
+        dashboard_user: "{{ dashboard_admin_user if dashboard_enabled | bool else omit }}"
+        dashboard_password: "{{ dashboard_admin_password if dashboard_enabled | bool else omit }}"
+        monitoring: false
+        firewalld: "{{ configure_firewall }}"
 
     - name: set default container image in ceph configuration
       command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} config set global container_image {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"

--- a/library/cephadm_bootstrap.py
+++ b/library/cephadm_bootstrap.py
@@ -1,0 +1,196 @@
+# Copyright 2020, Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible.module_utils.ca_common import exit_module
+except ImportError:
+    from module_utils.ca_common import exit_module
+import datetime
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: cephadm_bootstrap
+short_description: Bootstrap a Ceph cluster via cephadm
+version_added: "2.8"
+description:
+    - Bootstrap a Ceph cluster via cephadm
+options:
+    mon_ip:
+        description:
+            - Ceph monitor IP address.
+        required: true
+    image:
+        description:
+            - Ceph container image.
+        required: false
+    docker:
+        description:
+            - Use docker instead of podman.
+        required: false
+    fsid:
+        description:
+            - Ceph FSID.
+        required: false
+    pull:
+        description:
+            - Pull the Ceph container image.
+        required: false
+        default: true
+    dashboard:
+        description:
+            - Deploy the Ceph dashboard.
+        required: false
+        default: true
+    dashboard_user:
+        description:
+            - Ceph dashboard user.
+        required: false
+    dashboard_password:
+        description:
+            - Ceph dashboard password.
+        required: false
+    monitoring:
+        description:
+            - Deploy the monitoring stack.
+        required: false
+        default: true
+    firewalld:
+        description:
+            - Manage firewall rules with firewalld.
+        required: false
+        default: true
+author:
+    - Dimitri Savineau <dsavinea@redhat.com>
+'''
+
+EXAMPLES = '''
+- name: bootstrap a cluster via cephadm (with default values)
+  cephadm_bootstrap:
+    mon_ip: 192.168.42.1
+
+- name: bootstrap a cluster via cephadm (with custom values)
+  cephadm_bootstrap:
+    mon_ip: 192.168.42.1
+    fsid: 3c9ba63a-c7df-4476-a1e7-317dfc711f82
+    image: quay.ceph.io/ceph/daemon-base:latest-master-devel
+    dashboard: false
+    monitoring: false
+    firewalld: false
+
+- name: bootstrap a cluster via cephadm with custom image via env var
+  cephadm_bootstrap:
+    mon_ip: 192.168.42.1
+  environment:
+    CEPHADM_IMAGE: quay.ceph.io/ceph/daemon-base:latest-master-devel
+'''
+
+RETURN = '''#  '''
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            mon_ip=dict(type='str', required=True),
+            image=dict(type='str', required=False),
+            docker=dict(type='bool', required=False, default=False),
+            fsid=dict(type='str', required=False),
+            pull=dict(type='bool', required=False, default=True),
+            dashboard=dict(type='bool', required=False, default=True),
+            dashboard_user=dict(type='str', required=False),
+            dashboard_password=dict(type='str', required=False, no_log=True),
+            monitoring=dict(type='bool', required=False, default=True),
+            firewalld=dict(type='bool', required=False, default=True),
+        ),
+        supports_check_mode=True,
+    )
+
+    mon_ip = module.params.get('mon_ip')
+    docker = module.params.get('docker')
+    image = module.params.get('image')
+    fsid = module.params.get('fsid')
+    pull = module.params.get('pull')
+    dashboard = module.params.get('dashboard')
+    dashboard_user = module.params.get('dashboard_user')
+    dashboard_password = module.params.get('dashboard_password')
+    monitoring = module.params.get('monitoring')
+    firewalld = module.params.get('firewalld')
+
+    startd = datetime.datetime.now()
+
+    cmd = ['cephadm']
+
+    if docker:
+        cmd.append('--docker')
+
+    if image:
+        cmd.extend(['--image', image])
+
+    cmd.extend(['bootstrap', '--mon-ip', mon_ip])
+
+    if fsid:
+        cmd.extend(['--fsid', fsid])
+
+    if not pull:
+        cmd.append('--skip-pull')
+
+    if dashboard:
+        if dashboard_user:
+            cmd.extend(['--initial-dashboard-user', dashboard_user])
+        if dashboard_password:
+            cmd.extend(['--initial-dashboard-password', dashboard_password])
+    else:
+        cmd.append('--skip-dashboard')
+
+    if not monitoring:
+        cmd.append('--skip-monitoring-stack')
+
+    if not firewalld:
+        cmd.append('--skip-firewalld')
+
+    if module.check_mode:
+        exit_module(
+            module=module,
+            out='',
+            rc=0,
+            cmd=cmd,
+            err='',
+            startd=startd,
+            changed=False
+        )
+    else:
+        rc, out, err = module.run_command(cmd)
+        exit_module(
+            module=module,
+            out=out,
+            rc=rc,
+            cmd=cmd,
+            err=err,
+            startd=startd,
+            changed=True
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/functional/cephadm/group_vars/all
+++ b/tests/functional/cephadm/group_vars/all
@@ -4,5 +4,5 @@ public_network: "192.168.30.0/24"
 cluster_network: "192.168.31.0/24"
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image: ceph-ci/daemon-base
+ceph_docker_image_tag: latest-master-devel

--- a/tests/library/test_cephadm_bootstrap.py
+++ b/tests/library/test_cephadm_bootstrap.py
@@ -1,0 +1,252 @@
+from mock.mock import patch
+import pytest
+import ca_test_common
+import cephadm_bootstrap
+
+fake_fsid = '0f1e0605-db0b-485c-b366-bd8abaa83f3b'
+fake_image = 'quay.ceph.io/ceph/daemon-base:latest-master-devel'
+fake_ip = '192.168.42.1'
+
+
+class TestCephadmBootstrapModule(object):
+
+    @patch('ansible.module_utils.basic.AnsibleModule.fail_json')
+    def test_without_parameters(self, m_fail_json):
+        ca_test_common.set_module_args({})
+        m_fail_json.side_effect = ca_test_common.fail_json
+
+        with pytest.raises(ca_test_common.AnsibleFailJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['msg'] == 'missing required arguments: mon_ip'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    def test_with_check_mode(self, m_exit_json):
+        ca_test_common.set_module_args({
+            'mon_ip': fake_ip,
+            '_ansible_check_mode': True
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip]
+        assert result['rc'] == 0
+        assert not result['stdout']
+        assert not result['stderr']
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_failure(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'mon_ip': fake_ip
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = 'ERROR: cephadm should be run as root'
+        rc = 1
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip]
+        assert result['rc'] == 1
+        assert result['stderr'] == 'ERROR: cephadm should be run as root'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_default_values(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'mon_ip': fake_ip
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = 'Bootstrap complete.'
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip]
+        assert result['rc'] == 0
+        assert result['stdout'] == 'Bootstrap complete.'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_docker(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'mon_ip': fake_ip,
+            'docker': True
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', '--docker', 'bootstrap', '--mon-ip', fake_ip]
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_custom_image(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'mon_ip': fake_ip,
+            'image': fake_image
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', '--image', fake_image, 'bootstrap', '--mon-ip', fake_ip]
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_custom_fsid(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'mon_ip': fake_ip,
+            'fsid': fake_fsid
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--fsid', fake_fsid]
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_without_pull(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'mon_ip': fake_ip,
+            'pull': False
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--skip-pull']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_dashboard_user_password(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'mon_ip': fake_ip,
+            'dashboard': True,
+            'dashboard_user': 'foo',
+            'dashboard_password': 'bar'
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--initial-dashboard-user', 'foo', '--initial-dashboard-password', 'bar']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_without_dashboard(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'mon_ip': fake_ip,
+            'dashboard': False
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--skip-dashboard']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_without_monitoring(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'mon_ip': fake_ip,
+            'monitoring': False
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--skip-monitoring-stack']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_without_firewalld(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'mon_ip': fake_ip,
+            'firewalld': False
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--skip-firewalld']
+        assert result['rc'] == 0


### PR DESCRIPTION
This adds cephadm_bootstrap ansible module for replacing the command module
usage with the cephadm bootstrap command.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>