### PR TITLE
ceph-crash: Only deploy key to targeted hosts

### DIFF
--- a/roles/ceph-crash/tasks/main.yml
+++ b/roles/ceph-crash/tasks/main.yml
@@ -22,19 +22,9 @@
       command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get client.crash"
       register: _crash_keys
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
+      check_mode: False
+      changed_when: False
       run_once: true
-
-    - name: get a list of node where the keyring should be copied
-      set_fact:
-        list_target_node: "{{ list_target_node | default([]) | union(((groups.get('all') | difference(groups.get(monitoring_group_name, []) + groups.get(client_group_name, []) + groups.get(nfs_group_name, []) + groups.get(iscsi_gw_group_name, []))) + groups.get(item, [])) | unique) }}"
-      run_once: True
-      with_items:
-        - "{{ mon_group_name if groups.get(mon_group_name, []) | length > 0 else [] }}"
-        - "{{ osd_group_name if groups.get(osd_group_name, []) | length > 0 else [] }}"
-        - "{{ mds_group_name if groups.get(mds_group_name, []) | length > 0 else [] }}"
-        - "{{ rgw_group_name if groups.get(rgw_group_name, []) | length > 0 else [] }}"
-        - "{{ rbdmirror_group_name if groups.get(rbdmirror_group_name, []) | length > 0 else [] }}"
-        - "{{ mgr_group_name if groups.get(mgr_group_name, []) | length > 0 else [] }}"
 
     - name: copy ceph key(s) if needed
       copy:
@@ -43,10 +33,6 @@
         owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         mode: "{{ ceph_keyring_permissions }}"
-      with_items: "{{ list_target_node }}"
-      delegate_to: "{{ item }}"
-      run_once: True
-      when: _crash_keys is not skipped
 
 - name: start ceph-crash daemon
   when: containerized_deployment | bool


### PR DESCRIPTION
The current task installs the ceph-crash key to "most" hosts via
"delegate_to". This key is only used by the ceph-crash daemon and should
just be installed on all hosts targeted by this role. There is no need
for using a delegated task.

Signed-off-by: Gaudenz Steinlin <gaudenz.steinlin@cloudscale.ch>