### PR TITLE
config: Always use osd_memory_target if set

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -346,10 +346,12 @@ dummy:
 
 ## OSD options
 #
+# Variables to calculate a suitable osd_memory_target based on the number of OSDs
 #is_hci: false
 #hci_safety_factor: 0.2
 #non_hci_safety_factor: 0.7
-#osd_memory_target: 4294967296
+# You can also set an explicit value which will override the calculation if set.
+# osd_memory_target: 4294967296
 #journal_size: 5120 # OSD journal size in MB
 #block_db_size: -1 # block db size in bytes for the ceph-volume lvm batch. -1 means use the default of 'as big as possible'.
 #public_network: 0.0.0.0/0

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -346,10 +346,12 @@ ceph_iscsi_config_dev: false
 
 ## OSD options
 #
+# Variables to calculate a suitable osd_memory_target based on the number of OSDs
 #is_hci: false
 #hci_safety_factor: 0.2
 #non_hci_safety_factor: 0.7
-#osd_memory_target: 4294967296
+# You can also set an explicit value which will override the calculation if set.
+# osd_memory_target: 4294967296
 #journal_size: 5120 # OSD journal size in MB
 #block_db_size: -1 # block db size in bytes for the ceph-volume lvm batch. -1 means use the default of 'as big as possible'.
 #public_network: 0.0.0.0/0

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -82,18 +82,16 @@ filestore xattr use omap = true
 {% if osd_objectstore == 'bluestore' %}
 {% set _num_osds = num_osds | default(0) | int %}
 [osd]
-{% if is_hci | bool and _num_osds > 0 %}
+{% if is_hci | bool and _num_osds > 0 and not osd_memory_target is defined %}
 {# hci_safety_factor is the safety factor for HCI deployments #}
-{% if ansible_memtotal_mb * 1048576 * hci_safety_factor / _num_osds > osd_memory_target %}
 {% set _osd_memory_target = (ansible_memtotal_mb * 1048576 * hci_safety_factor / _num_osds) | int %}
-{% endif %}
-{% elif _num_osds > 0 %}
+{% elif _num_osds > 0 and not osd_memory_target is defined %}
 {# non_hci_safety_factor is the safety factor for dedicated nodes #}
-{% if ansible_memtotal_mb * 1048576 * non_hci_safety_factor / _num_osds > osd_memory_target %}
 {% set _osd_memory_target = (ansible_memtotal_mb * 1048576 * non_hci_safety_factor / _num_osds) | int %}
 {% endif %}
-{% endif %}
+{% if _osd_memory_target is defined or osd_memory_target is defined %}
 osd memory target = {{ _osd_memory_target | default(osd_memory_target) }}
+{% endif %}
 {% endif %}
 {% endif %}
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -338,10 +338,12 @@ cephfs_pools:
 
 ## OSD options
 #
+# Variables to calculate a suitable osd_memory_target based on the number of OSDs
 is_hci: false
 hci_safety_factor: 0.2
 non_hci_safety_factor: 0.7
-osd_memory_target: 4294967296
+# You can also set an explicit value which will override the calculation if set.
+# osd_memory_target: 4294967296
 journal_size: 5120 # OSD journal size in MB
 block_db_size: -1 # block db size in bytes for the ceph-volume lvm batch. -1 means use the default of 'as big as possible'.
 public_network: 0.0.0.0/0


### PR DESCRIPTION
The osd_memory_target variable was only used if it was higher than the
calculated value based on the number of OSDs. This is changed to always
use the value if it is set in the configuration. This allows this value
to be intentionally set lower so that it does not have to be changed
when more OSDs are added later.

Signed-off-by: Gaudenz Steinlin <gaudenz.steinlin@cloudscale.ch>