### PR TITLE
Fix Ansible check mode in ceph-mon and ceph-osd

### DIFF
--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -25,6 +25,7 @@
 - name: get initial keyring when it already exists
   set_fact:
     monitor_keyring: "{{ initial_mon_key.stdout if monitor_keyring.skipped is defined else monitor_keyring.stdout if initial_mon_key.skipped is defined }}"
+  when: initial_mon_key is not skipped or monitor_keyring is not skipped
 
 - name: create monitor initial keyring
   ceph_key:

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -48,4 +48,4 @@
     enabled: yes
     masked: no
     daemon_reload: yes
-  with_items: "{{ ((ceph_osd_ids.stdout | default('{}') | from_json).keys() | list) | union(osd_ids_non_container.stdout_lines) | default([]) }}"
+  with_items: "{{ ((ceph_osd_ids.stdout | default('{}') | from_json).keys() | list) | union(osd_ids_non_container.stdout_lines | default([])) }}"


### PR DESCRIPTION
Skip tasks that depend on the output of commands that are not being run in check mode.