### PR TITLE
mon: delegate mon socket in-use check

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -73,6 +73,7 @@
       run_once: true
       delegate_to: "{{ hostvars[item.item]['inventory_hostname'] }}"
       with_items: "{{ mon_socket_stat.results }}"
+      delegate_to: '{{ item.item }}'
       when:
         - not containerized_deployment | bool
         - item.rc == 0


### PR DESCRIPTION
This check must be delegated to the mon host.

Signed-off-by: Gaudenz Steinlin <gaudenz.steinlin@cloudscale.ch>