### PR TITLE
openstack: omit mode on key if not set on item

### DIFF
--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -49,7 +49,7 @@
         content: "{{ item.0.stdout + '\n' }}"
         owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
-        mode: "{{ item.0.item.mode }}"
+        mode: "{{ item.0.item.mode | default(ceph_keyring_permissions) }}"
       with_nested:
         - "{{ _osp_keys.results }}"
         - "{{ groups[mon_group_name] }}"


### PR DESCRIPTION
This was lost with commit ab370b6ad823e551cfc324fd9c264633a34b72b5.

Signed-off-by: Gaudenz Steinlin <gaudenz.steinlin@cloudscale.ch>