### PR TITLE
crash: refact caps definition

### DIFF
--- a/roles/ceph-crash/tasks/main.yml
+++ b/roles/ceph-crash/tasks/main.yml
@@ -5,7 +5,9 @@
     - name: create client.crash keyring
       ceph_key:
         name: "client.crash"
-        caps: "{{ {'mon': 'allow profile crash', 'mgr': 'allow profile crash'} }}"
+        caps:
+          mon: 'allow profile crash'
+          mgr: 'allow profile crash'
         cluster: "{{ cluster }}"
         dest: "{{ ceph_conf_key_directory }}"
         import_key: True


### PR DESCRIPTION
there is no need to use `{{ }}` syntax here.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>