### PR TITLE
iscsi: fix ownership on iscsi-gateway.cfg

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -44,6 +44,7 @@
     dest: /etc/ceph/iscsi-gateway.cfg
     config_type: ini
     config_overrides: '{{ iscsi_conf_overrides }}'
+    mode: "0600"
   notify: restart ceph rbd-target-api-gw
 
 - name: set_fact container_exec_cmd


### PR DESCRIPTION
This file is currently deployed with '0644' ownership making this file
readable by any user on the system.
Since it contains sensitive information it should be readable by the
owner only.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1890119

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>