### PR TITLE
podman: force log driver to journald

### DIFF
--- a/roles/ceph-crash/templates/ceph-crash.service.j2
+++ b/roles/ceph-crash/templates/ceph-crash.service.j2
@@ -14,7 +14,7 @@ ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f ceph-crash-%i
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-crash-%i \
 {% if container_binary == 'podman' %}
--d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+-d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
 --net=host \
 -v /var/lib/ceph:/var/lib/ceph:z \

--- a/roles/ceph-grafana/templates/grafana-server.service.j2
+++ b/roles/ceph-grafana/templates/grafana-server.service.j2
@@ -19,7 +19,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop grafana-server
 ExecStartPre=-/usr/bin/{{ container_binary }} rm grafana-server
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=grafana-server \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   -v /etc/grafana:/etc/grafana:Z \
   -v /var/lib/grafana:/var/lib/grafana:Z \

--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -17,7 +17,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-api
 ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-api
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   --memory={{ ceph_rbd_target_api_docker_memory_limit }} \
   --cpus={{ ceph_rbd_target_api_docker_cpu_limit }} \

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -17,7 +17,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-gw
 ExecStartPre=-/usr/bin/{{ container_binary }} rm rbd-target-gw
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   --memory={{ ceph_rbd_target_gw_docker_memory_limit }} \
   --cpus={{ ceph_rbd_target_gw_docker_cpu_limit }} \

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -17,7 +17,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop tcmu-runner
 ExecStartPre=-/usr/bin/{{ container_binary }} rm tcmu-runner
 ExecStart=/usr/bin/{{ container_binary }} run --rm \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   --memory={{ ceph_tcmu_runner_docker_memory_limit }} \
   --cpus={{ ceph_tcmu_runner_docker_cpu_limit }} \

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -18,7 +18,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mds-{{ ansible_hostname 
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mds-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   --memory={{ ceph_mds_docker_memory_limit }} \
   --cpus={{ cpu_limit }} \

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -17,7 +17,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mgr-{{ ansible_hostname 
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mgr-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   --memory={{ ceph_mgr_docker_memory_limit }} \
   --cpus={{ ceph_mgr_docker_cpu_limit }} \

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -16,7 +16,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mon-%i
 ExecStartPre=/bin/sh -c '"$(command -v mkdir)" -p /etc/ceph /var/lib/ceph/mon'
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   --memory={{ ceph_mon_docker_memory_limit }} \
   --cpus={{ ceph_mon_docker_cpu_limit }} \

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -17,7 +17,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-nfs-%i
 ExecStartPre={{ '/bin/mkdir' if ansible_os_family == 'Debian' else '/usr/bin/mkdir' }} -p /etc/ceph /etc/ganesha /var/lib/nfs/ganesha /var/log/ganesha
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   -v /var/lib/ceph:/var/lib/ceph:z \
   -v /etc/ceph:/etc/ceph:z \

--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -17,7 +17,7 @@ ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f node-exporter
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   --privileged \
   -v /proc:/host/proc:ro -v /sys:/host/sys:ro \

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -23,7 +23,7 @@ numactl \
 {% endif %}
 /usr/bin/{{ container_binary }} run \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   --rm \
   --net=host \

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -18,7 +18,7 @@ ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f alertmanager
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=alertmanager \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   -v "{{ alertmanager_conf_dir }}:/etc/alertmanager:Z" \
   -v "{{ alertmanager_data_dir }}:/alertmanager:Z" \

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -17,7 +17,7 @@ ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm -f prometheus
 ExecStart=/usr/bin/{{ container_binary }} run --rm --name=prometheus \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   -v "{{ prometheus_conf_dir }}:/etc/prometheus:Z" \
   -v "{{ prometheus_data_dir }}:/prometheus:Z" \

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -17,7 +17,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rbd-mirror-{{ ansible_ho
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rbd-mirror-{{ ansible_hostname }}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   --memory={{ ceph_rbd_mirror_docker_memory_limit }} \
   --cpus={{ ceph_rbd_mirror_docker_cpu_limit }} \

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -18,7 +18,7 @@ ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rgw-{{ ansible_hostname 
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-rgw-{{ ansible_hostname }}-${INST_NAME}
 ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
-  -d --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
+  -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   --memory={{ ceph_rgw_docker_memory_limit }} \
   --cpus={{ cpu_limit }} \


### PR DESCRIPTION
Since we've changed to podman configuration using the detach mode and
systemd type to forking then the container logs aren't present in the
journald anymore.
The default conmon log driver is using k8s-file.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1890439

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>