### PR TITLE
ceph-handler: fix curl ipv6 command with rgw

### DIFF
--- a/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
@@ -48,7 +48,7 @@ check_for_curl_or_wget() {
   if ${DOCKER_EXECS[i]} command -v wget &>/dev/null; then
     rgw_test_command="wget --no-check-certificate --tries 1 --quiet -O /dev/null"
   elif ${DOCKER_EXECS[i]} command -v curl &>/dev/null; then
-    rgw_test_command="curl -k --fail --silent --output /dev/null"
+    rgw_test_command="curl {{ '-g' if ip_version == 'ipv6' else '' }} -k --fail --silent --output /dev/null"
   else
     echo "It seems that neither curl nor wget are available on your system."
     echo "Cannot test rgw connection."


### PR DESCRIPTION
When using the curl command with ipv6 address and brackets then we need
to use the -g option otherwise the command fails.

```console
$ curl http://[fdc2:328:750b:6983::6]:8080
curl: (3) [globbing] error: bad range specification after pos 9
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>