### PR TITLE
infrastructure: consume ceph_fs module

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -480,12 +480,17 @@
                 CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
             - name: wait until only rank 0 is up
-              command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} fs get {{ cephfs }} -f json"
-              changed_when: false
+              ceph_fs:
+                name: "{{ cephfs }}"
+                cluster: "{{ cluster }}"
+                state: info
               register: wait_rank_zero
               retries: 720
               delay: 5
               until: (wait_rank_zero.stdout | from_json).mdsmap.in | length == 1 and (wait_rank_zero.stdout | from_json).mdsmap.in[0]  == 0
+              environment:
+                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
             - name: get name of remaining active mds
               command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} fs dump -f json"

--- a/infrastructure-playbooks/shrink-mds.yml
+++ b/infrastructure-playbooks/shrink-mds.yml
@@ -142,10 +142,16 @@
               (mds_to_kill in standby_mdss | default([]))
 
     - name: delete the filesystem when killing last mds
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} fs rm --yes-i-really-mean-it {{ cephfs }}"
+      ceph_fs:
+        name: "{{ cephfs }}"
+        cluster: "{{ cluster }}"
+        state: absent
       when:
         - (ceph_status.stdout | from_json)['fsmap']['up'] | int == 0
         - (ceph_status.stdout | from_json)['fsmap']['up:standby'] | int == 0
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
     - name: purge mds store
       file:


### PR DESCRIPTION
bd611a7 introduced the new ceph_fs module but missed some tasks in
rolling_update and shrink-mds playbooks.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>