### PR TITLE
Use ceph_key module when possible

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -280,8 +280,14 @@
         ceph_cmd: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph:/var/lib/ceph:z -v /var/run/ceph:/var/run/ceph:z --entrypoint=ceph ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph' }}"
 
     - name: get the client.admin keyring
-      command: "{{ ceph_cmd }} --cluster {{ cluster }} auth get client.admin"
-      changed_when: false
+      ceph_key:
+        name: client.admin
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       run_once: true
       delegate_to: '{{ groups[mon_group_name][0] }}'
       register: client_admin_keyring

--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -103,6 +103,12 @@ options:
             This command can ONLY run from a monitor node.
         required: false
         default: false
+    output_format:
+        description:
+            - The key output format when retrieving the information of an
+            entity.
+        required: false
+        default: json
 '''
 
 EXAMPLES = '''
@@ -162,6 +168,13 @@ caps:
   ceph_key:
     name: "my_key""
     state: info
+
+- name: info cephx admin key (plain)
+  ceph_key:
+    name: client.admin
+    output_format: plain
+    state: info
+  register: client_admin_key
 
 - name: list cephx keys
   ceph_key:
@@ -512,7 +525,8 @@ def run_module():
         import_key=dict(type='bool', required=False, default=True),
         dest=dict(type='str', required=False, default='/etc/ceph/'),
         user=dict(type='str', required=False, default='client.admin'),
-        user_key=dict(type='str', required=False, default=None)
+        user_key=dict(type='str', required=False, default=None),
+        output_format=dict(type='str', required=False, default='json', choices=['json', 'plain', 'xml', 'yaml'])
     )
 
     module = AnsibleModule(
@@ -533,6 +547,7 @@ def run_module():
     dest = module.params.get('dest')
     user = module.params.get('user')
     user_key = module.params.get('user_key')
+    output_format = module.params.get('output_format')
 
     changed = False
 
@@ -567,8 +582,6 @@ def run_module():
         user_key_path = os.path.join(user_key_dir, user_key_filename)
     else:
         user_key_path = user_key
-
-    output_format = "json"
 
     if (state in ["present", "update"]):
         # if dest is not a directory, the user wants to change the file's name

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -2,24 +2,25 @@
 - name: copy ceph admin keyring
   block:
     - name: get keys from monitors
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
-      register: _client_keys
-      with_items:
-        - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+      ceph_key:
+        name: client.admin
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+      register: _admin_key
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
       run_once: true
-      when:
-        - cephx | bool
-        - item.copy_key | bool
 
     - name: copy ceph key(s) if needed
       copy:
-        dest: "{{ item.item.path }}"
-        content: "{{ item.stdout + '\n' }}"
+        dest: "/etc/ceph/{{ cluster }}.client.admin.keyring"
+        content: "{{ _admin_key.stdout + '\n' }}"
         owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         mode: "{{ ceph_keyring_permissions }}"
-      with_items: "{{ _client_keys.results }}"
-      when:
-        - item.item.copy_key | bool
-  when: cephx | bool
+  when:
+    - cephx | bool
+    - copy_admin_key | bool

--- a/roles/ceph-crash/tasks/main.yml
+++ b/roles/ceph-crash/tasks/main.yml
@@ -21,11 +21,16 @@
       run_once: True
 
     - name: get keys from monitors
-      command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get client.crash"
+      ceph_key:
+        name: client.crash
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _crash_keys
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
-      check_mode: False
-      changed_when: False
       run_once: true
 
     - name: copy ceph key(s) if needed

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -1,26 +1,30 @@
 ---
 - name: get keys from monitors
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
-  register: _iscsi_keys
-  with_items:
-    - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  ceph_key:
+    name: client.admin
+    cluster: "{{ cluster }}"
+    output_format: plain
+    state: info
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+  register: _admin_key
   delegate_to: "{{ groups.get(mon_group_name)[0] }}"
   run_once: true
   when:
     - cephx | bool
-    - item.copy_key | bool
+    - copy_admin_key | bool
 
 - name: copy ceph key(s) if needed
   copy:
-    dest: "{{ item.item.path }}"
-    content: "{{ item.stdout + '\n' }}"
+    dest: "/etc/ceph/{{ cluster }}.client.admin.keyring"
+    content: "{{ _admin_key.stdout + '\n' }}"
     owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     mode: "{{ ceph_keyring_permissions }}"
-  with_items: "{{ _iscsi_keys.results }}"
   when:
     - cephx | bool
-    - item.item.copy_key | bool
+    - copy_admin_key | bool
 
 - name: add mgr ip address to trusted list with dashboard - ipv4
   set_fact:

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -11,7 +11,14 @@
     - /var/lib/ceph/mds/{{ cluster }}-{{ ansible_hostname }}
 
 - name: get keys from monitors
-  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  ceph_key:
+    name: "{{ item.name }}"
+    cluster: "{{ cluster }}"
+    output_format: plain
+    state: info
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _mds_keys
   with_items:
     - { name: "client.bootstrap-mds", path: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-mds/tasks/non_containerized.yml
+++ b/roles/ceph-mds/tasks/non_containerized.yml
@@ -21,18 +21,20 @@
     - ansible_os_family in ['Suse', 'RedHat']
 
 - name: create mds keyring
-  command: ceph --cluster {{ cluster }} --name client.bootstrap-mds --keyring /var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring auth get-or-create mds.{{ ansible_hostname }} osd 'allow rwx' mds 'allow' mon 'allow profile mds' -o /var/lib/ceph/mds/{{ cluster }}-{{ ansible_hostname }}/keyring
-  args:
-    creates: /var/lib/ceph/mds/{{ cluster }}-{{ ansible_hostname }}/keyring
-  changed_when: false
-  when: cephx | bool
-
-- name: set mds key permissions
-  file:
-    path: /var/lib/ceph/mds/{{ cluster }}-{{ ansible_hostname }}/keyring
-    owner: "ceph"
-    group: "ceph"
-    mode: "0600"
+  ceph_key:
+    name: "mds.{{ ansible_hostname }}"
+    cluster: "{{ cluster }}"
+    user: client.bootstrap-mds
+    user_key: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring"
+    caps:
+      mon: "allow profile mds"
+      mds: "allow"
+      osd: "allow rwx"
+    dest: "/var/lib/ceph/mds/{{ cluster }}-{{ ansible_hostname }}/keyring"
+    import_key: false
+    owner: ceph
+    group: ceph
+    mode: "{{ ceph_keyring_permissions }}"
   when: cephx | bool
 
 - name: ensure systemd service override directory exists

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -54,7 +54,14 @@
           - { 'name': "mgr.{{ ansible_hostname }}", 'path': "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring", 'copy_key': true }
 
     - name: get keys from monitors
-      command: "{{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      ceph_key:
+        name: "{{ item.name }}"
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _mgr_keys
       with_items: "{{ _mgr_keys }}"
       delegate_to: "{{ groups[mon_group_name][0] if running_mon is undefined else running_mon }}"

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -1,9 +1,15 @@
 ---
 - name: check if monitor initial keyring already exists
-  command: >
-    {{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} --name mon. -k
-    /var/lib/ceph/mon/{{ cluster }}-{{ hostvars[groups[mon_group_name][0] if running_mon is undefined else running_mon]['ansible_hostname'] }}/keyring
-    auth get-key mon.
+  ceph_key:
+    name: mon.
+    cluster: "{{ cluster }}"
+    user: mon.
+    user_key: "/var/lib/ceph/mon/{{ cluster }}-{{ hostvars[groups[mon_group_name][0] if running_mon is undefined else running_mon]['ansible_hostname'] }}/keyring"
+    output_format: json
+    state: info
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: initial_mon_key
   run_once: True
   delegate_to: "{{ groups[mon_group_name][0] if running_mon is undefined else running_mon }}"
@@ -24,7 +30,7 @@
 
 - name: get initial keyring when it already exists
   set_fact:
-    monitor_keyring: "{{ initial_mon_key.stdout if monitor_keyring.skipped is defined else monitor_keyring.stdout if initial_mon_key.skipped is defined }}"
+    monitor_keyring: "{{ (initial_mon_key.stdout | from_json)[0].key if monitor_keyring.skipped is defined else monitor_keyring.stdout if initial_mon_key.skipped is defined }}"
   when: initial_mon_key is not skipped or monitor_keyring is not skipped
 
 - name: create monitor initial keyring

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -10,7 +10,14 @@
       run_once: true
 
     - name: get keys from monitors
-      command: "{{ hostvars[groups.get(mon_group_name)[0]]['container_exec_cmd'] }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      ceph_key:
+        name: "{{ item.name }}"
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _rgw_keys
       with_items:
         - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -79,14 +79,16 @@
       when: nfs_obj_gw | bool
       block:
         - name: create rados gateway keyring
-          command: ceph --cluster {{ cluster }} --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring auth get-or-create client.rgw.{{ ansible_hostname }} osd 'allow rwx' mon 'allow rw' -o /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}/keyring
-          args:
-            creates: /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}/keyring
-          changed_when: false
-
-        - name: set rados gateway key permissions
-          file:
-            path: /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}/keyring
-            owner: "ceph"
-            group: "ceph"
-            mode: "0600"
+          ceph_key:
+            name: "client.rgw.{{ ansible_hostname }}"
+            cluster: "{{ cluster }}"
+            user: client.bootstrap-rgw
+            user_key: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring"
+            caps:
+              mon: "allow rw"
+              osd: "allow rwx"
+            dest: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_hostname }}/keyring"
+            import_key: false
+            owner: ceph
+            group: ceph
+            mode: "{{ ceph_keyring_permissions }}"

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -48,7 +48,11 @@
     - groups.get(mon_group_name, []) | length > 0
   block:
     - name: get keys from monitors
-      command: "ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      ceph_key:
+        name: "{{ item.name }}"
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
       register: _rgw_keys
       with_items:
         - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: "{{ nfs_obj_gw }}" }

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -12,7 +12,14 @@
     - /var/lib/ceph/osd/
 
 - name: get keys from monitors
-  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  ceph_key:
+    name: "{{ item.name }}"
+    cluster: "{{ cluster }}"
+    output_format: plain
+    state: info
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _osd_keys
   with_items:
     - { name: "client.bootstrap-osd", path: "/var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -37,10 +37,16 @@
       delegate_to: "{{ groups[mon_group_name][0] }}"
 
     - name: get keys from monitors
-      command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      ceph_key:
+        name: "{{ item.name }}"
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _osp_keys
       with_items: "{{ openstack_keys }}"
-      run_once: true
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
 
     - name: copy ceph key(s) if needed

--- a/roles/ceph-rbd-mirror/tasks/common.yml
+++ b/roles/ceph-rbd-mirror/tasks/common.yml
@@ -31,22 +31,17 @@
     - item.item.copy_key | bool
 
 - name: create rbd-mirror keyring
-  command: >
-    ceph --cluster {{ cluster }}
-    --name client.bootstrap-rbd-mirror
-    --keyring /var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring
-    auth get-or-create client.rbd-mirror.{{ ansible_hostname }}
-    mon 'profile rbd-mirror'
-    osd 'profile rbd'
-    -o /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring
-  args:
-    creates: /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring
-  when: not containerized_deployment | bool
-
-- name: set rbd-mirror key permissions
-  file:
-    path: /etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring
-    owner: "ceph"
-    group: "ceph"
+  ceph_key:
+    name: "client.rbd-mirror.{{ ansible_hostname }}"
+    cluster: "{{ cluster }}"
+    user: client.bootstrap-rbd-mirror
+    user_key: "/var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring"
+    caps:
+      mon: "profile rbd-mirror"
+      osd: "profile rbd"
+    dest: "/etc/ceph/{{ cluster }}.client.rbd-mirror.{{ ansible_hostname }}.keyring"
+    import_key: false
+    owner: ceph
+    group: ceph
     mode: "{{ ceph_keyring_permissions }}"
   when: not containerized_deployment | bool

--- a/roles/ceph-rbd-mirror/tasks/common.yml
+++ b/roles/ceph-rbd-mirror/tasks/common.yml
@@ -1,6 +1,13 @@
 ---
 - name: get keys from monitors
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  ceph_key:
+    name: "{{ item.name }}"
+    cluster: "{{ cluster }}"
+    output_format: plain
+    state: info
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _rbd_mirror_keys
   with_items:
     - { name: "client.bootstrap-rbd-mirror", path: "/var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -9,7 +9,14 @@
   with_items: "{{ rbd_client_admin_socket_path }}"
 
 - name: get keys from monitors
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  ceph_key:
+    name: "{{ item.name }}"
+    cluster: "{{ cluster }}"
+    output_format: plain
+    state: info
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _rgw_keys
   with_items:
     - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }


### PR DESCRIPTION
Whenever it's possible, use the ceph_key module instead of
  - `ceph auth get` commands
  - `ceph auth get-or-create` commands

This requires to modify the ceph_key module to handle the output format when using the info state.