### PR TITLE
Avoid running full ceph status command

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -479,13 +479,13 @@
       when: not containerized_deployment | bool
 
     - name: waiting for clean pgs...
-      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} -s --format json"
+      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} pg stat --format json"
       changed_when: false
       register: ceph_health_post
       until: >
-        (((ceph_health_post.stdout | from_json).pgmap.pgs_by_state | length) > 0)
+        (((ceph_health_post.stdout | from_json).pg_summary.num_pg_by_state | length) > 0)
         and
-        (((ceph_health_post.stdout | from_json).pgmap.pgs_by_state | selectattr('state_name', 'search', '^active\\+clean') | map(attribute='count') | list | sum) == (ceph_health_post.stdout | from_json).pgmap.num_pgs)
+        (((ceph_health_post.stdout | from_json).pg_summary.num_pg_by_state | selectattr('name', 'search', '^active\\+clean') | map(attribute='num') | list | sum) == (ceph_health_post.stdout | from_json).pg_summary.num_pgs)
       delegate_to: "{{ groups[mon_group_name][0] }}"
       retries: "{{ health_osd_check_retries }}"
       delay: "{{ health_osd_check_delay }}"

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -351,7 +351,7 @@
       when: not containerized_deployment | bool
 
     - name: waiting for the monitor to join the quorum...
-      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} -s --format json"
+      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} quorum_status --format json"
       changed_when: false
       register: ceph_health_raw
       until: >

--- a/infrastructure-playbooks/cephadm.yml
+++ b/infrastructure-playbooks/cephadm.yml
@@ -263,7 +263,7 @@
         CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
     - name: waiting for the monitor to join the quorum...
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} -s --format json"
+      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} quorum_status --format json"
       changed_when: false
       register: ceph_health_raw
       until: (ceph_health_raw.stdout | from_json)["quorum_names"] | length == groups.get(mon_group_name, []) | length

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -225,7 +225,7 @@
             or groups[mgr_group_name] | default([]) | length == 0
 
     - name: non container | waiting for the monitor to join the quorum...
-      command: ceph --cluster "{{ cluster }}" -m "{{ hostvars[groups[mon_group_name][0]]['_current_monitor_address'] }}" -s --format json
+      command: ceph --cluster "{{ cluster }}" -m "{{ hostvars[groups[mon_group_name][0]]['_current_monitor_address'] }}" quorum_status --format json
       register: ceph_health_raw
       until:
         - ceph_health_raw.rc == 0
@@ -237,7 +237,7 @@
 
     - name: container | waiting for the containerized monitor to join the quorum...
       command: >
-        {{ container_binary }} exec ceph-mon-{{ ansible_hostname }} ceph --cluster "{{ cluster }}" -m "{{ hostvars[groups[mon_group_name][0]]['_current_monitor_address'] }}" -s --format json
+        {{ container_binary }} exec ceph-mon-{{ ansible_hostname }} ceph --cluster "{{ cluster }}" -m "{{ hostvars[groups[mon_group_name][0]]['_current_monitor_address'] }}" quorum_status --format json
       register: ceph_health_raw
       until:
         - ceph_health_raw.rc == 0

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -415,21 +415,21 @@
         - not containerized_deployment | bool
 
     - name: get num_pgs - non container
-      command: "{{ container_exec_cmd_update_osd|default('') }} ceph --cluster {{ cluster }} -s --format json"
+      command: "{{ container_exec_cmd_update_osd|default('') }} ceph --cluster {{ cluster }} pg stat --format json"
       register: ceph_pgs
       delegate_to: "{{ groups[mon_group_name][0] }}"
 
     - name: waiting for clean pgs...
-      command: "{{ container_exec_cmd_update_osd|default('') }} ceph --cluster {{ cluster }} -s --format json"
+      command: "{{ container_exec_cmd_update_osd|default('') }} ceph --cluster {{ cluster }} pg stat --format json"
       register: ceph_health_post
       until: >
-        (((ceph_health_post.stdout | from_json).pgmap.pgs_by_state | length) > 0)
+        (((ceph_health_post.stdout | from_json).pg_summary.num_pg_by_state | length) > 0)
         and
-        (((ceph_health_post.stdout | from_json).pgmap.pgs_by_state | selectattr('state_name', 'search', '^active\\+clean') | map(attribute='count') | list | sum) == (ceph_pgs.stdout | from_json).pgmap.num_pgs)
+        (((ceph_health_post.stdout | from_json).pg_summary.num_pg_by_state | selectattr('name', 'search', '^active\\+clean') | map(attribute='num') | list | sum) == (ceph_pgs.stdout | from_json).pg_summary.num_pgs)
       delegate_to: "{{ groups[mon_group_name][0] }}"
       retries: "{{ health_osd_check_retries }}"
       delay: "{{ health_osd_check_delay }}"
-      when: (ceph_pgs.stdout | from_json).pgmap.num_pgs != 0
+      when: (ceph_pgs.stdout | from_json).pg_summary.num_pgs != 0
 
 
 - name: complete osd upgrade

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -136,8 +136,8 @@
 
     - block:
         - name: get ceph cluster status
-          command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} -s -f json"
-          register: check_cluster_status
+          command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} health -f json"
+          register: check_cluster_health
           delegate_to: "{{ mon_host }}"
 
         - block:
@@ -148,7 +148,7 @@
             - name: fail if cluster isn't in an acceptable state
               fail:
                 msg: "cluster is not in an acceptable state!"
-          when: (check_cluster_status.stdout | from_json).health.status == 'HEALTH_ERR'
+          when: (check_cluster_health.stdout | from_json).status == 'HEALTH_ERR'
       when: inventory_hostname == groups[mon_group_name] | first
 
     - name: ensure /var/lib/ceph/bootstrap-rbd-mirror is present

--- a/infrastructure-playbooks/shrink-mon.yml
+++ b/infrastructure-playbooks/shrink-mon.yml
@@ -112,7 +112,7 @@
 
   post_tasks:
     - name: verify the monitor is out of the cluster
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} -s -f json"
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} quorum_status -f json"
       delegate_to: "{{ mon_host }}"
       failed_when: false
       register: result

--- a/infrastructure-playbooks/shrink-rbdmirror.yml
+++ b/infrastructure-playbooks/shrink-rbdmirror.yml
@@ -67,7 +67,7 @@
         container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ ansible_hostname }}"
 
     - name: exit playbook, if can not connect to the cluster
-      command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} -s -f json"
+      command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} service dump -f json"
       register: ceph_health
       until: ceph_health is succeeded
       retries: 5
@@ -80,14 +80,14 @@
     - name: set_fact rbdmirror_gids
       set_fact:
         rbdmirror_gids: "{{ rbdmirror_gids | default([]) + [ item ] }}"
-      with_items: "{{  (ceph_health.stdout | from_json)['servicemap']['services']['rbd-mirror']['daemons'].keys() | list }}"
+      with_items: "{{  (ceph_health.stdout | from_json)['services']['rbd-mirror']['daemons'].keys() | list }}"
       when: item != 'summary'
 
     - name: set_fact rbdmirror_to_kill_gid
       set_fact:
-        rbdmirror_to_kill_gid: "{{ (ceph_health.stdout | from_json)['servicemap']['services']['rbd-mirror']['daemons'][item]['gid'] }}"
+        rbdmirror_to_kill_gid: "{{ (ceph_health.stdout | from_json)['services']['rbd-mirror']['daemons'][item]['gid'] }}"
       with_items: "{{ rbdmirror_gids }}"
-      when: (ceph_health.stdout | from_json)['servicemap']['services']['rbd-mirror']['daemons'][item]['metadata']['id'] == rbdmirror_to_kill_hostname
+      when: (ceph_health.stdout | from_json)['services']['rbd-mirror']['daemons'][item]['metadata']['id'] == rbdmirror_to_kill_hostname
 
   tasks:
     - name: stop rbdmirror service
@@ -106,14 +106,14 @@
 
   post_tasks:
     - name: get servicemap details
-      command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} -s -f json"
+      command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} service dump -f json"
       register: ceph_health
       failed_when:
-        - "'rbd-mirror' in (ceph_health.stdout | from_json)['servicemap']['services'].keys() | list"
-        - rbdmirror_to_kill_gid in (ceph_health.stdout | from_json)['servicemap']['services']['rbd-mirror']['daemons'].keys() | list
+        - "'rbd-mirror' in (ceph_health.stdout | from_json)['services'].keys() | list"
+        - rbdmirror_to_kill_gid in (ceph_health.stdout | from_json)['services']['rbd-mirror']['daemons'].keys() | list
       until:
-        - "'rbd-mirror' in (ceph_health.stdout | from_json)['servicemap']['services'].keys() | list"
-        - rbdmirror_to_kill_gid not in (ceph_health.stdout | from_json)['servicemap']['services']['rbd-mirror']['daemons'].keys() | list
+        - "'rbd-mirror' in (ceph_health.stdout | from_json)['services'].keys() | list"
+        - rbdmirror_to_kill_gid not in (ceph_health.stdout | from_json)['services']['rbd-mirror']['daemons'].keys() | list
       when: rbdmirror_to_kill_gid is defined
       retries: 12
       delay: 10

--- a/infrastructure-playbooks/shrink-rgw.yml
+++ b/infrastructure-playbooks/shrink-rgw.yml
@@ -76,12 +76,12 @@
       delay: 2
 
     - name: get rgw instances
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json"
+      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} service dump -f json"
       register: rgw_instances
 
 
     - name: exit playbook, if the rgw_to_kill doesn't exist
-      when: rgw_to_kill not in (rgw_instances.stdout | from_json).servicemap.services.rgw.daemons.keys() | list
+      when: rgw_to_kill not in (rgw_instances.stdout | from_json).services.rgw.daemons.keys() | list
       fail:
         msg: >
           It seems that the rgw instance given is not part of the ceph cluster. Please
@@ -111,14 +111,14 @@
       delay: 2
 
     - name: exit if rgw_to_kill is reported in ceph status
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json"
+      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} service dump -f json"
       register: ceph_status
       failed_when:
-        - (ceph_status.stdout | from_json).servicemap.services.rgw is defined
-        - rgw_to_kill in (ceph_status.stdout | from_json).servicemap.services.rgw.daemons.keys() | list
+        - (ceph_status.stdout | from_json).services.rgw is defined
+        - rgw_to_kill in (ceph_status.stdout | from_json).services.rgw.daemons.keys() | list
       until:
-        - (ceph_status.stdout | from_json).servicemap.services.rgw is defined
-        - rgw_to_kill not in (ceph_status.stdout | from_json).servicemap.services.rgw.daemons.keys() | list
+        - (ceph_status.stdout | from_json).services.rgw is defined
+        - rgw_to_kill not in (ceph_status.stdout | from_json).services.rgw.daemons.keys() | list
       retries: 3
       delay: 3
 

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -135,7 +135,7 @@
 
   post_tasks:
     - name: waiting for the monitor to join the quorum...
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} -s --format json"
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} quorum_status --format json"
       register: ceph_health_raw
       until: >
         hostvars[mon_host]['ansible_hostname'] in (ceph_health_raw.stdout | from_json)["quorum_names"]

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -320,12 +320,12 @@
   post_tasks:
     - name: container - waiting for clean pgs...
       command: >
-        {{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph --cluster {{ cluster }} -s --format json
+        {{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }} ceph --cluster {{ cluster }} pg stat --format json
       register: ceph_health_post
       until: >
-        (((ceph_health_post.stdout | from_json).pgmap.pgs_by_state | length) > 0)
+        (((ceph_health_post.stdout | from_json).pg_summary.num_pg_by_state | length) > 0)
         and
-        (((ceph_health_post.stdout | from_json).pgmap.pgs_by_state | selectattr('state_name', 'search', '^active\\+clean') | map(attribute='count') | list | sum) == (ceph_health_post.stdout | from_json).pgmap.num_pgs)
+        (((ceph_health_post.stdout | from_json).pg_summary.num_pg_by_state | selectattr('name', 'search', '^active\\+clean') | map(attribute='num') | list | sum) == (ceph_health_post.stdout | from_json).pg_summary.num_pgs)
       delegate_to: "{{ groups[mon_group_name][0] }}"
       retries: "{{ health_osd_check_retries }}"
       delay: "{{ health_osd_check_delay }}"

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -266,7 +266,7 @@
       or inventory_hostname in groups.get(nfs_group_name, [])
   block:
     - name: get ceph current status
-      command: "{{ timeout_command }} {{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s -f json"
+      command: "{{ timeout_command }} {{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} service dump -f json"
       changed_when: false
       failed_when: false
       check_mode: no
@@ -283,16 +283,15 @@
     - name: set_fact rgw_hostname
       set_fact:
         rgw_hostname: "{% set _value = ansible_hostname -%}
-        {% for key in (ceph_current_status['servicemap']['services']['rgw']['daemons'] | list) -%}
+        {% for key in (ceph_current_status['services']['rgw']['daemons'] | list) -%}
         {% if key == ansible_fqdn -%}
         {% set _value = key -%}
         {% endif -%}
         {% endfor -%}
         {{ _value }}"
       when:
-        - ceph_current_status['servicemap'] is defined
-        - ceph_current_status['servicemap']['services'] is defined
-        - ceph_current_status['servicemap']['services']['rgw'] is defined
+        - ceph_current_status['services'] is defined
+        - ceph_current_status['services']['rgw'] is defined
 
 - name: check if the ceph conf exists
   stat:

--- a/roles/ceph-handler/templates/restart_mon_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_mon_daemon.sh.j2
@@ -19,7 +19,7 @@ $DOCKER_EXEC test -S /var/run/ceph/{{ cluster }}-mon.{{ ansible_hostname }}.asok
 
 check_quorum() {
 while [ $RETRIES -ne 0 ]; do
-  $DOCKER_EXEC ceph --cluster {{ cluster }} -s --format json | "{{ discovered_interpreter_python }}" -c 'import sys, json; exit(0) if "{{ monitor_name }}" in json.load(sys.stdin)["quorum_names"] else exit(1)' && exit 0
+  $DOCKER_EXEC ceph --cluster {{ cluster }} quorum_status --format json | "{{ discovered_interpreter_python }}" -c 'import sys, json; exit(0) if "{{ monitor_name }}" in json.load(sys.stdin)["quorum_names"] else exit(1)' && exit 0
   sleep $DELAY
   let RETRIES=RETRIES-1
 done

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -76,15 +76,15 @@
     - inventory_hostname == ansible_play_hosts_all | last
 
 - name: wait for all osd to be up
-  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} -s -f json"
+  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd stat -f json"
   register: wait_for_all_osds_up
   retries: "{{ nb_retry_wait_osd_up }}"
   delay: "{{ delay_wait_osd_up }}"
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   until:
-    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] | int > 0
-    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_up_osds"]
+    - (wait_for_all_osds_up.stdout | from_json)["num_osds"] | int > 0
+    - (wait_for_all_osds_up.stdout | from_json)["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["num_up_osds"]
   when:
     - not ansible_check_mode
     - inventory_hostname == ansible_play_hosts_all | last


### PR DESCRIPTION
We're running the ceph status command multiple time but we only use few part of this output.
Instead we should use the closest ceph command to reduce the data returned in the output.
This means using:

- ceph osd stat
- ceph pg stat
- ceph quorum_status
- ceph service dump
- ceph health