### PR TITLE
library: remove unused module import

### DIFF
--- a/library/ceph_dashboard_user.py
+++ b/library/ceph_dashboard_user.py
@@ -15,6 +15,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ansible.module_utils.basic import AnsibleModule
+import datetime
+import json
+import os
+
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -98,13 +103,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''#  '''
-
-from ansible.module_utils.basic import AnsibleModule  # noqa E402
-import datetime  # noqa E402
-import json  # noqa E402
-import os  # noqa E402
-import stat  # noqa E402
-import time  # noqa E402
 
 
 def container_exec(binary, container_image):

--- a/library/ceph_fs.py
+++ b/library/ceph_fs.py
@@ -15,6 +15,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ansible.module_utils.basic import AnsibleModule
+import datetime
+import json
+import os
+
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -90,13 +95,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''#  '''
-
-from ansible.module_utils.basic import AnsibleModule  # noqa E402
-import datetime  # noqa E402
-import json  # noqa E402
-import os  # noqa E402
-import stat  # noqa E402
-import time  # noqa E402
 
 
 def container_exec(binary, container_image):

--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -17,6 +17,15 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ansible.module_utils.basic import AnsibleModule
+import datetime
+import json
+import os
+import struct
+import time
+import base64
+import socket
+
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -174,17 +183,6 @@ caps:
 
 RETURN = '''#  '''
 
-from ansible.module_utils.basic import AnsibleModule  # noqa E402
-import datetime  # noqa E402
-import grp  # noqa E402
-import json  # noqa E402
-import os  # noqa E402
-import pwd  # noqa E402
-import stat  # noqa E402
-import struct  # noqa E402
-import time  # noqa E402
-import base64  # noqa E402
-import socket  # noqa E402
 
 CEPH_INITIAL_KEYS = ['client.admin', 'client.bootstrap-mds', 'client.bootstrap-mgr',  # noqa E501
                      'client.bootstrap-osd', 'client.bootstrap-rbd', 'client.bootstrap-rbd-mirror', 'client.bootstrap-rgw']  # noqa E501

--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -17,6 +17,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ansible.module_utils.basic import AnsibleModule
+import datetime
+import json
+import os
+
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -134,13 +139,6 @@ pools:
 '''
 
 RETURN = '''#  '''
-
-from ansible.module_utils.basic import AnsibleModule  # noqa E402
-import datetime  # noqa E402
-import json  # noqa E402
-import os  # noqa E402
-import stat  # noqa E402
-import time  # noqa E402
 
 
 def container_exec(binary, container_image):

--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from ansible.module_utils.basic import AnsibleModule
 import datetime
 import copy
 import json
@@ -185,9 +186,6 @@ EXAMPLES = '''
     wal: /dev/sdc2
     action: create
 '''
-
-
-from ansible.module_utils.basic import AnsibleModule  # noqa 4502
 
 
 def fatal(message, module):

--- a/library/radosgw_realm.py
+++ b/library/radosgw_realm.py
@@ -15,6 +15,10 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ansible.module_utils.basic import AnsibleModule
+import datetime
+import os
+
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -80,13 +84,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''#  '''
-
-from ansible.module_utils.basic import AnsibleModule  # noqa E402
-import datetime  # noqa E402
-import json  # noqa E402
-import os  # noqa E402
-import stat  # noqa E402
-import time  # noqa E402
 
 
 def container_exec(binary, container_image):

--- a/library/radosgw_user.py
+++ b/library/radosgw_user.py
@@ -15,6 +15,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ansible.module_utils.basic import AnsibleModule
+import datetime
+import json
+import os
+
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -128,13 +133,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''#  '''
-
-from ansible.module_utils.basic import AnsibleModule  # noqa E402
-import datetime  # noqa E402
-import json  # noqa E402
-import os  # noqa E402
-import stat  # noqa E402
-import time  # noqa E402
 
 
 def container_exec(binary, container_image):

--- a/library/radosgw_zone.py
+++ b/library/radosgw_zone.py
@@ -15,6 +15,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ansible.module_utils.basic import AnsibleModule
+import datetime
+import json
+import os
+
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -113,13 +118,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''#  '''
-
-from ansible.module_utils.basic import AnsibleModule  # noqa E402
-import datetime  # noqa E402
-import json  # noqa E402
-import os  # noqa E402
-import stat  # noqa E402
-import time  # noqa E402
 
 
 def container_exec(binary, container_image):

--- a/library/radosgw_zonegroup.py
+++ b/library/radosgw_zonegroup.py
@@ -15,6 +15,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ansible.module_utils.basic import AnsibleModule
+import datetime
+import json
+import os
+
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -100,13 +105,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''#  '''
-
-from ansible.module_utils.basic import AnsibleModule  # noqa E402
-import datetime  # noqa E402
-import json  # noqa E402
-import os  # noqa E402
-import stat  # noqa E402
-import time  # noqa E402
 
 
 def container_exec(binary, container_image):


### PR DESCRIPTION
Move the import at the top of the file and remove unused module import.

- E402 module level import not at top of file
- F401 'xxxx' imported but unused

This also removes the `# noqa E402` statement from the code.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>