### PR TITLE
Add ceph_client tag to execute or skip the playbook

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -282,18 +282,19 @@
 
     - import_role:
         name: ceph-defaults
-      tags: ['ceph_update_config']
+      tags: ['ceph_update_config', 'ceph_client']
     - import_role:
         name: ceph-facts
-      tags: ['ceph_update_config']
+      tags: ['ceph_update_config', 'ceph_client']
     - import_role:
         name: ceph-handler
-      tags: ['ceph_update_config']
+      tags: ['ceph_update_config', 'ceph_client']
     - import_role:
         name: ceph-config
-      tags: ['ceph_update_config']
+      tags: ['ceph_update_config', 'ceph_client']
     - import_role:
         name: ceph-client
+      tags: ['ceph_client']
 
     # post-tasks for preceding imports -
     - name: set ceph client install 'Complete'

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -271,18 +271,19 @@
   tasks:
     - import_role:
         name: ceph-defaults
-      tags: ['ceph_update_config']
+      tags: ['ceph_update_config', 'ceph_client']
     - import_role:
         name: ceph-facts
-      tags: ['ceph_update_config']
+      tags: ['ceph_update_config', 'ceph_client']
     - import_role:
         name: ceph-handler
-      tags: ['ceph_update_config']
+      tags: ['ceph_update_config', 'ceph_client']
     - import_role:
         name: ceph-config
-      tags: ['ceph_update_config']
+      tags: ['ceph_update_config', 'ceph_client']
     - import_role:
         name: ceph-client
+      tags: ['ceph_client']
 
   post_tasks:
     - name: set ceph client install 'Complete'


### PR DESCRIPTION
There are some use cases where there's a need to skip the execution
of the ceph-ansible client role even though the client section of the
inventory isn't empty.
This can happen in contexts where the services are colocated or when
a all-in-one deployment is performed.
The purpose of this change is adding a 'ceph_client' tag to avoid
altering the ceph-ansible execution flow but at the same time be able
to include or exclude a set of tasks using this tag.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>