### PR TITLE
rolling_update: always run cv simple scan/activate

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -403,17 +403,13 @@
       command: "ceph-volume --cluster={{ cluster }} simple scan --force"
       environment:
         CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-      when:
-        - ceph_release in ["nautilus", "octopus"]
-        - not containerized_deployment | bool
+      when: not containerized_deployment | bool
 
     - name: activate scanned ceph-disk osds and migrate to ceph-volume if deploying nautilus
       command: "ceph-volume --cluster={{ cluster }} simple activate --all"
       environment:
         CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-      when:
-        - ceph_release in ["nautilus", "octopus"]
-        - not containerized_deployment | bool
+      when: not containerized_deployment | bool
 
     - name: get num_pgs - non container
       command: "{{ container_exec_cmd_update_osd|default('') }} ceph --cluster {{ cluster }} pg stat --format json"


### PR DESCRIPTION
There's no need to use a condition on the ceph release for the
ceph-volume simple commands.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>