### PR TITLE
Add additional check for radosgw network validation

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -52,6 +52,7 @@
     msg: "Either radosgw_address, radosgw_address_block or radosgw_interface must be provided"
   when:
     - rgw_group_name in group_names
+    - groups.get(rgw_group_name, []) | length > 0
     - radosgw_address == 'x.x.x.x'
     - radosgw_address_block == 'subnet'
     - radosgw_interface == 'interface'


### PR DESCRIPTION
When user doesn't want to have a radosgw, this check with fail without
this option. We should check if user defined hosts in rgw group.

Signed-off-by: Rafał Wądołowski <rwadolowski@cloudferro.com>