### PR TITLE
ceph-facts: fix read osd pool default crush fact

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -321,7 +321,6 @@
 - name: get default crush rule value from running monitor ceph configuration
   block:
     - <<: *read-osd-pool-default-crush-rule
-      run_once: true
       delegate_to: "{{ running_mon }}"
     - *set-osd-pool-default-crush-rule-fact
   when:


### PR DESCRIPTION
We don't need to use run_once on that task when having running monitors
otherwise the read task could be skip and the set task will fail.

```console
The conditional check 'crush_rule_variable.rc == 0' failed. The error
was: error while evaluating conditional (crush_rule_variable.rc == 0):
'dict object' has no attribute 'rc'
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1898856

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>