### PR TITLE
consume ceph_volume module when possible

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -432,13 +432,13 @@
         tasks_from: container_binary.yml
       when: containerized_deployment | bool
 
-    - name: set_fact ceph_volume
-      set_fact:
-        ceph_volume: "{{ container_binary + ' run --rm --privileged=true --net=host --pid=host --ipc=host -v /dev:/dev -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph:/var/lib/ceph:z -v /var/run:/var/run --entrypoint=ceph-volume ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph-volume' }}"
-
     - name: get osd list
-      command: "{{ ceph_volume }} --cluster {{ cluster }} lvm list --format json"
-      changed_when: false
+      ceph_volume:
+        cluster: "{{ cluster }}"
+        action: list
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: osd_list
 
     - name: set osd fsid for containerized deployment

--- a/infrastructure-playbooks/filestore-to-bluestore.yml
+++ b/infrastructure-playbooks/filestore-to-bluestore.yml
@@ -54,7 +54,12 @@
           run_once: true
 
         - name: get ceph-volume lvm inventory data
-          command: "{{ container_run_cmd }} --cluster {{ cluster }} inventory --format json"
+          ceph_volume:
+            cluster: "{{ cluster }}"
+            action: inventory
+          environment:
+            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
           register: ceph_volume_inventory
 
         - name: set_fact inventory
@@ -152,14 +157,28 @@
                 - (item.0.stdout | from_json).encrypted | default(False) | bool
 
             - name: zap data devices
-              command: "{{ container_run_cmd }} --cluster {{ cluster }} lvm zap --destroy {{ (item.0.stdout | from_json).data.path }}"
+              ceph_volume:
+                cluster: "{{ cluster }}"
+                action: zap
+                destroy: true
+                data: "{{ (item.0.stdout | from_json).data.path }}"
+              environment:
+                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               with_together:
                 - "{{ simple_scan.results }}"
                 - "{{ partlabel.results }}"
               when: item.1.stdout == 'ceph data'
 
             - name: zap journal devices
-              command: "{{ container_run_cmd }} --cluster {{ cluster }} lvm zap --destroy {{ (item.0.stdout | from_json).journal.path }}"
+              ceph_volume:
+                cluster: "{{ cluster }}"
+                action: zap
+                destroy: true
+                journal: "{{ (item.0.stdout | from_json).journal.path }}"
+              environment:
+                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               with_together:
                 - "{{ simple_scan.results }}"
                 - "{{ partlabel.results }}"
@@ -168,7 +187,12 @@
                 - (item.0.stdout | from_json).journal.path is defined
 
         - name: get ceph-volume lvm list data
-          command: "{{ container_run_cmd }} --cluster {{ cluster }} lvm list --format json"
+          ceph_volume:
+            cluster: "{{ cluster }}"
+            action: list
+          environment:
+            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
           register: ceph_volume_lvm_list
 
         - name: set_fact _lvm_list

--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -68,10 +68,6 @@
         container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ ansible_hostname }}"
       when: containerized_deployment | bool
 
-    - name: set_fact container_run_cmd
-      set_fact:
-        container_run_cmd: "{{ container_binary + ' run --rm --privileged=true --net=host --pid=host --ipc=host -v /dev:/dev -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph -v /var/run:/var/run --entrypoint=' if containerized_deployment | bool else '' }}ceph-volume {{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else '' }}"
-
     - name: exit playbook, if can not connect to the cluster
       command: "{{ container_exec_cmd }} timeout 5 ceph --cluster {{ cluster }} health"
       register: ceph_health
@@ -100,8 +96,12 @@
       when: hostvars[item.0]['ansible_hostname'] == item.1
 
     - name: get ceph-volume lvm list data
-      command: "{{ container_run_cmd }} lvm list --format json"
-      changed_when: false
+      ceph_volume:
+        cluster: "{{ cluster }}"
+        action: list
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _lvm_list_data
       delegate_to: "{{ item.0 }}"
       loop: "{{ _osd_hosts }}"
@@ -199,7 +199,14 @@
         - ceph_osd_data_json[item.2][item.3] is defined
 
     - name: use ceph-volume lvm zap to destroy all partitions
-      command: "{{ container_run_cmd }} lvm zap --destroy {{ ceph_osd_data_json[item.2]['pkname_data'] if item.3 == 'data' else ceph_osd_data_json[item.2][item.3]['path'] }}"
+      ceph_volume:
+        cluster: "{{ cluster }}"
+        action: zap
+        destroy: true
+        data: "{{ ceph_osd_data_json[item.2]['pkname_data'] if item.3 == 'data' else ceph_osd_data_json[item.2][item.3]['path'] }}"
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       with_nested:
         - "{{ _osd_hosts }}"
         - [ 'block', 'block.db', 'block.wal', 'journal', 'data' ]

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -9,14 +9,13 @@
   changed_when: false
   register: osd_ids_non_container
 
-- name: set_fact container_exec_start_osd
-  set_fact:
-    container_exec_start_osd: "{{ container_binary + ' run --rm --net=host --privileged=true -v /var/run/udev/:/var/run/udev/:z -v /run/lvm/:/run/lvm/ -v /etc/ceph:/etc/ceph:z -v /dev:/dev --entrypoint=ceph-volume ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph-volume' }}"
-
 - name: collect osd ids
-  command: "{{ container_exec_start_osd }} lvm list --format json"
-  changed_when: false
-  failed_when: false
+  ceph_volume:
+    cluster: "{{ cluster }}"
+    action: list
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: ceph_osd_ids
 
 - name: include_tasks systemd.yml


### PR DESCRIPTION
We should always use the ceph_volume ansible module when possible.
This patch replace the ceph-volume inventory and lvm {list,zap} commands
called via the command/shell modules by the corresponding call with the
ceph_volume module.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>