### PR TITLE
[skip ci] Redefine SSL variables

### DIFF
--- a/roles/ceph-rgw-loadbalancer/defaults/main.yml
+++ b/roles/ceph-rgw-loadbalancer/defaults/main.yml
@@ -8,6 +8,8 @@
 haproxy_frontend_port: 80
 haproxy_frontend_ssl_port: 443
 haproxy_frontend_ssl_certificate:
+haproxy_frontend_ssl_certificate_path: "{{ haproxy_frontend_ssl_certificate }}"
+haproxy_frontend_ssl_certificate_content:
 haproxy_ssl_dh_param: 4096
 haproxy_ssl_ciphers:
   - EECDH+AESGCM

--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -6,6 +6,16 @@
   register: result
   until: result is succeeded
 
+- name: create ssl certificate file
+  copy:
+    content: "{{ haproxy_frontend_ssl_certificate_content }}"
+    dest: "{{ haproxy_frontend_ssl_certificate_path }}"
+    owner: "root"
+    group: "root"
+    mode: "0600"
+  when: haproxy_frontend_ssl_certificate_content is defined
+  notify: restart haproxy
+
 - name: "generate haproxy configuration file: haproxy.cfg"
   template:
     src: haproxy.cfg.j2

--- a/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
+++ b/roles/ceph-rgw-loadbalancer/templates/haproxy.cfg.j2
@@ -9,7 +9,7 @@ global
     group       haproxy
     daemon
     stats socket /var/lib/haproxy/stats
-{% if haproxy_frontend_ssl_certificate %}
+{% if haproxy_frontend_ssl_certificate is defined or haproxy_frontend_ssl_certificate_content is defined %}
     tune.ssl.default-dh-param {{ haproxy_ssl_dh_param }}
     ssl-default-bind-ciphers {{ haproxy_ssl_ciphers | join(':') }}
     ssl-default-bind-options {{ haproxy_ssl_options | join(' ') }}
@@ -33,8 +33,8 @@ defaults
     maxconn                 8000
 
 frontend rgw-frontend
-{% if haproxy_frontend_ssl_certificate %}
-    bind *:{{ haproxy_frontend_ssl_port }} ssl crt {{ haproxy_frontend_ssl_certificate }}
+{% if haproxy_frontend_ssl_certificate is defined or haproxy_frontend_ssl_certificate_content is defined %}
+    bind *:{{ haproxy_frontend_ssl_port }} ssl crt {{ haproxy_frontend_ssl_certificate_path }}
 {% else %}
     bind *:{{ haproxy_frontend_port }}
 {% endif %}


### PR DESCRIPTION
Allow user to pass the certificate in
haproxy_frontend_ssl_certificate_content and to store it in
haproxy_frontend_ssl_certificate_path.

Signed-off-by: Rafał Wądołowski <rwadolowski@cloudferro.com>