### PR TITLE
mon: refact initial keyring generation

### DIFF
--- a/infrastructure-playbooks/add-mon.yml
+++ b/infrastructure-playbooks/add-mon.yml
@@ -68,6 +68,9 @@
         name: ceph-config
     - import_role:
         name: ceph-mon
+    - import_role:
+        name: ceph-crash
+      when: containerized_deployment | bool
 
 # update config files on OSD nodes
 - hosts: osds

--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -83,8 +83,9 @@ options:
             return a json output.
             If 'info' is used, the module will return in a json format the
             description of a given keyring.
+            If 'generate_secret' is used, the module will simply output a cephx keyring.
         required: false
-        choices: ['present', 'update', 'absent', 'list', 'info', 'fetch_initial_keys']
+        choices: ['present', 'update', 'absent', 'list', 'info', 'fetch_initial_keys', 'generate_secret']
         default: present
     caps:
         description:
@@ -491,7 +492,8 @@ def run_module():
     module_args = dict(
         cluster=dict(type='str', required=False, default='ceph'),
         name=dict(type='str', required=False),
-        state=dict(type='str', required=False, default='present', choices=['present', 'update', 'absent', 'list', 'info', 'fetch_initial_keys']),
+        state=dict(type='str', required=False, default='present', choices=['present', 'update', 'absent',
+                                                                           'list', 'info', 'fetch_initial_keys', 'generate_secret']),
         caps=dict(type='dict', required=False, default=None),
         secret=dict(type='str', required=False, default=None, no_log=True),
         import_key=dict(type='bool', required=False, default=True),
@@ -677,9 +679,12 @@ def run_module():
             file_args = module.load_file_common_arguments(module.params)
             file_args['path'] = key_path
             module.set_fs_attributes_if_different(file_args, False)
-    else:
-        module.fail_json(
-            msg='State must either be "present" or "absent" or "list" or "info" or "fetch_initial_keys".', changed=False, rc=1)  # noqa E501
+    elif state == "generate_secret":
+        out = generate_secret().decode()
+        cmd = ''
+        rc = 0
+        err = ''
+        changed = True
 
     endd = datetime.datetime.now()
     delta = endd - startd

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -50,10 +50,10 @@
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: copy the initial key in /etc/ceph (for containers)
-  command: >
-    cp /var/lib/ceph/tmp/{{ cluster }}.mon..keyring
-       /etc/ceph/{{ cluster }}.mon.keyring
-  changed_when: false
+  copy:
+    src: /var/lib/ceph/tmp/{{ cluster }}.mon..keyring
+    dest: /etc/ceph/{{ cluster }}.mon.keyring
+    remote_src: true
   when: containerized_deployment | bool
 
 - name: create monitor directory

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -4,7 +4,7 @@
     name: mon.
     cluster: "{{ cluster }}"
     user: mon.
-    user_key: "/var/lib/ceph/mon/{{ cluster }}-{{ hostvars[groups[mon_group_name][0] if running_mon is undefined else running_mon]['ansible_hostname'] }}/keyring"
+    user_key: "/var/lib/ceph/mon/{{ cluster }}-{{ hostvars[running_mon]['ansible_hostname'] }}/keyring"
     output_format: json
     state: info
   environment:
@@ -12,26 +12,21 @@
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: initial_mon_key
   run_once: True
-  delegate_to: "{{ groups[mon_group_name][0] if running_mon is undefined else running_mon }}"
-  when: ceph_current_status.fsid is defined
+  delegate_to: "{{ running_mon }}"
+  when: running_mon is defined
 
 - name: generate monitor initial keyring
-  command: >
-    {{ hostvars[groups[mon_group_name][0] if running_mon is undefined else running_mon]['discovered_interpreter_python'] }} -c "import os ; import struct ;
-    import time; import base64 ; key = os.urandom(16) ;
-    header = struct.pack('<hiih',1,int(time.time()),0,len(key)) ;
-    print(base64.b64encode(header + key).decode())"
+  ceph_key:
+    state: generate_secret
   register: monitor_keyring
-  run_once: True
-  delegate_to: "{{ groups[mon_group_name][0] if running_mon is undefined else running_mon }}"
+  delegate_to: localhost
+  run_once: true
   when:
     - initial_mon_key.skipped is defined
-    - ceph_current_status.fsid is undefined
 
 - name: get initial keyring when it already exists
   set_fact:
-    monitor_keyring: "{{ (initial_mon_key.stdout | from_json)[0].key if monitor_keyring.skipped is defined else monitor_keyring.stdout if initial_mon_key.skipped is defined }}"
-  when: initial_mon_key is not skipped or monitor_keyring is not skipped
+    monitor_keyring: "{{ (initial_mon_key.stdout | from_json)[0]['key'] if initial_mon_key is not skipped else monitor_keyring.stdout }}"
 
 - name: create monitor initial keyring
   ceph_key:

--- a/tests/library/test_ceph_key.py
+++ b/tests/library/test_ceph_key.py
@@ -565,3 +565,15 @@ class TestCephKeyModule(object):
 
         result = result.value.args[0]
         assert result['msg'] == 'value of output_format must be one of: json, plain, xml, yaml, got: {}'.format(invalid_format)
+
+    @mock.patch('ceph_key.generate_secret')
+    @mock.patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    def test_generate_key(self, m_exit_json, m_generate_secret):
+        fake_secret = b'AQDaLb1fAAAAABAAsIMKdGEKu+lGOyXnRfT0Hg=='
+        ca_test_common.set_module_args({"state": "generate_secret"})
+        m_exit_json.side_effect = ca_test_common.exit_json
+        m_generate_secret.return_value = fake_secret
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_key.run_module()
+        assert result.value.args[0]['stdout'] == fake_secret.decode()


### PR DESCRIPTION
adding monitor is no longer possible because we generate a new mon
keyring each time the playbook is run.
    
Fixes: #5864


Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>