### PR TITLE
ceph-iscsi: set the pool name in the config file

### DIFF
--- a/roles/ceph-iscsi-gw/templates/iscsi-gateway.cfg.j2
+++ b/roles/ceph-iscsi-gw/templates/iscsi-gateway.cfg.j2
@@ -6,6 +6,8 @@
 [config]
 cluster_name = {{ cluster }}
 
+pool = {{ iscsi_pool_name }}
+
 # API settings.
 # The API supports a number of options that allow you to tailor it to your
 # local environment. If you want to run the API under https, you will need to


### PR DESCRIPTION
When using a custom pool for iSCSI gateway then we need to set the pool
name in the configuration otherwise the default rbd pool name will be
used.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>