### PR TITLE
library: remove useless condition in ceph_volume

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -720,10 +720,6 @@ def run_module():
         else:
             cmd = batch_report_cmd
 
-    else:
-        module.fail_json(
-            msg='State must either be "create" or "prepare" or "activate" or "list" or "zap" or "batch" or "inventory".', changed=False, rc=1)  # noqa E501
-
     endd = datetime.datetime.now()
     delta = endd - startd
 


### PR DESCRIPTION
Since the action values are already defined as a list of choices in
ansible then we will never enter into this condition.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>