### PR TITLE
library: use exit_module from ca_common

### DIFF
--- a/library/ceph_volume_simple_activate.py
+++ b/library/ceph_volume_simple_activate.py
@@ -16,6 +16,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible.module_utils.ca_common import exit_module
+except ImportError:
+    from module_utils.ca_common import exit_module
 import datetime
 import os
 
@@ -91,23 +95,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''#  '''
-
-
-def exit_module(module, out, rc, cmd, err, startd, changed=False):
-    endd = datetime.datetime.now()
-    delta = endd - startd
-
-    result = dict(
-        cmd=cmd,
-        start=str(startd),
-        end=str(endd),
-        delta=str(delta),
-        rc=rc,
-        stdout=out.rstrip("\r\n"),
-        stderr=err.rstrip("\r\n"),
-        changed=changed,
-    )
-    module.exit_json(**result)
 
 
 def main():

--- a/library/ceph_volume_simple_scan.py
+++ b/library/ceph_volume_simple_scan.py
@@ -16,6 +16,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible.module_utils.ca_common import exit_module
+except ImportError:
+    from module_utils.ca_common import exit_module
 import datetime
 import os
 
@@ -83,23 +87,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''#  '''
-
-
-def exit_module(module, out, rc, cmd, err, startd, changed=False):
-    endd = datetime.datetime.now()
-    delta = endd - startd
-
-    result = dict(
-        cmd=cmd,
-        start=str(startd),
-        end=str(endd),
-        delta=str(delta),
-        rc=rc,
-        stdout=out.rstrip("\r\n"),
-        stderr=err.rstrip("\r\n"),
-        changed=changed,
-    )
-    module.exit_json(**result)
 
 
 def main():

--- a/tests/library/test_ceph_volume_simple_activate.py
+++ b/tests/library/test_ceph_volume_simple_activate.py
@@ -4,9 +4,7 @@ from ansible.module_utils._text import to_bytes
 import json
 import os
 import pytest
-import sys
-sys.path.append('./library')
-import ceph_volume_simple_activate  # noqa : E402
+import ceph_volume_simple_activate
 
 fake_cluster = 'ceph'
 fake_container_binary = 'podman'

--- a/tests/library/test_ceph_volume_simple_scan.py
+++ b/tests/library/test_ceph_volume_simple_scan.py
@@ -4,9 +4,7 @@ from ansible.module_utils._text import to_bytes
 import json
 import os
 import pytest
-import sys
-sys.path.append('./library')
-import ceph_volume_simple_scan  # noqa : E402
+import ceph_volume_simple_scan
 
 fake_cluster = 'ceph'
 fake_container_binary = 'podman'


### PR DESCRIPTION
pr #6054 got merged but could have been updated to use `ca_common` for
`exit_module()` ...

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>