### PR TITLE
module_utils: refact generate_ceph_cmd

### DIFF
--- a/library/ceph_dashboard_user.py
+++ b/library/ceph_dashboard_user.py
@@ -123,7 +123,7 @@ def create_user(module, container_image=None):
 
     args = ['ac-user-create', name, password]
 
-    cmd = generate_ceph_cmd(cluster=cluster, sub_cmd=['dashboard'], args=args, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -141,7 +141,7 @@ def set_roles(module, container_image=None):
 
     args.extend(roles)
 
-    cmd = generate_ceph_cmd(cluster=cluster, sub_cmd=['dashboard'], args=args, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -157,7 +157,7 @@ def set_password(module, container_image=None):
 
     args = ['ac-user-set-password', name, password]
 
-    cmd = generate_ceph_cmd(cluster=cluster, sub_cmd=['dashboard'], args=args, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -172,7 +172,7 @@ def get_user(module, container_image=None):
 
     args = ['ac-user-show', name, '--format=json']
 
-    cmd = generate_ceph_cmd(cluster=cluster, sub_cmd=['dashboard'], args=args, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -187,7 +187,7 @@ def remove_user(module, container_image=None):
 
     args = ['ac-user-delete', name]
 
-    cmd = generate_ceph_cmd(cluster=cluster, sub_cmd=['dashboard'], args=args, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 

--- a/library/ceph_ec_profile.py
+++ b/library/ceph_ec_profile.py
@@ -113,9 +113,9 @@ def get_profile(module, name, cluster='ceph', container_image=None):
 
     args = ['get', name, '--format=json']
 
-    cmd = generate_ceph_cmd(cluster=cluster,
-                            sub_cmd=['osd', 'erasure-code-profile'],
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
                             args=args,
+                            cluster=cluster,
                             container_image=container_image)
 
     return cmd
@@ -132,9 +132,9 @@ def create_profile(module, name, k, m, stripe_unit, cluster='ceph', force=False,
     if force:
         args.append('--force')
 
-    cmd = generate_ceph_cmd(cluster=cluster,
-                            sub_cmd=['osd', 'erasure-code-profile'],
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
                             args=args,
+                            cluster=cluster,
                             container_image=container_image)
 
     return cmd
@@ -147,9 +147,9 @@ def delete_profile(module, name, cluster='ceph', container_image=None):
 
     args = ['rm', name]
 
-    cmd = generate_ceph_cmd(cluster=cluster,
-                            sub_cmd=['osd', 'erasure-code-profile'],
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
                             args=args,
+                            cluster=cluster,
                             container_image=container_image)
 
     return cmd

--- a/library/ceph_fs.py
+++ b/library/ceph_fs.py
@@ -119,7 +119,7 @@ def create_fs(module, container_image=None):
 
     args = ['new', name, metadata, data]
 
-    cmd = generate_ceph_cmd(cluster=cluster, sub_cmd=['fs'], args=args, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -134,7 +134,7 @@ def get_fs(module, container_image=None):
 
     args = ['get', name, '--format=json']
 
-    cmd = generate_ceph_cmd(cluster=cluster, sub_cmd=['fs'], args=args, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -149,7 +149,7 @@ def remove_fs(module, container_image=None):
 
     args = ['rm', name, '--yes-i-really-mean-it']
 
-    cmd = generate_ceph_cmd(cluster=cluster, sub_cmd=['fs'], args=args, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -164,7 +164,7 @@ def fail_fs(module, container_image=None):
 
     args = ['fail', name]
 
-    cmd = generate_ceph_cmd(cluster=cluster, sub_cmd=['fs'], args=args, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -180,7 +180,7 @@ def set_fs(module, container_image=None):
 
     args = ['set', name, 'max_mds', str(max_mds)]
 
-    cmd = generate_ceph_cmd(cluster=cluster, sub_cmd=['fs'], args=args, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 

--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -167,9 +167,9 @@ def check_pool_exist(cluster,
 
     args = ['stats', name, '-f', output_format]
 
-    cmd = generate_ceph_cmd(cluster=cluster,
-                            sub_cmd=['osd', 'pool'],
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
                             args=args,
+                            cluster=cluster,
                             user=user,
                             user_key=user_key,
                             container_image=container_image)
@@ -211,9 +211,9 @@ def get_application_pool(cluster,
 
     args = ['application', 'get', name, '-f', output_format]
 
-    cmd = generate_ceph_cmd(cluster=cluster,
-                            sub_cmd=['osd', 'pool'],
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
                             args=args,
+                            cluster=cluster,
                             user=user,
                             user_key=user_key,
                             container_image=container_image)
@@ -233,9 +233,9 @@ def enable_application_pool(cluster,
 
     args = ['application', 'enable', name, application]
 
-    cmd = generate_ceph_cmd(cluster=cluster,
-                            sub_cmd=['osd', 'pool'],
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
                             args=args,
+                            cluster=cluster,
                             user=user,
                             user_key=user_key,
                             container_image=container_image)
@@ -256,9 +256,9 @@ def disable_application_pool(cluster,
     args = ['application', 'disable', name,
             application, '--yes-i-really-mean-it']
 
-    cmd = generate_ceph_cmd(cluster=cluster,
-                            sub_cmd=['osd', 'pool'],
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
                             args=args,
+                            cluster=cluster,
                             user=user,
                             user_key=user_key,
                             container_image=container_image)
@@ -279,9 +279,9 @@ def get_pool_details(module,
 
     args = ['ls', 'detail', '-f', output_format]
 
-    cmd = generate_ceph_cmd(cluster=cluster,
-                            sub_cmd=['osd', 'pool'],
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
                             args=args,
+                            cluster=cluster,
                             user=user,
                             user_key=user_key,
                             container_image=container_image)
@@ -367,9 +367,9 @@ def list_pools(cluster,
 
     args.extend(['-f', output_format])
 
-    cmd = generate_ceph_cmd(cluster=cluster,
-                            sub_cmd=['osd', 'pool'],
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
                             args=args,
+                            cluster=cluster,
                             user=user,
                             user_key=user_key,
                             container_image=container_image)
@@ -418,9 +418,9 @@ def create_pool(cluster,
                      '--autoscale-mode',
                      user_pool_config['pg_autoscale_mode']['value']])
 
-    cmd = generate_ceph_cmd(cluster=cluster,
-                            sub_cmd=['osd', 'pool'],
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
                             args=args,
+                            cluster=cluster,
                             user=user,
                             user_key=user_key,
                             container_image=container_image)
@@ -435,9 +435,9 @@ def remove_pool(cluster, name, user, user_key, container_image=None):
 
     args = ['rm', name, name, '--yes-i-really-really-mean-it']
 
-    cmd = generate_ceph_cmd(cluster=cluster,
-                            sub_cmd=['osd', 'pool'],
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
                             args=args,
+                            cluster=cluster,
                             user=user,
                             user_key=user_key,
                             container_image=container_image)
@@ -460,9 +460,9 @@ def update_pool(module, cluster, name,
                     delta[key]['cli_set_opt'],
                     delta[key]['value']]
 
-            cmd = generate_ceph_cmd(cluster=cluster,
-                                    sub_cmd=['osd', 'pool'],
+            cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
                                     args=args,
+                                    cluster=cluster,
                                     user=user,
                                     user_key=user_key,
                                     container_image=container_image)

--- a/module_utils/ca_common.py
+++ b/module_utils/ca_common.py
@@ -2,10 +2,13 @@ import os
 import datetime
 
 
-def generate_ceph_cmd(cluster, sub_cmd, args, user='client.admin', user_key='/etc/ceph/ceph.client.admin.keyring', container_image=None):
+def generate_ceph_cmd(sub_cmd, args, user_key=None, cluster='ceph', user='client.admin', container_image=None):
     '''
     Generate 'ceph' command line to execute
     '''
+
+    if not user_key:
+        user_key = '/etc/ceph/{}.{}.keyring'.format(cluster, user)
 
     cmd = pre_generate_ceph_cmd(container_image=container_image)
 


### PR DESCRIPTION
module_utils: refactor
    
- update `generate_ceph_cmd()` so `user_key` is automatically built from
`cluster` and `user` params.

- update and add testing.
    
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>