### PR TITLE
switch2containers: do not stop ceph.target in osd play

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -238,7 +238,7 @@
     - name: collect running osds
       shell: |
         set -o pipefail;
-        systemctl list-units | grep -E "loaded * active" | grep -Eo 'ceph-osd@[0-9]+.service|ceph-volume|ceph\.target'
+        systemctl list-units | grep -E "loaded * active" | grep -Eo 'ceph-osd@[0-9]+.service|ceph-volume'
       register: running_osds
       changed_when: false
       failed_when: false
@@ -258,6 +258,11 @@
         enabled: no
       with_items: "{{ running_osds.stdout_lines | default([]) }}"
       when: running_osds != []
+
+    - name: disable ceph.target
+      systemd:
+        name: ceph.target
+        enabled: no
 
     - name: remove old ceph-osd systemd units
       file:


### PR DESCRIPTION
`ceph.target` should be disabled only. Otherwise, in collocation
scenario you stop other collocated services in the OSD play which isn't
what we want to do. Each daemon has its corresponding play for managing
the transition to container.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1901865

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>