### PR TITLE
[skip ci] improve plugins/filter testing

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -4,9 +4,11 @@ on:
     paths:
       - 'library/**.py'
       - 'module_utils/**.py'
+      - 'plugins/filter/**.py'
       - 'tests/conftest.py'
       - 'tests/library/**.py'
       - 'tests/module_utils/**.py'
+      - 'tests/plugins/filter/**.py'
       - 'tests/functional/tests/**.py'
 jobs:
   build:
@@ -19,4 +21,4 @@ jobs:
           python-version: 3.8
           architecture: x64
       - run: pip install flake8
-      - run: flake8 --max-line-length 160 ./library/ ./module_utils/ ./tests/library/ ./tests/module_utils/ ./tests/conftest.py ./tests/functional/tests/
+      - run: flake8 --max-line-length 160 ./library/ ./module_utils/ ./plugins/filter/ ./tests/library/ ./tests/module_utils/ ./tests/plugins/filter/ ./tests/conftest.py ./tests/functional/tests/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,4 +25,4 @@ jobs:
       - run: pip install -r tests/requirements.txt
       - run: pytest --cov=library/ --cov=module_utils/ --cov=plugins/filter/ -vvvv tests/library/ tests/module_utils/ tests/plugins/filter/
         env:
-          PYTHONPATH: "$PYTHONPATH:/home/runner/work/ceph-ansible/ceph-ansible/library:/home/runner/work/ceph-ansible/ceph-ansible/module_utils:/home/runner/work/ceph-ansible/ceph-ansible"
+          PYTHONPATH: "$PYTHONPATH:/home/runner/work/ceph-ansible/ceph-ansible/library:/home/runner/work/ceph-ansible/ceph-ansible/module_utils:/home/runner/work/ceph-ansible/ceph-ansible/plugins/filter:/home/runner/work/ceph-ansible/ceph-ansible"

--- a/plugins/filter/ipaddrs_in_ranges.py
+++ b/plugins/filter/ipaddrs_in_ranges.py
@@ -1,3 +1,6 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 from ansible import errors
 
 try:

--- a/tests/plugins/filter/test_ipaddrs_in_ranges.py
+++ b/tests/plugins/filter/test_ipaddrs_in_ranges.py
@@ -1,8 +1,15 @@
-import sys
-sys.path.append('./plugins/filter')
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleFilterError
+
 import ipaddrs_in_ranges
+import pytest
+
+pytest.importorskip('netaddr')
 
 filter_plugin = ipaddrs_in_ranges.FilterModule()
+
 
 class TestIpaddrsInRanges(object):
 
@@ -41,5 +48,16 @@ class TestIpaddrsInRanges(object):
         ips = ['10.10.20.1', '192.168.2.1', '172.16.10.1']
         ranges = ['192.168.1.0/24', '10.10.10.1/24', '172.16.17.0/24']
         result = filter_plugin.ips_in_ranges(ips, ranges)
-        assert result == []
+        assert len(result) == 0
 
+    def test_ips_in_ranges_in_filters_dict(self):
+        assert 'ips_in_ranges' in filter_plugin.filters()
+
+    def test_missing_netaddr_module(self):
+        ipaddrs_in_ranges.netaddr = None
+
+        with pytest.raises(AnsibleFilterError) as result:
+            filter_plugin.filters()
+
+        assert result.type == AnsibleFilterError
+        assert str(result.value) == "The ips_in_ranges filter requires python's netaddr be installed on the ansible controller."


### PR DESCRIPTION
- The plugins/filter directory wasn't present in the flake8 workflow
configuration.
- Fix the flake8 syntax.
- Add the directory to PYTHONPATH environment variable for pytest
to avoid importing the plugin filter via sys.
- Add unittest on missing netaddr module import.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>