### PR TITLE
common: do not use pipefail when not needed

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -388,9 +388,7 @@
     when: lvm_volumes is not defined
 
   - name: get osd numbers
-    shell: |
-      set -o pipefail;
-      if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi
+    shell: if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi  # noqa 306
     register: osd_ids
     changed_when: false
 
@@ -412,17 +410,12 @@
 
   # NOTE(leseb): hope someone will find a more elegant way one day...
   - name: see if encrypted partitions are present
-    shell: |
-      set -o pipefail;
-      blkid -t TYPE=crypto_LUKS -s PARTLABEL -s PARTUUID | grep "ceph.*." | grep -o PARTUUID.* | cut -d '"' -f 2
+    shell: blkid -t TYPE=crypto_LUKS -s PARTLABEL -s PARTUUID | grep "ceph.*." | grep -o PARTUUID.* | cut -d '"' -f 2  # noqa 306
     register: encrypted_ceph_partuuid
-    failed_when: false
     changed_when: false
 
   - name: get osd data and lockbox mount points
-    shell: |
-      set -o pipefail;
-      (grep /var/lib/ceph/osd /proc/mounts || echo -n) | awk '{ print $2 }'
+    shell: (grep /var/lib/ceph/osd /proc/mounts || echo -n) | awk '{ print $2 }'  # noqa 306
     register: mounted_osd
     changed_when: false
 
@@ -466,9 +459,7 @@
     when: encrypted_ceph_partuuid.stdout_lines | length > 0
 
   - name: get payload_offset
-    shell: |
-      set -o pipefail;
-      cryptsetup luksDump /dev/disk/by-partuuid/{{ item }} | awk '/Payload offset:/ { print $3 }'
+    shell: cryptsetup luksDump /dev/disk/by-partuuid/{{ item }} | awk '/Payload offset:/ { print $3 }'  # noqa 306
     register: payload_offset
     with_items: "{{ encrypted_ceph_partuuid.stdout_lines }}"
     when: encrypted_ceph_partuuid.stdout_lines | length > 0
@@ -586,15 +577,13 @@
 
   - name: wipe partitions
     shell: |
-      set -o pipefail;
       wipefs --all "{{ item }}"
       dd if=/dev/zero of="{{ item }}" bs=1 count=4096
     changed_when: false
     with_items: "{{ combined_devices_list }}"
 
-  - name: zap ceph journal/block db/block wal partitions
+  - name: zap ceph journal/block db/block wal partitions  # noqa 306
     shell: |
-      set -o pipefail;
       # if the disk passed is a raw device AND the boot system disk
       if parted -s /dev/"{{ item }}" print | grep -sq boot; then
         echo "Looks like /dev/{{ item }} has a boot partition,"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -368,9 +368,7 @@
         name: ceph-facts
 
     - name: get osd numbers - non container
-      shell: |
-        set -o pipefail;
-        if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi
+      shell: if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi  # noqa 306
       register: osd_ids
       changed_when: false
 

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -1,12 +1,11 @@
 ---
 # this is for ceph-disk, the ceph-disk command is gone so we have to list /var/lib/ceph
 - name: get osd ids
-  shell: |
-    set -o pipefail;
-    ls /var/lib/ceph/osd/ | sed 's/.*-//'
+  shell: ls /var/lib/ceph/osd/ | sed 's/.*-//'  # noqa 306
   args:
     executable: /bin/bash
   changed_when: false
+  failed_when: false
   register: osd_ids_non_container
 
 - name: set_fact container_exec_start_osd


### PR DESCRIPTION
Let's discard the ansible lint error 306 and add a "# noqa 306" on tasks
where we don't need `set -o pipefail`

Fixes: #6090

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>