### PR TITLE
[skip ci] library: add cephadm_adopt module

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -337,11 +337,13 @@
         name: ceph-defaults
 
     - name: adopt mon daemon
-      command: "{{ cephadm_cmd }} adopt --cluster {{ cluster }} --skip-pull --style legacy --name mon.{{ ansible_hostname }} {{ '--skip-firewalld' if not configure_firewall | bool else '' }}"
-      args:
-        creates: '/var/lib/ceph/{{ fsid }}/mon.{{ ansible_hostname }}/unit.run'
-      environment:
-        CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+      cephadm_adopt:
+        name: "mon.{{ ansible_hostname }}"
+        cluster: "{{ cluster }}"
+        image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+        docker: "{{ true if container_binary == 'docker' else false }}"
+        pull: false
+        firewalld: "{{ true if configure_firewall | bool else false }}"
 
     - name: reset failed ceph-mon systemd unit
       command: 'systemctl reset-failed ceph-mon@{{ ansible_hostname }}'  # noqa 303
@@ -382,11 +384,13 @@
         name: ceph-defaults
 
     - name: adopt mgr daemon
-      command: "{{ cephadm_cmd }} adopt --cluster {{ cluster }} --skip-pull --style legacy --name mgr.{{ ansible_hostname }} {{ '--skip-firewalld' if not configure_firewall | bool else '' }}"
-      args:
-        creates: '/var/lib/ceph/{{ fsid }}/mgr.{{ ansible_hostname }}/unit.run'
-      environment:
-        CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+      cephadm_adopt:
+        name: "mgr.{{ ansible_hostname }}"
+        cluster: "{{ cluster }}"
+        image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+        docker: "{{ true if container_binary == 'docker' else false }}"
+        pull: false
+        firewalld: "{{ true if configure_firewall | bool else false }}"
 
     - name: reset failed ceph-mgr systemd unit
       command: 'systemctl reset-failed ceph-mgr@{{ ansible_hostname }}'  # noqa 303
@@ -467,12 +471,14 @@
       when: containerized_deployment | bool
 
     - name: adopt osd daemon
-      command: "{{ cephadm_cmd }} adopt --cluster {{ cluster }} --skip-pull --style legacy --name osd.{{ item }} {{ '--skip-firewalld' if not configure_firewall | bool else '' }}"
+      cephadm_adopt:
+        name: "osd.{{ item }}"
+        cluster: "{{ cluster }}"
+        image: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+        docker: "{{ true if container_binary == 'docker' else false }}"
+        pull: false
+        firewalld: "{{ true if configure_firewall | bool else false }}"
       loop: '{{ (osd_list.stdout | from_json).keys() | list }}'
-      args:
-        creates: '/var/lib/ceph/{{ fsid }}/osd.{{ item }}/unit.run'
-      environment:
-        CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
     - name: remove ceph-osd systemd unit and ceph-osd-run.sh files
       file:
@@ -862,11 +868,13 @@
             state: link
 
         - name: adopt alertmanager daemon
-          command: "{{ cephadm_cmd }} adopt --cluster {{ cluster }} --skip-pull --style legacy --name alertmanager.{{ ansible_hostname }} {{ '--skip-firewalld' if not configure_firewall | bool else '' }}"
-          args:
-            creates: '/var/lib/ceph/{{ fsid }}/alertmanager.{{ ansible_hostname }}/unit.run'
-          environment:
-            CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+          cephadm_adopt:
+            name: "alertmanager.{{ ansible_hostname }}"
+            cluster: "{{ cluster }}"
+            image: "{{ alertmanager_container_image }}"
+            docker: "{{ true if container_binary == 'docker' else false }}"
+            pull: false
+            firewalld: "{{ true if configure_firewall | bool else false }}"
 
         - name: remove alertmanager systemd unit file
           file:
@@ -922,11 +930,13 @@
             recurse: true
 
         - name: adopt prometheus daemon
-          command: "{{ cephadm_cmd }} adopt --cluster {{ cluster }} --skip-pull --style legacy --name prometheus.{{ ansible_hostname }} {{ '--skip-firewalld' if not configure_firewall | bool else '' }}"
-          args:
-            creates: '/var/lib/ceph/{{ fsid }}/prometheus.{{ ansible_hostname }}/unit.run'
-          environment:
-            CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+          cephadm_adopt:
+            name: "prometheus.{{ ansible_hostname }}"
+            cluster: "{{ cluster }}"
+            image: "{{ prometheus_container_image }}"
+            docker: "{{ true if container_binary == 'docker' else false }}"
+            pull: false
+            firewalld: "{{ true if configure_firewall | bool else false }}"
 
         - name: remove prometheus systemd unit file
           file:
@@ -946,11 +956,13 @@
             enabled: false
 
         - name: adopt grafana daemon
-          command: "{{ cephadm_cmd }} adopt --cluster {{ cluster }} --skip-pull --style legacy --name grafana.{{ ansible_hostname }} {{ '--skip-firewalld' if not configure_firewall | bool else '' }}"
-          args:
-            creates: '/var/lib/ceph/{{ fsid }}/grafana.{{ ansible_hostname }}/unit.run'
-          environment:
-            CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+          cephadm_adopt:
+            name: "grafana.{{ ansible_hostname }}"
+            cluster: "{{ cluster }}"
+            image: "{{ grafana_container_image }}"
+            docker: "{{ true if container_binary == 'docker' else false }}"
+            pull: false
+            firewalld: "{{ true if configure_firewall | bool else false }}"
 
         - name: remove grafana systemd unit file
           file:

--- a/library/cephadm_adopt.py
+++ b/library/cephadm_adopt.py
@@ -1,0 +1,165 @@
+# Copyright 2020, Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible.module_utils.ca_common import exit_module
+except ImportError:
+    from module_utils.ca_common import exit_module
+import datetime
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: cephadm_adopt
+short_description: Adopt a Ceph cluster with cephadm
+version_added: "2.8"
+description:
+    - Adopt a Ceph cluster with cephadm
+options:
+    name:
+        description:
+            - The ceph daemon name.
+        required: true
+    cluster:
+        description:
+            - The ceph cluster name.
+        required: false
+        default: ceph
+    style:
+        description:
+            - Cep deployment style.
+        required: false
+        default: legacy
+    image:
+        description:
+            - Ceph container image.
+        required: false
+    docker:
+        description:
+            - Use docker instead of podman.
+        required: false
+    pull:
+        description:
+            - Pull the Ceph container image.
+        required: false
+        default: true
+    firewalld:
+        description:
+            - Manage firewall rules with firewalld.
+        required: false
+        default: true
+author:
+    - Dimitri Savineau <dsavinea@redhat.com>
+'''
+
+EXAMPLES = '''
+- name: adopt a ceph monitor with cephadm (default values)
+  cephadm_adopt:
+    name: mon.foo
+    style: legacy
+
+- name: adopt a ceph monitor with cephadm (with custom values)
+  cephadm_adopt:
+    name: mon.foo
+    style: legacy
+    image: quay.ceph.io/ceph/daemon-base:latest-master-devel
+    pull: false
+    firewalld: false
+
+- name: adopt a ceph monitor with cephadm with custom image via env var
+  cephadm_adopt:
+    name: mon.foo
+    style: legacy
+  environment:
+    CEPHADM_IMAGE: quay.ceph.io/ceph/daemon-base:latest-master-devel
+'''
+
+RETURN = '''#  '''
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type='str', required=True),
+            cluster=dict(type='str', required=False, default='ceph'),
+            style=dict(type='str', required=False, default='legacy'),
+            image=dict(type='str', required=False),
+            docker=dict(type='bool', required=False, default=False),
+            pull=dict(type='bool', required=False, default=True),
+            firewalld=dict(type='bool', required=False, default=True),
+        ),
+        supports_check_mode=True,
+    )
+
+    name = module.params.get('name')
+    cluster = module.params.get('cluster')
+    style = module.params.get('style')
+    docker = module.params.get('docker')
+    image = module.params.get('image')
+    pull = module.params.get('pull')
+    firewalld = module.params.get('firewalld')
+
+    startd = datetime.datetime.now()
+
+    cmd = ['cephadm']
+
+    if docker:
+        cmd.append('--docker')
+
+    if image:
+        cmd.extend(['--image', image])
+
+    cmd.extend(['adopt', '--cluster', cluster, '--name', name, '--style', style])
+
+    if not pull:
+        cmd.append('--skip-pull')
+
+    if not firewalld:
+        cmd.append('--skip-firewalld')
+
+    if module.check_mode:
+        exit_module(
+            module=module,
+            out='',
+            rc=0,
+            cmd=cmd,
+            err='',
+            startd=startd,
+            changed=False
+        )
+    else:
+        rc, out, err = module.run_command(cmd)
+        exit_module(
+            module=module,
+            out=out,
+            rc=rc,
+            cmd=cmd,
+            err=err,
+            startd=startd,
+            changed=True
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/library/test_cephadm_adopt.py
+++ b/tests/library/test_cephadm_adopt.py
@@ -1,0 +1,173 @@
+from mock.mock import patch
+import pytest
+import ca_test_common
+import cephadm_adopt
+
+fake_cluster = 'ceph'
+fake_image = 'quay.ceph.io/ceph/daemon-base:latest'
+fake_name = 'mon.foo01'
+
+
+class TestCephadmAdoptModule(object):
+
+    @patch('ansible.module_utils.basic.AnsibleModule.fail_json')
+    def test_without_parameters(self, m_fail_json):
+        ca_test_common.set_module_args({})
+        m_fail_json.side_effect = ca_test_common.fail_json
+
+        with pytest.raises(ca_test_common.AnsibleFailJson) as result:
+            cephadm_adopt.main()
+
+        result = result.value.args[0]
+        assert result['msg'] == 'missing required arguments: name'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    def test_with_check_mode(self, m_exit_json):
+        ca_test_common.set_module_args({
+            'name': fake_name,
+            '_ansible_check_mode': True
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_adopt.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['cmd'] == ['cephadm', 'adopt', '--cluster', fake_cluster, '--name', fake_name, '--style', 'legacy']
+        assert result['rc'] == 0
+        assert not result['stdout']
+        assert not result['stderr']
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_failure(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'name': fake_name
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = 'ERROR: cephadm should be run as root'
+        rc = 1
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_adopt.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'adopt', '--cluster', fake_cluster, '--name', fake_name, '--style', 'legacy']
+        assert result['rc'] == 1
+        assert result['stderr'] == 'ERROR: cephadm should be run as root'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_default_values(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'name': fake_name
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = 'Stopping old systemd unit ceph-mon@{}...\n' \
+                 'Disabling old systemd unit ceph-mon@{}...\n' \
+                 'Moving data...\n' \
+                 'Chowning content...\n' \
+                 'Moving logs...\n' \
+                 'Creating new units...\n' \
+                 'firewalld ready'.format(fake_name, fake_name)
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_adopt.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'adopt', '--cluster', fake_cluster, '--name', fake_name, '--style', 'legacy']
+        assert result['rc'] == 0
+        assert result['stderr'] == stderr
+        assert result['stdout'] == stdout
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_docker(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'name': fake_name,
+            'docker': True
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_adopt.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', '--docker', 'adopt', '--cluster', fake_cluster, '--name', fake_name, '--style', 'legacy']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_custom_image(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'name': fake_name,
+            'image': fake_image
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_adopt.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', '--image', fake_image, 'adopt', '--cluster', fake_cluster, '--name', fake_name, '--style', 'legacy']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_without_pull(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'name': fake_name,
+            'pull': False
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_adopt.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'adopt', '--cluster', fake_cluster, '--name', fake_name, '--style', 'legacy', '--skip-pull']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_without_firewalld(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'name': fake_name,
+            'firewalld': False
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_adopt.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'adopt', '--cluster', fake_cluster, '--name', fake_name, '--style', 'legacy', '--skip-firewalld']
+        assert result['rc'] == 0


### PR DESCRIPTION
This adds cephadm_adopt ansible module for replacing the command module
usage with the cephadm adopt command.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>