### PR TITLE
Bugfix #6102: Assumptions about consistent container runtime in a Ceph cluster running mixed OS versions

### DIFF
--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -11,7 +11,7 @@
     - /var/lib/ceph/mds/{{ cluster }}-{{ mds_name }}
 
 - name: get keys from monitors
-  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  command: "{{ hostvars[groups.get(mon_group_name)[0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
   register: _mds_keys
   with_items:
     - { name: "client.bootstrap-mds", path: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -54,7 +54,7 @@
           - { 'name': "mgr.{{ ansible_hostname }}", 'path': "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring", 'copy_key': true }
 
     - name: get keys from monitors
-      command: "{{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      command: "{{ hostvars[groups[mon_group_name][0] if running_mon is undefined else running_mon]['_container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
       register: _mgr_keys
       with_items: "{{ _mgr_keys }}"
       delegate_to: "{{ groups[mon_group_name][0] if running_mon is undefined else running_mon }}"


### PR DESCRIPTION
Use hostvars from the delegated host to determine container binary.