### PR TITLE
[skip ci] rhcs: drop fetch_directory override

### DIFF
--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -1,7 +1,6 @@
 ceph_repository: rhcs
 ceph_origin: repository
 ceph_iscsi_config_dev: false
-fetch_directory: ~/ceph-ansible-keys
 ceph_rhcs_version: 5
 containerized_deployment: true
 ceph_docker_image: "rhceph/rhceph-5-rhel8"


### PR DESCRIPTION
Since the fetch_directory variable has been dropped then we don't need
the override in rhcs file.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>