### PR TITLE
backport: ceph-mon: No become during gen mon initial keyring

### DIFF
--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -19,6 +19,7 @@
     state: generate_secret
   register: monitor_keyring
   delegate_to: localhost
+  become: false
   run_once: true
   when:
     - initial_mon_key.skipped is defined


### PR DESCRIPTION
Since the backing generate_secret() just hands out urandom output,
running as privileged doesn't seem to be required. It's not
desireable to provide sudo in some Ansible runner environments.

Signed-off-by: Jukka Nousiainen <jukka.nousiainen@csc.fi>