### PR TITLE
ceph-osd: use global crush_device_class in lvm_volumes

### DIFF
--- a/roles/ceph-osd/tasks/scenarios/lvm.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm.yml
@@ -11,7 +11,7 @@
     db_vg: "{{ item.db_vg|default(omit) }}"
     wal: "{{ item.wal|default(omit) }}"
     wal_vg: "{{ item.wal_vg|default(omit) }}"
-    crush_device_class: "{{ item.crush_device_class|default(omit) }}"
+    crush_device_class: "{{ item.crush_device_class | default(crush_device_class) | default(omit) }}"
     dmcrypt: "{{ dmcrypt|default(omit) }}"
     action: "{{ 'prepare' if containerized_deployment | bool else 'create' }}"
   environment:


### PR DESCRIPTION
Use global `crush_device_class` variable if it's not set per OSD

Signed-off-by: Seena Fallah <seenafallah@gmail.com>