### PR TITLE
ceph-facts: fix grafana group conversion

### DIFF
--- a/roles/ceph-facts/tasks/convert_grafana_server_group_name.yml
+++ b/roles/ceph-facts/tasks/convert_grafana_server_group_name.yml
@@ -2,15 +2,8 @@
 - name: convert grafana-server group name if exist
   add_host:
     name: "{{ item }}"
-    groups: "monitoring"
+    groups: "{{ monitoring_group_name }}"
     ansible_host: "{{ hostvars[item]['ansible_host'] | default(omit) }}"
     ansible_port: "{{ hostvars[item]['ansible_port'] | default(omit) }}"
-  delegate_to: localhost
-  with_items: "{{ groups.get(grafana_server_group_name, []) }}"
-  when: groups.get(grafana_server_group_name, []) | length > 0
-  run_once: True
-
-- name: set_fact monitoring_group_name
-  set_fact:
-    monitoring_group_name: "{{ grafana_server_group_name | default(monitoring_group_name) }}"
+  with_items: "{{ groups.get((grafana_server_group_name|default('grafana-server')), []) }}"
   run_once: True

--- a/roles/ceph-facts/tasks/main.yml
+++ b/roles/ceph-facts/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: include_tasks convert_grafana_server_group_name.yml
   include_tasks: convert_grafana_server_group_name.yml
-  when: grafana_server_group_name is defined
+  when: groups.get((grafana_server_group_name|default('grafana-server')), []) | length > 0
 
 - name: include facts.yml
   include_tasks: facts.yml


### PR DESCRIPTION
The conversion fact task was only executed when the grafana_server_group_name
variable was explicitly set in the user configuration. If an user was using
the default value then the conversion wasn't executed.

This also adds back the default `grafana_server_group_name` value in case user
was using the default value and to avoid undefined variable error.

Instead of hardcoding the "monitoring" group name then we can reuse the
monitoring_group_name variable.

There's no need to override the `monitoring_group_name` variable, it's either
using the default value or the one defined by the user.

Finally removing the delegate_to statement on the add_host task since it's
always executed on the ansible controller.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1903732

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>