### PR TITLE
tests: update openssl package for containerized

### DIFF
--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -75,6 +75,16 @@
         resizefs: yes
       when: is_atomic | bool
 
+    - name: update openssl for CentOS 8.3
+      package:
+        name: openssl
+        state: latest
+      register: result
+      until: result is succeeded
+      when:
+        - ansible_distribution == 'CentOS'
+        - containerized_deployment | default(false) | bool
+
     # https://tracker.ceph.com/issues/46759
     - name: install pyyaml for ceph-volume
       package:


### PR DESCRIPTION
This is a temporary workaround since CentOS 8.3 has been released (the
content of the repository have been rebuild to 8.3) but we're still using
CentOS 8.2 because there's no newer image available.

At the moment, this causes the podman command to fails

```console
stderr: '/usr/libexec/platform-python: error while loading shared libraries:
libcrypto.so.1.1: cannot change memory protections'
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>