### PR TITLE
tests/vagrant: update box version to CentOS 8.3

### DIFF
--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -524,7 +524,7 @@
 
   - name: remove stopped/exited containers
     command: >
-      {{ container_binary }} container prune{% if container_binary == 'docker' %} -f{% endif %}
+      {{ container_binary }} container prune -f
     changed_when: false
 
   - name: show container list on all the nodes (should be empty)

--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 vagrant box remove --provider libvirt --box-version 1905.1 centos/8 || true
-vagrant box add --provider libvirt --name centos/8 https://cloud.centos.org/centos/8/vagrant/x86_64/images/CentOS-8-Vagrant-8.2.2004-20200611.2.x86_64.vagrant-libvirt.box || true
+vagrant box remove --provider libvirt --box-version 0 centos/8 || true
+vagrant box add --provider libvirt --name centos/8 https://cloud.centos.org/centos/8/vagrant/x86_64/images/CentOS-8-Vagrant-8.3.2011-20201204.2.x86_64.vagrant-libvirt.box || true
 
 retries=0
 until [ $retries -ge 5 ]


### PR DESCRIPTION
This updates the CentOS libvirt box version to 8.3

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>