### PR TITLE
ceph-config: Fix RadosGW remote address with HAproxy

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -121,6 +121,9 @@ rgw_realm = {{ instance['rgw_realm'] }}
 rgw_zonegroup = {{ instance['rgw_zonegroup'] }}
 rgw_zone = {{ instance['rgw_zone'] }}
 {% endif %}
+{% if groups.get(rgwloadbalancer_group_name) %}
+rgw remote addr param = HTTP_X_FORWARDED_FOR
+{% endif %}
 {% endfor %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
When RadosGW is behind a reverse proxy, it should get the client address from
the `X-Forwarded-For` header, so that S3 policies that refer to `aws:SourceIp`
work as expected.

This commit sets `rgw remote addr param = HTTP_X_FORWARDED_FOR` when the
`rgwloadbalancers` group is not empty.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>