### PR TITLE
monitoring: use config_template module for config

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -702,6 +702,7 @@ dummy:
 #  - grafana-piechart-panel
 #grafana_allow_embedding: True
 #grafana_port: 3000
+#grafana_conf_overrides: {}
 #prometheus_container_image: "docker.io/prom/prometheus:v2.7.2"
 #prometheus_container_cpu_period: 100000
 #prometheus_container_cpu_cores: 2
@@ -711,6 +712,7 @@ dummy:
 #prometheus_conf_dir: /etc/prometheus
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 #prometheus_port: 9092
+#prometheus_conf_overrides: {}
 #alertmanager_container_image: "docker.io/prom/alertmanager:v0.16.2"
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2
@@ -720,6 +722,7 @@ dummy:
 #alertmanager_conf_dir: /etc/alertmanager
 #alertmanager_port: 9093
 #alertmanager_cluster_port: 9094
+#alertmanager_conf_overrides: {}
 
 
 ##################################

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -702,6 +702,7 @@ grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
 #  - grafana-piechart-panel
 #grafana_allow_embedding: True
 #grafana_port: 3000
+#grafana_conf_overrides: {}
 prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
 #prometheus_container_cpu_period: 100000
 #prometheus_container_cpu_cores: 2
@@ -711,6 +712,7 @@ prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
 #prometheus_conf_dir: /etc/prometheus
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 #prometheus_port: 9092
+#prometheus_conf_overrides: {}
 alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:4.1
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2
@@ -720,6 +722,7 @@ alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alert
 #alertmanager_conf_dir: /etc/alertmanager
 #alertmanager_port: 9093
 #alertmanager_cluster_port: 9094
+#alertmanager_conf_overrides: {}
 
 
 ##################################

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -694,6 +694,7 @@ grafana_plugins:
   - grafana-piechart-panel
 grafana_allow_embedding: True
 grafana_port: 3000
+grafana_conf_overrides: {}
 prometheus_container_image: "docker.io/prom/prometheus:v2.7.2"
 prometheus_container_cpu_period: 100000
 prometheus_container_cpu_cores: 2
@@ -703,6 +704,7 @@ prometheus_data_dir: /var/lib/prometheus
 prometheus_conf_dir: /etc/prometheus
 prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 prometheus_port: 9092
+prometheus_conf_overrides: {}
 alertmanager_container_image: "docker.io/prom/alertmanager:v0.16.2"
 alertmanager_container_cpu_period: 100000
 alertmanager_container_cpu_cores: 2
@@ -712,6 +714,7 @@ alertmanager_data_dir: /var/lib/alertmanager
 alertmanager_conf_dir: /etc/alertmanager
 alertmanager_port: 9093
 alertmanager_cluster_port: 9094
+alertmanager_conf_overrides: {}
 
 
 ##################################

--- a/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -44,12 +44,14 @@
     - not ansible_os_family in ['RedHat', 'Suse']
 
 - name: write grafana.ini
-  template:
+  config_template:
     src: grafana.ini.j2
     dest: /etc/grafana/grafana.ini
     owner: "{{ grafana_uid }}"
     group: "{{ grafana_uid }}"
     mode: 0640
+    config_type: ini
+    config_overrides: "{{ grafana_conf_overrides }}"
 
 - name: write datasources provisioning config file
   template:

--- a/roles/ceph-prometheus/tasks/main.yml
+++ b/roles/ceph-prometheus/tasks/main.yml
@@ -10,12 +10,14 @@
    - "{{ prometheus_data_dir }}"
 
 - name: write prometheus config file
-  template:
+  config_template:
     src: prometheus.yml.j2
     dest: "{{ prometheus_conf_dir }}/prometheus.yml"
     owner: "{{ prometheus_user_id }}"
     group: "{{ prometheus_user_id }}"
     mode: 0640
+    config_type: yaml
+    config_overrides: "{{ prometheus_conf_overrides }}"
   notify: service handler
 
 - name: make sure the alerting rules directory exists
@@ -44,12 +46,14 @@
    - "{{ alertmanager_data_dir }}"
 
 - name: write alertmanager config file
-  template:
+  config_template:
     src: alertmanager.yml.j2
     dest: "{{ alertmanager_conf_dir }}/alertmanager.yml"
     owner: "{{ prometheus_user_id }}"
     group: "{{ prometheus_user_id }}"
     mode: 0640
+    config_type: yaml
+    config_overrides: "{{ alertmanager_conf_overrides }}"
   notify: service handler
 
 - name: include setup_container.yml


### PR DESCRIPTION
The alertmanager, grafana and prometheus configuration file are
generated with the template module which doesn't allow for using
config overrides.
Instead we could use the config_template plugin action and add a
new variable for overrides (one for each component).

With this patch, one should be able to add configuration to
prometheus with the following:

```yaml
---
alertmanager_conf_overrides:
  global:
    smtp_smarthost: 'localhost:25'
...

```
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1902999

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>