### PR TITLE
ceph-rgw: add cluster parameter on ceph_ec_profile

### DIFF
--- a/roles/ceph-rgw/tasks/rgw_create_pools.yml
+++ b/roles/ceph-rgw/tasks/rgw_create_pools.yml
@@ -2,6 +2,7 @@
 - name: create ec profile
   ceph_ec_profile:
     name: "{{ item.value.ec_profile }}"
+    cluster: "{{ cluster }}"
     k: "{{ item.value.ec_k }}"
     m: "{{ item.value.ec_m }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
81233dd introduced a regression with the `ceph_ec_profile` module call in
the ceph-rgw role due the missing cluster module parameter.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>