### PR TITLE
library: add missing `target_size_ratio` parameter support in ceph_pool module

### DIFF
--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -395,6 +395,9 @@ def create_pool(cluster,
                      user_pool_config['pg_num']['value'],
                      '--pgp_num',
                      user_pool_config['pgp_num']['value']])
+    elif user_pool_config['target_size_ratio']['value']:
+        args.extend(['--target_size_ratio',
+                     user_pool_config['target_size_ratio']['value']])
 
     if user_pool_config['type']['value'] == 'replicated':
         args.extend([user_pool_config['crush_rule']['value'],

--- a/roles/ceph-rgw/tasks/rgw_create_pools.yml
+++ b/roles/ceph-rgw/tasks/rgw_create_pools.yml
@@ -37,6 +37,7 @@
     pg_num: "{{ item.value.pg_num | default(omit) }}"
     pgp_num: "{{ item.value.pgp_num | default(omit) }}"
     size: "{{ item.value.size | default(omit) }}"
+    target_size_ratio: "{{ item.value.target_size_ratio | default(omit) }}"
     pool_type: erasure
     erasure_profile: "{{ item.value.ec_profile }}"
     application: rgw
@@ -58,6 +59,7 @@
     pgp_num: "{{ item.value.pgp_num | default(omit) }}"
     size: "{{ item.value.size | default(omit) }}"
     min_size: "{{ item.value.min_size | default(omit) }}"
+    target_size_ratio: "{{ item.value.target_size_ratio | default(omit) }}"
     pool_type: replicated
     rule_name: "{{ item.value.rule_name | default(ceph_osd_pool_default_crush_rule_name) }}"
     application: rgw

--- a/tests/library/test_ceph_pool.py
+++ b/tests/library/test_ceph_pool.py
@@ -82,7 +82,7 @@ class TestCephPoolModule(object):
             # 'target_size_ratio' is a key present in the dict above
             # 'options': {}
             # see comment in get_pool_details() for more details
-            'target_size_ratio': None,
+            'target_size_ratio': 0.3,
             'application_metadata': {
                 'rbd': {}
             },
@@ -105,7 +105,7 @@ class TestCephPoolModule(object):
                 'cli_set_opt': 'pg_autoscale_mode'
             },
             'target_size_ratio': {
-                'value': None,
+                'value': '0.3',
                 'cli_set_opt': 'target_size_ratio'
             },
             'application': {
@@ -430,6 +430,8 @@ class TestCephPoolModule(object):
                 'create',
                 self.fake_user_pool_config['pool_name']['value'],
                 self.fake_user_pool_config['type']['value'],
+                '--target_size_ratio',
+                self.fake_user_pool_config['target_size_ratio']['value'],
                 self.fake_user_pool_config['crush_rule']['value'],
                 '--expected_num_objects',
                 self.fake_user_pool_config['expected_num_objects']['value'],
@@ -522,6 +524,8 @@ class TestCephPoolModule(object):
                 'create',
                 self.fake_user_pool_config['pool_name']['value'],
                 self.fake_user_pool_config['type']['value'],
+                '--target_size_ratio',
+                self.fake_user_pool_config['target_size_ratio']['value'],
                 self.fake_user_pool_config['erasure_profile']['value'],
                 self.fake_user_pool_config['crush_rule']['value'],
                 '--expected_num_objects',


### PR DESCRIPTION
When creating a new pool, target_size_ratio is ignored by ansible module ceph_pool.py.
It's neither used in role ceph-rgw.

This PR fixes this 2 issues.


Signed-off-by: Fabien Brachere <fabien.brachere@celeste.fr>