### PR TITLE
[skip ci] mergify: add configuration for 4.2z1 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,3 +35,10 @@ pull_request_rules:
     conditions:
       - label=backport-stable-5.0
     name: backport stable-5.0
+  - actions:
+      backport:
+        branches:
+        - 4.2z1
+    conditions:
+      - label=backport-4.2z1
+    name: backport 4.2z1


### PR DESCRIPTION
So we get backports against 4.2z1 branch (downstream related) automatically
created by mergify

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>