### PR TITLE
ceph_osd_flag: support setting noout flag at osd or bucket level

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,6 +23,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - run: pip install -r tests/requirements.txt
-      - run: pytest --cov=library/ --cov=module_utils/ --cov=plugins/filter/ -vvvv tests/library/ tests/module_utils/ tests/plugins/filter/
+      - run: pytest --cov=library/ --cov=module_utils/ --cov=plugins/filter/ --cov-report term-missing -vvvv tests/library/ tests/module_utils/ tests/plugins/filter/
         env:
           PYTHONPATH: "$PYTHONPATH:/home/runner/work/ceph-ansible/ceph-ansible/library:/home/runner/work/ceph-ansible/ceph-ansible/module_utils:/home/runner/work/ceph-ansible/ceph-ansible/plugins/filter:/home/runner/work/ceph-ansible/ceph-ansible"

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -694,8 +694,8 @@
         CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
 
-- name: set osd flags
-  hosts: "{{ osd_group_name|default('osds') }}"
+- name: set osd flag nodeep-scrub
+  hosts: "{{ mon_group_name|default('mons') }}[0]"
   become: true
   gather_facts: false
   any_errors_fatal: True
@@ -707,7 +707,6 @@
       command: "{{ ceph_cmd }} --cluster {{ cluster }} osd pool ls detail -f json"
       register: pool_list
       run_once: true
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
       check_mode: false
 
@@ -715,7 +714,6 @@
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer status -f json"
       register: balancer_status_adopt
       run_once: true
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
       check_mode: false
 
@@ -738,7 +736,6 @@
         cluster: "{{ cluster }}"
         pg_autoscale_mode: false
       with_items: "{{ pools_pgautoscaler_mode }}"
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
       when:
         - pools_pgautoscaler_mode is defined
@@ -755,7 +752,6 @@
       with_items:
         - noout
         - nodeep-scrub
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
       environment:
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
@@ -775,6 +771,12 @@
         name: ceph-facts
         tasks_from: container_binary.yml
       when: containerized_deployment | bool
+
+    - name: set osd flag noout
+      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} osd set-group noout {{ inventory_hostname }}"
+      changed_when: false
+      environment:
+        CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
     - name: get osd list
       ceph_volume:
@@ -850,8 +852,14 @@
       environment:
         CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
-- name: unset osd flags
-  hosts: "{{ osd_group_name|default('osds') }}"
+    - name: unset osd flag noout
+      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} osd unset-group noout {{ inventory_hostname }}"
+      changed_when: false
+      environment:
+        CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+
+- name: unset osd flag nodeep-scrub
+  hosts: "{{ mon_group_name|default('mons') }}[0]"
   become: true
   gather_facts: false
   any_errors_fatal: True
@@ -865,7 +873,6 @@
         cluster: "{{ cluster }}"
         pg_autoscale_mode: true
       with_items: "{{ pools_pgautoscaler_mode }}"
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
       when:
         - pools_pgautoscaler_mode is defined
@@ -882,8 +889,11 @@
       with_items:
         - noout
         - nodeep-scrub
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
+
+    - name: unset osd flag nodeep-scrub
+      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} osd unset nodeep-scrub"
+      changed_when: false
       environment:
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
         CEPH_CONTAINER_BINARY: "{{ container_binary }}"
@@ -891,7 +901,6 @@
     - name: re-enable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer on"
       run_once: true
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
       when: (balancer_status_adopt.stdout | from_json)['active'] | bool
 

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -412,9 +412,8 @@
         name: ceph-mgr
 
 
-- name: set osd flags
-  hosts: "{{ osd_group_name | default('osds') }}"
-  tags: osds
+- name: set osd flag nodeep-scrub
+  hosts: "{{ mon_group_name | default('mons') }}[0]"
   become: True
   gather_facts: false
   tasks:
@@ -426,7 +425,6 @@
 
     - name: set osd flags, disable autoscaler and balancer
       run_once: true
-      delegate_to: "{{ groups[mon_group_name][0] }}"
       block:
         - name: get pool list
           command: "{{ ceph_cmd }} --cluster {{ cluster }} osd pool ls detail -f json"
@@ -475,6 +473,14 @@
             - noout
             - nodeep-scrub
 
+    - name: set osd flag nodeep-scrub
+      ceph_osd_flag:
+        name: "nodeep-scrub"
+        cluster: "{{ cluster }}"
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+
 - name: upgrade ceph osds cluster
   vars:
     health_osd_check_retries: 600
@@ -490,6 +496,17 @@
         name: ceph-defaults
     - import_role:
         name: ceph-facts
+
+    - name: set osd flag noout
+      ceph_osd_flag:
+        name: noout
+        level: bucket
+        bucket: "{{ inventory_hostname }}"
+        cluster: "{{ cluster }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
     - name: get osd numbers - non container
       shell: if [ -d /var/lib/ceph/osd ] ; then ls /var/lib/ceph/osd | sed 's/.*-//' ; fi  # noqa 306
@@ -554,6 +571,18 @@
       retries: "{{ health_osd_check_retries }}"
       delay: "{{ health_osd_check_delay }}"
 
+    - name: unset osd flag noout
+      ceph_osd_flag:
+        name: noout
+        state: absent
+        level: bucket
+        bucket: "{{ inventory_hostname }}"
+        cluster: "{{ cluster }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+
 
 - name: complete osd upgrade
   hosts: "{{ osd_group_name | default('osds') }}"
@@ -600,6 +629,16 @@
           command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer on"
           changed_when: false
           when: (balancer_status_update.stdout | from_json)['active'] | bool
+
+    - name: unset osd flag nodeep-scrub
+      ceph_osd_flag:
+        name: "nodeep-scrub"
+        cluster: "{{ cluster }}"
+        state: absent
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+
 
 - name: upgrade ceph mdss cluster, deactivate all rank > 0
   hosts: "{{ mon_group_name | default('mons') }}[0]"

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -213,7 +213,7 @@
         name: ceph-mgr
 
 
-- name: set osd flags
+- name: set osd flag nodeep-scrub
   hosts: "{{ mon_group_name | default('mons') }}[0]"
   become: True
   tasks:
@@ -258,16 +258,13 @@
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
         CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
-    - name: set osd flags
+    - name: set osd flag nodeep-scrub
       ceph_osd_flag:
-        name: "{{ item }}"
+        name: "nodeep-scrub"
         cluster: "{{ cluster }}"
       environment:
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
         CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-      with_items:
-        - noout
-        - nodeep-scrub
 
 
 - name: switching from non-containerized to containerized ceph osd
@@ -285,6 +282,21 @@
 
     - import_role:
         name: ceph-defaults
+
+    - import_role:
+        name: ceph-facts
+        tasks_from: container_binary.yml
+
+    - name: set osd flag noout
+      ceph_osd_flag:
+        name: noout
+        level: bucket
+        bucket: "{{ inventory_hostname }}"
+        cluster: "{{ cluster }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
     - name: collect running osds
       shell: |
@@ -398,8 +410,19 @@
       delay: "{{ health_osd_check_delay }}"
       changed_when: false
 
+    - name: unset osd flag noout
+      ceph_osd_flag:
+        name: noout
+        state: absent
+        level: bucket
+        bucket: "{{ inventory_hostname }}"
+        cluster: "{{ cluster }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
-- name: unset osd flags
+- name: unset osd flag nodeep-scrub
   hosts: "{{ mon_group_name | default('mons') }}[0]"
   become: True
   tasks:
@@ -422,17 +445,14 @@
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
         CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
-    - name: unset osd flags
+    - name: set osd flag nodeep-scrub
       ceph_osd_flag:
-        name: "{{ item }}"
+        name: "nodeep-scrub"
         cluster: "{{ cluster }}"
         state: absent
       environment:
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
         CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-      with_items:
-        - noout
-        - nodeep-scrub
 
     - name: re-enable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer on"

--- a/tests/library/test_ceph_osd_flag.py
+++ b/tests/library/test_ceph_osd_flag.py
@@ -154,3 +154,80 @@ class TestCephOSDFlagModule(object):
         assert result['rc'] == rc
         assert result['stderr'] == stderr
         assert result['stdout'] == stdout
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    @pytest.mark.parametrize('state', ['present', 'absent'])
+    def test_flag_noout_osd_level(self, m_run_command, m_exit_json, state):
+        ca_test_common.set_module_args({
+            'name': 'noout',
+            'state': state,
+            'level': 'osd',
+            'osd': 'osd.123'
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_osd_flag.main()
+
+        result = result.value.args[0]
+
+        assert result['cmd'] == ['ceph', '-n', 'client.admin', '-k', '/etc/ceph/ceph.client.admin.keyring',
+                                 '--cluster', 'ceph', 'osd', 'add-noout' if state == 'present' else 'rm-noout', 'osd.123']
+        assert result['rc'] == rc
+        assert result['stderr'] == ''
+        assert result['stdout'] == ''
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    @pytest.mark.parametrize('state', ['present', 'absent'])
+    def test_flag_noout_bucket_level(self, m_run_command, m_exit_json, state):
+        ca_test_common.set_module_args({
+            'name': 'noout',
+            'state': state,
+            'level': 'bucket',
+            'bucket': 'my_osd_host_123'
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_osd_flag.main()
+
+        result = result.value.args[0]
+        assert result['cmd'] == ['ceph', '-n', 'client.admin', '-k', '/etc/ceph/ceph.client.admin.keyring',
+                                 '--cluster', 'ceph', 'osd', 'set-group' if state == 'present' else 'unset-group', 'noout', 'my_osd_host_123']
+        assert result['rc'] == rc
+        assert result['stderr'] == ''
+        assert result['stdout'] == ''
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    @pytest.mark.parametrize('state', ['present', 'absent'])
+    def test_flag_noout_cluster_level(self, m_run_command, m_exit_json, state):
+        ca_test_common.set_module_args({
+            'name': 'noout',
+            'state': state
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_osd_flag.main()
+
+        result = result.value.args[0]
+        assert result['cmd'] == ['ceph', '-n', 'client.admin', '-k', '/etc/ceph/ceph.client.admin.keyring',
+                                 '--cluster', 'ceph', 'osd', 'set' if state == 'present' else 'unset', 'noout']
+        assert result['rc'] == rc
+        assert result['stderr'] == ''
+        assert result['stdout'] == ''


### PR DESCRIPTION
Currently `ceph_osd_flag` module only supports setting `noout` flag at
the cluster level.
Ceph supports setting this flag at the osd or the bucket level so let's
implement this support in `ceph_osd_flag` module.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>