### PR TITLE
[skip ci] library: remove containerized parameter from cv

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -145,12 +145,6 @@ options:
             - Results will be returned in json format.
             - Only applicable if action is 'batch'.
         required: false
-    containerized:
-        description:
-            - Wether or not this is a containerized cluster. The value is
-            assigned or not depending on how the playbook runs.
-        required: false
-        default: None
     list:
         description:
             - List potential Ceph LVM metadata on a device
@@ -543,7 +537,6 @@ def run_module():
         block_db_devices=dict(type='list', required=False, default=[]),
         wal_devices=dict(type='list', required=False, default=[]),
         report=dict(type='bool', required=False, default=False),
-        containerized=dict(type='str', required=False, default=False),
         osd_fsid=dict(type='str', required=False),
         destroy=dict(type='bool', required=False, default=True),
     )


### PR DESCRIPTION
The ceph-volume module relies on environment variables to determine if
the command should be executed within a container or not.
The containerized parameter isn't used anymore and we can remove it.

Fixes: #6153

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>