### PR TITLE
move environment variables at play level

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -89,6 +89,9 @@
 - hosts: "{{ groups[mgr_group_name] | default(groups[mon_group_name]) | default(omit) }}"
   gather_facts: false
   become: true
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   pre_tasks:
     - name: set ceph dashboard install 'In Progress'
       run_once: true

--- a/infrastructure-playbooks/filestore-to-bluestore.yml
+++ b/infrastructure-playbooks/filestore-to-bluestore.yml
@@ -9,6 +9,9 @@
   serial: 1
   vars:
     delegate_facts_host: true
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   tasks:
     - name: gather and delegate facts
       setup:
@@ -57,9 +60,6 @@
           ceph_volume:
             cluster: "{{ cluster }}"
             action: inventory
-          environment:
-            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
           register: ceph_volume_inventory
 
         - name: set_fact inventory
@@ -87,9 +87,6 @@
                 path: "{{ item.item + 'p1' if item.item is match('/dev/(cciss/c[0-9]d[0-9]|nvme[0-9]n[0-9]){1,2}$') else item.item + '1' }}"
                 cluster: "{{ cluster }"
                 stdout: true
-              environment:
-                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               register: simple_scan
               with_items: "{{ partlabel.results | default([]) }}"
               when: item.stdout == 'ceph data'
@@ -100,9 +97,6 @@
                 ids: "{{ (item.0.stdout | from_json).whoami }}"
                 cluster: "{{ cluster }}"
                 state: out
-              environment:
-                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               with_together:
                 - "{{ simple_scan.results }}"
                 - "{{ partlabel.results }}"
@@ -168,9 +162,6 @@
                 action: zap
                 destroy: true
                 data: "{{ (item.0.stdout | from_json).data.path }}"
-              environment:
-                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               with_together:
                 - "{{ simple_scan.results }}"
                 - "{{ partlabel.results }}"
@@ -182,9 +173,6 @@
                 action: zap
                 destroy: true
                 journal: "{{ (item.0.stdout | from_json).journal.path }}"
-              environment:
-                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               with_together:
                 - "{{ simple_scan.results }}"
                 - "{{ partlabel.results }}"
@@ -196,9 +184,6 @@
           ceph_volume:
             cluster: "{{ cluster }}"
             action: list
-          environment:
-            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
           register: ceph_volume_lvm_list
 
         - name: set_fact _lvm_list
@@ -213,9 +198,6 @@
                 ids: "{{ (ceph_volume_lvm_list.stdout | default('{}') | from_json).keys() | list }}"
                 cluster: "{{ cluster }}"
                 state: out
-              environment:
-                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               delegate_to: "{{ groups[mon_group_name][0] }}"
               run_once: true
 
@@ -241,9 +223,6 @@
                 ids: "{{ (ceph_volume_lvm_list.stdout | default('{}') | from_json).keys() | list }}"
                 cluster: "{{ cluster }}"
                 state: down
-              environment:
-                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               delegate_to: "{{ groups[mon_group_name][0] }}"
               run_once: true
 
@@ -267,8 +246,6 @@
                 destroy: false
               environment:
                 CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               loop: "{{ osd_fsid_list }}"
               when: osd_fsid_list is defined
 
@@ -279,8 +256,6 @@
                 destroy: true
               environment:
                 CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               loop: "{{ osd_fsid_list }}"
               when:
                 - osd_fsid_list is defined
@@ -304,8 +279,6 @@
                 destroy: true
               environment:
                 CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-                CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-                CEPH_CONTAINER_BINARY: "{{ container_binary }}"
               loop: "{{ osd_fsid_list | zip(journal_path.results) | list }}"
               when:
                 - osd_fsid_list is defined
@@ -345,9 +318,6 @@
             ids: "{{ item }}"
             cluster: "{{ cluster }}"
             state: purge
-          environment:
-            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
           run_once: true
           delegate_to: "{{ groups[mon_group_name][0] }}"
           with_items: "{{ osd_ids }}"

--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -37,6 +37,10 @@
     mon_group_name: mons
     osd_group_name: osds
 
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+
   pre_tasks:
     - name: exit playbook, if user did not mean to shrink cluster
       fail:
@@ -99,9 +103,6 @@
       ceph_volume:
         cluster: "{{ cluster }}"
         action: list
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _lvm_list_data
       delegate_to: "{{ item.0 }}"
       loop: "{{ _osd_hosts }}"
@@ -141,9 +142,6 @@
         ids: "{{ osd_to_kill.split(',') }}"
         cluster: "{{ cluster }}"
         state: out
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       run_once: true
 
     - name: stop osd(s) service
@@ -209,9 +207,6 @@
         action: zap
         destroy: true
         data: "{{ ceph_osd_data_json[item.2]['pkname_data'] if item.3 == 'data' else ceph_osd_data_json[item.2][item.3]['path'] }}"
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       with_nested:
         - "{{ _osd_hosts }}"
         - [ 'block', 'block.db', 'block.wal', 'journal', 'data' ]
@@ -228,8 +223,6 @@
         osd_fsid: "{{ item.1 }}"
       environment:
         CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       delegate_to: "{{ item.0 }}"
       loop: "{{ _osd_hosts }}"
       when: item.2 in _lvm_list.keys()
@@ -239,9 +232,6 @@
         ids: "{{ osd_to_kill.split(',') }}"
         cluster: "{{ cluster }}"
         state: down
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       run_once: true
       delegate_to: "{{ groups[mon_group_name][0] }}"
 
@@ -250,9 +240,6 @@
         ids: "{{ item }}"
         cluster: "{{ cluster }}"
         state: purge
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       run_once: true
       with_items: "{{ osd_to_kill.split(',') }}"
 

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -29,9 +29,6 @@
     mode: "{{ item.mode | default(ceph_keyring_permissions) }}"
     owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   with_items:
     - "{{ keys }}"
   delegate_to: "{{ delegated_node }}"
@@ -74,9 +71,6 @@
         pg_autoscale_mode: "{{ item.pg_autoscale_mode | default(omit) }}"
         target_size_ratio: "{{ item.target_size_ratio | default(omit) }}"
         application: "{{ item.application | default(omit) }}"
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       with_items: "{{ pools }}"
       changed_when: false
       delegate_to: "{{ delegated_node }}"

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -7,9 +7,6 @@
         cluster: "{{ cluster }}"
         output_format: plain
         state: info
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _admin_key
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
       run_once: true

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -27,8 +27,6 @@
         register: rejected_devices
         environment:
           CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-          CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-          CEPH_CONTAINER_BINARY: "{{ container_binary }}"
           PYTHONIOENCODING: utf-8
 
       - name: set_fact rejected_devices
@@ -54,8 +52,6 @@
         register: lvm_batch_report
         environment:
           CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-          CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-          CEPH_CONTAINER_BINARY: "{{ container_binary }}"
           PYTHONIOENCODING: utf-8
         when: _devices | default([]) | length > 0
 
@@ -81,8 +77,6 @@
     register: lvm_list
     environment:
       CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-      CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-      CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       PYTHONIOENCODING: utf-8
     changed_when: false
     when:

--- a/roles/ceph-crash/tasks/main.yml
+++ b/roles/ceph-crash/tasks/main.yml
@@ -14,9 +14,6 @@
         mode: "{{ ceph_keyring_permissions }}"
         owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       delegate_to: "{{ groups.get(mon_group_name, [])[0] }}"
       run_once: True
 
@@ -26,9 +23,6 @@
         cluster: "{{ cluster }}"
         output_format: plain
         state: info
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _crash_keys
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
       run_once: true

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -114,9 +114,6 @@
     name: dashboard
     cluster: "{{ cluster }}"
     state: disable
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
 
@@ -125,9 +122,6 @@
     name: dashboard
     cluster: "{{ cluster }}"
     state: enable
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
 
@@ -139,9 +133,6 @@
     roles: ["{{ 'read-only' if dashboard_admin_user_ro | bool else 'administrator' }}"]
   run_once: true
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: set grafana api user
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-username {{ grafana_admin_user }}"
@@ -200,9 +191,6 @@
         system: true
       delegate_to: "{{ groups[mon_group_name][0] }}"
       register: rgw_dashboard_user
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
     - name: get the rgw access and secret keys
       set_fact:
@@ -284,9 +272,6 @@
     name: dashboard
     cluster: "{{ cluster }}"
     state: disable
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
 
@@ -295,8 +280,5 @@
     name: dashboard
     cluster: "{{ cluster }}"
     state: enable
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true

--- a/roles/ceph-facts/tasks/get_def_crush_rule_name.yml
+++ b/roles/ceph-facts/tasks/get_def_crush_rule_name.yml
@@ -4,9 +4,6 @@
     name: null
     cluster: "{{ cluster }}"
     state: info
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: default_crush_rule_details
   delegate_to: "{{ delegated_node | default(groups[mon_group_name][0]) }}"
   run_once: true

--- a/roles/ceph-handler/tasks/handler_osds.yml
+++ b/roles/ceph-handler/tasks/handler_osds.yml
@@ -8,9 +8,6 @@
     name: noup
     cluster: "{{ cluster }}"
     state: absent
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
 

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -5,9 +5,6 @@
     cluster: "{{ cluster }}"
     output_format: plain
     state: info
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _admin_key
   delegate_to: "{{ groups.get(mon_group_name)[0] }}"
   run_once: true
@@ -65,6 +62,3 @@
     application: "rbd"
   run_once: true
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -16,9 +16,6 @@
     cluster: "{{ cluster }}"
     output_format: plain
     state: info
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _mds_keys
   with_items:
     - { name: "client.bootstrap-mds", path: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -18,9 +18,6 @@
     target_size_ratio: "{{ item.target_size_ratio | default(omit) }}"
   with_items: "{{ cephfs_pools }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: create ceph filesystem
   ceph_fs:
@@ -30,6 +27,3 @@
     metadata: "{{ cephfs_metadata_pool.name }}"
     max_mds: "{{ mds_max_mds if not rolling_update | bool else omit }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -20,9 +20,6 @@
     group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     mode: "0400"
     dest: "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_hostname }}/keyring"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   when: groups.get(mgr_group_name, []) | length == 0 # the key is present already since one of the mons created it in "create ceph mgr keyring(s)"
 
 - name: create and copy keyrings
@@ -40,9 +37,6 @@
         owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         mode: "0400"
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       with_items: "{{ groups.get(mgr_group_name, []) }}"
       run_once: True
       delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -59,9 +53,6 @@
         cluster: "{{ cluster }}"
         output_format: plain
         state: info
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _mgr_keys
       with_items: "{{ _mgr_keys }}"
       delegate_to: "{{ groups[mon_group_name][0] if running_mon is undefined else running_mon }}"

--- a/roles/ceph-mgr/tasks/mgr_modules.yml
+++ b/roles/ceph-mgr/tasks/mgr_modules.yml
@@ -36,9 +36,6 @@
     name: "{{ item }}"
     cluster: "{{ cluster }}"
     state: disable
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   with_items: "{{ _ceph_mgr_modules.get('enabled_modules', []) }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when: item not in ceph_mgr_modules
@@ -48,9 +45,6 @@
     name: "{{ item }}"
     cluster: "{{ cluster }}"
     state: enable
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   with_items: "{{ ceph_mgr_modules }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when: (item in _disabled_ceph_mgr_modules or _disabled_ceph_mgr_modules == [])

--- a/roles/ceph-mon/tasks/ceph_keys.yml
+++ b/roles/ceph-mon/tasks/ceph_keys.yml
@@ -24,8 +24,6 @@
     group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     mode: "0400"
   environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     CEPH_ROLLING_UPDATE: "{{ rolling_update }}"
   when:
     - cephx | bool

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -7,9 +7,6 @@
     user_key: "/var/lib/ceph/mon/{{ cluster }}-{{ hostvars[running_mon]['ansible_hostname'] }}/keyring"
     output_format: json
     state: info
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: initial_mon_key
   run_once: True
   delegate_to: "{{ running_mon }}"
@@ -41,9 +38,6 @@
     owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     mode: "0400"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: copy the initial key in /etc/ceph (for containers)
   copy:
@@ -83,9 +77,6 @@
     owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     mode: "0400"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: create_custom_admin_secret
   when:
     - cephx | bool

--- a/roles/ceph-nfs/tasks/create_rgw_nfs_user.yml
+++ b/roles/ceph-nfs/tasks/create_rgw_nfs_user.yml
@@ -16,9 +16,6 @@
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when: nfs_obj_gw | bool
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: set_fact ceph_nfs_rgw_access_key and ceph_nfs_rgw_secret_key
   set_fact:

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -15,9 +15,6 @@
         cluster: "{{ cluster }}"
         output_format: plain
         state: info
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _rgw_keys
       with_items:
         - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -17,9 +17,6 @@
     cluster: "{{ cluster }}"
     output_format: plain
     state: info
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _osd_keys
   with_items:
     - { name: "client.bootstrap-osd", path: "/var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-osd/tasks/crush_rules.yml
+++ b/roles/ceph-osd/tasks/crush_rules.yml
@@ -18,9 +18,6 @@
     bucket_root: "{{ item.root }}"
     bucket_type: "{{ item.type }}"
     device_class: "{{ item.class | default(omit) }}"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   with_items: "{{ hostvars[groups[mon_group_name][0]]['crush_rules'] | default(crush_rules) | unique }}"
   delegate_to: '{{ groups[mon_group_name][0] }}'
   run_once: true
@@ -30,9 +27,6 @@
     name: "{{ item.name }}"
     cluster: "{{ cluster }}"
     state: info
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: info_ceph_default_crush_rule
   with_items: "{{ hostvars[groups[mon_group_name][0]]['crush_rules'] | default(crush_rules) | unique }}"
   delegate_to: '{{ groups[mon_group_name][0] }}'

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -42,9 +42,6 @@
   ceph_osd_flag:
     name: noup
     cluster: "{{ cluster }}"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: True
   when:
@@ -75,9 +72,6 @@
     name: noup
     cluster: "{{ cluster }}"
     state: absent
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
     - not rolling_update | default(False) | bool

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -17,9 +17,6 @@
         application: "{{ item.application | default(omit) }}"
       with_items: "{{ openstack_pools }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: create openstack cephx key(s)
   block:
@@ -30,9 +27,6 @@
         secret: "{{ item.key | default('') }}"
         cluster: "{{ cluster }}"
         mode: "{{ item.mode | default(ceph_keyring_permissions) }}"
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       with_items: "{{ openstack_keys }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
 
@@ -42,9 +36,6 @@
         cluster: "{{ cluster }}"
         output_format: plain
         state: info
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _osp_keys
       with_items: "{{ openstack_keys }}"
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"

--- a/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
@@ -16,7 +16,5 @@
     action: "batch"
   environment:
     CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     PYTHONIOENCODING: utf-8
   when: _devices | default([]) | length > 0

--- a/roles/ceph-osd/tasks/scenarios/lvm.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm.yml
@@ -16,8 +16,6 @@
     action: "{{ 'prepare' if containerized_deployment | bool else 'create' }}"
   environment:
     CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     PYTHONIOENCODING: utf-8
   with_items: "{{ lvm_volumes }}"
   tags: prepare_osd

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -12,9 +12,6 @@
   ceph_volume:
     cluster: "{{ cluster }}"
     action: list
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: ceph_osd_ids
 
 - name: include_tasks systemd.yml

--- a/roles/ceph-rbd-mirror/tasks/common.yml
+++ b/roles/ceph-rbd-mirror/tasks/common.yml
@@ -5,9 +5,6 @@
     cluster: "{{ cluster }}"
     output_format: plain
     state: info
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _rbd_mirror_keys
   with_items:
     - { name: "client.bootstrap-rbd-mirror", path: "/var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -14,9 +14,6 @@
     cluster: "{{ cluster }}"
     output_format: plain
     state: info
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _rgw_keys
   with_items:
     - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-rgw/tasks/multisite/create_zone_user.yml
+++ b/roles/ceph-rgw/tasks/multisite/create_zone_user.yml
@@ -22,6 +22,3 @@
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   loop: "{{ zone_users }}"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"

--- a/roles/ceph-rgw/tasks/multisite/master.yml
+++ b/roles/ceph-rgw/tasks/multisite/master.yml
@@ -8,9 +8,6 @@
   run_once: true
   loop: "{{ realms }}"
   when: realms is defined
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: create zonegroup(s)
   radosgw_zonegroup:
@@ -23,9 +20,6 @@
   run_once: true
   loop: "{{ zonegroups }}"
   when: zonegroups is defined
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: create the master zone(s)
   radosgw_zone:
@@ -43,9 +37,6 @@
   when:
     - zones is defined
     - item.is_master | bool
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: add endpoints to their zone groups(s)
   radosgw_zonegroup:
@@ -59,9 +50,6 @@
   when:
     - zone_endpoints_list is defined
     - item.is_master | bool
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: add endpoints to their zone(s)
   radosgw_zone:
@@ -76,9 +64,6 @@
   when:
     - zone_endpoints_list is defined
     - item.is_master | bool
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: update period for zone creation
   command: "{{ container_exec_cmd }} radosgw-admin --cluster={{ cluster }} --rgw-realm={{ item.realm }} --rgw-zonegroup={{ item.zonegroup }} --rgw-zone={{ item.zone }} period update --commit"

--- a/roles/ceph-rgw/tasks/multisite/secondary.yml
+++ b/roles/ceph-rgw/tasks/multisite/secondary.yml
@@ -42,9 +42,6 @@
   when:
     - zones is defined
     - not item.is_master | bool
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: add endpoints to their zone(s)
   radosgw_zone:
@@ -59,9 +56,6 @@
   when:
     - zone_endpoints_list is defined
     - not item.is_master | bool
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: update period for zone creation
   command: "{{ container_exec_cmd }} radosgw-admin --cluster={{ cluster }} --rgw-realm={{ item.realm }} --rgw-zonegroup={{ item.zonegroup }} --rgw-zone={{ item.zone }} period update --commit"

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -13,8 +13,5 @@
     owner: "ceph"
     group: "ceph"
     mode: "0600"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   with_items: "{{ rgw_instances }}"
   when: cephx | bool

--- a/roles/ceph-rgw/tasks/rgw_create_pools.yml
+++ b/roles/ceph-rgw/tasks/rgw_create_pools.yml
@@ -10,9 +10,6 @@
   when:
     - item.value.type is defined
     - item.value.type == 'ec'
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: set crush rule
   ceph_crush_rule:
@@ -20,9 +17,6 @@
     cluster: "{{ cluster }}"
     rule_type: erasure
     profile: "{{ item.value.ec_profile }}"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when:
@@ -46,9 +40,6 @@
   when:
     - item.value.type is defined
     - item.value.type == 'ec'
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: create replicated pools for rgw
   ceph_pool:
@@ -66,6 +57,3 @@
   loop: "{{ rgw_create_pools | dict2items }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   when: item.value.type is not defined or item.value.type == 'replicated'
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -20,6 +20,10 @@
   vars:
     delegate_facts_host: True
 
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+
   pre_tasks:
     - import_tasks: raw_install_python.yml
 
@@ -83,6 +87,9 @@
   become: True
   gather_facts: false
   any_errors_fatal: true
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   tasks:
     - import_role:
         name: ceph-defaults
@@ -118,6 +125,9 @@
   become: True
   gather_facts: false
   any_errors_fatal: true
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   tasks:
     # pre-tasks for following imports -
     - name: set ceph manager install 'In Progress'
@@ -156,6 +166,9 @@
   become: True
   gather_facts: false
   any_errors_fatal: true
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   tasks:
     # pre-tasks for upcoming imports -
     - name: set ceph osd install 'In Progress'
@@ -194,6 +207,9 @@
   become: True
   gather_facts: false
   any_errors_fatal: true
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   tasks:
     # pre-tasks for following imports -
     - name: set ceph mds install 'In Progress'
@@ -232,6 +248,9 @@
   become: True
   gather_facts: false
   any_errors_fatal: true
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   tasks:
     # pre-tasks for following imports -
     - name: set ceph rgw install 'In Progress'
@@ -270,6 +289,9 @@
   become: True
   gather_facts: false
   any_errors_fatal: true
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   tags: 'ceph_client'
   tasks:
     # pre-tasks for following imports -
@@ -309,6 +331,9 @@
   become: True
   gather_facts: false
   any_errors_fatal: true
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   tasks:
     # pre-tasks for following imports -
     - name: set ceph nfs install 'In Progress'
@@ -347,6 +372,9 @@
   become: True
   gather_facts: false
   any_errors_fatal: true
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   tasks:
     # pre-tasks for following imports -
     - name: set ceph rbd mirror install 'In Progress'
@@ -386,6 +414,9 @@
   gather_facts: false
   any_errors_fatal: true
   become: True
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   tasks:
     # pre-tasks for following imports -
     - name: set ceph iscsi gateway install 'In Progress'
@@ -437,7 +468,9 @@
   gather_facts: false
   become: True
   any_errors_fatal: true
-
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   tasks:
     - import_role:
         name: ceph-defaults


### PR DESCRIPTION
All ansible modules are using two common environment variables to
determine if the deployment is containerized or not.
Setting those variables on each module call makes a lot of duplicate
code and also useless when the deployment isn't containeried.
Instead we should set the evironment variables at play level and only
on containerized deployment.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>