### PR TITLE
[skip ci] rgw: support switching from single-site to multisite

### DIFF
--- a/roles/ceph-handler/tasks/main.yml
+++ b/roles/ceph-handler/tasks/main.yml
@@ -63,3 +63,9 @@
         name: ceph-rgw
         tasks_from: pre_requisite.yml
       when: not containerized_deployment | bool
+
+    - name: import_role ceph-rgw
+      import_role:
+        name: ceph-rgw
+        tasks_from: multisite.yml
+      when: rgw_multisite | bool

--- a/roles/ceph-rgw/tasks/multisite.yml
+++ b/roles/ceph-rgw/tasks/multisite.yml
@@ -1,0 +1,3 @@
+---
+- name: include_tasks multisite
+  include_tasks: multisite/main.yml


### PR DESCRIPTION
When collocating rgw with either a mon, mgr or osd, switching from
single site to a multisite rgw setup failed because of the handlers
triggered between the ansible play of the collocated daemon and the play
of the rgw. Since the multisite changes are not yet applied the handlers
fail.
The idea here is to ensure we run the multisite configuration from the
ceph-handler role before the restart happens, this way it won't complain
because of non existing multisite configuration.

(Note: this is also valid when simply changing a multisite configuration)

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1888630

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>