### PR TITLE
library: refact ceph_dashboard_user

### DIFF
--- a/library/ceph_dashboard_user.py
+++ b/library/ceph_dashboard_user.py
@@ -119,11 +119,10 @@ def create_user(module, container_image=None):
 
     cluster = module.params.get('cluster')
     name = module.params.get('name')
-    password = module.params.get('password')
 
-    args = ['ac-user-create', name, password]
+    args = ['ac-user-create', '-i', '-',  name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image, interactive=True)
 
     return cmd
 
@@ -153,11 +152,10 @@ def set_password(module, container_image=None):
 
     cluster = module.params.get('cluster')
     name = module.params.get('name')
-    password = module.params.get('password')
 
-    args = ['ac-user-set-password', name, password]
+    args = ['ac-user-set-password', '-i', '-', name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
+    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image, interactive=True)
 
     return cmd
 
@@ -214,6 +212,7 @@ def run_module():
     name = module.params.get('name')
     state = module.params.get('state')
     roles = module.params.get('roles')
+    password = module.params.get('password')
 
     if module.check_mode:
         module.exit_json(
@@ -241,9 +240,9 @@ def run_module():
             if user['roles'] != roles:
                 rc, cmd, out, err = exec_command(module, set_roles(module, container_image=container_image))
                 changed = True
-            rc, cmd, out, err = exec_command(module, set_password(module, container_image=container_image))
+            rc, cmd, out, err = exec_command(module, set_password(module, container_image=container_image), stdin=password)
         else:
-            rc, cmd, out, err = exec_command(module, create_user(module, container_image=container_image))
+            rc, cmd, out, err = exec_command(module, create_user(module, container_image=container_image), stdin=password)
             rc, cmd, out, err = exec_command(module, set_roles(module, container_image=container_image))
             changed = True
 

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -4,6 +4,10 @@
     container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
   when: containerized_deployment | bool
 
+- name: set_fact container_run_cmd
+  set_fact:
+    ceph_cmd: "{{ hostvars[groups[mon_group_name][0]]['container_binary'] + ' run --interactive --rm -v /etc/ceph:/etc/ceph:z --entrypoint=ceph ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph' }}"
+
 - name: disable SSL for dashboard
   when: dashboard_protocol == "http"
   delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -150,7 +154,10 @@
   changed_when: false
 
 - name: set grafana api password
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-password {{ grafana_admin_password }}"
+  command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard set-grafana-api-password -i -"
+  args:
+    stdin: "{{ grafana_admin_password }}"
+    stdin_add_newline: no
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   changed_when: false
@@ -215,12 +222,18 @@
       changed_when: false
 
     - name: set the rgw access key
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-access-key {{ rgw_access_key }}"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard set-rgw-api-access-key -i -"
+      args:
+        stdin: "{{ rgw_access_key }}"
+        stdin_add_newline: no
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
 
     - name: set the rgw secret key
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-secret-key {{ rgw_secret_key }}"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard set-rgw-api-secret-key -i -"
+      args:
+        stdin: "{{ rgw_secret_key }}"
+        stdin_add_newline: no
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
 
@@ -266,14 +279,20 @@
         - generate_crt | default(false) | bool
 
     - name: add iscsi gateways - ipv4
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-add {{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard iscsi-gateway-add -i -"
+      args:
+        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+        stdin_add_newline: no
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       with_items: "{{ groups[iscsi_gw_group_name] }}"
       when: ip_version == 'ipv4'
 
     - name: add iscsi gateways - ipv6
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-add {{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard iscsi-gateway-add -i -"
+      args:
+        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+        stdin_add_newline: no
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       with_items: "{{ groups[iscsi_gw_group_name] }}"

--- a/tests/functional/all_daemons/group_vars/nfss
+++ b/tests/functional/all_daemons/group_vars/nfss
@@ -7,4 +7,5 @@ ganesha_conf_overrides: |
     }
 nfs_ganesha_stable: true
 nfs_ganesha_dev: false
-nfs_ganesha_flavor: "ceph_master"
+#nfs_ganesha_flavor: "ceph_master"
+nfs_ganesha_flavor: ceph_dgalloway

--- a/tests/library/test_ceph_dashboard_user.py
+++ b/tests/library/test_ceph_dashboard_user.py
@@ -1,102 +1,146 @@
-from mock.mock import MagicMock
+from mock.mock import MagicMock, patch
+import os
 import ceph_dashboard_user
 
-fake_binary = 'ceph'
-fake_cluster = 'ceph'
 fake_container_binary = 'podman'
 fake_container_image = 'docker.io/ceph/daemon:latest'
-fake_container_cmd = [
-    fake_container_binary,
-    'run',
-    '--rm',
-    '--net=host',
-    '-v', '/etc/ceph:/etc/ceph:z',
-    '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
-    '-v', '/var/log/ceph/:/var/log/ceph/:z',
-    '--entrypoint=' + fake_binary,
-    fake_container_image
-]
-fake_user = 'foo'
-fake_password = 'bar'
-fake_roles = ['read-only', 'block-manager']
-fake_params = {'cluster': fake_cluster,
-               'name': fake_user,
-               'password': fake_password,
-               'roles': fake_roles}
 
 
 class TestCephDashboardUserModule(object):
+    def setup_method(self):
+        self.fake_params = []
+        self.fake_binary = 'ceph'
+        self.fake_cluster = 'ceph'
+        self.fake_name = 'foo'
+        self.fake_user = 'foo'
+        self.fake_password = 'bar'
+        self.fake_module = MagicMock()
+        self.fake_module.params = self.fake_params
+        self.fake_roles = ['read-only', 'block-manager']
+        self.fake_params = {'cluster': self.fake_cluster,
+                            'name': self.fake_user,
+                            'password': self.fake_password,
+                            'roles': self.fake_roles}
 
     def test_create_user(self):
-        fake_module = MagicMock()
-        fake_module.params = fake_params
+        self.fake_module.params = self.fake_params
         expected_cmd = [
-            fake_binary,
+            self.fake_binary,
             '-n', 'client.admin',
             '-k', '/etc/ceph/ceph.client.admin.keyring',
-            '--cluster', fake_cluster,
+            '--cluster', self.fake_cluster,
             'dashboard', 'ac-user-create',
-            fake_user,
-            fake_password
+            '-i', '-',
+            self.fake_user
         ]
 
-        assert ceph_dashboard_user.create_user(fake_module) == expected_cmd
+        assert ceph_dashboard_user.create_user(self.fake_module) == expected_cmd
+
+    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
+    @patch.dict(os.environ, {'CEPH_CONTAINER_IMAGE': fake_container_image})
+    def test_create_user_container(self):
+        fake_container_cmd = [
+            fake_container_binary,
+            'run',
+            '--interactive',
+            '--rm',
+            '--net=host',
+            '-v', '/etc/ceph:/etc/ceph:z',
+            '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
+            '-v', '/var/log/ceph/:/var/log/ceph/:z',
+            '--entrypoint=' + self.fake_binary,
+            fake_container_image
+        ]
+        self.fake_module.params = self.fake_params
+        expected_cmd = fake_container_cmd + [
+            '-n', 'client.admin',
+            '-k', '/etc/ceph/ceph.client.admin.keyring',
+            '--cluster', self.fake_cluster,
+            'dashboard', 'ac-user-create',
+            '-i', '-',
+            self.fake_user
+        ]
+
+        assert ceph_dashboard_user.create_user(self.fake_module, container_image=fake_container_image) == expected_cmd
 
     def test_set_roles(self):
-        fake_module = MagicMock()
-        fake_module.params = fake_params
+        self.fake_module.params = self.fake_params
         expected_cmd = [
-            fake_binary,
+            self.fake_binary,
             '-n', 'client.admin',
             '-k', '/etc/ceph/ceph.client.admin.keyring',
-            '--cluster', fake_cluster,
+            '--cluster', self.fake_cluster,
             'dashboard', 'ac-user-set-roles',
-            fake_user
+            self.fake_user
         ]
-        expected_cmd.extend(fake_roles)
+        expected_cmd.extend(self.fake_roles)
 
-        assert ceph_dashboard_user.set_roles(fake_module) == expected_cmd
+        assert ceph_dashboard_user.set_roles(self.fake_module) == expected_cmd
 
     def test_set_password(self):
-        fake_module = MagicMock()
-        fake_module.params = fake_params
+        self.fake_module.params = self.fake_params
         expected_cmd = [
-            fake_binary,
+            self.fake_binary,
             '-n', 'client.admin',
             '-k', '/etc/ceph/ceph.client.admin.keyring',
-            '--cluster', fake_cluster,
+            '--cluster', self.fake_cluster,
             'dashboard', 'ac-user-set-password',
-            fake_user,
-            fake_password
+            '-i', '-',
+            self.fake_user
         ]
 
-        assert ceph_dashboard_user.set_password(fake_module) == expected_cmd
+        assert ceph_dashboard_user.set_password(self.fake_module) == expected_cmd
 
-    def test_get_user(self):
-        fake_module = MagicMock()
-        fake_module.params = fake_params
-        expected_cmd = [
-            fake_binary,
+    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
+    @patch.dict(os.environ, {'CEPH_CONTAINER_IMAGE': fake_container_image})
+    def test_set_password_container(self):
+        fake_container_cmd = [
+            fake_container_binary,
+            'run',
+            '--interactive',
+            '--rm',
+            '--net=host',
+            '-v', '/etc/ceph:/etc/ceph:z',
+            '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
+            '-v', '/var/log/ceph/:/var/log/ceph/:z',
+            '--entrypoint=' + self.fake_binary,
+            fake_container_image
+        ]
+        self.fake_module.params = self.fake_params
+        expected_cmd = fake_container_cmd + [
             '-n', 'client.admin',
             '-k', '/etc/ceph/ceph.client.admin.keyring',
-            '--cluster', fake_cluster,
+            '--cluster', self.fake_cluster,
+            'dashboard', 'ac-user-set-password',
+            '-i', '-',
+            self.fake_user
+        ]
+
+        assert ceph_dashboard_user.set_password(self.fake_module, container_image=fake_container_image) == expected_cmd
+
+    def test_get_user(self):
+        self.fake_module.params = self.fake_params
+        expected_cmd = [
+            self.fake_binary,
+            '-n', 'client.admin',
+            '-k', '/etc/ceph/ceph.client.admin.keyring',
+            '--cluster', self.fake_cluster,
             'dashboard', 'ac-user-show',
-            fake_user,
+            self.fake_user,
             '--format=json'
         ]
 
-        assert ceph_dashboard_user.get_user(fake_module) == expected_cmd
+        assert ceph_dashboard_user.get_user(self.fake_module) == expected_cmd
 
     def test_remove_user(self):
-        fake_module = MagicMock()
-        fake_module.params = fake_params
+        self.fake_module.params = self.fake_params
         expected_cmd = [
-            fake_binary,
+            self.fake_binary,
             '-n', 'client.admin',
             '-k', '/etc/ceph/ceph.client.admin.keyring',
-            '--cluster', fake_cluster,
+            '--cluster', self.fake_cluster,
             'dashboard', 'ac-user-delete',
-            fake_user
+            self.fake_user
         ]
 
-        assert ceph_dashboard_user.remove_user(fake_module) == expected_cmd
+        assert ceph_dashboard_user.remove_user(self.fake_module) == expected_cmd


### PR DESCRIPTION
refact this module due to recent changes in ceph pacific.
The password must be passed with `-i` option.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>