### PR TITLE
[skip ci] spec: add module_utils directory

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -38,7 +38,7 @@ Ansible playbooks for Ceph
 %install
 mkdir -p %{buildroot}%{_datarootdir}/ceph-ansible
 
-for f in ansible.cfg *.yml *.sample group_vars roles library plugins infrastructure-playbooks; do
+for f in ansible.cfg *.yml *.sample group_vars roles library module_utils plugins infrastructure-playbooks; do
   cp -a $f %{buildroot}%{_datarootdir}/ceph-ansible
 done
 


### PR DESCRIPTION
Since d7fd468 the ansible modules are using the common code shared in
the module_utils directory but that one wasn't added to the spec file.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1910214

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>