### PR TITLE
Revert "tests: temporarily use david's flavor"

### DIFF
--- a/tests/functional/all_daemons/group_vars/nfss
+++ b/tests/functional/all_daemons/group_vars/nfss
@@ -7,5 +7,4 @@ ganesha_conf_overrides: |
     }
 nfs_ganesha_stable: true
 nfs_ganesha_dev: false
-#nfs_ganesha_flavor: "ceph_master"
-nfs_ganesha_flavor: ceph_dgalloway
+nfs_ganesha_flavor: "ceph_master"


### PR DESCRIPTION
This reverts commit ed9f0641eee3da314a66f5ed7c2722ac973481d3.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>