### PR TITLE
(stable-5.0) dashboard: configure passwords via stdin

### DIFF
--- a/library/ceph_dashboard_user.py
+++ b/library/ceph_dashboard_user.py
@@ -179,7 +179,10 @@ def exec_commands(module, cmd, stdin=None):
     Execute command(s)
     '''
 
-    rc, out, err = module.run_command(cmd, data=stdin)
+    binary_data = False
+    if stdin:
+        binary_data = True
+    rc, out, err = module.run_command(cmd, data=stdin, binary_data=binary_data)
 
     return rc, cmd, out, err
 

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -4,6 +4,10 @@
     container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
   when: containerized_deployment | bool
 
+- name: set_fact container_run_cmd
+  set_fact:
+    ceph_cmd: "{{ hostvars[groups[mon_group_name][0]]['container_binary'] + ' run --interactive --rm -v /etc/ceph:/etc/ceph:z --entrypoint=ceph ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph' }}"
+
 - name: disable SSL for dashboard
   when: dashboard_protocol == "http"
   delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -140,7 +144,10 @@
   changed_when: false
 
 - name: set grafana api password
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-password {{ grafana_admin_password }}"
+  command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard set-grafana-api-password -i -"
+  args:
+    stdin: "{{ grafana_admin_password }}"
+    stdin_add_newline: no
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   changed_when: false
@@ -205,12 +212,18 @@
       changed_when: false
 
     - name: set the rgw access key
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-access-key {{ rgw_access_key }}"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard set-rgw-api-access-key -i -"
+      args:
+        stdin: "{{ rgw_access_key }}"
+        stdin_add_newline: no
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
 
     - name: set the rgw secret key
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-secret-key {{ rgw_secret_key }}"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard set-rgw-api-secret-key -i -"
+      args:
+        stdin: "{{ rgw_secret_key }}"
+        stdin_add_newline: no
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
 
@@ -256,14 +269,20 @@
         - generate_crt | default(false) | bool
 
     - name: add iscsi gateways - ipv4
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-add {{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard iscsi-gateway-add -i -"
+      args:
+        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+        stdin_add_newline: no
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       with_items: "{{ groups[iscsi_gw_group_name] }}"
       when: ip_version == 'ipv4'
 
     - name: add iscsi gateways - ipv6
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-add {{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard iscsi-gateway-add -i -"
+      args:
+        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+        stdin_add_newline: no
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       with_items: "{{ groups[iscsi_gw_group_name] }}"

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -125,12 +125,26 @@
   run_once: true
   changed_when: false
 
+- name: check dashboard password in file option command
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard ac-user-set-password"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  changed_when: false
+  failed_when: false
+  register: dashboard_password_in_file_option
+
+- name: set_fact dashboard_password_from_stdin
+  set_fact:
+    dashboard_password_from_stdin: "{{ ' -i ' in dashboard_password_in_file_option.stderr }}"
+  run_once: true
+
 - name: create dashboard admin user
   ceph_dashboard_user:
     name: "{{ dashboard_admin_user }}"
     cluster: "{{ cluster }}"
     password: "{{ dashboard_admin_password }}"
     roles: ["{{ 'read-only' if dashboard_admin_user_ro | bool else 'administrator' }}"]
+    interactive: "{{ dashboard_password_from_stdin }}"
   run_once: true
   delegate_to: "{{ groups[mon_group_name][0] }}"
   environment:
@@ -151,6 +165,14 @@
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   changed_when: false
+  when: dashboard_password_from_stdin | bool
+
+- name: set grafana api password (legacy)
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-password {{ grafana_admin_password }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  changed_when: false
+  when: not dashboard_password_from_stdin | bool
 
 - name: disable ssl verification for grafana
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-ssl-verify False"
@@ -218,6 +240,13 @@
         stdin_add_newline: no
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
+      when: dashboard_password_from_stdin | bool
+
+    - name: set the rgw access key (legacy)
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-access-key {{ rgw_access_key }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      changed_when: false
+      when: not dashboard_password_from_stdin | bool
 
     - name: set the rgw secret key
       command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard set-rgw-api-secret-key -i -"
@@ -226,6 +255,13 @@
         stdin_add_newline: no
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
+      when: dashboard_password_from_stdin | bool
+
+    - name: set the rgw secret key (legacy)
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-secret-key {{ rgw_secret_key }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      changed_when: false
+      when: not dashboard_password_from_stdin | bool
 
     - name: set the rgw host
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-host {{ hostvars[groups[rgw_group_name][0]]['rgw_instances'][0]['radosgw_address'] }}"
@@ -276,7 +312,18 @@
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       with_items: "{{ groups[iscsi_gw_group_name] }}"
-      when: ip_version == 'ipv4'
+      when:
+        - ip_version == 'ipv4'
+        - dashboard_password_from_stdin | bool
+
+    - name: add iscsi gateways - ipv4 (legacy)
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-add {{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+      changed_when: false
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      with_items: "{{ groups[iscsi_gw_group_name] }}"
+      when:
+        - ip_version == 'ipv4'
+        - not dashboard_password_from_stdin | bool
 
     - name: add iscsi gateways - ipv6
       command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard iscsi-gateway-add -i -"
@@ -286,7 +333,18 @@
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       with_items: "{{ groups[iscsi_gw_group_name] }}"
-      when: ip_version == 'ipv6'
+      when:
+        - ip_version == 'ipv6'
+        - dashboard_password_from_stdin | bool
+
+    - name: add iscsi gateways - ipv6 (legacy)
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-add {{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+      changed_when: false
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      with_items: "{{ groups[iscsi_gw_group_name] }}"
+      when:
+        - ip_version == 'ipv6'
+        - not dashboard_password_from_stdin | bool
 
 - name: disable mgr dashboard module (restart)
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} mgr module disable dashboard"

--- a/tests/library/test_ceph_dashboard_user.py
+++ b/tests/library/test_ceph_dashboard_user.py
@@ -241,3 +241,17 @@ class TestCephDashboardUserModule(object):
         ]
 
         assert ceph_dashboard_user.remove_user(self.fake_module) == expected_cmd
+
+    @pytest.mark.parametrize('stdin', [None, 'foo'])
+    def test_exec_command(self, stdin):
+        fake_module = MagicMock()
+        rc = 0
+        stderr = ''
+        stdout = 'ceph version 1.2.3'
+        fake_module.run_command.return_value = 0, stdout, stderr
+        expected_cmd = [self.fake_binary, '--version']
+        _rc, _cmd, _out, _err = ceph_dashboard_user.exec_commands(fake_module, expected_cmd, stdin=stdin)
+        assert _rc == rc
+        assert _cmd == expected_cmd
+        assert _err == stderr
+        assert _out == stdout

--- a/tests/library/test_ceph_dashboard_user.py
+++ b/tests/library/test_ceph_dashboard_user.py
@@ -91,26 +91,41 @@ class TestCephDashboardUserModule(object):
         ])
         assert ceph_dashboard_user.generate_ceph_cmd(self.fake_cluster, [], image) == expected_cmd
 
-    def test_create_user(self):
+    @pytest.mark.parametrize('interactive', [True, False])
+    def test_create_user(self, interactive):
+        self.fake_params.update({'interactive': interactive})
         self.fake_module.params = self.fake_params
         expected_cmd = [
             self.fake_binary,
             '--cluster', self.fake_cluster,
-            'dashboard', 'ac-user-create',
-            '-i', '-',
-            self.fake_user
+            'dashboard', 'ac-user-create'
         ]
+        if interactive:
+            expected_cmd.extend([
+                '-i', '-',
+                self.fake_user
+            ])
+        else:
+            expected_cmd.extend([
+                self.fake_user,
+                self.fake_password
+            ])
 
         assert ceph_dashboard_user.create_user(self.fake_module) == expected_cmd
 
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
     @patch.dict(os.environ, {'CEPH_CONTAINER_IMAGE': fake_container_image})
-    def test_create_user_container(self):
+    @pytest.mark.parametrize('interactive', [True, False])
+    def test_create_user_container(self, interactive):
+        self.fake_params.update({'interactive': interactive})
         self.fake_module.params = self.fake_params
         expected_cmd = [
             fake_container_binary,
             'run',
-            '--interactive',
+        ]
+        if interactive:
+            expected_cmd.append('--interactive')
+        expected_cmd.extend([
             '--rm',
             '--net=host',
             '-v', '/etc/ceph:/etc/ceph:z',
@@ -120,9 +135,17 @@ class TestCephDashboardUserModule(object):
             fake_container_image,
             '--cluster', self.fake_cluster,
             'dashboard', 'ac-user-create',
-            '-i', '-',
-            self.fake_user
-        ]
+        ])
+        if interactive:
+            expected_cmd.extend([
+                '-i', '-',
+                self.fake_user
+            ])
+        else:
+            expected_cmd.extend([
+                self.fake_user,
+                self.fake_password
+            ])
 
         assert ceph_dashboard_user.create_user(self.fake_module, container_image=fake_container_image) == expected_cmd
 
@@ -138,26 +161,41 @@ class TestCephDashboardUserModule(object):
 
         assert ceph_dashboard_user.set_roles(self.fake_module) == expected_cmd
 
-    def test_set_password(self):
+    @pytest.mark.parametrize('interactive', [True, False])
+    def test_set_password(self, interactive):
+        self.fake_params.update({'interactive': interactive})
         self.fake_module.params = self.fake_params
         expected_cmd = [
             self.fake_binary,
             '--cluster', self.fake_cluster,
             'dashboard', 'ac-user-set-password',
-            '-i', '-',
-            self.fake_user
         ]
+        if interactive:
+            expected_cmd.extend([
+                '-i', '-',
+                self.fake_user
+            ])
+        else:
+            expected_cmd.extend([
+                self.fake_user,
+                self.fake_password
+            ])
 
         assert ceph_dashboard_user.set_password(self.fake_module) == expected_cmd
 
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
     @patch.dict(os.environ, {'CEPH_CONTAINER_IMAGE': fake_container_image})
-    def test_set_password_container(self):
+    @pytest.mark.parametrize('interactive', [True, False])
+    def test_set_password_container(self, interactive):
+        self.fake_params.update({'interactive': interactive})
         self.fake_module.params = self.fake_params
         expected_cmd = [
             fake_container_binary,
             'run',
-            '--interactive',
+        ]
+        if interactive:
+            expected_cmd.append('--interactive')
+        expected_cmd.extend([
             '--rm',
             '--net=host',
             '-v', '/etc/ceph:/etc/ceph:z',
@@ -167,9 +205,17 @@ class TestCephDashboardUserModule(object):
             fake_container_image,
             '--cluster', self.fake_cluster,
             'dashboard', 'ac-user-set-password',
-            '-i', '-',
-            self.fake_user
-        ]
+        ])
+        if interactive:
+            expected_cmd.extend([
+                '-i', '-',
+                self.fake_user
+            ])
+        else:
+            expected_cmd.extend([
+                self.fake_user,
+                self.fake_password
+            ])
 
         assert ceph_dashboard_user.set_password(self.fake_module, container_image=fake_container_image) == expected_cmd
 


### PR DESCRIPTION
Due to recent changes in ceph, the few dashboard passwors must be passed via `-i` either in the `ceph_dashboard_module` or in the `command` task.
This also adds backward compatibility for older ceph release manage by recent ceph-ansible version.