### PR TITLE
ceph-mon: add ExecStartPre docker stop to systemd

### DIFF
--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -12,6 +12,8 @@ EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm --storage ceph-mon-%i
+{% else %}
+ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mon-%i
 {% endif %}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-mon-%i
 ExecStartPre=/bin/sh -c '"$(command -v mkdir)" -p /etc/ceph /var/lib/ceph/mon'


### PR DESCRIPTION
We already do that in the other systemd templates (mgr, mds, etc..)
and would present to add workaround in other orchestration tool.
This change is for containerized deployment only.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1882724

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>