### PR TITLE
osd: support adding osd in auto discovery scenario

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -31,6 +31,34 @@
           ls /var/lib/ceph/osd/ | sed 's/.*-//'
         register: activated_osds
 
+      - name: auto discovery specific tasks
+        when: osd_auto_discovery | bool
+        block:
+          - name: get prepared disk list
+            command: >
+              docker run --rm --net=host --privileged=true --pid=host --ipc=host --cpu-quota=100000
+              -v /dev:/dev
+              -v /etc/localtime:/etc/localtime:ro
+              -v /var/lib/ceph:/var/lib/ceph:z,rshared
+              -v /etc/ceph:/etc/ceph:z
+              -v /var/run/ceph:/var/run/ceph:z
+              -v /var/run/udev/:/var/run/udev/
+              --entrypoint=ceph-disk
+              {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
+              list --format json
+            register: ceph_disk_list
+
+          - name: set_fact prepared_devices
+            set_fact:
+              prepared_devices: "{{ prepared_devices | default([]) | union([item.path]) }}"
+            with_items: "{{ ceph_disk_list.stdout | default('{}') | from_json }}"
+            when:
+              - ceph_disk_list.skipped is undefined
+              - item.path is defined
+              - item.partitions is defined
+              - (item.partitions | selectattr('type', 'match', 'data') | selectattr('state', 'defined') | map(attribute='state') | default([]) | list == ['prepared']) or
+                (item.partitions | selectattr('type', 'match', 'lockbox') | selectattr('state', 'defined') | map(attribute='state') | list == ['prepared'])
+
       - name: activate containerized osd(s)
         shell: |
           DOCKER_ENV=$(docker run --rm --net=host --ulimit nofile=1024:4096 \
@@ -53,10 +81,8 @@
           {{ docker_env_args }} \
           {{ ceph_osd_docker_prepare_env }} \
           {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
-        with_items: "{{ devices }}"
-        when:
-          - devices is defined
-          - devices | length > activated_osds.stdout_lines | length
+        with_items: "{{ prepared_devices }}"
+        when: prepared_devices is defined
 
   - name: include systemd.yml
     include_tasks: systemd.yml

--- a/roles/ceph-osd/templates/ceph-osd-run.sh.j2
+++ b/roles/ceph-osd/templates/ceph-osd-run.sh.j2
@@ -114,7 +114,7 @@ numactl \
   {% endif -%}
   -v /dev:/dev \
   -v /etc/localtime:/etc/localtime:ro \
-  -v /var/lib/ceph:/var/lib/ceph:z \
+  -v /var/lib/ceph:/var/lib/ceph:z,rshared \
   -v /etc/ceph:/etc/ceph:z \
   -v /var/run/ceph:/var/run/ceph:z \
   -v /var/run/udev/:/var/run/udev/ \


### PR DESCRIPTION
The task in charge of activating new osd is skipped because
`devices` is populated with the devices being added only.
It means it doesn't enter the condition since the length of `devices` is less
than the number of activated osds.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1906293

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>