### PR TITLE
module_utils: don't add newline to the data

### DIFF
--- a/module_utils/ca_common.py
+++ b/module_utils/ca_common.py
@@ -76,7 +76,10 @@ def exec_command(module, cmd, stdin=None):
     Execute command(s)
     '''
 
-    rc, out, err = module.run_command(cmd, data=stdin)
+    binary_data = False
+    if stdin:
+        binary_data = True
+    rc, out, err = module.run_command(cmd, data=stdin, binary_data=binary_data)
 
     return rc, cmd, out, err
 

--- a/tests/module_utils/test_ca_common.py
+++ b/tests/module_utils/test_ca_common.py
@@ -1,4 +1,4 @@
-from mock.mock import patch
+from mock.mock import patch, MagicMock
 import os
 import ca_common
 import pytest
@@ -128,3 +128,17 @@ class TestCommon(object):
         ])
         result = ca_common.generate_ceph_cmd(sub_cmd, args, user='client.foo', container_image=image)
         assert result == expected_cmd
+
+    @pytest.mark.parametrize('stdin', [None, 'foo'])
+    def test_exec_command(self, stdin):
+        fake_module = MagicMock()
+        rc = 0
+        stderr = ''
+        stdout = 'ceph version 1.2.3'
+        fake_module.run_command.return_value = 0, stdout, stderr
+        expected_cmd = [self.fake_binary, '--version']
+        _rc, _cmd, _out, _err = ca_common.exec_command(fake_module, expected_cmd, stdin=stdin)
+        assert _rc == rc
+        assert _cmd == expected_cmd
+        assert _err == stderr
+        assert _out == stdout


### PR DESCRIPTION
When executing a command via the run_command method and passing some
data with stdin then the default behavior is to add append a newline.
This breaks the value of password used by our modules.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>