### PR TITLE
library: add ceph_dashboard_iscsi

### DIFF
--- a/infrastructure-playbooks/purge-iscsi-gateways.yml
+++ b/infrastructure-playbooks/purge-iscsi-gateways.yml
@@ -81,16 +81,22 @@
             name: ceph-facts
             tasks_from: container_binary
 
-        - name: set_fact container_exec_cmd
-          set_fact:
-            container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ ansible_hostname }}"
-          when: containerized_deployment | bool
-
         - name: get iscsi gateway list
-          command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-list -f json"
+          ceph_dashboard_iscsi:
+            cluster: "{{ cluster }}"
+            state: list
           changed_when: false
           register: gateways
+          environment:
+            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
         - name: remove iscsi gateways
-          command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} dashboard iscsi-gateway-rm {{ item }}"
+          ceph_dashboard_iscsi:
+            cluster: "{{ cluster }}"
+            name: "{{ item }}"
+            state: absent
           with_items: '{{ (gateways.stdout | from_json)["gateways"] }}'
+          environment:
+            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+            CEPH_CONTAINER_BINARY: "{{ container_binary }}"

--- a/library/ceph_dashboard_iscsi.py
+++ b/library/ceph_dashboard_iscsi.py
@@ -1,0 +1,203 @@
+# Copyright 2021, Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible.module_utils.ca_common import generate_ceph_cmd, \
+                                               is_containerized, \
+                                               exec_command, \
+                                               exit_module
+except ImportError:
+    from module_utils.ca_common import generate_ceph_cmd, is_containerized, exec_command, exit_module
+
+import datetime
+import json
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ceph_dashboard_iscsi
+
+short_description: Manage Ceph Dashboard User
+
+version_added: "2.8"
+
+description:
+    - Manage Ceph Dashboard iSCSI(s) gateway adding, deletion and list.
+options:
+    cluster:
+        description:
+            - The ceph cluster name.
+        required: false
+        default: ceph
+    url:
+        description:
+            - url of the Ceph Dashboard iSCSI gateway.
+        required: false
+    name:
+        description:
+            - name of the Ceph Dashboard iSCSI gateway.
+        required: false
+    state:
+        description:
+            If 'present' is used, the module adds a iSCSI gateway if it doesn't
+            exist.
+            If 'absent' is used, the module will simply delete the iSCSI gateway.
+            If 'list' is used, the module will return the iSCSI gateway list (json formatted).
+        required: false
+        choices: ['present', 'absent', 'list']
+        default: present
+author:
+    - Dimitri Savineau <dsavinea@redhat.com>
+'''
+
+EXAMPLES = '''
+- name: add a Ceph Dashboard iSCSI gateway
+  ceph_dashboard_iscsi:
+    cluster: ceph
+    url: https://foo:bar@192.168.42.1:5000/
+
+- name: add a Ceph Dashboard iSCSI gateway with explicit name
+  ceph_dashboard_iscsi:
+    url: https://foo:bar@192.168.42.1:5000/
+    name: gw00
+    state: present
+
+- name: delete a Ceph Dashboard iSCSI gateway
+  ceph_dashboard_iscsi:
+    name: gw00
+    state: absent
+
+- name: list the Ceph Dashboard iSCSI gateways
+  ceph_dashboard_iscsi:
+    state: list
+'''
+
+RETURN = '''#  '''
+
+
+def add_iscsi_gateway(module, container_image=None):
+    '''
+    Add an iSCSI gateway
+    '''
+
+    cluster = module.params.get('cluster')
+    name = module.params.get('name')
+
+    args = ['iscsi-gateway-add', '-i', '-']
+
+    if name:
+        args.append(name)
+
+    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image, interactive=True)
+
+    return cmd
+
+
+def list_iscsi_gateway(module, container_image=None):
+    '''
+    List existing iSCSI gateways
+    '''
+
+    cluster = module.params.get('cluster')
+
+    args = ['iscsi-gateway-list', '--format=json']
+
+    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def remove_iscsi_gateway(module, container_image=None):
+    '''
+    Remove an iSCSI gateway
+    '''
+
+    cluster = module.params.get('cluster')
+    name = module.params.get('name')
+
+    args = ['iscsi-gateway-rm', name]
+
+    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
+
+    return cmd
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            cluster=dict(type='str', required=False, default='ceph'),
+            url=dict(type='str', required=False, no_log=True),
+            name=dict(type='str', required=False),
+            state=dict(type='str', required=False, choices=['present', 'absent', 'list'], default='present'),
+        ),
+        supports_check_mode=True,
+        required_if=[
+            ('state', 'present', ['url']),
+            ('state', 'absent', ['name'])
+        ]
+    )
+
+    # Gather module parameters in variables
+    url = module.params.get('url')
+    name = module.params.get('name')
+    state = module.params.get('state')
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            stdout='',
+            stderr='',
+            rc=0,
+            start='',
+            end='',
+            delta='',
+        )
+
+    startd = datetime.datetime.now()
+    changed = False
+
+    # will return either the image name or None
+    container_image = is_containerized()
+
+    rc, cmd, out, err = exec_command(module, list_iscsi_gateway(module, container_image=container_image))
+    if state == "present":
+        gws = json.loads(out)
+        urls = list(map(lambda x: x["service_url"], gws["gateways"].values()))
+        if url not in urls:
+            rc, cmd, out, err = exec_command(module, add_iscsi_gateway(module, container_image=container_image), stdin=url)
+            changed = True
+    elif state == "absent":
+        gws = json.loads(out)
+        if name in gws["gateways"]:
+            rc, cmd, out, err = exec_command(module, remove_iscsi_gateway(module, container_image=container_image))
+            changed = True
+        else:
+            rc = 0
+            out = "iSCSI gateway {} doesn't exist".format(name)
+
+    exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=changed)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -279,23 +279,25 @@
         - generate_crt | default(false) | bool
 
     - name: add iscsi gateways - ipv4
-      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard iscsi-gateway-add -i -"
-      args:
-        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}:{{ hostvars[item]['api_port'] | default(5000) }}"
-        stdin_add_newline: no
-      changed_when: false
+      ceph_dashboard_iscsi:
+        cluster: "{{ cluster }}"
+        url: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}:{{ hostvars[item]['api_port'] | default(5000) }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       with_items: "{{ groups[iscsi_gw_group_name] }}"
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       when: ip_version == 'ipv4'
 
     - name: add iscsi gateways - ipv6
-      command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard iscsi-gateway-add -i -"
-      args:
-        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
-        stdin_add_newline: no
-      changed_when: false
+      ceph_dashboard_iscsi:
+        cluster: "{{ cluster }}"
+        url: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       with_items: "{{ groups[iscsi_gw_group_name] }}"
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       when: ip_version == 'ipv6'
 
 - name: disable mgr dashboard module (restart)

--- a/tests/library/test_ceph_dashboard_iscsi.py
+++ b/tests/library/test_ceph_dashboard_iscsi.py
@@ -1,0 +1,162 @@
+from mock.mock import patch
+import os
+import pytest
+import ca_test_common
+import ceph_dashboard_iscsi
+
+fake_cluster = 'ceph'
+fake_container_binary = 'podman'
+fake_container_image = 'quay.ceph.io/ceph/daemon:latest'
+fake_gw_url = 'https://foo:bar@192.168.42.100:5000'
+fake_gw_name = 'iscsigw01'
+fake_user = 'client.admin'
+fake_keyring = '/etc/ceph/{}.{}.keyring'.format(fake_cluster, fake_user)
+
+
+class TestCephDashboardiSCSIModule(object):
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    def test_with_check_mode(self, m_exit_json):
+        ca_test_common.set_module_args({
+            'url': fake_gw_url,
+            '_ansible_check_mode': True
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_dashboard_iscsi.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['rc'] == 0
+        assert not result['stdout']
+        assert not result['stderr']
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_add_iscsi_gateway(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'url': fake_gw_url,
+            'name': fake_gw_name
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        m_run_command.side_effect = [
+            (0, '{"gateways": {}}', ''),
+            (0, 'Success', ''),
+        ]
+        cmd = ['ceph', '-n', fake_user, '-k', fake_keyring, '--cluster', fake_cluster, 'dashboard', 'iscsi-gateway-add', '-i', '-', fake_gw_name]
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_dashboard_iscsi.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == cmd
+        assert result['rc'] == 0
+        assert result['stderr'] == ''
+        assert result['stdout'] == 'Success'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
+    @patch.dict(os.environ, {'CEPH_CONTAINER_IMAGE': fake_container_image})
+    def test_add_iscsi_gateway_container(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'url': fake_gw_url,
+            'name': fake_gw_name
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        m_run_command.side_effect = [
+            (0, '{"gateways": {}}', ''),
+            (0, 'Success', ''),
+        ]
+        cmd = [fake_container_binary, 'run', '--interactive',
+               '--rm', '--net=host',
+               '-v', '/etc/ceph:/etc/ceph:z',
+               '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
+               '-v', '/var/log/ceph/:/var/log/ceph/:z',
+               '--entrypoint=ceph', fake_container_image,
+               '-n', fake_user, '-k', fake_keyring,
+               '--cluster', fake_cluster,
+               'dashboard', 'iscsi-gateway-add', '-i', '-', fake_gw_name]
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_dashboard_iscsi.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == cmd
+        assert result['rc'] == 0
+        assert result['stderr'] == ''
+        assert result['stdout'] == 'Success'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_add_iscsi_gateway_already_exist(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'url': fake_gw_url
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        rc = 0
+        stderr = ''
+        stdout = '{{"gateways": {{"{}": {{"service_url": "{}"}}}}}}'.format(fake_gw_name, fake_gw_url)
+        m_run_command.return_value = rc, stdout, stderr
+        cmd = ['ceph', '-n', fake_user, '-k', fake_keyring, '--cluster', fake_cluster, 'dashboard', 'iscsi-gateway-list', '--format=json']
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_dashboard_iscsi.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['cmd'] == cmd
+        assert result['rc'] == rc
+        assert result['stderr'] == stderr
+        assert result['stdout'] == stdout
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_delete_iscsi_gateway(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'name': fake_gw_name,
+            'state': 'absent'
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        m_run_command.side_effect = [
+            (0, '{{"gateways": {{"{}": {{"service_url": "{}"}}}}}}'.format(fake_gw_name, fake_gw_url), ''),
+            (0, 'Success', ''),
+        ]
+        cmd = ['ceph', '-n', fake_user, '-k', fake_keyring, '--cluster', fake_cluster, 'dashboard', 'iscsi-gateway-rm', fake_gw_name]
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_dashboard_iscsi.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == cmd
+        assert result['rc'] == 0
+        assert result['stderr'] == ''
+        assert result['stdout'] == 'Success'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_delete_iscsi_gateway_not_exist(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'name': fake_gw_name,
+            'state': 'absent'
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        rc = 0
+        stderr = ''
+        stdout = '{"gateways": {}}'
+        m_run_command.return_value = rc, stdout, stderr
+        cmd = ['ceph', '-n', fake_user, '-k', fake_keyring, '--cluster', fake_cluster, 'dashboard', 'iscsi-gateway-list', '--format=json']
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            ceph_dashboard_iscsi.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['cmd'] == cmd
+        assert result['rc'] == rc
+        assert result['stderr'] == stderr
+        assert result['stdout'] == "iSCSI gateway {} doesn't exist".format(fake_gw_name)


### PR DESCRIPTION
This adds ceph_dashboard_iscsi ansible module for replacing the command
module usage with the ceph dashboard iscsi-gateway-xx commands.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>