### PR TITLE
grafana: update container tag to 6.7.4

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -674,7 +674,7 @@ dummy:
 #grafana_key: ''
 # When using https, please fill with a hostname for which grafana_crt is valid.
 #grafana_server_fqdn: ''
-#grafana_container_image: "docker.io/grafana/grafana:5.4.3"
+#grafana_container_image: "docker.io/grafana/grafana:6.7.4"
 #grafana_container_cpu_period: 100000
 #grafana_container_cpu_cores: 2
 # container_memory is in GB

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -674,7 +674,7 @@ node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node
 #grafana_key: ''
 # When using https, please fill with a hostname for which grafana_crt is valid.
 #grafana_server_fqdn: ''
-grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
 #grafana_container_cpu_period: 100000
 #grafana_container_cpu_cores: 2
 # container_memory is in GB

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -8,7 +8,7 @@ ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"
 ceph_docker_registry_auth: true
 node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1
-grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
 prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
 alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:4.1
 # END OF FILE, DO NOT TOUCH ME!

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -666,7 +666,7 @@ grafana_crt: ''
 grafana_key: ''
 # When using https, please fill with a hostname for which grafana_crt is valid.
 grafana_server_fqdn: ''
-grafana_container_image: "docker.io/grafana/grafana:5.4.3"
+grafana_container_image: "docker.io/grafana/grafana:6.7.4"
 grafana_container_cpu_period: 100000
 grafana_container_cpu_cores: 2
 # container_memory is in GB

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -40,4 +40,4 @@ ceph_docker_image_tag: latest-master
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:5.4.3"
+grafana_container_image: "quay.io/app-sre/grafana:6.7.4"

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -32,5 +32,5 @@ ceph_docker_registry: quay.ceph.io
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:5.4.3"
+grafana_container_image: "quay.io/app-sre/grafana:6.7.4"
 grafana_server_group_name: ceph_monitoring

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -29,4 +29,4 @@ ceph_docker_image_tag: latest-master
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:5.4.3"
+grafana_container_image: "quay.io/app-sre/grafana:6.7.4"

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -24,4 +24,4 @@ ceph_docker_registry: quay.ceph.io
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:5.4.3"
+grafana_container_image: "quay.io/app-sre/grafana:6.7.4"

--- a/tests/functional/docker2podman/group_vars/all
+++ b/tests/functional/docker2podman/group_vars/all
@@ -39,4 +39,4 @@ ceph_docker_image_tag: latest-master
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:5.4.3"
+grafana_container_image: "quay.io/app-sre/grafana:6.7.4"

--- a/tests/functional/podman/group_vars/all
+++ b/tests/functional/podman/group_vars/all
@@ -38,4 +38,4 @@ ceph_docker_image_tag: latest-master
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:5.4.3"
+grafana_container_image: "quay.io/app-sre/grafana:6.7.4"


### PR DESCRIPTION
This update the grafana container tag to 6.7.4.
The RHCS version is now based on the RHCS 5 container image which is
also based on 6.7.4.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>