### PR TITLE
[skip ci] library: fix idempotency in ceph_mgr_module

### DIFF
--- a/library/ceph_mgr_module.py
+++ b/library/ceph_mgr_module.py
@@ -107,7 +107,7 @@ def main():
         )
     else:
         rc, out, err = module.run_command(cmd)
-        if out == "module '{}' is already enabled".format(name):
+        if 'is already enabled' in err:
             changed = False
         else:
             changed = True

--- a/tests/library/test_ceph_mgr_module.py
+++ b/tests/library/test_ceph_mgr_module.py
@@ -93,8 +93,8 @@ class TestCephMgrModuleModule(object):
             'name': fake_module,
         })
         m_exit_json.side_effect = ca_test_common.exit_json
-        stdout = 'module \'{}\' is already enabled'.format(fake_module)
-        stderr = ''
+        stderr = 'module \'{}\' is already enabled'.format(fake_module)
+        stdout = ''
         rc = 0
         m_run_command.return_value = rc, stdout, stderr
 


### PR DESCRIPTION
The ceph mgr command output is printed on stderr instead of stdout which
prevent to set the changed flag to false if the module is already enabled.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>