### PR TITLE
make the cephadm-adopt.yml playbook idempotent

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -172,13 +172,12 @@
           command: "{{ container_binary }} rm cephadm"
           changed_when: false
 
-    - name: set_fact container_exec_cmd
+    - name: set_fact ceph_cmd
       set_fact:
-        container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
-      when: containerized_deployment | bool
+        ceph_cmd: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph:/var/lib/ceph:z -v /var/run/ceph:/var/run/ceph:z --entrypoint=ceph ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph' }} --cluster {{ cluster }}"
 
     - name: get current fsid
-      command: "{{ container_exec_cmd | default('') }} ceph --admin-daemon /var/run/ceph/{{ cluster }}-mon.{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}.asok config get fsid --format json"
+      command: "{{ ceph_cmd }} fsid"
       register: current_fsid
       run_once: true
       changed_when: false
@@ -186,7 +185,8 @@
 
     - name: set_fact fsid
       set_fact:
-        fsid: "{{ (current_fsid.stdout | from_json).fsid }}"
+        fsid: "{{ current_fsid.stdout }}"
+      run_once: true
 
     - name: enable cephadm mgr module
       ceph_mgr_module:
@@ -200,19 +200,19 @@
       delegate_to: '{{ groups[mon_group_name][0] }}'
 
     - name: set cephadm as orchestrator backend
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} orch set backend cephadm"
+      command: "{{ ceph_cmd }} orch set backend cephadm"
       changed_when: false
       run_once: true
       delegate_to: '{{ groups[mon_group_name][0] }}'
 
     - name: generate cephadm ssh key
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} cephadm generate-key"
+      command: "{{ ceph_cmd }} cephadm generate-key"
       changed_when: false
       run_once: true
       delegate_to: '{{ groups[mon_group_name][0] }}'
 
     - name: get the cephadm ssh pub key
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} cephadm get-pub-key"
+      command: "{{ ceph_cmd }} cephadm get-pub-key"
       changed_when: false
       run_once: true
       register: cephadm_pubpkey
@@ -230,13 +230,13 @@
         CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
     - name: set default container image in ceph configuration
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} config set global container_image {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
+      command: "{{ ceph_cmd }} config set global container_image {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       changed_when: false
       run_once: true
       delegate_to: '{{ groups[mon_group_name][0] }}'
 
     - name: set container image base in ceph configuration
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} config set mgr mgr/cephadm/container_image_base {{ ceph_docker_registry }}/{{ ceph_docker_image }}"
+      command: "{{ ceph_cmd }} config set mgr mgr/cephadm/container_image_base {{ ceph_docker_registry }}/{{ ceph_docker_image }}"
       changed_when: false
       run_once: true
       delegate_to: '{{ groups[mon_group_name][0] }}'
@@ -246,32 +246,32 @@
       run_once: true
       block:
         - name: set alertmanager container image in ceph configuration
-          command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} config set mgr mgr/cephadm/container_image_alertmanager {{ alertmanager_container_image }}"
+          command: "{{ ceph_cmd }} config set mgr mgr/cephadm/container_image_alertmanager {{ alertmanager_container_image }}"
           changed_when: false
           delegate_to: '{{ groups[mon_group_name][0] }}'
 
         - name: set grafana container image in ceph configuration
-          command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} config set mgr mgr/cephadm/container_image_grafana {{ grafana_container_image }}"
+          command: "{{ ceph_cmd }} config set mgr mgr/cephadm/container_image_grafana {{ grafana_container_image }}"
           changed_when: false
           delegate_to: '{{ groups[mon_group_name][0] }}'
 
         - name: set node-exporter container image in ceph configuration
-          command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} config set mgr mgr/cephadm/container_image_node_exporter {{ node_exporter_container_image }}"
+          command: "{{ ceph_cmd }} config set mgr mgr/cephadm/container_image_node_exporter {{ node_exporter_container_image }}"
           changed_when: false
           delegate_to: '{{ groups[mon_group_name][0] }}'
 
         - name: set prometheus container image in ceph configuration
-          command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} config set mgr mgr/cephadm/container_image_prometheus {{ prometheus_container_image }}"
+          command: "{{ ceph_cmd }} config set mgr mgr/cephadm/container_image_prometheus {{ prometheus_container_image }}"
           changed_when: false
           delegate_to: '{{ groups[mon_group_name][0] }}'
 
     - name: manage nodes with cephadm
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} orch host add {{ ansible_hostname }} {{ ansible_default_ipv4.address }} {{ group_names | join(' ') }}"
+      command: "{{ ceph_cmd }} orch host add {{ ansible_hostname }} {{ ansible_default_ipv4.address }} {{ group_names | join(' ') }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
 
     - name: add ceph label for core component
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} orch host label add {{ ansible_hostname }} ceph"
+      command: "{{ ceph_cmd }} orch host label add {{ ansible_hostname }} ceph"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
       when: inventory_hostname in groups.get(mon_group_name, []) or
@@ -280,10 +280,6 @@
             inventory_hostname in groups.get(rgw_group_name, []) or
             inventory_hostname in groups.get(mgr_group_name, []) or
             inventory_hostname in groups.get(rbdmirror_group_name, [])
-
-    - name: set_fact ceph_cmd
-      set_fact:
-        ceph_cmd: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph:/var/lib/ceph:z -v /var/run/ceph:/var/run/ceph:z --entrypoint=ceph ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph' }}"
 
     - name: get the client.admin keyring
       ceph_key:
@@ -315,7 +311,7 @@
         - "{{ groups.get(rbdmirror_group_name, []) }}"
 
     - name: assimilate ceph configuration
-      command: "{{ ceph_cmd }} --cluster {{ cluster }} config assimilate-conf -i /etc/ceph/{{ cluster }}.conf"
+      command: "{{ ceph_cmd }} config assimilate-conf -i /etc/ceph/{{ cluster }}.conf"
       changed_when: false
       when: inventory_hostname in groups.get(mon_group_name, []) or
             inventory_hostname in groups.get(osd_group_name, []) or
@@ -496,6 +492,12 @@
         state: absent
       when: not containerized_deployment | bool
 
+    - name: remove osd directory
+      file:
+        path: "/var/lib/ceph/osd/{{ cluster }}-{{ item }}"
+        state: absent
+      loop: '{{ (osd_list.stdout | from_json).keys() | list }}'
+
     - name: waiting for clean pgs...
       command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} pg stat --format json"
       changed_when: false
@@ -557,6 +559,7 @@
         name: 'ceph-mds@{{ ansible_hostname }}'
         state: stopped
         enabled: false
+      failed_when: false
 
     - name: stop and disable ceph-mds systemd target
       service:
@@ -655,6 +658,7 @@
         name: 'ceph-radosgw@rgw.{{ ansible_hostname }}.{{ item.instance_name }}'
         state: stopped
         enabled: false
+      failed_when: false
       loop: '{{ rgw_instances }}'
 
     - name: stop and disable ceph-radosgw systemd target
@@ -724,6 +728,7 @@
         name: 'ceph-rbd-mirror@rbd-mirror.{{ ansible_hostname }}'
         state: stopped
         enabled: false
+      failed_when: false
 
     - name: stop and disable rbd-mirror systemd target
       service:
@@ -780,6 +785,7 @@
         name: '{{ item }}'
         state: stopped
         enabled: false
+      failed_when: false
       with_items:
         - rbd-target-api
         - rbd-target-gw
@@ -847,12 +853,23 @@
     - name: with dashboard enabled
       when: dashboard_enabled | bool
       block:
+        - name: ensure alertmanager/prometheus data directories are present
+          file:
+            path: "{{ item }}"
+            state: directory
+            owner: "{{ prometheus_user_id }}"
+            group: "{{ prometheus_user_id }}"
+          with_items:
+           - "{{ alertmanager_data_dir }}"
+           - "{{ prometheus_data_dir }}"
+
         # (workaround) cephadm adopt alertmanager only stops prometheus-alertmanager systemd service
         - name: stop and disable alertmanager systemd unit
           service:
             name: alertmanager
             state: stopped
             enabled: false
+          failed_when: false
 
         # (workaround) cephadm adopt alertmanager only uses /etc/prometheus/alertmanager.yml
         - name: create alertmanager config symlink
@@ -892,6 +909,7 @@
             name: prometheus
             state: stopped
             enabled: false
+          failed_when: false
 
         - name: remove alertmanager data symlink
           file:
@@ -955,6 +973,7 @@
             name: grafana-server
             state: stopped
             enabled: false
+          failed_when: false
 
         - name: adopt grafana daemon
           cephadm_adopt:
@@ -1000,6 +1019,7 @@
             name: node_exporter
             state: stopped
             enabled: false
+          failed_when: false
 
         - name: remove node_exporter systemd unit file
           file:

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -605,29 +605,39 @@
       delegate_to: "{{ groups[mon_group_name][0] }}"
       block:
         - name: create a default realm
-          command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- radosgw-admin --cluster {{ cluster }} realm create --rgw-realm=default --default"
-          run_once: true
-          changed_when: false
+          radosgw_realm:
+            cluster: "{{ cluster }}"
+            name: default
+            default: true
           environment:
-            CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
         - name: modify the default zonegroup
-          command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- radosgw-admin --cluster {{ cluster }} zonegroup modify --rgw-realm=default --rgw-zonegroup=default"
-          run_once: true
-          changed_when: false
+          radosgw_zonegroup:
+            cluster: "{{ cluster }}"
+            name: default
+            realm: default
+            master: true
+            default: true
           environment:
-            CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
         - name: modify the default zone
-          command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- radosgw-admin --cluster {{ cluster }} zone modify --rgw-realm=default --rgw-zonegroup=default --rgw-zone=default"
-          run_once: true
-          changed_when: false
+          radosgw_zone:
+            cluster: "{{ cluster }}"
+            name: default
+            realm: default
+            zonegroup: default
+            master: true
+            default: true
           environment:
-            CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
         - name: commit the period
           command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- radosgw-admin --cluster {{ cluster }} period update --commit"
-          run_once: true
           changed_when: false
           environment:
             CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'

--- a/tests/library/test_cephadm_adopt.py
+++ b/tests/library/test_cephadm_adopt.py
@@ -34,31 +34,29 @@ class TestCephadmAdoptModule(object):
 
         result = result.value.args[0]
         assert not result['changed']
-        assert result['cmd'] == ['cephadm', 'adopt', '--cluster', fake_cluster, '--name', fake_name, '--style', 'legacy']
+        assert result['cmd'] == ['cephadm', 'ls', '--no-detail']
         assert result['rc'] == 0
         assert not result['stdout']
         assert not result['stderr']
 
-    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.fail_json')
     @patch('ansible.module_utils.basic.AnsibleModule.run_command')
-    def test_with_failure(self, m_run_command, m_exit_json):
+    def test_with_failure(self, m_run_command, m_fail_json):
         ca_test_common.set_module_args({
             'name': fake_name
         })
-        m_exit_json.side_effect = ca_test_common.exit_json
+        m_fail_json.side_effect = ca_test_common.fail_json
         stdout = ''
         stderr = 'ERROR: cephadm should be run as root'
         rc = 1
         m_run_command.return_value = rc, stdout, stderr
 
-        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+        with pytest.raises(ca_test_common.AnsibleFailJson) as result:
             cephadm_adopt.main()
 
         result = result.value.args[0]
-        assert result['changed']
-        assert result['cmd'] == ['cephadm', 'adopt', '--cluster', fake_cluster, '--name', fake_name, '--style', 'legacy']
         assert result['rc'] == 1
-        assert result['stderr'] == 'ERROR: cephadm should be run as root'
+        assert result['msg'] == 'ERROR: cephadm should be run as root'
 
     @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
     @patch('ansible.module_utils.basic.AnsibleModule.run_command')
@@ -76,7 +74,10 @@ class TestCephadmAdoptModule(object):
                  'firewalld ready'.format(fake_name, fake_name)
         stderr = ''
         rc = 0
-        m_run_command.return_value = rc, stdout, stderr
+        m_run_command.side_effect = [
+            (0, '[{{"style":"legacy","name":"{}"}}]'.format(fake_name), ''),
+            (rc, stdout, stderr)
+        ]
 
         with pytest.raises(ca_test_common.AnsibleExitJson) as result:
             cephadm_adopt.main()
@@ -90,6 +91,28 @@ class TestCephadmAdoptModule(object):
 
     @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
     @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_already_adopted(self, m_run_command, m_exit_json):
+        ca_test_common.set_module_args({
+            'name': fake_name
+        })
+        m_exit_json.side_effect = ca_test_common.exit_json
+        stderr = ''
+        stdout = '[{{"style":"cephadm:v1","name":"{}"}}]'.format(fake_name)
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(ca_test_common.AnsibleExitJson) as result:
+            cephadm_adopt.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['cmd'] == ['cephadm', 'ls', '--no-detail']
+        assert result['rc'] == 0
+        assert result['stderr'] == stderr
+        assert result['stdout'] == '{} is already adopted'.format(fake_name)
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
     def test_with_docker(self, m_run_command, m_exit_json):
         ca_test_common.set_module_args({
             'name': fake_name,
@@ -99,7 +122,10 @@ class TestCephadmAdoptModule(object):
         stdout = ''
         stderr = ''
         rc = 0
-        m_run_command.return_value = rc, stdout, stderr
+        m_run_command.side_effect = [
+            (0, '[{{"style":"legacy","name":"{}"}}]'.format(fake_name), ''),
+            (rc, stdout, stderr)
+        ]
 
         with pytest.raises(ca_test_common.AnsibleExitJson) as result:
             cephadm_adopt.main()
@@ -120,7 +146,10 @@ class TestCephadmAdoptModule(object):
         stdout = ''
         stderr = ''
         rc = 0
-        m_run_command.return_value = rc, stdout, stderr
+        m_run_command.side_effect = [
+            (0, '[{{"style":"legacy","name":"{}"}}]'.format(fake_name), ''),
+            (rc, stdout, stderr)
+        ]
 
         with pytest.raises(ca_test_common.AnsibleExitJson) as result:
             cephadm_adopt.main()
@@ -141,7 +170,10 @@ class TestCephadmAdoptModule(object):
         stdout = ''
         stderr = ''
         rc = 0
-        m_run_command.return_value = rc, stdout, stderr
+        m_run_command.side_effect = [
+            (0, '[{{"style":"legacy","name":"{}"}}]'.format(fake_name), ''),
+            (rc, stdout, stderr)
+        ]
 
         with pytest.raises(ca_test_common.AnsibleExitJson) as result:
             cephadm_adopt.main()
@@ -162,7 +194,10 @@ class TestCephadmAdoptModule(object):
         stdout = ''
         stderr = ''
         rc = 0
-        m_run_command.return_value = rc, stdout, stderr
+        m_run_command.side_effect = [
+            (0, '[{{"style":"legacy","name":"{}"}}]'.format(fake_name), ''),
+            (rc, stdout, stderr)
+        ]
 
         with pytest.raises(ca_test_common.AnsibleExitJson) as result:
             cephadm_adopt.main()

--- a/tests/library/test_radosgw_zone.py
+++ b/tests/library/test_radosgw_zone.py
@@ -136,6 +136,19 @@ class TestRadosgwZoneModule(object):
 
         assert radosgw_zone.get_zonegroup(fake_module) == expected_cmd
 
+    def test_get_realm(self):
+        fake_module = MagicMock()
+        fake_module.params = fake_params
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'realm', 'get',
+            '--rgw-realm=' + fake_realm,
+            '--format=json'
+        ]
+
+        assert radosgw_zone.get_realm(fake_module) == expected_cmd
+
     def test_remove_zone(self):
         fake_module = MagicMock()
         fake_module.params = fake_params

--- a/tests/library/test_radosgw_zonegroup.py
+++ b/tests/library/test_radosgw_zonegroup.py
@@ -117,6 +117,19 @@ class TestRadosgwZonegroupModule(object):
 
         assert radosgw_zonegroup.get_zonegroup(fake_module) == expected_cmd
 
+    def test_get_realm(self):
+        fake_module = MagicMock()
+        fake_module.params = fake_params
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'realm', 'get',
+            '--rgw-realm=' + fake_realm,
+            '--format=json'
+        ]
+
+        assert radosgw_zonegroup.get_realm(fake_module) == expected_cmd
+
     def test_remove_zonegroup(self):
         fake_module = MagicMock()
         fake_module.params = fake_params

--- a/tox.ini
+++ b/tox.ini
@@ -256,6 +256,11 @@ commands=
       ireallymeanit=yes \
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
   "
+  # idempotency test
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/cephadm-adopt.yml --extra-vars "\
+      ireallymeanit=yes \
+      delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
+  "
 
 [testenv]
 whitelist_externals =


### PR DESCRIPTION
- remove the container exec because the old containers won't exist anymore
- add idempotency to the cephadm_adopt module because the cephadm adopt command doesn't support it.
- test idempotency in the CI
- use radosgw modules for idempotency purpose

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1918424

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>