### PR TITLE
cephadm-adopt: remove prometheus workaround

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -921,15 +921,6 @@
             path: /var/lib/prom_metrics
             state: absent
 
-        # (workaround) https://tracker.ceph.com/issues/45120
-        - name: create missing prometheus target directory
-          file:
-            path: '/var/lib/ceph/{{ fsid }}/prometheus.{{ ansible_hostname }}/etc/prometheus'
-            state: directory
-            owner: 65534
-            group: 65534
-            recurse: true
-
         - name: adopt prometheus daemon
           cephadm_adopt:
             name: "prometheus.{{ ansible_hostname }}"


### PR DESCRIPTION
This was fixed by [1][2]

[1] https://tracker.ceph.com/issues/45120
[2] https://github.com/ceph/ceph/commit/252d4b30

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>