### PR TITLE
ceph-defaults: change default ceph container tag

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -555,7 +555,7 @@ dummy:
 # DOCKER #
 ##########
 #ceph_docker_image: "ceph/daemon"
-#ceph_docker_image_tag: latest
+#ceph_docker_image_tag: latest-master
 #ceph_docker_registry: docker.io
 #ceph_docker_registry_auth: false
 #ceph_docker_registry_username:

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -547,7 +547,7 @@ ceph_tcmalloc_max_total_thread_cache: 0
 # DOCKER #
 ##########
 ceph_docker_image: "ceph/daemon"
-ceph_docker_image_tag: latest
+ceph_docker_image_tag: latest-master
 ceph_docker_registry: docker.io
 ceph_docker_registry_auth: false
 #ceph_docker_registry_username:


### PR DESCRIPTION
The "latest" ceph container tag references the latest stable release
(octopus at the moment). "latest" is an alias on "latest-octopus".
On the devel branch we should use "latest-master" tag instead.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>