### PR TITLE
facts: support device aliases for (dedicated|bluestore_wal)_devices (bp #5584)

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -217,6 +217,62 @@
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery | default(False) | bool
 
+- name: resolve dedicated_device link(s)
+  command: readlink -f {{ item }}
+  changed_when: false
+  check_mode: no
+  with_items: "{{ dedicated_devices }}"
+  register: dedicated_devices_prepare_canonicalize
+  when:
+    - dedicated_devices is defined
+    - inventory_hostname in groups.get(osd_group_name, [])
+    - not osd_auto_discovery | default(False) | bool
+
+- name: set_fact build dedicated_devices from resolved symlinks
+  set_fact:
+    dedicated_devices: "{{ dedicated_devices | default([]) + [ item.stdout ] }}"
+  with_items: "{{ dedicated_devices_prepare_canonicalize.results }}"
+  when:
+    - dedicated_devices is defined
+    - inventory_hostname in groups.get(osd_group_name, [])
+    - not osd_auto_discovery | default(False) | bool
+
+- name: set_fact build final dedicated_devices list
+  set_fact:
+    dedicated_devices: "{{ dedicated_devices | reject('search','/dev/disk') | list | unique }}"
+  when:
+    - dedicated_devices is defined
+    - inventory_hostname in groups.get(osd_group_name, [])
+    - not osd_auto_discovery | default(False) | bool
+
+- name: resolve bluestore_wal_device link(s)
+  command: readlink -f {{ item }}
+  changed_when: false
+  check_mode: no
+  with_items: "{{ bluestore_wal_devices }}"
+  register: bluestore_wal_devices_prepare_canonicalize
+  when:
+    - bluestore_wal_devices is defined
+    - inventory_hostname in groups.get(osd_group_name, [])
+    - not osd_auto_discovery | default(False) | bool
+
+- name: set_fact build bluestore_wal_devices from resolved symlinks
+  set_fact:
+    bluestore_wal_devices: "{{ bluestore_wal_devices | default([]) + [ item.stdout ] }}"
+  with_items: "{{ bluestore_wal_devices_prepare_canonicalize.results }}"
+  when:
+    - bluestore_wal_devices is defined
+    - inventory_hostname in groups.get(osd_group_name, [])
+    - not osd_auto_discovery | default(False) | bool
+
+- name: set_fact build final bluestore_wal_devices list
+  set_fact:
+    bluestore_wal_devices: "{{ bluestore_wal_devices | reject('search','/dev/disk') | list | unique }}"
+  when:
+    - bluestore_wal_devices is defined
+    - inventory_hostname in groups.get(osd_group_name, [])
+    - not osd_auto_discovery | default(False) | bool
+
 - name: set_fact devices generate device list when osd_auto_discovery
   set_fact:
     devices: "{{ (devices | default([]) + [ item.key | regex_replace('^', '/dev/') ]) | unique }}"


### PR DESCRIPTION
Just likve `devices`, this commit adds the support for linux device aliases for
`dedicated_devices` and `bluestore_wal_devices`.

Backports: #5584
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1919084

Signed-off-by: Tyler Bishop <tbishop@liquidweb.com>
(cherry picked from commit ee4b8804ae1260a84737b7db8de2e9d2eb3a5737)