### PR TITLE
ceph-facts: set rgw_instances_all fact once

### DIFF
--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -78,6 +78,7 @@
   set_fact:
     rgw_instances_all: '{{ rgw_instances_all | default([]) | union(hostvars[item]["rgw_instances_host"]) }}'
   with_items: "{{ groups.get(rgw_group_name, []) }}"
+  run_once: true
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])
     - hostvars[item]["rgw_multisite"] | default(False) | bool


### PR DESCRIPTION
There's no need to set the rgw_instances_all fact for each node. We can
rely on run_once for that one.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>