### PR TITLE
rgw/multisite: add endpoints key to zones list

### DIFF
--- a/roles/ceph-rgw/tasks/multisite/main.yml
+++ b/roles/ceph-rgw/tasks/multisite/main.yml
@@ -13,21 +13,15 @@
   loop: "{{ rgw_instances_all }}"
   when: item.rgw_zonegroupmaster | default(hostvars[item.host]['rgw_zonemaster']) | bool
 
-- name: create list zones
-  set_fact:
-    zones: "{{ zones | default([]) | union([{ 'realm': item.rgw_realm, 'zonegroup': item.rgw_zonegroup, 'zone': item.rgw_zone, 'is_master': item.rgw_zonemaster | default(hostvars[item.host]['rgw_zonemaster']), 'system_access_key': item.system_access_key, 'system_secret_key': item.system_secret_key }]) }}"
-  run_once: true
-  loop: "{{ rgw_instances_all }}"
-
 - name: create a list of dicts with each rgw endpoint and it's zone
   set_fact:
-    zone_endpoint_pairs: "{{ zone_endpoint_pairs | default([]) | union([{ 'endpoint': hostvars[item.host]['rgw_multisite_proto'] + '://' + item.radosgw_address + ':' + item.radosgw_frontend_port | string, 'rgw_zone': item.rgw_zone, 'rgw_realm': item.rgw_realm, 'rgw_zonegroup': item.rgw_zonegroup, 'rgw_zonemaster': item.rgw_zonemaster | default(hostvars[item.host]['rgw_zonemaster']) }]) }}"
+    zone_endpoint_pairs: "{{ zone_endpoint_pairs | default([]) | union([{ 'endpoint': hostvars[item.host]['rgw_multisite_proto'] + '://' + item.radosgw_address + ':' + item.radosgw_frontend_port | string, 'rgw_zone': item.rgw_zone, 'rgw_realm': item.rgw_realm, 'rgw_zonegroup': item.rgw_zonegroup, 'rgw_zonemaster': item.rgw_zonemaster | default(hostvars[item.host]['rgw_zonemaster']), 'system_access_key': item.system_access_key, 'system_secret_key': item.system_secret_key }]) }}"
   loop: "{{ rgw_instances_all }}"
   run_once: true
 
 - name: create a list of zones and all their endpoints
   set_fact:
-    zone_endpoints_list: "{{ zone_endpoints_list | default([]) | union([{'zone': item.rgw_zone, 'zonegroup': item.rgw_zonegroup, 'realm': item.rgw_realm, 'is_master': item.rgw_zonemaster, 'endpoints': ','.join(zone_endpoint_pairs | selectattr('rgw_zone','match','^'+item.rgw_zone+'$') | selectattr('rgw_realm','match','^'+item.rgw_realm+'$') | selectattr('rgw_zonegroup', 'match','^'+item.rgw_zonegroup+'$') | map(attribute='endpoint'))}]) }}"
+    zones: "{{ zones | default([]) | union([{'zone': item.rgw_zone, 'zonegroup': item.rgw_zonegroup, 'realm': item.rgw_realm, 'is_master': item.rgw_zonemaster, 'system_access_key': item.system_access_key, 'system_secret_key': item.system_secret_key, 'endpoints': ','.join(zone_endpoint_pairs | selectattr('rgw_zone','match','^'+item.rgw_zone+'$') | selectattr('rgw_realm','match','^'+item.rgw_realm+'$') | selectattr('rgw_zonegroup', 'match','^'+item.rgw_zonegroup+'$') | map(attribute='endpoint'))}]) }}"
   loop: "{{ zone_endpoint_pairs }}"
   run_once: true
 

--- a/roles/ceph-rgw/tasks/multisite/master.yml
+++ b/roles/ceph-rgw/tasks/multisite/master.yml
@@ -35,6 +35,7 @@
     zonegroup: "{{ item.zonegroup }}"
     access_key: "{{ item.system_access_key }}"
     secret_key: "{{ item.system_secret_key }}"
+    endpoints: "{{ item.endpoints.split(',') }}"
     default: "{{ true if zones | length == 1 else false }}"
     master: true
   delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -55,26 +56,9 @@
     endpoints: "{{ item.endpoints.split(',') }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
-  loop: "{{ zone_endpoints_list }}"
+  loop: "{{ zones }}"
   when:
-    - zone_endpoints_list is defined
-    - item.is_master | bool
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-
-- name: add endpoints to their zone(s)
-  radosgw_zone:
-    name: "{{ item.zone }}"
-    cluster: "{{ cluster }}"
-    realm: "{{ item.realm }}"
-    zonegroup: "{{ item.zonegroup }}"
-    endpoints: "{{ item.endpoints.split(',') }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  run_once: true
-  loop: "{{ zone_endpoints_list }}"
-  when:
-    - zone_endpoints_list is defined
+    - zones is defined
     - item.is_master | bool
   environment:
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
@@ -84,9 +68,9 @@
   command: "{{ container_exec_cmd }} radosgw-admin --cluster={{ cluster }} --rgw-realm={{ item.realm }} --rgw-zonegroup={{ item.zonegroup }} --rgw-zone={{ item.zone }} period update --commit"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
-  loop: "{{ zone_endpoints_list }}"
+  loop: "{{ zones }}"
   when:
-    - zone_endpoints_list is defined
+    - zones is defined
     - item.is_master | bool
 
 - name: include_tasks create_zone_user.yml

--- a/roles/ceph-rgw/tasks/multisite/secondary.yml
+++ b/roles/ceph-rgw/tasks/multisite/secondary.yml
@@ -42,6 +42,7 @@
     zonegroup: "{{ item.zonegroup }}"
     access_key: "{{ item.system_access_key }}"
     secret_key: "{{ item.system_secret_key }}"
+    endpoints: "{{ item.endpoints.split(',') }}"
     default: "{{ true if zones | length == 1 else false }}"
     master: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -54,28 +55,11 @@
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
-- name: add endpoints to their zone(s)
-  radosgw_zone:
-    name: "{{ item.zone }}"
-    cluster: "{{ cluster }}"
-    realm: "{{ item.realm }}"
-    zonegroup: "{{ item.zonegroup }}"
-    endpoints: "{{ item.endpoints.split(',') }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
-  run_once: true
-  loop: "{{ zone_endpoints_list }}"
-  when:
-    - zone_endpoints_list is defined
-    - not item.is_master | bool
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-
 - name: update period for zone creation
   command: "{{ container_exec_cmd }} radosgw-admin --cluster={{ cluster }} --rgw-realm={{ item.realm }} --rgw-zonegroup={{ item.zonegroup }} --rgw-zone={{ item.zone }} period update --commit"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
-  loop: "{{ zone_endpoints_list }}"
+  loop: "{{ zones }}"
   when:
-    - zone_endpoints_list is defined
+    - zones is defined
     - not item.is_master | bool


### PR DESCRIPTION
This removes the zone_endpoints_list fact since we can define it as the
zones fact to avoid duplicate facts and two calls to radosgw_zone module
(one with access/secret key and another one with the endpoints).
Now the endpoints key is merged into the zones definition so we can remove
the dedicated task which adds the endpoints to the zone.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>