### PR TITLE
library: add realm pull to radosgw_realm module

### DIFF
--- a/roles/ceph-rgw/tasks/multisite/secondary.yml
+++ b/roles/ceph-rgw/tasks/multisite/secondary.yml
@@ -13,11 +13,20 @@
   loop: "{{ rgw_instances }}"
 
 - name: fetch the realm(s)
-  command: "{{ container_exec_cmd }} radosgw-admin realm pull --cluster={{ cluster }} --rgw-realm={{ item.realm }} --url={{ item.endpoint }} --access-key={{ item.system_access_key }} --secret={{ item.system_secret_key }}"
+  radosgw_realm:
+    name: "{{ item.realm }}"
+    cluster: "{{ cluster }}"
+    url: "{{ item.endpoint }}"
+    access_key: "{{ item.system_access_key }}"
+    secret_key: "{{ item.system_secret_key }}"
+    state: pull
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   loop: "{{ secondary_realms }}"
   when: secondary_realms is defined
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: get the period(s)
   command: "{{ container_exec_cmd }} radosgw-admin period get --cluster={{ cluster }} --rgw-realm={{ item.realm }}"

--- a/tests/library/test_radosgw_realm.py
+++ b/tests/library/test_radosgw_realm.py
@@ -25,6 +25,9 @@ fake_realm = 'foo'
 fake_params = {'cluster': fake_cluster,
                'name': fake_realm,
                'default': True}
+fake_url = 'http://192.168.42.100:8080'
+fake_access_key = '8XQHmFxixz7LCM2AdM2p'
+fake_secret_key = 'XC8IhEPJprL6SrpaJDmolVs7jbOvoe2E3AaWKGRx'
 
 
 class TestRadosgwRealmModule(object):
@@ -103,3 +106,19 @@ class TestRadosgwRealmModule(object):
         ]
 
         assert radosgw_realm.remove_realm(fake_module) == expected_cmd
+
+    def test_pull_realm(self):
+        fake_module = MagicMock()
+        fake_params.update({'url': fake_url, 'access_key': fake_access_key, 'secret_key': fake_secret_key})
+        fake_module.params = fake_params
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'realm', 'pull',
+            '--rgw-realm=' + fake_realm,
+            '--url=' + fake_url,
+            '--access-key=' + fake_access_key,
+            '--secret=' + fake_secret_key
+        ]
+
+        assert radosgw_realm.pull_realm(fake_module) == expected_cmd


### PR DESCRIPTION
This adds the realm pull operation to the current `radosgw_realm` module.
The pull operation requires the url, access/secret key variables.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>