### PR TITLE
rgw: avoid useless call to ceph-rgw

### DIFF
--- a/roles/ceph-handler/tasks/main.yml
+++ b/roles/ceph-handler/tasks/main.yml
@@ -68,4 +68,10 @@
       import_role:
         name: ceph-rgw
         tasks_from: multisite.yml
-      when: rgw_multisite | bool
+      when:
+        - rgw_multisite | bool
+        - not multisite_called_from_handler_role | default(False) | bool
+
+    - name: set_fact multisite_called_from_handler_role
+      set_fact:
+        multisite_called_from_handler_role: true

--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -29,4 +29,6 @@
 
 - name: include_tasks multisite/main.yml
   include_tasks: multisite/main.yml
-  when: rgw_multisite | bool
+  when:
+    - rgw_multisite | bool
+    - not multisite_called_from_handler_role | default(False) | bool


### PR DESCRIPTION
since `ceph-rgw` may be called from `ceph-handler` in some contexts we
should avoid rerunning it unnecessarily.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>