### PR TITLE
update radosgw modules to consume ca_common from module_utils

### DIFF
--- a/library/ceph_crush_rule.py
+++ b/library/ceph_crush_rule.py
@@ -17,9 +17,9 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 try:
-    from ansible.module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized, exec_command
+    from ansible.module_utils.ca_common import exit_module, generate_cmd, is_containerized, exec_command
 except ImportError:
-    from module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized, exec_command
+    from module_utils.ca_common import exit_module, generate_cmd, is_containerized, exec_command
 import datetime
 import json
 
@@ -135,7 +135,7 @@ def create_rule(module, container_image=None):
         if profile:
             args.append(profile)
 
-    cmd = generate_ceph_cmd(['osd', 'crush', 'rule'], args, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(['osd', 'crush', 'rule'], args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -150,7 +150,7 @@ def get_rule(module, container_image=None):
 
     args = ['dump', name, '--format=json']
 
-    cmd = generate_ceph_cmd(['osd', 'crush', 'rule'], args, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(['osd', 'crush', 'rule'], args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -165,7 +165,7 @@ def remove_rule(module, container_image=None):
 
     args = ['rm', name]
 
-    cmd = generate_ceph_cmd(['osd', 'crush', 'rule'], args, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(['osd', 'crush', 'rule'], args, cluster=cluster, container_image=container_image)
 
     return cmd
 

--- a/library/ceph_dashboard_user.py
+++ b/library/ceph_dashboard_user.py
@@ -17,12 +17,12 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 try:
-    from ansible.module_utils.ca_common import generate_ceph_cmd, \
+    from ansible.module_utils.ca_common import generate_cmd, \
                                                is_containerized, \
                                                exec_command, \
                                                exit_module
 except ImportError:
-    from module_utils.ca_common import generate_ceph_cmd, is_containerized, exec_command, exit_module
+    from module_utils.ca_common import generate_cmd, is_containerized, exec_command, exit_module
 
 import datetime
 import json
@@ -122,7 +122,7 @@ def create_user(module, container_image=None):
 
     args = ['ac-user-create', '-i', '-',  name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image, interactive=True)
+    cmd = generate_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image, interactive=True)
 
     return cmd
 
@@ -140,7 +140,7 @@ def set_roles(module, container_image=None):
 
     args.extend(roles)
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -155,7 +155,7 @@ def set_password(module, container_image=None):
 
     args = ['ac-user-set-password', '-i', '-', name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image, interactive=True)
+    cmd = generate_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image, interactive=True)
 
     return cmd
 
@@ -170,7 +170,7 @@ def get_user(module, container_image=None):
 
     args = ['ac-user-show', name, '--format=json']
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -185,7 +185,7 @@ def remove_user(module, container_image=None):
 
     args = ['ac-user-delete', name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['dashboard'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 

--- a/library/ceph_ec_profile.py
+++ b/library/ceph_ec_profile.py
@@ -18,12 +18,12 @@ __metaclass__ = type
 from ansible.module_utils.basic import AnsibleModule
 try:
     from ansible.module_utils.ca_common import is_containerized, \
-                                               generate_ceph_cmd, \
+                                               generate_cmd, \
                                                exec_command, \
                                                exit_module
 except ImportError:
     from module_utils.ca_common import is_containerized, \
-                                            generate_ceph_cmd, \
+                                            generate_cmd, \
                                             exec_command, \
                                             exit_module
 import datetime
@@ -113,10 +113,10 @@ def get_profile(module, name, cluster='ceph', container_image=None):
 
     args = ['get', name, '--format=json']
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'erasure-code-profile'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -132,10 +132,10 @@ def create_profile(module, name, k, m, stripe_unit, cluster='ceph', force=False,
     if force:
         args.append('--force')
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'erasure-code-profile'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -147,10 +147,10 @@ def delete_profile(module, name, cluster='ceph', container_image=None):
 
     args = ['rm', name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'erasure-code-profile'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 

--- a/library/ceph_fs.py
+++ b/library/ceph_fs.py
@@ -19,12 +19,12 @@ from ansible.module_utils.basic import AnsibleModule
 try:
     from ansible.module_utils.ca_common import is_containerized, \
                                                exec_command, \
-                                               generate_ceph_cmd, \
+                                               generate_cmd, \
                                                exit_module
 except ImportError:
     from module_utils.ca_common import is_containerized, \
                                        exec_command, \
-                                       generate_ceph_cmd, \
+                                       generate_cmd, \
                                        exit_module
 
 import datetime
@@ -119,7 +119,7 @@ def create_fs(module, container_image=None):
 
     args = ['new', name, metadata, data]
 
-    cmd = generate_ceph_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -134,7 +134,7 @@ def get_fs(module, container_image=None):
 
     args = ['get', name, '--format=json']
 
-    cmd = generate_ceph_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -149,7 +149,7 @@ def remove_fs(module, container_image=None):
 
     args = ['rm', name, '--yes-i-really-mean-it']
 
-    cmd = generate_ceph_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -164,7 +164,7 @@ def fail_fs(module, container_image=None):
 
     args = ['fail', name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 
@@ -180,7 +180,7 @@ def set_fs(module, container_image=None):
 
     args = ['set', name, 'max_mds', str(max_mds)]
 
-    cmd = generate_ceph_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['fs'], args=args, cluster=cluster, container_image=container_image)
 
     return cmd
 

--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -250,7 +250,7 @@ def generate_caps(_type, caps):
     return caps_cli
 
 
-def generate_ceph_cmd(cluster, args, user, user_key_path, container_image=None):
+def generate_cmd(cluster, args, user, user_key_path, container_image=None):
     '''
     Generate 'ceph' command line to execute
     '''
@@ -326,7 +326,7 @@ def create_key(module, result, cluster, user, user_key_path, name, secret, caps,
         cluster, name, secret, caps, dest, container_image))
 
     if import_key or user != 'client.admin':
-        cmd_list.append(generate_ceph_cmd(
+        cmd_list.append(generate_cmd(
             cluster, args, user, user_key_path, container_image))
 
     return cmd_list
@@ -344,7 +344,7 @@ def delete_key(cluster, user, user_key_path, name, container_image=None):
         name,
     ]
 
-    cmd_list.append(generate_ceph_cmd(
+    cmd_list.append(generate_cmd(
         cluster, args, user, user_key_path, container_image))
 
     return cmd_list
@@ -364,7 +364,7 @@ def get_key(cluster, user, user_key_path, name, dest, container_image=None):
         dest,
     ]
 
-    cmd_list.append(generate_ceph_cmd(
+    cmd_list.append(generate_cmd(
         cluster, args, user, user_key_path, container_image))
 
     return cmd_list
@@ -384,7 +384,7 @@ def info_key(cluster, name, user, user_key_path, output_format, container_image=
         output_format,
     ]
 
-    cmd_list.append(generate_ceph_cmd(
+    cmd_list.append(generate_cmd(
         cluster, args, user, user_key_path, container_image))
 
     return cmd_list
@@ -403,7 +403,7 @@ def list_keys(cluster, user, user_key_path, container_image=None):
         'json',
     ]
 
-    cmd_list.append(generate_ceph_cmd(
+    cmd_list.append(generate_cmd(
         cluster, args, user, user_key_path, container_image))
 
     return cmd_list

--- a/library/ceph_mgr_module.py
+++ b/library/ceph_mgr_module.py
@@ -17,9 +17,9 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 try:
-    from ansible.module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized
+    from ansible.module_utils.ca_common import exit_module, generate_cmd, is_containerized
 except ImportError:
-    from module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized
+    from module_utils.ca_common import exit_module, generate_cmd, is_containerized
 import datetime
 
 
@@ -93,7 +93,7 @@ def main():
 
     container_image = is_containerized()
 
-    cmd = generate_ceph_cmd(['mgr', 'module'], [state, name], cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(['mgr', 'module'], [state, name], cluster=cluster, container_image=container_image)
 
     if module.check_mode:
         exit_module(

--- a/library/ceph_osd.py
+++ b/library/ceph_osd.py
@@ -17,9 +17,9 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 try:
-    from ansible.module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized
+    from ansible.module_utils.ca_common import exit_module, generate_cmd, is_containerized
 except ImportError:
-    from module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized
+    from module_utils.ca_common import exit_module, generate_cmd, is_containerized
 import datetime
 
 
@@ -111,7 +111,7 @@ def main():
 
     container_image = is_containerized()
 
-    cmd = generate_ceph_cmd(['osd', state], ids, cluster=cluster, container_image=container_image)
+    cmd = generate_cmd(['osd', state], ids, cluster=cluster, container_image=container_image)
 
     if state in ['destroy', 'purge']:
         cmd.append('--yes-i-really-mean-it')

--- a/library/ceph_osd_flag.py
+++ b/library/ceph_osd_flag.py
@@ -17,9 +17,9 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 try:
-    from ansible.module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized
+    from ansible.module_utils.ca_common import exit_module, generate_cmd, is_containerized
 except ImportError:
-    from module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized
+    from module_utils.ca_common import exit_module, generate_cmd, is_containerized
 import datetime
 
 
@@ -94,9 +94,9 @@ def main():
     container_image = is_containerized()
 
     if state == 'present':
-        cmd = generate_ceph_cmd(['osd', 'set'], [name], cluster=cluster, container_image=container_image)
+        cmd = generate_cmd(['osd', 'set'], [name], cluster=cluster, container_image=container_image)
     else:
-        cmd = generate_ceph_cmd(['osd', 'unset'], [name], cluster=cluster, container_image=container_image)
+        cmd = generate_cmd(['osd', 'unset'], [name], cluster=cluster, container_image=container_image)
 
     if module.check_mode:
         exit_module(

--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -19,12 +19,12 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 try:
-    from ansible.module_utils.ca_common import generate_ceph_cmd, \
+    from ansible.module_utils.ca_common import generate_cmd, \
                                                is_containerized, \
                                                exec_command, \
                                                exit_module
 except ImportError:
-    from module_utils.ca_common import generate_ceph_cmd, \
+    from module_utils.ca_common import generate_cmd, \
                                        is_containerized, \
                                        exec_command, \
                                        exit_module
@@ -165,12 +165,12 @@ def check_pool_exist(cluster,
 
     args = ['stats', name, '-f', output_format]
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -183,12 +183,12 @@ def generate_get_config_cmd(param,
 
     args = ['get', 'mon.*', param]
 
-    cmd = generate_ceph_cmd(sub_cmd=['config'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['config'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -205,12 +205,12 @@ def get_application_pool(cluster,
 
     args = ['application', 'get', name, '-f', output_format]
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -227,12 +227,12 @@ def enable_application_pool(cluster,
 
     args = ['application', 'enable', name, application]
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -250,12 +250,12 @@ def disable_application_pool(cluster,
     args = ['application', 'disable', name,
             application, '--yes-i-really-mean-it']
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -273,12 +273,12 @@ def get_pool_details(module,
 
     args = ['ls', 'detail', '-f', output_format]
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     rc, cmd, out, err = exec_command(module, cmd)
 
@@ -361,12 +361,12 @@ def list_pools(cluster,
 
     args.extend(['-f', output_format])
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -415,12 +415,12 @@ def create_pool(cluster,
                      '--autoscale-mode',
                      user_pool_config['pg_autoscale_mode']['value']])
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -432,12 +432,12 @@ def remove_pool(cluster, name, user, user_key, container_image=None):
 
     args = ['rm', name, name, '--yes-i-really-really-mean-it']
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -457,12 +457,12 @@ def update_pool(module, cluster, name,
                     delta[key]['cli_set_opt'],
                     delta[key]['value']]
 
-            cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                                    args=args,
-                                    cluster=cluster,
-                                    user=user,
-                                    user_key=user_key,
-                                    container_image=container_image)
+            cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                               args=args,
+                               cluster=cluster,
+                               user=user,
+                               user_key=user_key,
+                               container_image=container_image)
 
             rc, cmd, out, err = exec_command(module, cmd)
             if rc != 0:

--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -20,13 +20,11 @@ __metaclass__ = type
 from ansible.module_utils.basic import AnsibleModule
 try:
     from ansible.module_utils.ca_common import generate_ceph_cmd, \
-                                               pre_generate_ceph_cmd, \
                                                is_containerized, \
                                                exec_command, \
                                                exit_module
 except ImportError:
     from module_utils.ca_common import generate_ceph_cmd, \
-                                       pre_generate_ceph_cmd, \
                                        is_containerized, \
                                        exec_command, \
                                        exit_module
@@ -182,20 +180,16 @@ def generate_get_config_cmd(param,
                             user,
                             user_key,
                             container_image=None):
-    _cmd = pre_generate_ceph_cmd(container_image=container_image)
-    args = [
-        '-n',
-        user,
-        '-k',
-        user_key,
-        '--cluster',
-        cluster,
-        'config',
-        'get',
-        'mon.*',
-        param
-    ]
-    cmd = _cmd + args
+
+    args = ['get', 'mon.*', param]
+
+    cmd = generate_ceph_cmd(sub_cmd=['config'],
+                            args=args,
+                            cluster=cluster,
+                            user=user,
+                            user_key=user_key,
+                            container_image=container_image)
+
     return cmd
 
 

--- a/library/radosgw_realm.py
+++ b/library/radosgw_realm.py
@@ -16,8 +16,11 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible.module_utils.ca_common import exec_command, exit_module, generate_cmd, is_containerized
+except ImportError:
+    from module_utils.ca_common import exec_command, exit_module, generate_cmd, is_containerized
 import datetime
-import os
 
 
 ANSIBLE_METADATA = {
@@ -86,76 +89,6 @@ EXAMPLES = '''
 RETURN = '''#  '''
 
 
-def container_exec(binary, container_image):
-    '''
-    Build the docker CLI to run a command inside a container
-    '''
-
-    container_binary = os.getenv('CEPH_CONTAINER_BINARY')
-    command_exec = [container_binary,
-                    'run',
-                    '--rm',
-                    '--net=host',
-                    '-v', '/etc/ceph:/etc/ceph:z',
-                    '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
-                    '-v', '/var/log/ceph/:/var/log/ceph/:z',
-                    '--entrypoint=' + binary, container_image]
-    return command_exec
-
-
-def is_containerized():
-    '''
-    Check if we are running on a containerized cluster
-    '''
-
-    if 'CEPH_CONTAINER_IMAGE' in os.environ:
-        container_image = os.getenv('CEPH_CONTAINER_IMAGE')
-    else:
-        container_image = None
-
-    return container_image
-
-
-def pre_generate_radosgw_cmd(container_image=None):
-    '''
-    Generate radosgw-admin prefix comaand
-    '''
-    if container_image:
-        cmd = container_exec('radosgw-admin', container_image)
-    else:
-        cmd = ['radosgw-admin']
-
-    return cmd
-
-
-def generate_radosgw_cmd(cluster, args, container_image=None):
-    '''
-    Generate 'radosgw' command line to execute
-    '''
-
-    cmd = pre_generate_radosgw_cmd(container_image=container_image)
-
-    base_cmd = [
-        '--cluster',
-        cluster,
-        'realm'
-    ]
-
-    cmd.extend(base_cmd + args)
-
-    return cmd
-
-
-def exec_commands(module, cmd):
-    '''
-    Execute command(s)
-    '''
-
-    rc, out, err = module.run_command(cmd)
-
-    return rc, cmd, out, err
-
-
 def create_realm(module, container_image=None):
     '''
     Create a new realm
@@ -170,7 +103,7 @@ def create_realm(module, container_image=None):
     if default:
         args.append('--default')
 
-    cmd = generate_radosgw_cmd(cluster=cluster, args=args, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['realm'], binary='radosgw-admin', cluster=cluster, args=args, container_image=container_image)
 
     return cmd
 
@@ -185,7 +118,7 @@ def get_realm(module, container_image=None):
 
     args = ['get', '--rgw-realm=' + name, '--format=json']
 
-    cmd = generate_radosgw_cmd(cluster=cluster, args=args, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['realm'], binary='radosgw-admin', cluster=cluster, args=args, container_image=container_image)
 
     return cmd
 
@@ -200,26 +133,9 @@ def remove_realm(module, container_image=None):
 
     args = ['delete', '--rgw-realm=' + name]
 
-    cmd = generate_radosgw_cmd(cluster=cluster, args=args, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['realm'], binary='radosgw-admin', cluster=cluster, args=args, container_image=container_image)
 
     return cmd
-
-
-def exit_module(module, out, rc, cmd, err, startd, changed=False):
-    endd = datetime.datetime.now()
-    delta = endd - startd
-
-    result = dict(
-        cmd=cmd,
-        start=str(startd),
-        end=str(endd),
-        delta=str(delta),
-        rc=rc,
-        stdout=out.rstrip("\r\n"),
-        stderr=err.rstrip("\r\n"),
-        changed=changed,
-    )
-    module.exit_json(**result)
 
 
 def run_module():
@@ -257,22 +173,22 @@ def run_module():
     container_image = is_containerized()
 
     if state == "present":
-        rc, cmd, out, err = exec_commands(module, get_realm(module, container_image=container_image))
+        rc, cmd, out, err = exec_command(module, get_realm(module, container_image=container_image))
         if rc != 0:
-            rc, cmd, out, err = exec_commands(module, create_realm(module, container_image=container_image))
+            rc, cmd, out, err = exec_command(module, create_realm(module, container_image=container_image))
             changed = True
 
     elif state == "absent":
-        rc, cmd, out, err = exec_commands(module, get_realm(module, container_image=container_image))
+        rc, cmd, out, err = exec_command(module, get_realm(module, container_image=container_image))
         if rc == 0:
-            rc, cmd, out, err = exec_commands(module, remove_realm(module, container_image=container_image))
+            rc, cmd, out, err = exec_command(module, remove_realm(module, container_image=container_image))
             changed = True
         else:
             rc = 0
             out = "Realm {} doesn't exist".format(name)
 
     elif state == "info":
-        rc, cmd, out, err = exec_commands(module, get_realm(module, container_image=container_image))
+        rc, cmd, out, err = exec_command(module, get_realm(module, container_image=container_image))
 
     exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=changed)
 

--- a/library/radosgw_user.py
+++ b/library/radosgw_user.py
@@ -16,9 +16,12 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible.module_utils.ca_common import exec_command, exit_module, generate_cmd, is_containerized
+except ImportError:
+    from module_utils.ca_common import exec_command, exit_module, generate_cmd, is_containerized
 import datetime
 import json
-import os
 
 
 ANSIBLE_METADATA = {
@@ -135,76 +138,6 @@ EXAMPLES = '''
 RETURN = '''#  '''
 
 
-def container_exec(binary, container_image):
-    '''
-    Build the docker CLI to run a command inside a container
-    '''
-
-    container_binary = os.getenv('CEPH_CONTAINER_BINARY')
-    command_exec = [container_binary,
-                    'run',
-                    '--rm',
-                    '--net=host',
-                    '-v', '/etc/ceph:/etc/ceph:z',
-                    '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
-                    '-v', '/var/log/ceph/:/var/log/ceph/:z',
-                    '--entrypoint=' + binary, container_image]
-    return command_exec
-
-
-def is_containerized():
-    '''
-    Check if we are running on a containerized cluster
-    '''
-
-    if 'CEPH_CONTAINER_IMAGE' in os.environ:
-        container_image = os.getenv('CEPH_CONTAINER_IMAGE')
-    else:
-        container_image = None
-
-    return container_image
-
-
-def pre_generate_radosgw_cmd(container_image=None):
-    '''
-    Generate radosgw-admin prefix comaand
-    '''
-    if container_image:
-        cmd = container_exec('radosgw-admin', container_image)
-    else:
-        cmd = ['radosgw-admin']
-
-    return cmd
-
-
-def generate_radosgw_cmd(cluster, args, container_image=None):
-    '''
-    Generate 'radosgw' command line to execute
-    '''
-
-    cmd = pre_generate_radosgw_cmd(container_image=container_image)
-
-    base_cmd = [
-        '--cluster',
-        cluster,
-        'user'
-    ]
-
-    cmd.extend(base_cmd + args)
-
-    return cmd
-
-
-def exec_commands(module, cmd):
-    '''
-    Execute command(s)
-    '''
-
-    rc, out, err = module.run_command(cmd)
-
-    return rc, cmd, out, err
-
-
 def create_user(module, container_image=None):
     '''
     Create a new user
@@ -250,7 +183,7 @@ def create_user(module, container_image=None):
     if admin:
         args.append('--admin')
 
-    cmd = generate_radosgw_cmd(cluster=cluster, args=args, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['user'], binary='radosgw-admin', cluster=cluster, args=args, container_image=container_image)
 
     return cmd
 
@@ -303,7 +236,7 @@ def modify_user(module, container_image=None):
     if admin:
         args.append('--admin')
 
-    cmd = generate_radosgw_cmd(cluster=cluster, args=args, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['user'], binary='radosgw-admin', cluster=cluster, args=args, container_image=container_image)
 
     return cmd
 
@@ -330,9 +263,7 @@ def get_user(module, container_image=None):
     if zone:
         args.extend(['--rgw-zone=' + zone])
 
-    cmd = generate_radosgw_cmd(cluster=cluster,
-                               args=args,
-                               container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['user'], binary='radosgw-admin', cluster=cluster, args=args, container_image=container_image)
 
     return cmd
 
@@ -359,26 +290,9 @@ def remove_user(module, container_image=None):
     if zone:
         args.extend(['--rgw-zone=' + zone])
 
-    cmd = generate_radosgw_cmd(cluster=cluster, args=args, container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['user'], binary='radosgw-admin', cluster=cluster, args=args, container_image=container_image)
 
     return cmd
-
-
-def exit_module(module, out, rc, cmd, err, startd, changed=False):
-    endd = datetime.datetime.now()
-    delta = endd - startd
-
-    result = dict(
-        cmd=cmd,
-        start=str(startd),
-        end=str(endd),
-        delta=str(delta),
-        rc=rc,
-        stdout=out.rstrip("\r\n"),
-        stderr=err.rstrip("\r\n"),
-        changed=changed,
-    )
-    module.exit_json(**result)
 
 
 def run_module():
@@ -432,7 +346,7 @@ def run_module():
     container_image = is_containerized()
 
     if state == "present":
-        rc, cmd, out, err = exec_commands(module, get_user(module, container_image=container_image))
+        rc, cmd, out, err = exec_command(module, get_user(module, container_image=container_image))
         if rc == 0:
             user = json.loads(out)
             current = {
@@ -456,23 +370,23 @@ def run_module():
                 asked['secret_key'] = secret_key
 
             if current != asked:
-                rc, cmd, out, err = exec_commands(module, modify_user(module, container_image=container_image))
+                rc, cmd, out, err = exec_command(module, modify_user(module, container_image=container_image))
                 changed = True
         else:
-            rc, cmd, out, err = exec_commands(module, create_user(module, container_image=container_image))
+            rc, cmd, out, err = exec_command(module, create_user(module, container_image=container_image))
             changed = True
 
     elif state == "absent":
-        rc, cmd, out, err = exec_commands(module, get_user(module, container_image=container_image))
+        rc, cmd, out, err = exec_command(module, get_user(module, container_image=container_image))
         if rc == 0:
-            rc, cmd, out, err = exec_commands(module, remove_user(module, container_image=container_image))
+            rc, cmd, out, err = exec_command(module, remove_user(module, container_image=container_image))
             changed = True
         else:
             rc = 0
             out = "User {} doesn't exist".format(name)
 
     elif state == "info":
-        rc, cmd, out, err = exec_commands(module, get_user(module, container_image=container_image))
+        rc, cmd, out, err = exec_command(module, get_user(module, container_image=container_image))
 
     exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=changed)
 

--- a/module_utils/ca_common.py
+++ b/module_utils/ca_common.py
@@ -2,7 +2,7 @@ import os
 import datetime
 
 
-def generate_ceph_cmd(sub_cmd, args, user_key=None, cluster='ceph', user='client.admin', container_image=None, interactive=False):
+def generate_cmd(sub_cmd, args, binary='ceph', user_key=None, cluster='ceph', user='client.admin', container_image=None, interactive=False):
     '''
     Generate 'ceph' command line to execute
     '''
@@ -11,9 +11,9 @@ def generate_ceph_cmd(sub_cmd, args, user_key=None, cluster='ceph', user='client
         user_key = '/etc/ceph/{}.{}.keyring'.format(cluster, user)
 
     if container_image:
-        cmd = container_exec('ceph', container_image, interactive=interactive)
+        cmd = container_exec(binary, container_image, interactive=interactive)
     else:
-        cmd = ['ceph']
+        cmd = [binary]
 
     base_cmd = [
         '-n',

--- a/module_utils/ca_common.py
+++ b/module_utils/ca_common.py
@@ -10,7 +10,10 @@ def generate_ceph_cmd(sub_cmd, args, user_key=None, cluster='ceph', user='client
     if not user_key:
         user_key = '/etc/ceph/{}.{}.keyring'.format(cluster, user)
 
-    cmd = pre_generate_ceph_cmd(container_image=container_image, interactive=interactive)
+    if container_image:
+        cmd = container_exec('ceph', container_image, interactive=interactive)
+    else:
+        cmd = ['ceph']
 
     base_cmd = [
         '-n',
@@ -57,18 +60,6 @@ def is_containerized():
         container_image = None
 
     return container_image
-
-
-def pre_generate_ceph_cmd(container_image=None, interactive=False):
-    '''
-    Generate ceph prefix comaand
-    '''
-    if container_image:
-        cmd = container_exec('ceph', container_image, interactive=interactive)
-    else:
-        cmd = ['ceph']
-
-    return cmd
 
 
 def exec_command(module, cmd, stdin=None):

--- a/tests/library/test_ceph_key.py
+++ b/tests/library/test_ceph_key.py
@@ -46,7 +46,7 @@ class TestCephKeyModule(object):
         result = ceph_key.generate_caps(fake_type, fake_caps)
         assert result == expected_command_list
 
-    def test_generate_ceph_cmd_list_non_container(self):
+    def test_generate_cmd_list_non_container(self):
         fake_cluster = "fake"
         fake_args = ['arg']
         fake_user = "fake-user"
@@ -62,11 +62,11 @@ class TestCephKeyModule(object):
             'auth',
             'arg'
         ]
-        result = ceph_key.generate_ceph_cmd(
+        result = ceph_key.generate_cmd(
             fake_cluster, fake_args, fake_user, fake_key)
         assert result == expected_command_list
 
-    def test_generate_ceph_cmd_list_container(self):
+    def test_generate_cmd_list_container(self):
         fake_cluster = "fake"
         fake_args = ['arg']
         fake_user = "fake-user"
@@ -89,7 +89,7 @@ class TestCephKeyModule(object):
                                  fake_cluster,
                                  'auth',
                                  'arg']
-        result = ceph_key.generate_ceph_cmd(
+        result = ceph_key.generate_cmd(
             fake_cluster, fake_args, fake_user, fake_key, fake_container_image)
         assert result == expected_command_list
 

--- a/tests/library/test_radosgw_realm.py
+++ b/tests/library/test_radosgw_realm.py
@@ -1,9 +1,5 @@
-import os
-import sys
-from mock.mock import patch, MagicMock
-import pytest
-sys.path.append('./library')
-import radosgw_realm  # noqa: E402
+from mock.mock import MagicMock
+import radosgw_realm
 
 
 fake_binary = 'radosgw-admin'
@@ -25,52 +21,18 @@ fake_realm = 'foo'
 fake_params = {'cluster': fake_cluster,
                'name': fake_realm,
                'default': True}
+fake_admin = 'client.admin'
+fake_keyring = '/etc/ceph/{}.{}.keyring'.format(fake_cluster, fake_admin)
 
 
 class TestRadosgwRealmModule(object):
-
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_container_exec(self):
-        cmd = radosgw_realm.container_exec(fake_binary, fake_container_image)
-        assert cmd == fake_container_cmd
-
-    def test_not_is_containerized(self):
-        assert radosgw_realm.is_containerized() is None
-
-    @patch.dict(os.environ, {'CEPH_CONTAINER_IMAGE': fake_container_image})
-    def test_is_containerized(self):
-        assert radosgw_realm.is_containerized() == fake_container_image
-
-    @pytest.mark.parametrize('image', [None, fake_container_image])
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_pre_generate_radosgw_cmd(self, image):
-        if image:
-            expected_cmd = fake_container_cmd
-        else:
-            expected_cmd = [fake_binary]
-
-        assert radosgw_realm.pre_generate_radosgw_cmd(image) == expected_cmd
-
-    @pytest.mark.parametrize('image', [None, fake_container_image])
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_radosgw_cmd(self, image):
-        if image:
-            expected_cmd = fake_container_cmd
-        else:
-            expected_cmd = [fake_binary]
-
-        expected_cmd.extend([
-            '--cluster',
-            fake_cluster,
-            'realm'
-        ])
-        assert radosgw_realm.generate_radosgw_cmd(fake_cluster, [], image) == expected_cmd
 
     def test_create_realm(self):
         fake_module = MagicMock()
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'realm', 'create',
             '--rgw-realm=' + fake_realm,
@@ -84,6 +46,7 @@ class TestRadosgwRealmModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'realm', 'get',
             '--rgw-realm=' + fake_realm,
@@ -97,6 +60,7 @@ class TestRadosgwRealmModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'realm', 'delete',
             '--rgw-realm=' + fake_realm

--- a/tests/library/test_radosgw_user.py
+++ b/tests/library/test_radosgw_user.py
@@ -1,9 +1,5 @@
-import os
-import sys
-from mock.mock import patch, MagicMock
-import pytest
-sys.path.append('./library')
-import radosgw_user  # noqa: E402
+from mock.mock import MagicMock
+import radosgw_user
 
 
 fake_binary = 'radosgw-admin'
@@ -36,52 +32,18 @@ fake_params = {'cluster': fake_cluster,
                'zone': fake_zone,
                'system': True,
                'admin': True}
+fake_admin = 'client.admin'
+fake_keyring = '/etc/ceph/{}.{}.keyring'.format(fake_cluster, fake_admin)
 
 
 class TestRadosgwUserModule(object):
-
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_container_exec(self):
-        cmd = radosgw_user.container_exec(fake_binary, fake_container_image)
-        assert cmd == fake_container_cmd
-
-    def test_not_is_containerized(self):
-        assert radosgw_user.is_containerized() is None
-
-    @patch.dict(os.environ, {'CEPH_CONTAINER_IMAGE': fake_container_image})
-    def test_is_containerized(self):
-        assert radosgw_user.is_containerized() == fake_container_image
-
-    @pytest.mark.parametrize('image', [None, fake_container_image])
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_pre_generate_radosgw_cmd(self, image):
-        if image:
-            expected_cmd = fake_container_cmd
-        else:
-            expected_cmd = [fake_binary]
-
-        assert radosgw_user.pre_generate_radosgw_cmd(image) == expected_cmd
-
-    @pytest.mark.parametrize('image', [None, fake_container_image])
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_radosgw_cmd(self, image):
-        if image:
-            expected_cmd = fake_container_cmd
-        else:
-            expected_cmd = [fake_binary]
-
-        expected_cmd.extend([
-            '--cluster',
-            fake_cluster,
-            'user'
-        ])
-        assert radosgw_user.generate_radosgw_cmd(fake_cluster, [], image) == expected_cmd
 
     def test_create_user(self):
         fake_module = MagicMock()
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'user', 'create',
             '--uid=' + fake_user,
@@ -103,6 +65,7 @@ class TestRadosgwUserModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'user', 'modify',
             '--uid=' + fake_user,
@@ -124,6 +87,7 @@ class TestRadosgwUserModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'user', 'info',
             '--uid=' + fake_user,
@@ -140,6 +104,7 @@ class TestRadosgwUserModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'user', 'rm',
             '--uid=' + fake_user,

--- a/tests/library/test_radosgw_zone.py
+++ b/tests/library/test_radosgw_zone.py
@@ -1,9 +1,5 @@
-import os
-import sys
-from mock.mock import patch, MagicMock
-import pytest
-sys.path.append('./library')
-import radosgw_zone  # noqa: E402
+from mock.mock import MagicMock
+import radosgw_zone
 
 
 fake_binary = 'radosgw-admin'
@@ -32,52 +28,18 @@ fake_params = {'cluster': fake_cluster,
                'endpoints': fake_endpoints,
                'default': True,
                'master': True}
+fake_admin = 'client.admin'
+fake_keyring = '/etc/ceph/{}.{}.keyring'.format(fake_cluster, fake_admin)
 
 
 class TestRadosgwZoneModule(object):
-
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_container_exec(self):
-        cmd = radosgw_zone.container_exec(fake_binary, fake_container_image)
-        assert cmd == fake_container_cmd
-
-    def test_not_is_containerized(self):
-        assert radosgw_zone.is_containerized() is None
-
-    @patch.dict(os.environ, {'CEPH_CONTAINER_IMAGE': fake_container_image})
-    def test_is_containerized(self):
-        assert radosgw_zone.is_containerized() == fake_container_image
-
-    @pytest.mark.parametrize('image', [None, fake_container_image])
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_pre_generate_radosgw_cmd(self, image):
-        if image:
-            expected_cmd = fake_container_cmd
-        else:
-            expected_cmd = [fake_binary]
-
-        assert radosgw_zone.pre_generate_radosgw_cmd(image) == expected_cmd
-
-    @pytest.mark.parametrize('image', [None, fake_container_image])
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_radosgw_cmd(self, image):
-        if image:
-            expected_cmd = fake_container_cmd
-        else:
-            expected_cmd = [fake_binary]
-
-        expected_cmd.extend([
-            '--cluster',
-            fake_cluster,
-            'zone'
-        ])
-        assert radosgw_zone.generate_radosgw_cmd(fake_cluster, [], image) == expected_cmd
 
     def test_create_zone(self):
         fake_module = MagicMock()
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'zone', 'create',
             '--rgw-realm=' + fake_realm,
@@ -95,6 +57,7 @@ class TestRadosgwZoneModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'zone', 'modify',
             '--rgw-realm=' + fake_realm,
@@ -112,6 +75,7 @@ class TestRadosgwZoneModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'zone', 'get',
             '--rgw-realm=' + fake_realm,
@@ -127,6 +91,7 @@ class TestRadosgwZoneModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'zonegroup', 'get',
             '--rgw-realm=' + fake_realm,
@@ -141,6 +106,7 @@ class TestRadosgwZoneModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'realm', 'get',
             '--rgw-realm=' + fake_realm,
@@ -154,6 +120,7 @@ class TestRadosgwZoneModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'zone', 'delete',
             '--rgw-realm=' + fake_realm,

--- a/tests/library/test_radosgw_zonegroup.py
+++ b/tests/library/test_radosgw_zonegroup.py
@@ -1,9 +1,5 @@
-import os
-import sys
-from mock.mock import patch, MagicMock
-import pytest
-sys.path.append('./library')
-import radosgw_zonegroup  # noqa: E402
+from mock.mock import MagicMock
+import radosgw_zonegroup
 
 
 fake_binary = 'radosgw-admin'
@@ -30,52 +26,18 @@ fake_params = {'cluster': fake_cluster,
                'endpoints': fake_endpoints,
                'default': True,
                'master': True}
+fake_admin = 'client.admin'
+fake_keyring = '/etc/ceph/{}.{}.keyring'.format(fake_cluster, fake_admin)
 
 
 class TestRadosgwZonegroupModule(object):
-
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_container_exec(self):
-        cmd = radosgw_zonegroup.container_exec(fake_binary, fake_container_image)
-        assert cmd == fake_container_cmd
-
-    def test_not_is_containerized(self):
-        assert radosgw_zonegroup.is_containerized() is None
-
-    @patch.dict(os.environ, {'CEPH_CONTAINER_IMAGE': fake_container_image})
-    def test_is_containerized(self):
-        assert radosgw_zonegroup.is_containerized() == fake_container_image
-
-    @pytest.mark.parametrize('image', [None, fake_container_image])
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_pre_generate_radosgw_cmd(self, image):
-        if image:
-            expected_cmd = fake_container_cmd
-        else:
-            expected_cmd = [fake_binary]
-
-        assert radosgw_zonegroup.pre_generate_radosgw_cmd(image) == expected_cmd
-
-    @pytest.mark.parametrize('image', [None, fake_container_image])
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_radosgw_cmd(self, image):
-        if image:
-            expected_cmd = fake_container_cmd
-        else:
-            expected_cmd = [fake_binary]
-
-        expected_cmd.extend([
-            '--cluster',
-            fake_cluster,
-            'zonegroup'
-        ])
-        assert radosgw_zonegroup.generate_radosgw_cmd(fake_cluster, [], image) == expected_cmd
 
     def test_create_zonegroup(self):
         fake_module = MagicMock()
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'zonegroup', 'create',
             '--rgw-realm=' + fake_realm,
@@ -92,6 +54,7 @@ class TestRadosgwZonegroupModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'zonegroup', 'modify',
             '--rgw-realm=' + fake_realm,
@@ -108,6 +71,7 @@ class TestRadosgwZonegroupModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'zonegroup', 'get',
             '--rgw-realm=' + fake_realm,
@@ -122,6 +86,7 @@ class TestRadosgwZonegroupModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'realm', 'get',
             '--rgw-realm=' + fake_realm,
@@ -135,6 +100,7 @@ class TestRadosgwZonegroupModule(object):
         fake_module.params = fake_params
         expected_cmd = [
             fake_binary,
+            '-n', fake_admin, '-k', fake_keyring,
             '--cluster', fake_cluster,
             'zonegroup', 'delete',
             '--rgw-realm=' + fake_realm,

--- a/tests/module_utils/test_ca_common.py
+++ b/tests/module_utils/test_ca_common.py
@@ -38,16 +38,6 @@ class TestCommon(object):
 
     @pytest.mark.parametrize('image', [None, fake_container_image])
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_pre_generate_ceph_cmd(self, image):
-        if image:
-            expected_cmd = self.fake_container_cmd
-        else:
-            expected_cmd = [self.fake_binary]
-
-        assert ca_common.pre_generate_ceph_cmd(image) == expected_cmd
-
-    @pytest.mark.parametrize('image', [None, fake_container_image])
-    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
     def test_generate_ceph_cmd(self, image):
         sub_cmd = ['osd', 'pool']
         args = ['create', 'foo']

--- a/tests/module_utils/test_ca_common.py
+++ b/tests/module_utils/test_ca_common.py
@@ -38,7 +38,7 @@ class TestCommon(object):
 
     @pytest.mark.parametrize('image', [None, fake_container_image])
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_ceph_cmd(self, image):
+    def test_generate_cmd(self, image):
         sub_cmd = ['osd', 'pool']
         args = ['create', 'foo']
         if image:
@@ -54,11 +54,11 @@ class TestCommon(object):
             'osd', 'pool',
             'create', 'foo'
         ])
-        assert ca_common.generate_ceph_cmd(sub_cmd, args, cluster=self.fake_cluster, container_image=image) == expected_cmd
+        assert ca_common.generate_cmd(sub_cmd, args, cluster=self.fake_cluster, container_image=image) == expected_cmd
 
     @pytest.mark.parametrize('image', [None, fake_container_image])
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_ceph_cmd_different_cluster_name(self, image):
+    def test_generate_cmd_different_cluster_name(self, image):
         sub_cmd = ['osd', 'pool']
         args = ['create', 'foo']
         if image:
@@ -74,12 +74,12 @@ class TestCommon(object):
             'osd', 'pool',
             'create', 'foo'
         ])
-        result = ca_common.generate_ceph_cmd(sub_cmd, args, cluster='foo', container_image=image)
+        result = ca_common.generate_cmd(sub_cmd, args, cluster='foo', container_image=image)
         assert result == expected_cmd
 
     @pytest.mark.parametrize('image', [None, fake_container_image])
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_ceph_cmd_different_cluster_name_and_user(self, image):
+    def test_generate_cmd_different_cluster_name_and_user(self, image):
         sub_cmd = ['osd', 'pool']
         args = ['create', 'foo']
         if image:
@@ -95,12 +95,12 @@ class TestCommon(object):
             'osd', 'pool',
             'create', 'foo'
         ])
-        result = ca_common.generate_ceph_cmd(sub_cmd, args, cluster='foo', user='client.foo', container_image=image)
+        result = ca_common.generate_cmd(sub_cmd, args, cluster='foo', user='client.foo', container_image=image)
         assert result == expected_cmd
 
     @pytest.mark.parametrize('image', [None, fake_container_image])
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_ceph_cmd_different_user(self, image):
+    def test_generate_cmd_different_user(self, image):
         sub_cmd = ['osd', 'pool']
         args = ['create', 'foo']
         if image:
@@ -116,7 +116,7 @@ class TestCommon(object):
             'osd', 'pool',
             'create', 'foo'
         ])
-        result = ca_common.generate_ceph_cmd(sub_cmd, args, user='client.foo', container_image=image)
+        result = ca_common.generate_cmd(sub_cmd, args, user='client.foo', container_image=image)
         assert result == expected_cmd
 
     @pytest.mark.parametrize('stdin', [None, 'foo'])


### PR DESCRIPTION
- remove pre_generate_ceph_cmd
- rename  generate_ceph_cmd to make it generic
- update radosgw modules to consume module_utils

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>