### PR TITLE
rgw: quick fix in create_zone_user.yml

### DIFF
--- a/roles/ceph-rgw/tasks/multisite/create_zone_user.yml
+++ b/roles/ceph-rgw/tasks/multisite/create_zone_user.yml
@@ -17,6 +17,7 @@
   check_mode: no
   run_once: True
   loop: "{{ zone_users }}"
+  when: zone_users is defined
 
 - name: create the zone user(s)
   command: "{{ container_exec_cmd }} radosgw-admin user create --cluster={{ cluster }} --rgw-realm={{ item.item.realm }} --rgw-zonegroup={{ item.item.zonegroup }} --rgw-zone={{ item.item.zone }} --uid={{ item.item.user }} --display-name='{{ item.item.display_name }}' --access-key={{ item.item.system_access_key }} --secret={{ item.item.system_secret_key }} --system"


### PR DESCRIPTION
typical error:

```
2021-02-01 03:11:09,809 p=93834 u=cephuser n=ansible | TASK [ceph-rgw : check if the realm system user already exists] ***************************************************************************************************************************************************
2021-02-01 03:11:09,809 p=93834 u=cephuser n=ansible | Monday 01 February 2021  03:11:09 -0500 (0:00:00.084)       0:14:38.607 *******
2021-02-01 03:11:09,836 p=93834 u=cephuser n=ansible | fatal: [ceph-kvm-ms2-1611241931591-node7-rgw]: FAILED! =>
  msg: |-
    The task includes an option with an undefined variable. The error was: 'None' has no attribute 'realm'
```

This task should be skipped when `zone_users` is undefined.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1922998

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>