### PR TITLE
[skip ci] purge: zap and destroy db and wal devices for lvm batch

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -512,10 +512,8 @@
       action: "zap"
     environment:
       CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-    with_items: "{{ lvm_volumes }}"
-    when:
-      - lvm_volumes | default([]) | length > 0
-      - ceph_volume_present.rc == 0
+    with_items: "{{ lvm_volumes | default([]) }}"
+    when: ceph_volume_present.rc == 0
 
   - name: zap and destroy osds created by ceph-volume with devices
     ceph_volume:
@@ -523,10 +521,11 @@
       action: "zap"
     environment:
       CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
-    with_items: "{{ devices | default([]) }}"
-    when:
-      - devices | default([]) | length > 0
-      - ceph_volume_present.rc == 0
+    with_items:
+      - "{{ devices | default([]) }}"
+      - "{{ dedicated_devices | default([]) }}"
+      - "{{ bluestore_wal_devices | default([]) }}"
+    when: ceph_volume_present.rc == 0
 
   - name: get ceph block partitions
     shell: |

--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -316,8 +316,10 @@
       CEPH_VOLUME_DEBUG: "{{ ceph_volume_debug }}"
       CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
       CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-    with_items: "{{ devices | default([]) }}"
-    when: devices | default([]) | length > 0
+    with_items:
+      - "{{ devices | default([]) }}"
+      - "{{ dedicated_devices | default([]) }}"
+      - "{{ bluestore_wal_devices | default([]) }}"
 
   - name: remove ceph osd service
     file:


### PR DESCRIPTION
Those devices (db/wal) are never zapped in lvm batch deployment.
Iterating over `dedicated_devices` and `bluestore_wal_devices` fixes
this issue.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1922926

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>