### PR TITLE
ceph-defaults: use https for download.ceph.com

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -139,7 +139,7 @@ dummy:
 #
 # Enabled when ceph_repository == 'community'
 #
-#ceph_mirror: http://download.ceph.com
+#ceph_mirror: https://download.ceph.com
 #ceph_stable_key: https://download.ceph.com/keys/release.asc
 #ceph_stable_release: dummy
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -139,7 +139,7 @@ ceph_repository: rhcs
 #
 # Enabled when ceph_repository == 'community'
 #
-#ceph_mirror: http://download.ceph.com
+#ceph_mirror: https://download.ceph.com
 #ceph_stable_key: https://download.ceph.com/keys/release.asc
 #ceph_stable_release: dummy
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -131,7 +131,7 @@ valid_ceph_repository:
 #
 # Enabled when ceph_repository == 'community'
 #
-ceph_mirror: http://download.ceph.com
+ceph_mirror: https://download.ceph.com
 ceph_stable_key: https://download.ceph.com/keys/release.asc
 ceph_stable_release: dummy
 ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"


### PR DESCRIPTION
There's no reason to still use http on download.ceph.com instead of
https.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>