### PR TITLE
[skip ci] osd: add missing '--ulimit' flag

### DIFF
--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -36,7 +36,7 @@
         block:
           - name: get prepared disk list
             command: >
-              docker run --rm --net=host --privileged=true --pid=host --ipc=host --cpu-quota=100000
+              docker run --rm --net=host --privileged=true --pid=host --ipc=host --ulimit nofile=1024:4096 --cpu-quota=100000
               -v /dev:/dev
               -v /etc/localtime:/etc/localtime:ro
               -v /var/lib/ceph:/var/lib/ceph:z,rshared


### PR DESCRIPTION
This commit adds the missing `--ulimit nofile=1024:4096` on this task.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>