### PR TITLE
dashboard: update with the new monitoring group

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -8,7 +8,7 @@
     - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
-    - "{{ grafana_server_group_name|default('grafana-server') }}"
+    - "{{ monitoring_group_name|default('monitoring') }}"
   gather_facts: false
   become: true
   pre_tasks:


### PR DESCRIPTION
Since eefe11d the grafana-server group has been renamed to monitoring
but the dashboard playbook wasn't updated.
This was still working due to the backward compatibility added in the
ceph-facts role.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>