### PR TITLE
[skip ci] monitoring: add missing repository and requirements

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -92,11 +92,17 @@
         name: ceph-validate
 
     - import_role:
+        name: ceph-container-engine
+      when:
+        - (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
+        - (containerized_deployment | bool) or (dashboard_enabled | bool)
+
+    - import_role:
         name: ceph-container-common
         tasks_from: registry
       when:
         - (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
-        - containerized_deployment | bool
+        - (containerized_deployment | bool) or (dashboard_enabled | bool)
         - ceph_docker_registry_auth | bool
 
     - name: set_fact rolling_update

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
@@ -12,4 +12,4 @@
 - name: enable red hat storage tools repository
   rhsm_repository:
     name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_architecture }}-rpms"
-  when: (mgr_group_name in group_names or rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names)
+  when: (mgr_group_name in group_names or rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names or monitoring_group_name in group_names)


### PR DESCRIPTION
- enable rhcs tools repository on the monitoring node with non containerized deployment for the ceph-grafana-dashboards package.
- enforce ceph-container-engine installation during rolling_update execution to avoid having node without podman/docker installed and failing on the registry authentication.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1903504
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1918650
    
Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>