### PR TITLE
[skip ci] rgw: fix a typo in multisite

### DIFF
--- a/roles/ceph-rgw/tasks/multisite/main.yml
+++ b/roles/ceph-rgw/tasks/multisite/main.yml
@@ -11,7 +11,7 @@
     zonegroups: "{{ zonegroups | default([]) | union([{ 'realm': item.rgw_realm, 'zonegroup': item.rgw_zonegroup, 'is_master': item.rgw_zonegroupmaster | default(hostvars[item.host]['rgw_zonegroupmaster']) }]) }}"
   run_once: true
   loop: "{{ rgw_instances_all }}"
-  when: item.rgw_zonegroupmaster | default(hostvars[item.host]['rgw_zonemaster']) | bool
+  when: item.rgw_zonegroupmaster | default(hostvars[item.host]['rgw_zonegroupmaster']) | bool
 
 - name: create list zones
   set_fact:

--- a/tests/functional/rgw-multisite/container/group_vars/all
+++ b/tests/functional/rgw-multisite/container/group_vars/all
@@ -26,6 +26,7 @@ ceph_conf_overrides:
     mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
+    mon_max_pg_per_osd: 512
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon

--- a/tests/functional/rgw-multisite/container/secondary/group_vars/all
+++ b/tests/functional/rgw-multisite/container/secondary/group_vars/all
@@ -26,6 +26,7 @@ ceph_conf_overrides:
     mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
+    mon_max_pg_per_osd: 512
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon

--- a/tests/functional/rgw-multisite/group_vars/all
+++ b/tests/functional/rgw-multisite/group_vars/all
@@ -24,4 +24,5 @@ ceph_conf_overrides:
     mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
+    mon_max_pg_per_osd: 512
 dashboard_enabled: False

--- a/tests/functional/rgw-multisite/secondary/group_vars/all
+++ b/tests/functional/rgw-multisite/secondary/group_vars/all
@@ -24,4 +24,5 @@ ceph_conf_overrides:
     mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
+    mon_max_pg_per_osd: 512
 dashboard_enabled: False


### PR DESCRIPTION
if `rgw_zonegroupmaster` is not defined at the rgw instance level in
`rgw_instances` it will fallback to a wrong variable (`rgw_zonemaster`).

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1925247

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>