### PR TITLE
vagrant: remove centos/8 workaround

### DIFF
--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-vagrant box remove --force --provider libvirt --box-version 1905.1 centos/8 || true
-vagrant box remove --force --provider libvirt --box-version 0 centos/8 || true
-vagrant box add --provider libvirt --name centos/8 https://cloud.centos.org/centos/8/vagrant/x86_64/images/CentOS-8-Vagrant-8.3.2011-20201204.2.x86_64.vagrant-libvirt.box || true
-
 retries=0
 until [ $retries -ge 5 ]
 do


### PR DESCRIPTION
The CentOS 8 vagrant box has finally been updated [1] with a recent
version (the latest one 2011 which means CentOS 8.3).
We don't need to download the vagrant libvirt box with a direct url
anymore from the CentOS infrastructure.

[1] https://app.vagrantup.com/centos/boxes/8

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>