### PR TITLE
Add option to configure container --memory-swappiness for OSDs

### DIFF
--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -180,6 +180,9 @@ dummy:
 #ceph_osd_docker_cpuset_cpus: "0,2,4,6,8,10,12,14,16"
 #ceph_osd_docker_cpuset_mems: "0"
 
+# The following variable is undefined, and thus, unused by default.
+#ceph_osd_docker_memory_swappiness: "0"
+
 # PREPARE DEVICE
 #
 # WARNING /!\ DMCRYPT scenario ONLY works with Docker version 1.12.5 and above

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -172,6 +172,9 @@ ceph_osd_docker_cpu_limit: 4
 #ceph_osd_docker_cpuset_cpus: "0,2,4,6,8,10,12,14,16"
 #ceph_osd_docker_cpuset_mems: "0"
 
+# The following variable is undefined, and thus, unused by default.
+#ceph_osd_docker_memory_swappiness: "0"
+
 # PREPARE DEVICE
 #
 # WARNING /!\ DMCRYPT scenario ONLY works with Docker version 1.12.5 and above

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -41,6 +41,9 @@ numactl \
   {% if ceph_osd_docker_cpuset_mems is defined -%}
   --cpuset-mems='{{ ceph_osd_docker_cpuset_mems }}' \
   {% endif -%}
+  {% if ceph_osd_docker_memory_swappiness is defined -%}
+  --memory-swappiness='{{ ceph_osd_docker_memory_swappiness }}' \
+  {% endif -%}
   -v /dev:/dev \
   -v /etc/localtime:/etc/localtime:ro \
   -v /var/lib/ceph:/var/lib/ceph:z \


### PR DESCRIPTION
Add new variable ceph_osd_docker_memory_swappiness which is
undefined by default. If ceph_osd_docker_memory_swappiness
is defined, OSD service is started with --memory-swappiness
set to the value in this variable.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1925555
Signed-off-by: John Fulton <fulton@redhat.com>