### PR TITLE
library: do not always add --yes in batch mode

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -249,7 +249,7 @@ def get_wal(wal, wal_vg):
     return wal
 
 
-def batch(module, container_image):
+def batch(module, container_image, report=None):
     '''
     Batch prepare OSD devices
     '''
@@ -280,7 +280,8 @@ def batch(module, container_image):
     action = ['lvm', 'batch']
     cmd = build_cmd(action, container_image, cluster)
     cmd.extend(['--%s' % objectstore])
-    cmd.append('--yes')
+    if not report:
+        cmd.append('--yes')
 
     if container_image:
         cmd.append('--prepare')
@@ -646,7 +647,7 @@ def run_module():
             '--format=json',
         ]
 
-        cmd = batch(module, container_image)
+        cmd = batch(module, container_image, report=True)
         batch_report_cmd = copy.copy(cmd)
         batch_report_cmd.extend(report_flags)
 


### PR DESCRIPTION
When asking `ceph-volume` to report only in `lvm batch` context, there's
a bug described in bz1896803 [1] when `--yes` is passed (which by the
way isn't necessary with `--report`).
This commit ensure `--yes` isn't passed to `ceph-volume` when `--report`
is used.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1896803

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1896803

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>