### PR TITLE
[skip ci] tests: pin ansible-lint version

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - run: pip install -r <(grep ansible tests/requirements.txt) ansible-lint
+      - run: pip install -r <(grep ansible tests/requirements.txt) ansible-lint==4.3.7
       - run: ansible-lint -x 106,204,205,208 -v --force-color ./roles/*/ ./infrastructure-playbooks/*.yml site-container.yml.sample site-container.yml.sample


### PR DESCRIPTION
This commit pins the ansible-lint version to 4.3.7 as ceph-ansible isn't
compatible with recent changes in 5.0.0

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>