### PR TITLE
[skip ci] mergify: add stable-6.0 backport configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,3 +35,10 @@ pull_request_rules:
     conditions:
       - label=backport-stable-5.0
     name: backport stable-5.0
+  - actions:
+      backport:
+        branches:
+        - stable-6.0
+    conditions:
+      - label=backport-stable-6.0
+    name: backport stable-6.0


### PR DESCRIPTION
This adds the stable-6.0 backport configuration in mergify.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>