### PR TITLE
infra: skip timedatectl set-ntp no

### DIFF
--- a/roles/ceph-infra/tasks/setup_ntp.yml
+++ b/roles/ceph-infra/tasks/setup_ntp.yml
@@ -43,7 +43,9 @@
 
     - name: disable time sync using timesyncd if we are not using it
       command: timedatectl set-ntp no
-      when: ntp_daemon_type != "timesyncd"
+      when:
+        - not (ansible_distribution == 'RedHat' and ansible_distribution_version is version('8.3', '>'))
+        - ntp_daemon_type != "timesyncd"
 
     - name: enable ntpd
       service:


### PR DESCRIPTION
As of RHEL 8.4, this task should be skipped.
Otherwise, it fails like following:

```
stderr: 'Failed to set ntp: NTP not supported'
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>