### PR TITLE
[skip ci] switch2container: do not serialize the ceph-crash migration

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -601,7 +601,6 @@
 
   vars:
     containerized_deployment: true
-  serial: 1
   become: true
   tasks:
     - name: stop non-containerized ceph-crash


### PR DESCRIPTION
There's no need to slow down the playbook execution time by migrating
all the `ceph-crash` instances in a serial way. Let's remove the
`serial: 1` so the migration is achieved in a parallel way.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>