### PR TITLE
tests: use V3.3-stable branch for nfs-ganesha

### DIFF
--- a/tests/functional/all_daemons/group_vars/nfss
+++ b/tests/functional/all_daemons/group_vars/nfss
@@ -8,3 +8,4 @@ ganesha_conf_overrides: |
 nfs_ganesha_stable: true
 nfs_ganesha_dev: false
 nfs_ganesha_flavor: "ceph_master"
+nfs_ganesha_stable_branch: "V3.3-stable"


### PR DESCRIPTION
This is the latest stable release available for octopus.
Let's use it instead of using master builds.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>