### PR TITLE
requirements.txt: Move the six dependency into the general requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # These are Python requirements needed to run ceph-ansible master
 ansible>=2.9,<2.10,!=2.9.10
 netaddr
+six

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 # These are Python requirements needed to run the functional tests
-six==1.10.0
 testinfra>=3,<4
 pytest-xdist==1.28.0
 pytest>=4.6,<5.0


### PR DESCRIPTION
We've just noticed that deploying Nautilus with ceph-ansible stable-4.0 on Ubuntu Bionic breaks with:

```
Unexpected Exception, this is probably a bug: No module named 'six'
```

The fix looks pretty simple so here's a PR. :)

`config_template.py` relies on `six`, which isn't listed in the default `requirements.txt`. This previously frequently wasn't a problem, because `six` used to be a standard package being installed into a venv, and lots of other projects depended on it.

It also does get installed for unit and integration tests via `tests/requirements.txt`, so any broken dependency on `six` wouldn't be detected by `tox` runs.

However, as other projects and distributions have phased out Python 2.7 support the dependency on `six` becomes less common. To complicate matters further, *some* versions of `virtualenv` do install `six` automatically, others do not. To fix that ambiguity, as long as `ceph-ansible` does require it for `config_template.py`, add it to the base requirements.

This PR is for `master` but if accepted, it would probably make sense to cherry-pick this commit into the `stable-*` branches.