### PR TITLE
defaults: update rhcs dashboard images versions

### DIFF
--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -665,7 +665,7 @@ containerized_deployment: true
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
 #dashboard_frontend_vip: ''
-node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1
+node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
 #node_exporter_port: 9100
 #grafana_admin_user: admin
 # This variable must be set with a strong custom password when dashboard_enabled is True
@@ -702,7 +702,7 @@ grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
 #grafana_allow_embedding: True
 #grafana_port: 3000
 #grafana_conf_overrides: {}
-prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
+prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
 #prometheus_container_cpu_period: 100000
 #prometheus_container_cpu_cores: 2
 # container_memory is in GB
@@ -712,7 +712,7 @@ prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 #prometheus_port: 9092
 #prometheus_conf_overrides: {}
-alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:4.1
+alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2
 # container_memory is in GB

--- a/rhcs_edits.txt
+++ b/rhcs_edits.txt
@@ -7,8 +7,8 @@ ceph_docker_image: "rhceph/rhceph-5-rhel8"
 ceph_docker_image_tag: "latest"
 ceph_docker_registry: "registry.redhat.io"
 ceph_docker_registry_auth: true
-node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1
+node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
 grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
-prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
-alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:4.1
+prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
 # END OF FILE, DO NOT TOUCH ME!


### PR DESCRIPTION
The current dashboard images deployed have a bad health index.
Updating to a newer version fixes this issue.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1925350

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>