### PR TITLE
[skip ci] Fix typo and broken link for documenting RGW frontends

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -372,7 +372,7 @@ dummy:
 
 ## Rados Gateway options
 #
-#radosgw_frontend_type: beast # For additionnal frontends see: http://docs.ceph.com/docs/nautilus/radosgw/frontends/
+#radosgw_frontend_type: beast # For additional frontends see: https://docs.ceph.com/en/latest/radosgw/frontends/
 
 #radosgw_civetweb_port: 8080
 #radosgw_civetweb_num_threads: 512

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -372,7 +372,7 @@ ceph_iscsi_config_dev: false
 
 ## Rados Gateway options
 #
-#radosgw_frontend_type: beast # For additionnal frontends see: http://docs.ceph.com/docs/nautilus/radosgw/frontends/
+#radosgw_frontend_type: beast # For additional frontends see: https://docs.ceph.com/en/latest/radosgw/frontends/
 
 #radosgw_civetweb_port: 8080
 #radosgw_civetweb_num_threads: 512

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -364,7 +364,7 @@ mds_max_mds: 1
 
 ## Rados Gateway options
 #
-radosgw_frontend_type: beast # For additionnal frontends see: http://docs.ceph.com/docs/nautilus/radosgw/frontends/
+radosgw_frontend_type: beast # For additional frontends see: https://docs.ceph.com/en/latest/radosgw/frontends/
 
 radosgw_civetweb_port: 8080
 radosgw_civetweb_num_threads: 512


### PR DESCRIPTION
http://docs.ceph.com/docs/nautilus/radosgw/frontends/ 404s so replace
it with a working Octopus docs link, and correct the spelling of
"additional" while I'm at it.

Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>