### PR TITLE
debian/uca: remove the handler notification (backport)

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_uca_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_uca_repository.yml
@@ -9,5 +9,4 @@
   apt_repository:
     repo: "deb {{ ceph_stable_repo_uca }} {{ ceph_stable_release_uca }} main"
     state: present
-    update_cache: no
-  notify: update apt cache if a repo was added
+    update_cache: yes

--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -4,13 +4,6 @@
      - not rolling_update | bool
      - not docker2podman | default(False) | bool
   block:
-    - name: update apt cache
-      apt:
-        update-cache: yes
-      when: ansible_os_family == 'Debian'
-      register: result
-      until: result is succeeded
-
     - name: mons handler
       include_tasks: handler_mons.yml
       when: mon_group_name in group_names


### PR DESCRIPTION
This is a cherry-pick of 0f8a61a3ae08cc3b3f2b91968764eeecb565aab6 with the merge conflict resolved.

The "update apt cache" in the ceph-handler role was never called and the
handler trigger after adding the uca repository doesn't exist at all.
Instead of using a handler for that we can just set the update_cache
parameter to true like the other apt_repository tasks.

Justification for commit to a stable branch: this change was already made in master, but stable-5.0 is broken because it isn't applied there - failure log extract:
```
2021-02-25 15:03:50,357 p=4824 u=mv3 n=ansible | TASK [ceph-common : include debian_uca_repository.yml] *************************
2021-02-25 15:03:50,358 p=4824 u=mv3 n=ansible | Thursday 25 February 2021  15:03:50 +0000 (0:00:00.067)       0:01:48.924 ***** 
2021-02-25 15:03:50,427 p=4824 u=mv3 n=ansible | included: /nfs/users/nfs_m/mv3/software/ceph-ansible/roles/ceph-common/tasks/installs/debian_uca_repository.yml for sto-t1-1
2021-02-25 15:03:50,477 p=4824 u=mv3 n=ansible | TASK [ceph-common : add ubuntu cloud archive key package] **********************
2021-02-25 15:03:50,477 p=4824 u=mv3 n=ansible | Thursday 25 February 2021  15:03:50 +0000 (0:00:00.119)       0:01:49.043 ***** 
2021-02-25 15:03:51,521 p=4824 u=mv3 n=ansible | ok: [sto-t1-1]
2021-02-25 15:03:51,571 p=4824 u=mv3 n=ansible | TASK [ceph-common : add ubuntu cloud archive repository] ***********************
2021-02-25 15:03:51,572 p=4824 u=mv3 n=ansible | Thursday 25 February 2021  15:03:51 +0000 (0:00:01.094)       0:01:50.137 ***** 
2021-02-25 15:03:52,218 p=4824 u=mv3 n=ansible | ERROR! The requested handler 'update apt cache if a repo was added' was not found in either the main handlers list nor in the listening handlers list
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>