### PR TITLE
ceph-mon: Fix check mode for deploy monitor tasks

### DIFF
--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -30,6 +30,7 @@
     - name: get initial keyring when it already exists
       set_fact:
         monitor_keyring: "{{ (initial_mon_key.stdout | from_json)[0]['key'] if initial_mon_key is not skipped else monitor_keyring.stdout }}"
+      when: initial_mon_key.stdout|default('')|length > 0 or monitor_keyring is not skipped
 
     - name: create monitor initial keyring
       ceph_key:


### PR DESCRIPTION
Skip the `get initial keyring when it already exists` task when both commands
whose `stdout` output it requires have been skipped (e.g. when running in check
mode).

This was previously fixed in #5946, but got lost in the refactoring from #6064.

The fix is also slightly different from the original, because the `ceph_key` module is now being used instead of `command`, and that task is not skipped in check mode, it just returns an empty `stdout`.