### PR TITLE
Add logic to fail when missing ansible_python_interpreter

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -19,6 +19,11 @@
     discovered_interpreter_python: "{{ ansible_python_interpreter }}"
   when: ansible_python_interpreter is defined
 
+- name: Check discovered_interpreter_python is set
+  fail:
+    msg: "ansible_python_interpreter was not defined"
+  when: discovered_interpreter_python is not defined
+
 # Set ceph_release to ceph_stable by default
 - name: set_fact ceph_release ceph_stable_release
   set_fact:


### PR DESCRIPTION
Currently the facts assume that discovered_interpreter_python will be
defined, but this won't happen if ansible_python_interpreter is not
available

Signed-off-by: Alex Schultz <aschultz@redhat.com>