### PR TITLE
common: ensure shaman returns right repo

### DIFF
--- a/roles/ceph-common/tasks/installs/redhat_dev_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_dev_repository.yml
@@ -1,8 +1,15 @@
 ---
+- name: get latest available build
+  uri:
+    url: "https://shaman.ceph.com/api/search/?status=ready&project=ceph&flavor=default&distros=centos/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}&ref={{ ceph_dev_branch }}&sha1={{ ceph_dev_sha1 }}"
+    return_content: yes
+  run_once: true
+  register: latest_build
+
 - name: fetch ceph red hat development repository
   uri:
     # Use the centos repo since we don't currently have a dedicated red hat repo
-    url: https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/centos/{{ ansible_distribution_major_version }}/repo
+    url: "{{ (latest_build.content | from_json)[0]['chacra_url'] }}repo"
     return_content: yes
   register: ceph_dev_yum_repo
 


### PR DESCRIPTION
Due to recent changes in shaman, there's a chance it returns the wrong
repository from architecture point of view.
We can query shaman and ask for the correct architecture to get around
this.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 39649f0ce8dd1c7b911fb7442f16e141735685b0)