### PR TITLE
ceph-osd: add prepare_osd tag to lvm-batch scenario, document usage

### DIFF
--- a/docs/source/osds/scenarios.rst
+++ b/docs/source/osds/scenarios.rst
@@ -21,6 +21,11 @@ The ``lvm`` scenario mentionned above support both containerized and non-contain
 As a reminder, deploying a containerized cluster can be done by setting ``containerized_deployment``
 to ``True``.
 
+If you want to skip OSD creation during a ``ceph-ansible run``
+(e.g. because you have already provisioned your OSDs but disk IDs have
+changed), you can skip the ``prepare_osd`` tag i.e. by specifying
+``--skip-tags prepare_osd`` on the ``ansible-playbook`` command line.
+
 .. _osd_scenario_lvm:
 
 lvm

--- a/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
+++ b/roles/ceph-osd/tasks/scenarios/lvm-batch.yml
@@ -20,3 +20,4 @@
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
     PYTHONIOENCODING: utf-8
   when: _devices | default([]) | length > 0
+  tags: prepare_osd


### PR DESCRIPTION
It's sometimes useful to be able to skip the OSD creation phase of a `ceph-ansible` run (see #1777 for example), and the lvm scenario already has a `prepare_osd` tag on the relevant play. This PR applies that tag to the equivalent play for the lvm-batch scenario, and documents the availability of this tag.

Could this be backported to (at least) stable-5 please?