### PR TITLE
Disable facts by default in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -22,6 +22,7 @@ nocows = 1
 callback_whitelist = profile_tasks
 stdout_callback = yaml
 force_valid_group_names = ignore
+inject_facts_as_vars = False
 
 # Disable them in the context of https://review.openstack.org/#/c/469644
 retry_files_enabled = False

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -19,6 +19,16 @@
     discovered_interpreter_python: "{{ ansible_python_interpreter }}"
   when: ansible_python_interpreter is defined
 
+# If ansible_python_interpreter is not defined, this can result in the
+# discovered_interpreter_python fact from being set. This fails later in this
+# playbook and is used elsewhere.
+- name: set_fact discovered_interpreter_python if not previously set
+  set_fact:
+    discovered_interpreter_python: "{{ ansible_facts['discovered_interpreter_python'] }}"
+  when:
+    - discovered_interpreter_python is not defined
+    - ansible_facts['discovered_interpreter_python'] is defined
+
 # Set ceph_release to ceph_stable by default
 - name: set_fact ceph_release ceph_stable_release
   set_fact:


### PR DESCRIPTION
As a continuation of a7f2fa73e63e69dba2e41aaac9732397eec437c9, this
change switches fact injection to off by default in the provided
ansible.cfg.