### PR TITLE
config: reset num_osds

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -14,6 +14,10 @@
     # running osds
     - not rolling_update | bool
   block:
+  - name: reset num_osds
+    set_fact:
+      num_osds: 0
+
   - name: count number of osds for lvm scenario
     set_fact:
       num_osds: "{{ lvm_volumes | length | int }}"


### PR DESCRIPTION
When collocating OSDs with other daemon, `num_osds` is incorrectly calculated
because `ceph-config` is called multiple times.

Indeed, the following code:
```
num_osds: "{{ lvm_list.stdout | default('{}') | from_json | length | int + num_osds | default(0) | int }}"
```

makes `num_osds` be incremented each time `ceph-config` is called.

We have to reset it in order to get the correct number of expected OSDs.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>