### PR TITLE
nfs: bump nfs-ganesha version

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -146,7 +146,7 @@ dummy:
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-#nfs_ganesha_stable_branch: V3.3-stable
+#nfs_ganesha_stable_branch: V3.5-stable
 #nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 
 
@@ -798,3 +798,4 @@ dummy:
 #container_exec_cmd:
 #docker: false
 #ceph_volume_debug: "{{ enable_ceph_volume_debug | ternary(1, 0)  }}"
+

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -146,7 +146,7 @@ ceph_repository: rhcs
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-#nfs_ganesha_stable_branch: V3.3-stable
+#nfs_ganesha_stable_branch: V3.5-stable
 #nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 
 
@@ -798,3 +798,4 @@ alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alert
 #container_exec_cmd:
 #docker: false
 #ceph_volume_debug: "{{ enable_ceph_volume_debug | ternary(1, 0)  }}"
+

--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -1,15 +1,4 @@
 ---
-# dummy container setup is only supported on x86_64
-# when running with containerized_deployment: true this task
-# creates a group that contains only x86_64 hosts.
-# when running with containerized_deployment: false this task
-# will add all client hosts to the group (and not filter).
-- name: create filtered clients group
-  group_by:
-    key: _filtered_clients
-    parents: "{{ client_group_name }}"
-  when: (ansible_facts['architecture'] == 'x86_64') or (not containerized_deployment | bool)
-
 - name: set_fact delegated_node
   set_fact:
     delegated_node: "{{ groups[mon_group_name][0] if groups.get(mon_group_name, []) | length > 0 else inventory_hostname }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -138,7 +138,7 @@ ceph_stable_release: dummy
 ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-nfs_ganesha_stable_branch: V3.3-stable
+nfs_ganesha_stable_branch: V3.5-stable
 nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 
 

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -23,7 +23,7 @@
       when:
         - ceph_origin == 'repository'
         - ceph_repository == 'community'
-        - ceph_stable_release not in ['nautilus', 'octopus']
+        - ceph_stable_release not in ['quincy']
 
     - name: validate ceph_repository_type
       fail:

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -49,6 +49,19 @@
 
     - import_role:
         name: ceph-defaults
+
+    # dummy container setup is only supported on x86_64
+    # when running with containerized_deployment: true this task
+    # creates a group that contains only x86_64 hosts.
+    # when running with containerized_deployment: false this task
+    # will add all client hosts to the group (and not filter).
+    - name: create filtered clients group
+      add_host:
+        name: "{{ item }}"
+        groups: _filtered_clients
+      with_items: "{{ groups.get(client_group_name, []) | intersect(ansible_play_batch) }}"
+      when: (hostvars[item]['ansible_architecture'] == 'x86_64') or (not containerized_deployment | bool)
+
       tags: [with_pkg, fetch_container_image]
     - import_role:
         name: ceph-facts
@@ -61,11 +74,11 @@
     - import_role:
         name: ceph-container-engine
       tags: with_pkg
-      when: (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
+      when: (group_names != ['clients'] and group_names != ['clients', '_filtered_clients'] and group_names != ['_filtered_clients', 'clients']) or (inventory_hostname == groups.get('_filtered_clients', [''])|first)
     - import_role:
         name: ceph-container-common
       tags: fetch_container_image
-      when: (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
+      when: (group_names != ['clients'] and group_names != ['clients', '_filtered_clients'] and group_names != ['_filtered_clients', 'clients']) or (inventory_hostname == groups.get('_filtered_clients', [''])|first)
 
 - hosts: mons
   gather_facts: false

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -53,6 +53,19 @@
   tasks:
     - import_role:
         name: ceph-defaults
+
+    # dummy container setup is only supported on x86_64
+    # when running with containerized_deployment: true this task
+    # creates a group that contains only x86_64 hosts.
+    # when running with containerized_deployment: false this task
+    # will add all client hosts to the group (and not filter).
+    - name: create filtered clients group
+      add_host:
+        name: "{{ item }}"
+        groups: _filtered_clients
+      with_items: "{{ groups.get(client_group_name, []) | intersect(ansible_play_batch) }}"
+      when: (hostvars[item]['ansible_architecture'] == 'x86_64') or (not containerized_deployment | bool)
+
     - import_role:
         name: ceph-facts
     - import_role:

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -23,8 +23,8 @@ rgw0
 client0
 client1
 
-[nfss]
-nfs0
+#[nfss]
+#nfs0
 
 [rbdmirrors]
 rbd-mirror0

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -8,7 +8,7 @@ mon_vms: 3
 osd_vms: 3
 mds_vms: 3
 rgw_vms: 1
-nfs_vms: 1
+nfs_vms: 0
 grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2

--- a/tests/functional/external_clients/container/vagrant_variables.yml
+++ b/tests/functional/external_clients/container/vagrant_variables.yml
@@ -11,7 +11,7 @@ rgw_vms: 0
 nfs_vms: 0
 grafana_server_vms: 0
 rbd_mirror_vms: 0
-client_vms: 3
+client_vms: 2
 iscsi_gw_vms: 0
 mgr_vms: 0
 

--- a/tests/functional/external_clients/vagrant_variables.yml
+++ b/tests/functional/external_clients/vagrant_variables.yml
@@ -7,7 +7,7 @@ rgw_vms: 0
 nfs_vms: 0
 grafana_server_vms: 0
 rbd_mirror_vms: 0
-client_vms: 3
+client_vms: 2
 iscsi_gw_vms: 0
 mgr_vms: 0
 


### PR DESCRIPTION
This commit updates the default version of nfs-ganesha to V3.5 which is the
latest version available upstream.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>