### PR TITLE
facts: fix nfs/external cluster scenario

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -262,8 +262,8 @@
 
 - name: backward compatibility tasks related
   when:
-    - inventory_hostname in groups.get(rgw_group_name, [])
-      or inventory_hostname in groups.get(nfs_group_name, [])
+    - (inventory_hostname in groups.get(rgw_group_name, []) or inventory_hostname in groups.get(nfs_group_name, []))
+    - groups.get(mon_group_name, []) | length > 0
   block:
     - name: get ceph current status
       command: "{{ timeout_command }} {{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} service dump -f json"


### PR DESCRIPTION
These tasks shouldn't be run when at least 1 monitor isn't present in
the inventory.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1937997

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>