### PR TITLE
adopt: convert legacy grafana-server groupname early

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -23,6 +23,16 @@
            invoking the playbook
       when: ireallymeanit != 'yes'
 
+    - name: import_role ceph-defaults
+      import_role:
+        name: ceph-defaults
+
+    - name: check if a legacy grafana-server group exists
+      import_role:
+        name: ceph-facts
+        tasks_from: convert_grafana_server_group_name.yml
+      when: groups.get((grafana_server_group_name | default('grafana-server')), []) | length > 0
+
 - name: gather facts and prepare system for cephadm
   hosts:
     - "{{ mon_group_name|default('mons') }}"


### PR DESCRIPTION
This is a follow up on PR #6332

cephadm-adopt.yml playbook is affected by the same bug

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1938658

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>