### PR TITLE
nfs: bump nfs-ganesha version

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -145,7 +145,7 @@ dummy:
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-#nfs_ganesha_stable_branch: V3.3-stable
+#nfs_ganesha_stable_branch: V3.5-stable
 #nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 
 
@@ -797,3 +797,4 @@ dummy:
 #container_exec_cmd:
 #docker: false
 #ceph_volume_debug: "{{ enable_ceph_volume_debug | ternary(1, 0)  }}"
+

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -145,7 +145,7 @@ ceph_repository: rhcs
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-#nfs_ganesha_stable_branch: V3.3-stable
+#nfs_ganesha_stable_branch: V3.5-stable
 #nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 
 
@@ -797,3 +797,4 @@ alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alert
 #container_exec_cmd:
 #docker: false
 #ceph_volume_debug: "{{ enable_ceph_volume_debug | ternary(1, 0)  }}"
+

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -137,7 +137,7 @@ ceph_stable_release: dummy
 ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-nfs_ganesha_stable_branch: V3.3-stable
+nfs_ganesha_stable_branch: V3.5-stable
 nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
 
 

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -19,11 +19,11 @@
 
     - name: validate ceph_repository_community
       fail:
-        msg: "ceph_stable_release must be either 'nautilus' or 'octopus'"
+        msg: "ceph_stable_release must be 'pacific'"
       when:
         - ceph_origin == 'repository'
         - ceph_repository == 'community'
-        - ceph_stable_release not in ['nautilus', 'octopus']
+        - ceph_stable_release not in ['pacific']
 
     - name: validate ceph_repository_type
       fail:

--- a/tests/functional/external_clients/container/vagrant_variables.yml
+++ b/tests/functional/external_clients/container/vagrant_variables.yml
@@ -11,7 +11,7 @@ rgw_vms: 0
 nfs_vms: 0
 grafana_server_vms: 0
 rbd_mirror_vms: 0
-client_vms: 3
+client_vms: 2
 iscsi_gw_vms: 0
 mgr_vms: 0
 

--- a/tests/functional/external_clients/vagrant_variables.yml
+++ b/tests/functional/external_clients/vagrant_variables.yml
@@ -7,7 +7,7 @@ rgw_vms: 0
 nfs_vms: 0
 grafana_server_vms: 0
 rbd_mirror_vms: 0
-client_vms: 3
+client_vms: 2
 iscsi_gw_vms: 0
 mgr_vms: 0
 


### PR DESCRIPTION
This commit updates the default version of nfs-ganesha to V3.5 which is the latest version available upstream.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit c78388e580c40b236321d9f8a3a656b81a1f9015)