### PR TITLE
[skip ci] cephadm_adopt: fetch and write ceph minimal config

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -183,6 +183,13 @@
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
 
+    - name: get a minimal ceph configuration
+      command: "{{ ceph_cmd }} config generate-minimal-conf"
+      register: minimal_config
+      run_once: true
+      changed_when: false
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+
     - name: set_fact fsid
       set_fact:
         fsid: "{{ current_fsid.stdout }}"
@@ -870,6 +877,20 @@
     - import_role:
         name: ceph-defaults
 
+    - name: check whether a ceph config file is present
+      stat:
+        path: "/etc/ceph/{{ cluster }}.conf"
+      register: ceph_config
+
+    - name: write a ceph.conf with minimal config
+      copy:
+        dest: "/etc/ceph/{{ cluster }}.conf"
+        content: "{{ minimal_config.stdout }}"
+        owner: "{{ ceph_uid | int if containerized_deployment | bool else 'ceph' }}"
+        group: "{{ ceph_uid | int if containerized_deployment | bool else 'ceph' }}"
+        mode: "{{ ceph_keyring_permissions }}"
+      when: not ceph_config.stat.exists | bool
+
     - name: with dashboard enabled
       when: dashboard_enabled | bool
       block:
@@ -1044,6 +1065,7 @@
           delegate_to: '{{ groups[mon_group_name][0] }}'
           environment:
             CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+
 
 - name: adjust placement daemons
   hosts: "{{ mon_group_name|default('mons') }}[0]"


### PR DESCRIPTION
This commit makes the playbook fetch the minimal current ceph
configuration and write it later on monitoring nodes so `cephadm` can
proceed with the adoption.
When a monitoring stack was deployed on a dedicated node, it means no
`ceph.conf` file was written, `cephadm` requires a `ceph.conf` in order
to adopt the daemon present on the node.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1939887

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>