### PR TITLE
[skip ci] fix 'command -v' tasks

### DIFF
--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -79,8 +79,8 @@
       tags: with_pkg
       when: not is_atomic | bool
 
-    - name: check podman presence
-      command: command -v podman
+    - name: check podman presence # noqa : 305
+      shell: command -v podman
       register: podman_presence
       changed_when: false
       failed_when: false

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -493,8 +493,8 @@
     failed_when: false
     register: ceph_lockbox_partition_to_erase_path
 
-  - name: see if ceph-volume is installed
-    command: command -v ceph-volume
+  - name: see if ceph-volume is installed # noqa : 305
+    shell: command -v ceph-volume
     changed_when: false
     failed_when: false
     register: ceph_volume_present


### PR DESCRIPTION
`command -v` is a bash script which needs a shell to run.

Fixes: #6325

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>