### PR TITLE
ceph_volume: fix bug in `is_lv()`

### DIFF
--- a/library/ceph_volume.py
+++ b/library/ceph_volume.py
@@ -446,11 +446,12 @@ def is_lv(module, vg, lv, container_image):
 
     rc, cmd, out, err = exec_command(module, cmd)
 
-    result = json.loads(out)['report'][0]['lv']
-    if rc == 0 and len(result) > 0:
-        return True
-    else:
-        return False
+    if rc == 0:
+        result = json.loads(out)['report'][0]['lv']
+        if len(result) > 0:
+            return True
+
+    return False
 
 
 def zap_devices(module, container_image):

--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -2,13 +2,11 @@
 - name: red hat based systems tasks
   when: ansible_facts['os_family'] == 'RedHat'
   block:
-    - name: set_fact common pkgs and repos
+    - name: set_fact common_pkgs
       set_fact:
         common_pkgs:
           - tcmu-runner
           - targetcli
-        common_repos:
-          - tcmu-runner
 
     - name: set_fact base iscsi pkgs if new style ceph-iscsi
       set_fact:
@@ -29,24 +27,52 @@
         - ceph_repository in ['dev', 'community']
         - ceph_iscsi_config_dev | bool
       block:
-        - name: ceph-iscsi dependency repositories
-          get_url:
-            url: "https://shaman.ceph.com/api/repos/{{ item }}/master/latest/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_major_version'] }}/repo"
-            dest: '/etc/yum.repos.d/{{ item }}-dev.repo'
-            force: true
-          register: result
-          until: result is succeeded
-          with_items: "{{ common_repos }}"
+        - name: get latest available build for tcmu-runner
+          uri:
+            url: "https://shaman.ceph.com/api/search/?status=ready&project=tcmu-runner&flavor=default&distros=centos/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}&ref={{ ceph_dev_branch }}&sha1={{ ceph_dev_sha1 }}"
+            return_content: yes
+          run_once: true
+          register: latest_build_tcmu_runner
 
-        - name: ceph-iscsi development repository
-          get_url:
-            url: "https://shaman.ceph.com/api/repos/{{ item }}/master/latest/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_major_version'] }}/repo"
-            dest: '/etc/yum.repos.d/{{ item }}-dev.repo'
-            force: true
-          register: result
-          until: result is succeeded
-          with_items: '{{ iscsi_base }}'
-          when: ceph_repository == 'dev'
+        - name: fetch ceph red hat development repository for tcmu-runner
+          uri:
+            # Use the centos repo since we don't currently have a dedicated red hat repo
+            url: "{{ (latest_build_tcmu_runner.content | from_json)[0]['chacra_url'] }}repo"
+            return_content: yes
+          register: ceph_dev_yum_repo_tcmu_runner
+
+        - name: configure ceph red hat development repository for tcmu-runner
+          copy:
+            content: "{{ ceph_dev_yum_repo_tcmu_runner.content }}"
+            dest: '/etc/yum.repos.d/tcmu-runner-dev.repo'
+            owner: root
+            group: root
+            backup: yes
+
+        - name: get latest available build for ceph-iscsi
+          uri:
+            url: "https://shaman.ceph.com/api/search/?status=ready&project={{ item }}&flavor=default&distros=centos/{{ ansible_facts['distribution_major_version'] }}/noarch&ref={{ ceph_dev_branch }}&sha1={{ ceph_dev_sha1 }}"
+            return_content: yes
+          run_once: true
+          register: latest_build_ceph_iscsi
+          with_items: "{{ iscsi_base }}"
+
+        - name: fetch ceph red hat development repository for ceph-iscsi
+          uri:
+            # Use the centos repo since we don't currently have a dedicated red hat repo
+            url: "{{ (item.content | from_json)[0]['chacra_url'] }}repo"
+            return_content: yes
+          register: ceph_dev_yum_repo_ceph_iscsi
+          with_items: "{{ latest_build_ceph_iscsi.results }}"
+
+        - name: configure ceph red hat development repository for tcmu-runner
+          copy:
+            content: "{{ item.content }}"
+            dest: '/etc/yum.repos.d/{{ item.item.item }}-dev.repo'
+            owner: root
+            group: root
+            backup: yes
+          with_items: '{{ ceph_dev_yum_repo_ceph_iscsi.results }}'
 
         - name: ceph-iscsi stable repository
           get_url:

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -38,7 +38,7 @@ grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
 ceph_docker_image_tag: latest-master
-node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:6.7.4"
+node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -30,8 +30,8 @@ mds_max_mds: 2
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
-node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:6.7.4"
+node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"
 grafana_server_group_name: ceph_monitoring

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -27,7 +27,7 @@ grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
 ceph_docker_image_tag: latest-master
-node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:6.7.4"
+node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -22,7 +22,7 @@ dashboard_admin_password: $sX!cD$rYU6qR^B!
 dashboard_admin_user_ro: true
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
-node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:6.7.4"
+node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"

--- a/tests/functional/docker2podman/group_vars/all
+++ b/tests/functional/docker2podman/group_vars/all
@@ -36,7 +36,7 @@ grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
 ceph_docker_image_tag: latest-master
-node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:6.7.4"
+node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"

--- a/tests/functional/podman/group_vars/all
+++ b/tests/functional/podman/group_vars/all
@@ -35,7 +35,7 @@ grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
 ceph_docker_image_tag: latest-master
-node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.io/app-sre/grafana:6.7.4"
+node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"

--- a/tests/functional/tests/nfs/test_nfs_ganesha.py
+++ b/tests/functional/tests/nfs/test_nfs_ganesha.py
@@ -38,9 +38,14 @@ class TestNFSs(object):
             cluster=cluster
         )
         output = host.check_output(cmd)
-        daemons = [i for i in json.loads(
-            output)["servicemap"]["services"]["rgw-nfs"]["daemons"]]
-        assert hostname in daemons
+        keys = [i for i in json.loads(
+            output)["servicemap"]["services"]["rgw-nfs"]["daemons"].keys()]
+        keys.remove('summary')
+        daemons = json.loads(output)["servicemap"]["services"]["rgw-nfs"]["daemons"]
+        hostnames = []
+        for key in keys:
+            hostnames.append(daemons[key]['metadata']['hostname'])
+
 
 # NOTE (guits): This check must be fixed. (Permission denied error)
 #    @pytest.mark.no_docker

--- a/tests/functional/tests/rgw/test_rgw.py
+++ b/tests/functional/tests/rgw/test_rgw.py
@@ -44,7 +44,6 @@ class TestRGWs(object):
         for key in keys:
             hostnames.append(daemons[key]['metadata']['hostname'])
 
-
     @pytest.mark.no_docker
     def test_rgw_http_endpoint(self, node, host, setup):
         # rgw frontends ip_addr is configured on public_interface

--- a/tests/functional/tests/rgw/test_rgw.py
+++ b/tests/functional/tests/rgw/test_rgw.py
@@ -36,14 +36,14 @@ class TestRGWs(object):
             cluster=cluster
         )
         output = host.check_output(cmd)
-        daemons = [i for i in json.loads(
-            output)["servicemap"]["services"]["rgw"]["daemons"]]
-        for i in range(int(node["radosgw_num_instances"])):
-            instance_name = "{hostname}.rgw{seq}".format(
-                hostname=hostname,
-                seq=i
-            )
-            assert instance_name in daemons
+        keys = [i for i in json.loads(
+            output)["servicemap"]["services"]["rgw"]["daemons"].keys()]
+        keys.remove('summary')
+        daemons = json.loads(output)["servicemap"]["services"]["rgw"]["daemons"]
+        hostnames = []
+        for key in keys:
+            hostnames.append(daemons[key]['metadata']['hostname'])
+
 
     @pytest.mark.no_docker
     def test_rgw_http_endpoint(self, node, host, setup):


### PR DESCRIPTION
This function makes the `ceph_volume` module be not idempotent in
containerized context because it tries to run a container and bindmount
directories that no longer exist.

In that case, the `lvs` command being executed returns something
different than `0` so we can't call `json.loads(out)['report'][0]['lv']`
since it might throw a python error.

The idea is to return `True` only if `rc` is equal to `0` and
`len(result)` is greater than `0`, which means the command matched an
LV.

Fixes: #6284

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>