### PR TITLE
main: use `ansible_facts` for `architecture`

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -60,7 +60,7 @@
         name: "{{ item }}"
         groups: _filtered_clients
       with_items: "{{ groups.get(client_group_name, []) | intersect(ansible_play_batch) }}"
-      when: (hostvars[item]['ansible_architecture'] == 'x86_64') or (not containerized_deployment | bool)
+      when: (hostvars[item]['ansible_facts']['architecture'] == 'x86_64') or (not containerized_deployment | bool)
 
       tags: [with_pkg, fetch_container_image]
     - import_role:

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -64,7 +64,7 @@
         name: "{{ item }}"
         groups: _filtered_clients
       with_items: "{{ groups.get(client_group_name, []) | intersect(ansible_play_batch) }}"
-      when: (hostvars[item]['ansible_architecture'] == 'x86_64') or (not containerized_deployment | bool)
+      when: (hostvars[item]['ansible_facts']['architecture'] == 'x86_64') or (not containerized_deployment | bool)
 
     - import_role:
         name: ceph-facts


### PR DESCRIPTION
commit f6a0e95e51798316fce5e82b2463ff62396a681a reverted the change made
by a7f2fa73e63e69dba2e41aaac9732397eec437c9.

This commit bring back this change.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>