### PR TITLE
convert some missed `ansible_*`` calls to `ansible_facts['*']`

### DIFF
--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -29,7 +29,7 @@ dummy:
 # ideal when ceph-nfs is managed by pacemaker across multiple hosts - in
 # such case it's better to have constant instance id instead which
 # can be set by 'ceph_nfs_service_suffix'
-# ceph_nfs_service_suffix: ansible_hostname
+# ceph_nfs_service_suffix: "{{ ansible_facts['hostname'] }}"
 
 ######################
 # NFS Ganesha Config #

--- a/group_vars/osds.yml.sample
+++ b/group_vars/osds.yml.sample
@@ -58,7 +58,7 @@ dummy:
 #bluestore_wal_devices: []
 
 #'osd_auto_discovery'  mode prevents you from filling out the 'devices' variable above.
-# Device discovery is based on the Ansible fact 'ansible_devices'
+# Device discovery is based on the Ansible fact 'ansible_facts["devices"]'
 # which reports all the devices on a system. If chosen, all the disks
 # found will be passed to ceph-volume lvm batch. You should not be worried on using
 # this option since ceph-volume has a built-in check which looks for empty devices.

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -34,7 +34,7 @@
   set_fact:
     ceph_release: "{{ ceph_stable_release }}"
 
-- name: set_fact monitor_name ansible_hostname
+- name: set_fact monitor_name ansible_facts['hostname']
   set_fact:
     monitor_name: "{{ hostvars[item]['ansible_facts']['hostname'] }}"
   delegate_to: "{{ item }}"

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -21,7 +21,7 @@ ceph_nfs_enable_service: true
 # ideal when ceph-nfs is managed by pacemaker across multiple hosts - in
 # such case it's better to have constant instance id instead which
 # can be set by 'ceph_nfs_service_suffix'
-# ceph_nfs_service_suffix: ansible_hostname
+# ceph_nfs_service_suffix: "{{ ansible_facts['hostname'] }}"
 
 ######################
 # NFS Ganesha Config #

--- a/roles/ceph-osd/defaults/main.yml
+++ b/roles/ceph-osd/defaults/main.yml
@@ -50,7 +50,7 @@ dedicated_devices: []
 bluestore_wal_devices: []
 
 #'osd_auto_discovery'  mode prevents you from filling out the 'devices' variable above.
-# Device discovery is based on the Ansible fact 'ansible_devices'
+# Device discovery is based on the Ansible fact 'ansible_facts["devices"]'
 # which reports all the devices on a system. If chosen, all the disks
 # found will be passed to ceph-volume lvm batch. You should not be worried on using
 # this option since ceph-volume has a built-in check which looks for empty devices.


### PR DESCRIPTION
This converts some missed calls to `ansible_*` that were missed in initial PR #6312

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>