### PR TITLE
[skip ci] tests: pin ruamel.yaml version

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -16,6 +16,6 @@ jobs:
           architecture: x64
       - run: pip install -r <(grep ansible tests/requirements.txt) ansible-lint==4.3.7
         if: matrix.python-version == '3.6'
-      - run: pip install -r <(grep ansible tests/requirements.txt) ansible-lint
+      - run: pip install -r <(grep ansible tests/requirements.txt) ansible-lint ruamel.yaml==0.16.13
         if: matrix.python-version == '2.7'
       - run: ansible-lint -x 106,204,205,208 -v --force-color ./roles/*/ ./infrastructure-playbooks/*.yml site-container.yml.sample site-container.yml.sample


### PR DESCRIPTION
0.17.0 which was released yesterday breaks ansible-lint execution

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>