### PR TITLE
rgw: supports pg_autoscale_mode option for pool creation

### DIFF
--- a/roles/ceph-rgw/tasks/rgw_create_pools.yml
+++ b/roles/ceph-rgw/tasks/rgw_create_pools.yml
@@ -37,6 +37,7 @@
     pg_num: "{{ item.value.pg_num | default(omit) }}"
     pgp_num: "{{ item.value.pgp_num | default(omit) }}"
     size: "{{ item.value.size | default(omit) }}"
+    pg_autoscale_mode: "{{ item.pg_autoscale_mode | default(omit) }}"
     target_size_ratio: "{{ item.value.target_size_ratio | default(omit) }}"
     pool_type: erasure
     erasure_profile: "{{ item.value.ec_profile }}"
@@ -59,6 +60,7 @@
     pgp_num: "{{ item.value.pgp_num | default(omit) }}"
     size: "{{ item.value.size | default(omit) }}"
     min_size: "{{ item.value.min_size | default(omit) }}"
+    pg_autoscale_mode: "{{ item.pg_autoscale_mode | default(omit) }}"
     target_size_ratio: "{{ item.value.target_size_ratio | default(omit) }}"
     pool_type: replicated
     rule_name: "{{ item.value.rule_name | default(ceph_osd_pool_default_crush_rule_name) }}"


### PR DESCRIPTION
Support enabling/disabling the pg autoscaler for rgw pools.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>