### PR TITLE
[skip ci] defaults: add a comment about `igw_network`

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -723,6 +723,14 @@ dummy:
 #alertmanager_cluster_port: 9094
 #alertmanager_conf_overrides: {}
 # igw
+#
+# `igw_network` variable is intended for allowing dashboard deployment with iSCSI node not residing in the same subnet than what is defined in `public_network`.
+# For example:
+# If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
+# at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}" will be empty.
+# As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
+# Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 #igw_network: "{{ public_network }}"
 
 

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -723,6 +723,14 @@ alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alert
 #alertmanager_cluster_port: 9094
 #alertmanager_conf_overrides: {}
 # igw
+#
+# `igw_network` variable is intended for allowing dashboard deployment with iSCSI node not residing in the same subnet than what is defined in `public_network`.
+# For example:
+# If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
+# at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}" will be empty.
+# As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
+# Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 #igw_network: "{{ public_network }}"
 
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -715,6 +715,14 @@ alertmanager_port: 9093
 alertmanager_cluster_port: 9094
 alertmanager_conf_overrides: {}
 # igw
+#
+# `igw_network` variable is intended for allowing dashboard deployment with iSCSI node not residing in the same subnet than what is defined in `public_network`.
+# For example:
+# If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
+# at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}" will be empty.
+# As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
+# Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 igw_network: "{{ public_network }}"
 
 


### PR DESCRIPTION
This add a quick documentation in ceph-defaults about `igw_network`

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>