### PR TITLE
common,iscsi: don't use the shaman search endpoint

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_dev_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_dev_repository.yml
@@ -1,14 +1,7 @@
 ---
-- name: get latest available build
-  uri:
-    url: "https://shaman.ceph.com/api/search/?status=ready&project=ceph&flavor=default&distros={{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_release'] }}/{{ ansible_facts['architecture'] }}&ref={{ ceph_dev_branch }}&sha1={{ ceph_dev_sha1 }}"
-    return_content: yes
-  run_once: true
-  register: latest_build
-
 - name: fetch ceph debian development repository
   uri:
-    url: "{{ (latest_build.content | from_json)[0]['chacra_url'] }}repo"
+    url: "https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_release'] }}/repo?arch={{ ansible_facts['architecture'] }}"
     return_content: yes
   register: ceph_dev_deb_repo
 

--- a/roles/ceph-common/tasks/installs/redhat_dev_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_dev_repository.yml
@@ -1,15 +1,8 @@
 ---
-- name: get latest available build
-  uri:
-    url: "https://shaman.ceph.com/api/search/?status=ready&project=ceph&flavor=default&distros=centos/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}&ref={{ ceph_dev_branch }}&sha1={{ ceph_dev_sha1 }}"
-    return_content: yes
-  run_once: true
-  register: latest_build
-
 - name: fetch ceph red hat development repository
   uri:
     # Use the centos repo since we don't currently have a dedicated red hat repo
-    url: "{{ (latest_build.content | from_json)[0]['chacra_url'] }}repo"
+    url: "https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/centos/{{ ansible_facts['distribution_major_version'] }}/repo?arch={{ ansible_facts['architecture'] }}"
     return_content: yes
   register: ceph_dev_yum_repo
 

--- a/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
+++ b/roles/ceph-iscsi-gw/tasks/non-container/prerequisites.yml
@@ -27,52 +27,23 @@
         - ceph_repository in ['dev', 'community']
         - ceph_iscsi_config_dev | bool
       block:
-        - name: get latest available build for tcmu-runner
-          uri:
-            url: "https://shaman.ceph.com/api/search/?status=ready&project=tcmu-runner&flavor=default&distros=centos/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}&ref={{ ceph_dev_branch }}&sha1={{ ceph_dev_sha1 }}"
-            return_content: yes
-          run_once: true
-          register: latest_build_tcmu_runner
-
-        - name: fetch ceph red hat development repository for tcmu-runner
-          uri:
-            # Use the centos repo since we don't currently have a dedicated red hat repo
-            url: "{{ (latest_build_tcmu_runner.content | from_json)[0]['chacra_url'] }}repo"
-            return_content: yes
-          register: ceph_dev_yum_repo_tcmu_runner
-
-        - name: configure ceph red hat development repository for tcmu-runner
-          copy:
-            content: "{{ ceph_dev_yum_repo_tcmu_runner.content }}"
+        - name: ceph-iscsi dependency repositories
+          get_url:
+            url: "https://shaman.ceph.com/api/repos/tcmu-runner/master/latest/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_major_version'] }}/repo?arch={{ ansible_facts['architecture'] }}"
             dest: '/etc/yum.repos.d/tcmu-runner-dev.repo'
-            owner: root
-            group: root
-            backup: yes
+            force: true
+          register: result
+          until: result is succeeded
 
-        - name: get latest available build for ceph-iscsi
-          uri:
-            url: "https://shaman.ceph.com/api/search/?status=ready&project={{ item }}&flavor=default&distros=centos/{{ ansible_facts['distribution_major_version'] }}/noarch&ref={{ ceph_dev_branch }}&sha1={{ ceph_dev_sha1 }}"
-            return_content: yes
-          run_once: true
-          register: latest_build_ceph_iscsi
-          with_items: "{{ iscsi_base }}"
-
-        - name: fetch ceph red hat development repository for ceph-iscsi
-          uri:
-            # Use the centos repo since we don't currently have a dedicated red hat repo
-            url: "{{ (item.content | from_json)[0]['chacra_url'] }}repo"
-            return_content: yes
-          register: ceph_dev_yum_repo_ceph_iscsi
-          with_items: "{{ latest_build_ceph_iscsi.results }}"
-
-        - name: configure ceph red hat development repository for tcmu-runner
-          copy:
-            content: "{{ item.content }}"
-            dest: '/etc/yum.repos.d/{{ item.item.item }}-dev.repo'
-            owner: root
-            group: root
-            backup: yes
-          with_items: '{{ ceph_dev_yum_repo_ceph_iscsi.results }}'
+        - name: ceph-iscsi development repository
+          get_url:
+            url: "https://shaman.ceph.com/api/repos/{{ item }}/master/latest/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_major_version'] }}/repo"
+            dest: '/etc/yum.repos.d/{{ item }}-dev.repo'
+            force: true
+          register: result
+          until: result is succeeded
+          with_items: '{{ iscsi_base }}'
+          when: ceph_repository == 'dev'
 
         - name: ceph-iscsi stable repository
           get_url:


### PR DESCRIPTION
In commits 39649f0 and bf8cdad we switch from using the shaman /repos endpoint
to the /search endpoint for using the architecture filter.
In fact that filter is also available with the /repos endpoint, which requires
less ansible tasks.

This also adds back a condition remove in 5801171 on the ceph-iscsi
repository and that repository doesn't need to filter on the architecture
because the ceph-iscsi project is noarch.
Both ceph-iscsi and tcmu-runner shaman URLs were using the ceph_dev_branch
and ceph_dev_sha1 variables which doesn't make sense. Those variables are
only useful for the ceph core repository.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>