### PR TITLE
dashboard: support prometheus storage.tsdb.retention.time parameter

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -712,6 +712,9 @@ dummy:
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 #prometheus_port: 9092
 #prometheus_conf_overrides: {}
+# Uncomment out this variable if you need to customize the retention period for prometheus storage.
+# set it to '30d' if you want to retain 30 days of data.
+#prometheus_storage_tsdb_retention_time: 15d
 #alertmanager_container_image: "docker.io/prom/alertmanager:v0.16.2"
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -712,6 +712,9 @@ prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
 #prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 #prometheus_port: 9092
 #prometheus_conf_overrides: {}
+# Uncomment out this variable if you need to customize the retention period for prometheus storage.
+# set it to '30d' if you want to retain 30 days of data.
+#prometheus_storage_tsdb_retention_time: 15d
 alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
 #alertmanager_container_cpu_period: 100000
 #alertmanager_container_cpu_cores: 2

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -704,6 +704,9 @@ prometheus_conf_dir: /etc/prometheus
 prometheus_user_id: '65534'  # This is the UID used by the prom/prometheus container image
 prometheus_port: 9092
 prometheus_conf_overrides: {}
+# Uncomment out this variable if you need to customize the retention period for prometheus storage.
+# set it to '30d' if you want to retain 30 days of data.
+#prometheus_storage_tsdb_retention_time: 15d
 alertmanager_container_image: "docker.io/prom/alertmanager:v0.16.2"
 alertmanager_container_cpu_period: 100000
 alertmanager_container_cpu_cores: 2

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -31,6 +31,9 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=prometheus \
   {{ prometheus_container_image }} \
   --config.file=/etc/prometheus/prometheus.yml \
   --storage.tsdb.path=/prometheus \
+{% if prometheus_storage_tsdb_retention_time is defined %}
+  --storage.tsdb.retention.time={{ prometheus_storage_tsdb_retention_time }} \
+{% endif %}
   --web.external-url=http://{{ ansible_facts['fqdn'] }}:{{ prometheus_port }}/ \
   --web.listen-address={{ grafana_server_addr }}:{{ prometheus_port }}
 {% if container_binary == 'podman' %}


### PR DESCRIPTION
This commit adds the parameter `--storage.tsdb.retention.time` to the
prometheus systemd unit template.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1928000

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>