### PR TITLE
library/ceph_key: add output format parameter

### DIFF
--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -104,6 +104,12 @@ options:
             This command can ONLY run from a monitor node.
         required: false
         default: false
+    output_format:
+        description:
+            - The key output format when retrieving the information of an
+            entity.
+        required: false
+        default: json
 '''
 
 EXAMPLES = '''
@@ -163,6 +169,13 @@ caps:
   ceph_key:
     name: "my_key""
     state: info
+
+- name: info cephx admin key (plain)
+  ceph_key:
+    name: client.admin
+    output_format: plain
+    state: info
+  register: client_admin_key
 
 - name: list cephx keys
   ceph_key:
@@ -514,7 +527,8 @@ def run_module():
         import_key=dict(type='bool', required=False, default=True),
         dest=dict(type='str', required=False, default='/etc/ceph/'),
         user=dict(type='str', required=False, default='client.admin'),
-        user_key=dict(type='str', required=False, default=None)
+        user_key=dict(type='str', required=False, default=None),
+        output_format=dict(type='str', required=False, default='json', choices=['json', 'plain', 'xml', 'yaml'])
     )
 
     module = AnsibleModule(
@@ -535,6 +549,7 @@ def run_module():
     dest = module.params.get('dest')
     user = module.params.get('user')
     user_key = module.params.get('user_key')
+    output_format = module.params.get('output_format')
 
     changed = False
 
@@ -569,8 +584,6 @@ def run_module():
         user_key_path = os.path.join(user_key_dir, user_key_filename)
     else:
         user_key_path = user_key
-
-    output_format = "json"
 
     if (state in ["present", "update"]):
         # if dest is not a directory, the user wants to change the file's name

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -2,15 +2,17 @@
 - name: copy ceph admin keyring
   block:
     - name: get keys from monitors
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
-      register: _client_keys
-      with_items:
-        - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+      ceph_key:
+        name: client.admin
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+      register: _admin_key
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
       run_once: true
-      when:
-        - cephx | bool
-        - item.copy_key | bool
 
     - name: copy ceph key(s) if needed
       copy:
@@ -19,7 +21,6 @@
         owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
         mode: "{{ ceph_keyring_permissions }}"
-      with_items: "{{ _client_keys.results }}"
-      when:
-        - item.item.copy_key | bool
-  when: cephx | bool
+  when:
+    - cephx | bool
+    - copy_admin_key | bool

--- a/roles/ceph-crash/tasks/main.yml
+++ b/roles/ceph-crash/tasks/main.yml
@@ -21,11 +21,16 @@
       run_once: True
 
     - name: get keys from monitors
-      command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get client.crash"
+      ceph_key:
+        name: client.crash
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _crash_keys
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
-      check_mode: False
-      changed_when: False
       run_once: true
 
     - name: copy ceph key(s) if needed

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -1,14 +1,19 @@
 ---
 - name: get keys from monitors
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
-  register: _iscsi_keys
-  with_items:
-    - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  ceph_key:
+    name: client.admin
+    cluster: "{{ cluster }}"
+    output_format: plain
+    state: info
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+  register: _admin_key
   delegate_to: "{{ groups.get(mon_group_name)[0] }}"
   run_once: true
   when:
     - cephx | bool
-    - item.copy_key | bool
+    - copy_admin_key | bool
 
 - name: copy ceph key(s) if needed
   copy:
@@ -17,10 +22,9 @@
     owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: "{{ ceph_keyring_permissions }}"
-  with_items: "{{ _iscsi_keys.results }}"
   when:
     - cephx | bool
-    - item.item.copy_key | bool
+    - copy_admin_key | bool
 
 - name: add mgr ip address to trusted list with dashboard - ipv4
   set_fact:

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -11,7 +11,14 @@
     - /var/lib/ceph/mds/{{ cluster }}-{{ mds_name }}
 
 - name: get keys from monitors
-  command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  ceph_key:
+    name: "{{ item.name }}"
+    cluster: "{{ cluster }}"
+    output_format: plain
+    state: info
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _mds_keys
   with_items:
     - { name: "client.bootstrap-mds", path: "/var/lib/ceph/bootstrap-mds/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -54,7 +54,14 @@
           - { 'name': "mgr.{{ ansible_facts['hostname'] }}", 'path': "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_facts['hostname'] }}/keyring", 'copy_key': true }
 
     - name: get keys from monitors
-      command: "{{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      ceph_key:
+        name: "{{ item.name }}"
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _mgr_keys
       with_items: "{{ _mgr_keys }}"
       delegate_to: "{{ groups[mon_group_name][0] if running_mon is undefined else running_mon }}"

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -8,6 +8,7 @@
         cluster: "{{ cluster }}"
         user: mon.
         user_key: "/var/lib/ceph/mon/{{ cluster }}-{{ hostvars[running_mon]['ansible_facts']['hostname'] }}/keyring"
+        output_format: json
         state: info
       environment:
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -10,7 +10,14 @@
       run_once: true
 
     - name: get keys from monitors
-      command: "{{ hostvars[groups.get(mon_group_name)[0]]['container_exec_cmd'] }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      ceph_key:
+        name: "{{ item.name }}"
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _rgw_keys
       with_items:
         - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -47,7 +47,11 @@
     - groups.get(mon_group_name, []) | length > 0
   block:
     - name: get keys from monitors
-      command: "ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      ceph_key:
+        name: "{{ item.name }}"
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
       register: _rgw_keys
       with_items:
         - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: "{{ nfs_obj_gw }}" }

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -12,7 +12,14 @@
     - /var/lib/ceph/osd/
 
 - name: get keys from monitors
-  command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  ceph_key:
+    name: "{{ item.name }}"
+    cluster: "{{ cluster }}"
+    output_format: plain
+    state: info
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _osd_keys
   with_items:
     - { name: "client.bootstrap-osd", path: "/var/lib/ceph/bootstrap-osd/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -104,10 +104,16 @@
       delegate_to: "{{ groups[mon_group_name][0] }}"
 
     - name: get keys from monitors
-      command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+      ceph_key:
+        name: "{{ item.name }}"
+        cluster: "{{ cluster }}"
+        output_format: plain
+        state: info
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _osp_keys
       with_items: "{{ openstack_keys }}"
-      run_once: true
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
 
     - name: copy ceph key(s) if needed

--- a/roles/ceph-rbd-mirror/tasks/common.yml
+++ b/roles/ceph-rbd-mirror/tasks/common.yml
@@ -1,6 +1,13 @@
 ---
 - name: get keys from monitors
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  ceph_key:
+    name: "{{ item.name }}"
+    cluster: "{{ cluster }}"
+    output_format: plain
+    state: info
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _rbd_mirror_keys
   with_items:
     - { name: "client.bootstrap-rbd-mirror", path: "/var/lib/ceph/bootstrap-rbd-mirror/{{ cluster }}.keyring", copy_key: true }

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -9,7 +9,14 @@
   with_items: "{{ rbd_client_admin_socket_path }}"
 
 - name: get keys from monitors
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
+  ceph_key:
+    name: "{{ item.name }}"
+    cluster: "{{ cluster }}"
+    output_format: plain
+    state: info
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   register: _rgw_keys
   with_items:
     - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }

--- a/tests/library/test_ceph_key.py
+++ b/tests/library/test_ceph_key.py
@@ -25,8 +25,16 @@ class AnsibleExitJson(Exception):
     pass
 
 
+class AnsibleFailJson(Exception):
+    pass
+
+
 def exit_json(*args, **kwargs):
     raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    raise AnsibleFailJson(kwargs)
 
 
 @mock.patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': 'docker'})
@@ -373,27 +381,27 @@ class TestCephKeyModule(object):
             fake_cluster, fake_user, fake_user_key, fake_name, fake_container_image)
         assert result == expected_command_list
 
-    def test_info_key_non_container(self):
+    @pytest.mark.parametrize('output_format', ['json', 'plain', 'xml', 'yaml'])
+    def test_info_key_non_container(self, output_format):
         fake_user = 'client.admin'
         fake_user_key = '/etc/ceph/fake.client.admin.keyring'
         fake_cluster = "fake"
         fake_name = "client.fake"
         fake_user = "fake-user"
-        fake_output_format = "json"
         expected_command_list = [
             ['ceph', '-n', fake_user, '-k', fake_user_key, '--cluster', fake_cluster, 'auth',
-                'get', fake_name, '-f', 'json'],
+                'get', fake_name, '-f', output_format],
         ]
         result = ceph_key.info_key(
-            fake_cluster, fake_name, fake_user, fake_user_key, fake_output_format)
+            fake_cluster, fake_name, fake_user, fake_user_key, output_format)
         assert result == expected_command_list
 
-    def test_info_key_container(self):
+    @pytest.mark.parametrize('output_format', ['json', 'plain', 'xml', 'yaml'])
+    def test_info_key_container_json(self, output_format):
         fake_cluster = "fake"
         fake_name = "client.fake"
         fake_user = 'client.admin'
         fake_user_key = '/etc/ceph/fake.client.admin.keyring'
-        fake_output_format = "json"
         fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest-nautilus"
         expected_command_list = [['docker',
                                   'run',
@@ -408,9 +416,9 @@ class TestCephKeyModule(object):
                                   '-k', fake_user_key,
                                   '--cluster', fake_cluster,
                                   'auth', 'get', fake_name,
-                                  '-f', 'json']]
+                                  '-f', output_format]]
         result = ceph_key.info_key(
-            fake_cluster, fake_name, fake_user, fake_user_key, fake_output_format, fake_container_image)  # noqa E501
+            fake_cluster, fake_name, fake_user, fake_user_key, output_format, fake_container_image)  # noqa E501
         assert result == expected_command_list
 
     def test_list_key_non_container(self):
@@ -552,14 +560,16 @@ class TestCephKeyModule(object):
 
     @mock.patch('ansible.module_utils.basic.AnsibleModule.exit_json')
     @mock.patch('ceph_key.exec_commands')
-    def test_state_info(self, m_exec_commands, m_exit_json):
+    @pytest.mark.parametrize('output_format', ['json', 'plain', 'xml', 'yaml'])
+    def test_state_info(self, m_exec_commands, m_exit_json, output_format):
         set_module_args({"state": "info",
                          "cluster": "ceph",
-                         "name": "client.admin"}
+                         "name": "client.admin",
+                         "output_format": output_format}
                         )
         m_exit_json.side_effect = exit_json
         m_exec_commands.return_value = (0,
-                                        ['ceph', 'auth', 'get', 'client.admin', '-f', 'json'],
+                                        ['ceph', 'auth', 'get', 'client.admin', '-f', output_format],
                                         '[{"entity":"client.admin","key":"AQC1tw5fF156GhAAoJCvHGX/jl/k7/N4VZm8iQ==","caps":{"mds":"allow *","mgr":"allow *","mon":"allow *","osd":"allow *"}}]',  # noqa: E501
                                         'exported keyring for client.admin')
 
@@ -568,18 +578,23 @@ class TestCephKeyModule(object):
 
         result = result.value.args[0]
         assert not result['changed']
+        assert result['cmd'] == ['ceph', 'auth', 'get', 'client.admin', '-f', output_format]
         assert result['stdout'] == '[{"entity":"client.admin","key":"AQC1tw5fF156GhAAoJCvHGX/jl/k7/N4VZm8iQ==","caps":{"mds":"allow *","mgr":"allow *","mon":"allow *","osd":"allow *"}}]'  # noqa: E501
         assert result['stderr'] == 'exported keyring for client.admin'
         assert result['rc'] == 0
 
-    @mock.patch('ceph_key.generate_secret')
-    @mock.patch('ansible.module_utils.basic.AnsibleModule.exit_json')
-    def test_generate_key(self, m_exit_json, m_generate_secret):
-        fake_secret = b'AQDaLb1fAAAAABAAsIMKdGEKu+lGOyXnRfT0Hg=='
-        set_module_args({"state": "generate_secret"})
-        m_exit_json.side_effect = exit_json
-        m_generate_secret.return_value = fake_secret
+    @mock.patch('ansible.module_utils.basic.AnsibleModule.fail_json')
+    def test_state_info_invalid_format(self, m_fail_json):
+        invalid_format = 'txt'
+        set_module_args({"state": "info",
+                         "cluster": "ceph",
+                         "name": "client.admin",
+                         "output_format": invalid_format}
+                        )
+        m_fail_json.side_effect = fail_json
 
-        with pytest.raises(AnsibleExitJson) as result:
+        with pytest.raises(AnsibleFailJson) as result:
             ceph_key.run_module()
-        assert result.value.args[0]['stdout'] == fake_secret.decode()
+
+        result = result.value.args[0]
+        assert result['msg'] == 'value of output_format must be one of: json, plain, xml, yaml, got: {}'.format(invalid_format)


### PR DESCRIPTION
The ceph_key module currently only supports the json output for the
info state.
When using this state on an entity then we something want the output
as:
  - plain for copying it to another node.
  - json in order to get only a subset information of the entity (like
the key or caps).

This patch adds the output_format parameter which uses json as a
default value for backward compatibility. It removes the internal and
hardcoded variable also called output_format.
In addition of json and plain outputs, there's also xml and yaml
values available.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1947297

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit 7d3d51d6da9214a95923e870c2c5bd9627656ff2)