### PR TITLE
docker2podman: skip some role imports from handler

### DIFF
--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -58,17 +58,17 @@
   gather_facts: false
   become: true
   tasks:
+    - name: set_fact docker2podman and container_binary
+      set_fact:
+        docker2podman: True
+        container_binary: podman
+
     - import_role:
         name: ceph-defaults
     - import_role:
         name: ceph-facts
     - import_role:
         name: ceph-handler
-
-    - name: set_fact docker2podman and container_binary
-      set_fact:
-        docker2podman: True
-        container_binary: podman
 
     - name: install podman
       package:

--- a/roles/ceph-facts/tasks/container_binary.yml
+++ b/roles/ceph-facts/tasks/container_binary.yml
@@ -7,3 +7,4 @@
 - name: set_fact container_binary
   set_fact:
     container_binary: "{{ 'podman' if (podman_binary.stat.exists and ansible_facts['distribution'] == 'Fedora') or (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '8') else 'docker' }}"
+  when: not docker2podman | default(false) | bool

--- a/roles/ceph-handler/tasks/main.yml
+++ b/roles/ceph-handler/tasks/main.yml
@@ -51,6 +51,7 @@
 
 - name: rgw multi-instances related tasks
   when:
+    - not docker2podman | default(false) | bool
     - inventory_hostname in groups.get(rgw_group_name, [])
     - handler_rgw_status | bool
   block:


### PR DESCRIPTION
when running docker-to-podman playbook, there's no need to call
`ceph-config` and `ceph-rgw` from the role `ceph-handler`.
It can even have side effects when coming from a baremetal cluster that
was previously migrated using the switch-to-containers playbook. Indeed
it might complain about missing .target systemd unit since they are
removed during that migration.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1944999

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>