### PR TITLE
[skip ci] docker2podman: add documentation/header

### DIFF
--- a/infrastructure-playbooks/docker-to-podman.yml
+++ b/infrastructure-playbooks/docker-to-podman.yml
@@ -1,3 +1,10 @@
+---
+# This playbook is intended to be used as part of the el7 to el8 OS upgrade.
+# It modifies the systemd unit files so containers are launched with podman
+# instead of docker after the OS reboot once it is upgraded.
+# It is *not* intended to restart services since we don't want to multiple services
+# restarts.
+
 - hosts:
   - mons
   - osds


### PR DESCRIPTION
this adds a small documentation in the header of the playbook in order
to explain what is the goal of this playbook.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>