### PR TITLE
[skip ci] ceph-rgw-loadbalancer: Fix rgw_ports fact

### DIFF
--- a/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw-loadbalancer/tasks/pre_requisite.yml
@@ -41,7 +41,7 @@
   block:
     - name: set_fact rgw_ports
       set_fact:
-        rgw_ports: "{{ rgw_ports | default([]) + [hostvars[item]['rgw_instances']['radosgw_frontend_port']] | unique }}"
+        rgw_ports: "{{ rgw_ports | default([]) | union(hostvars[item]['rgw_instances'] | map(attribute='radosgw_frontend_port') | map('string') | list) }}"
       with_items: "{{ groups.get(rgw_group_name, []) }}"
 
     - name: add selinux rules


### PR DESCRIPTION
The `set_fact rgw_ports` task was failing due to a templating error, because
`hostvars[item].rgw_instances` is a list, but it was treated as if it was a
dictionary.

Another issue was the fact that the `unique` filter only applied to the list
being appended to `rgw_ports` instead of the entire list, which means it was
possible to have duplicate items.

Lastly, `rgw_ports` would have been a list of integers, but the `seport` module
expects a list of strings.

This commit fixes all of the issues above, allowing the `ceph-rgw-loadbalancer`
role to work on systems with SELinux enabled.

This should be backported to the stable branches as well.