### PR TITLE
Config the monitoring stack components api urls using a VIP

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -665,6 +665,8 @@ dummy:
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
 #dashboard_frontend_vip: ''
+#alertmanager_frontend_vip: ''
+#prometheus_frontend_vip: ''
 #node_exporter_container_image: "docker.io/prom/node-exporter:v0.17.0"
 #node_exporter_port: 9100
 #grafana_admin_user: admin

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -665,6 +665,8 @@ containerized_deployment: true
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
 #dashboard_frontend_vip: ''
+#prometheus_frontend_vip: ''
+#alertmanager_frontend_vip: ''
 node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
 #node_exporter_port: 9100
 #grafana_admin_user: admin

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -188,12 +188,26 @@
   vars:
     grafana_server_addr: '{{ item }}'
 
-- name: config grafana api url vip
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ dashboard_frontend_vip }}:{{ grafana_port }}"
-  delegate_to: "{{ groups[mon_group_name][0] }}"
+- name: config monitoring api url vip
   run_once: true
-  changed_when: false
-  when: dashboard_frontend_vip is defined and dashboard_frontend_vip |length > 0
+  block:
+    - name: config grafana api url vip
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-url {{ dashboard_protocol }}://{{ dashboard_frontend_vip }}:{{ grafana_port }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      changed_when: false
+      when: dashboard_frontend_vip is defined and dashboard_frontend_vip | length > 0
+
+    - name: config alertmanager api url
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-alertmanager-api-host {{ dashboard_protocol }}://{{ alertmanager_frontend_vip }}:{{ alertmanager_port }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      changed_when: false
+      when: alertmanager_frontend_vip is defined and alertmanager_frontend_vip | length > 0
+
+    - name: config prometheus api url
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-prometheus-api-host {{ dashboard_protocol }}://{{ prometheus_frontend_vip }}:{{ prometheus_port }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      changed_when: false
+      when: prometheus_frontend_vip is defined and prometheus_frontend_vip | length > 0
 
 - name: dashboard object gateway management frontend
   when: groups.get(rgw_group_name, []) | length > 0

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -657,6 +657,8 @@ dashboard_rgw_api_user_id: ceph-dashboard
 dashboard_rgw_api_admin_resource: ''
 dashboard_rgw_api_no_ssl_verify: False
 dashboard_frontend_vip: ''
+prometheus_frontend_vip: ''
+alertmanager_frontend_vip: ''
 node_exporter_container_image: "docker.io/prom/node-exporter:v0.17.0"
 node_exporter_port: 9100
 grafana_admin_user: admin


### PR DESCRIPTION
When VIPs are provided, all the monitoring services should be
configured using the related VIP. For this reason a  new VIP
variable is added for both prometheus and alertmanager: we're
already able to properly config the grafana frontend vip using
the dashboard_frontend_vip variable.
This change adds the same variable for both prometheus and
alertmanager.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1949391

Signed-off-by: Francesco Pantano <fpantano@redhat.com>