### PR TITLE
container/systemd: ensure /var/log/ceph exists

### DIFF
--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -12,6 +12,7 @@ EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm --storage rbd-target-api
+ExecStartPre=-/usr/bin/mkdir -p /var/log/rbd-target-api
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-api
 {% endif %}

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -12,6 +12,7 @@ EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm --storage rbd-target-gw
+ExecStartPre=-/usr/bin/mkdir -p /var/log/rbd-target-gw
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop rbd-target-gw
 {% endif %}

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -12,6 +12,7 @@ EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm --storage tcmu-runner
+ExecStartPre=-/usr/bin/mkdir -p /var/log/tcmu-runner
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop tcmu-runner
 {% endif %}

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -13,6 +13,7 @@ EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm --storage ceph-mds-{{ ansible_facts['hostname'] }}
+ExecStartPre=-/usr/bin/mkdir -p /var/log/ceph
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mds-{{ ansible_facts['hostname'] }}
 {% endif %}

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -12,6 +12,7 @@ EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm --storage ceph-mgr-{{ ansible_facts['hostname'] }}
+ExecStartPre=-/usr/bin/mkdir -p /var/log/ceph
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mgr-{{ ansible_facts['hostname'] }}
 {% endif %}

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -12,6 +12,7 @@ EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm --storage ceph-mon-%i
+ExecStartPre=-/usr/bin/mkdir -p /var/log/ceph
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-mon-%i
 {% endif %}

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -13,6 +13,7 @@ EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm --storage ceph-nfs-%i
+ExecStartPre=-/usr/bin/mkdir -p /var/log/ceph /var/log/ganesha
 {% endif %}
 ExecStartPre=-/usr/bin/{{ container_binary }} rm ceph-nfs-%i
 ExecStartPre={{ '/bin/mkdir' if ansible_facts['os_family'] == 'Debian' else '/usr/bin/mkdir' }} -p /etc/ceph /etc/ganesha /var/lib/nfs/ganesha /var/log/ganesha

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -14,6 +14,7 @@ EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm --storage ceph-osd-%i
+ExecStartPre=-/usr/bin/mkdir -p /var/log/ceph
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-osd-%i
 {% endif %}

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -12,6 +12,7 @@ EnvironmentFile=-/etc/environment
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm --storage ceph-rbd-mirror-{{ ansible_facts['hostname'] }}
+ExecStartPre=-/usr/bin/mkdir -p /var/log/ceph
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rbd-mirror-{{ ansible_facts['hostname'] }}
 {% endif %}

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -13,6 +13,7 @@ EnvironmentFile=/var/lib/ceph/radosgw/{{ cluster }}-%i/EnvironmentFile
 {% if container_binary == 'podman' %}
 ExecStartPre=-/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
 ExecStartPre=-/usr/bin/{{ container_binary }} rm --storage ceph-rgw-{{ ansible_facts['hostname'] }}-${INST_NAME}
+ExecStartPre=-/usr/bin/mkdir -p /var/log/ceph
 {% else %}
 ExecStartPre=-/usr/bin/{{ container_binary }} stop ceph-rgw-{{ ansible_facts['hostname'] }}-${INST_NAME}
 {% endif %}


### PR DESCRIPTION
This adds a `ExecStartPre=-/usr/bin/mkdir -p /var/log/ceph` in all
systemd service templates for all ceph daemon.
This is specific to RHCS after a Leapp upgrade is done. Indeed, the
`/var/log/ceph` seems to be removed after the upgrade.
In order to work around this issue let's ensure the directory is present
before trying to start the containers with podman.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1949489

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>