### PR TITLE
osd: always allow setting target_size_ratio

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -109,9 +109,7 @@
       command: "{{ ceph_admin_command | default('') }} --cluster {{ cluster }} osd pool set {{ item.name }} target_size_ratio {{ item.target_size_ratio }}"
       with_items: "{{ pools | unique }}"
       delegate_to: "{{ delegated_node }}"
-      when:
-        - item.pg_autoscale_mode | default(False) | bool
-        - item.target_size_ratio is defined
+      when: item.target_size_ratio is defined
 
     - name: set pg_autoscale_mode value on pool(s)
       command: "{{ ceph_admin_command | default('') }} --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -43,9 +43,7 @@
     - name: set the target ratio on pool(s)
       command: "{{ ceph_run_cmd }} --cluster {{ cluster }} osd pool set {{ item.name }} target_size_ratio {{ item.target_size_ratio }}"
       with_items: "{{ cephfs_pools | unique }}"
-      when:
-        - item.pg_autoscale_mode | default(False) | bool
-        - item.target_size_ratio is defined
+      when: item.target_size_ratio is defined
 
     - name: set pg_autoscale_mode value on pool(s)
       command: "{{ ceph_run_cmd }} --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -36,9 +36,7 @@
       command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} target_size_ratio {{ item.target_size_ratio }}"
       with_items: "{{ openstack_pools | unique }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
-      when:
-        - item.pg_autoscale_mode | default(False) | bool
-        - item.target_size_ratio is defined
+      when: item.target_size_ratio is defined
 
     - name: set pg_autoscale_mode value on pool(s)
       command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"


### PR DESCRIPTION
We shouldn't prevent from setting target_size_ratio when the autoscaler
is set to 'warn'.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1906305

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>