### PR TITLE
[skip ci] docs: update ansible version for master

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -83,7 +83,7 @@ The ``master`` branch should be considered experimental and used with caution.
 
 - ``stable-6.0`` Supports Ceph version ``pacific``. This branch requires Ansible version ``2.9``.
 
-- ``master`` Supports the master branch of Ceph. This branch requires Ansible version ``2.9``.
+- ``master`` Supports the master branch of Ceph. This branch requires Ansible version ``2.10``.
 
 .. NOTE:: ``stable-3.0`` and ``stable-3.1`` branches of ceph-ansible are deprecated and no longer maintained.
 


### PR DESCRIPTION
Since 839fac8 we now use ansible 2.10 on the master branch.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>