### PR TITLE
[skip ci] group_vars: fix default values

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -665,8 +665,8 @@ dummy:
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
 #dashboard_frontend_vip: ''
-#alertmanager_frontend_vip: ''
 #prometheus_frontend_vip: ''
+#alertmanager_frontend_vip: ''
 #node_exporter_container_image: "docker.io/prom/node-exporter:v0.17.0"
 #node_exporter_port: 9100
 #grafana_admin_user: admin

--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -127,3 +127,4 @@ dummy:
 #ceph_docker_image_tag: latest
 #ceph_nfs_docker_extra_env:
 #ceph_config_keys: [] # DON'T TOUCH ME
+


### PR DESCRIPTION
It looks like the `generate_group_vars_sample.sh` script wasn't executed
during previous PRs that were modifying the default values.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>