### PR TITLE
[skip ci] cephadm_adopt: create a 'nfs-ganesha' pool

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -670,7 +670,7 @@
             CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
     - name: update the placement of radosgw hosts
-      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} orch apply rgw {{ rgw_realm | default('default') }} {{ rgw_zone | default('default') }} --placement='count-per-host:{{ radosgw_num_instances }} label:{{ rgw_group_name }}' --port={{ radosgw_frontend_port }} {{ '--ssl' if radosgw_frontend_ssl_certificate else '' }}"
+      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} orch apply rgw {{ cluster }} {{ rgw_realm | default('default') }} {{ rgw_zone | default('default') }} --placement='count-per-host:{{ radosgw_num_instances }} label:{{ rgw_group_name }}' --port={{ radosgw_frontend_port }} {{ '--ssl' if radosgw_frontend_ssl_certificate else '' }}"
       run_once: true
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -848,8 +848,18 @@
           {{ nfs_file_gw_export | default('') }}
           {{ nfs_obj_gw_export | default('') }}
 
+    - name: create nfs exports pool
+      ceph_pool:
+        name: "{{ nfs_ganesha_export_pool_name | default('nfs-ganesha') }}"
+        cluster: "{{ cluster }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
+      environment:
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+
     - name: push the new exports in a rados object
-      command: "{{ rados_cmd }} -p {{ cephfs_data_pool.name }} -N {{ cephfs_data_pool.name }} put conf-nfs.{{ nfs_group_name | default('nfss') }} -"
+      command: "{{ rados_cmd }} -p {{ nfs_ganesha_export_pool_name | default('nfs-ganesha') }} -N {{ nfs_ganesha_export_namespace | default('nfs-ganesha') }} put conf-nfs.{{ nfs_group_name | default('nfss') }} -"
       args:
         stdin: "{{ new_export }}"
         stdin_add_newline: no
@@ -857,7 +867,7 @@
       delegate_to: "{{ groups[mon_group_name][0] }}"
 
     - name: update the placement of nfs hosts
-      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} orch apply nfs {{ nfs_group_name | default('nfss') }} {{ cephfs_data_pool.name }} {{ cephfs_data_pool.name }} --placement='{{ groups.get(nfs_group_name, []) | length }} label:{{ nfs_group_name }}'"
+      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} orch apply nfs {{ nfs_group_name | default('nfss') }} {{ nfs_ganesha_export_pool_name | default('nfs-ganesha') }} {{ nfs_ganesha_export_namespace | default('nfs-ganesha') }} --placement='{{ groups.get(nfs_group_name, []) | length }} label:{{ nfs_group_name }}'"
       run_once: true
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
When migrating from a cluster with no MDS nodes deployed,
`{{ cephfs_data_pool.name }}` doesn't exist so we need to create a pool
for storing nfs export objects.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1950403

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>