### PR TITLE
[skip ci] cephadm_adopt: fix ceph-crash migration

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -1003,11 +1003,10 @@
 
     - name: stop and disable ceph-crash systemd service
       service:
-        name: ceph-crash
+        name: "{{ 'ceph-crash@' + ansible_facts['hostname'] if containerized_deployment | bool else 'ceph-crash.service' }}"
         state: stopped
         enabled: false
       failed_when: false
-      when: not containerized_deployment | bool
 
     - name: update the placement of ceph-crash hosts
       command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} orch apply crash --placement='label:ceph'"


### PR DESCRIPTION
ceph-ansible leaves a ceph-crash container in containerized deployment.
It means we end up with 2 ceph-crash containers running after the
migration playbook is complete.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1954614

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>