### PR TITLE
WIP: Add proxy support

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -581,9 +581,6 @@ dummy:
 #ceph_docker_registry_auth: false
 #ceph_docker_registry_username:
 #ceph_docker_registry_password:
-#ceph_docker_http_proxy:
-#ceph_docker_https_proxy:
-#ceph_docker_no_proxy: "localhost,127.0.0.1"
 ## Client only docker image - defaults to {{ ceph_docker_image }}
 #ceph_client_docker_image: "{{ ceph_docker_image }}"
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
@@ -605,6 +602,19 @@ dummy:
 #docker_pull_retry: 3
 #docker_pull_timeout: "300s"
 
+#####################
+# Proxy Configuration #
+#####################
+# Instruct Ansible to use a proxy to fetch assest from the internet. 
+# This may be required for systems placed in DMZs.
+#proxy_env:
+#  http_proxy: http://example.com:80
+#  https_proxy: https://example.com:443
+
+# Instruct docker to pull image through a proxy
+#ceph_docker_http_proxy: http://example.com:80
+#ceph_docker_https_proxy: https://example.com:443
+#ceph_docker_no_proxy: "localhost,127.0.0.1"
 
 #############
 # OPENSTACK #

--- a/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -42,6 +42,7 @@
   when:
     - not containerized_deployment | bool
     - not ansible_facts['os_family'] in ['RedHat', 'Suse']
+  environment: "{{ proxy_env | default('') }}"
 
 - name: write grafana.ini
   template:


### PR DESCRIPTION
This PR is to begin discussion around adding proxy support to the role. Currently the role targets stable-4.0, but will be ported forward when accepted.

Problem:
Servers may be placed in environments where direct internet access is prohibited. Process dictates servers must connect to a proxy server before terminating with the remote end.

Proposed solution:
Add HTTP/HTTPS proxy support where needed by setting environment variables.
https://docs.ansible.com/ansible/latest/user_guide/playbooks_environment.html

Question:
1) Where else would could this feature be implemented?

2) Should #6182 get proxy support or leave it up to sysadmins to handle their own repository configuration?