### PR TITLE
ceph-rgw: fix pg_autoscale_mode for pool

### DIFF
--- a/roles/ceph-rgw/tasks/rgw_create_pools.yml
+++ b/roles/ceph-rgw/tasks/rgw_create_pools.yml
@@ -37,7 +37,7 @@
     pg_num: "{{ item.value.pg_num | default(omit) }}"
     pgp_num: "{{ item.value.pgp_num | default(omit) }}"
     size: "{{ item.value.size | default(omit) }}"
-    pg_autoscale_mode: "{{ item.pg_autoscale_mode | default(omit) }}"
+    pg_autoscale_mode: "{{ item.value.pg_autoscale_mode | default(omit) }}"
     target_size_ratio: "{{ item.value.target_size_ratio | default(omit) }}"
     pool_type: erasure
     erasure_profile: "{{ item.value.ec_profile }}"
@@ -60,7 +60,7 @@
     pgp_num: "{{ item.value.pgp_num | default(omit) }}"
     size: "{{ item.value.size | default(omit) }}"
     min_size: "{{ item.value.min_size | default(omit) }}"
-    pg_autoscale_mode: "{{ item.pg_autoscale_mode | default(omit) }}"
+    pg_autoscale_mode: "{{ item.value.pg_autoscale_mode | default(omit) }}"
     target_size_ratio: "{{ item.value.target_size_ratio | default(omit) }}"
     pool_type: replicated
     rule_name: "{{ item.value.rule_name | default(ceph_osd_pool_default_crush_rule_name) }}"


### PR DESCRIPTION
The pg_autoscale_mode for rgw pools introduced in 9f03a52 was wrong
and was missing a `value` keyword because `rgw_create_pools` is a
dict.

Fixes: #6516

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>