### PR TITLE
Revert "nfs: remove legacy file"

### DIFF
--- a/roles/ceph-nfs/files/org.ganesha.nfsd.conf
+++ b/roles/ceph-nfs/files/org.ganesha.nfsd.conf
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!-- Only root can own the service -->
+  <policy user="root">
+    <allow own="org.ganesha.nfsd"/>
+    <allow send_destination="org.ganesha.nfsd"/>
+
+    <allow send_destination="org.ganesha.nfsd"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+
+    <allow send_destination="org.ganesha.nfsd"
+           send_interface="org.ganesha.nfsd.CBSIM"/>
+
+    <allow send_destination="org.ganesha.nfsd"
+           send_interface="org.ganesha.nfsd.admin"/>
+  </policy>
+</busconfig>

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -41,3 +41,16 @@
         - item.item.copy_key | bool
   when: groups.get(mon_group_name, []) | length > 0
 
+- name: dbus related tasks
+  block:
+    - name: create dbus service file
+      copy:
+        src: "org.ganesha.nfsd.conf"
+        dest: /etc/dbus-1/system.d/org.ganesha.nfsd.conf
+        owner: "root"
+        group: "root"
+        mode: "0644"
+
+    - name: reload dbus configuration
+      command: "killall -SIGHUP dbus-daemon"
+  when: ceph_nfs_dynamic_exports | bool


### PR DESCRIPTION
This reverts commit 33bfb10af993faf97a976972f47344ab7ba51edf.

We still need this file with containerized deployment because the
nfs-ganesha package isn't installed on the host.

Fixes: #6501

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>