### PR TITLE
[skip ci] nfs: get org.ganesha.nfsd.conf from container

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -41,3 +41,22 @@
         - item.item.copy_key | bool
   when: groups.get(mon_group_name, []) | length > 0
 
+- name: dbus related tasks
+  block:
+    - name: get file
+      command: "{{ container_binary }} run --rm --entrypoint=cat {{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag }} /etc/dbus-1/system.d/org.ganesha.nfsd.conf"
+      register: dbus_ganesha_file
+      run_once: true
+      changed_when: false
+
+    - name: create dbus service file
+      copy:
+        content: "{{ dbus_ganesha_file.stdout }}"
+        dest: /etc/dbus-1/system.d/org.ganesha.nfsd.conf
+        owner: "root"
+        group: "root"
+        mode: "0644"
+
+    - name: reload dbus configuration
+      command: "killall -SIGHUP dbus-daemon"
+  when: ceph_nfs_dynamic_exports | bool


### PR DESCRIPTION
Since we need to revert 33bfb10, this is an alternative to initial approach.
We can avoid maintaining this file since it is present in container
image. The idea is to simply get it from the image container and write
it to the host.

Fixes: #6501

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>