### PR TITLE
[skip ci] nfs: replace a command task

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -56,7 +56,11 @@
         owner: "root"
         group: "root"
         mode: "0644"
+      register: dbus_svc_file
 
     - name: reload dbus configuration
-      command: "killall -SIGHUP dbus-daemon"
+      service:
+        name: dbus
+        state: reloaded
+      when: dbus_svc_file.changed | bool
   when: ceph_nfs_dynamic_exports | bool


### PR DESCRIPTION
Let's use the ansible service module instead of using command module.
by the way, killall isn't POSIX standard.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>