### PR TITLE
Make sure the repo url contains the correct arch

### DIFF
--- a/roles/ceph-common/tasks/installs/debian_dev_repository.yml
+++ b/roles/ceph-common/tasks/installs/debian_dev_repository.yml
@@ -1,7 +1,14 @@
 ---
+- name: get latest available build
+  uri:
+    url: "https://shaman.ceph.com/api/search/?status=ready&project=ceph&flavor=default&distros={{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_release'] }}/{{ ansible_facts['architecture'] }}&ref={{ ceph_dev_branch }}&sha1={{ ceph_dev_sha1 }}"
+    return_content: yes
+  run_once: true
+  register: latest_build
+
 - name: fetch ceph debian development repository
   uri:
-    url: https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_release'] }}/repo
+    url: "{{ (latest_build.content | from_json)[0]['chacra_url'] }}repo"
     return_content: yes
   register: ceph_dev_deb_repo
 


### PR DESCRIPTION
We can end up with an arm only repo unless we are specific about the
architecture we require. Brings the deb code in line with the rpm
equivalent.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>
(cherry picked from commit 267cce9e8360fc8cb9c192fde2406e5dca724610)