### PR TITLE
Sensitive key data now hidden in output log

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -28,6 +28,7 @@
     - cephx | bool
     - keys | length > 0
     - inventory_hostname == groups.get('_filtered_clients') | first
+  no_log: true
 
 - name: slurp client cephx key(s)
   slurp:
@@ -39,6 +40,7 @@
     - cephx | bool
     - keys | length > 0
     - inventory_hostname == groups.get('_filtered_clients') | first
+  no_log: true
 
 - name: pool related tasks
   when:
@@ -79,3 +81,5 @@
     group: "{{ ceph_uid }}"
   with_items: "{{ hostvars[groups['_filtered_clients'][0]]['slurp_client_keys']['results'] }}"
   when: not item.get('skipped', False)
+  no_log: true
+

--- a/roles/ceph-client/tasks/pre_requisite.yml
+++ b/roles/ceph-client/tasks/pre_requisite.yml
@@ -21,6 +21,7 @@
         owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         mode: "{{ ceph_keyring_permissions }}"
+      no_log: true
   when:
     - cephx | bool
     - copy_admin_key | bool

--- a/roles/ceph-crash/tasks/main.yml
+++ b/roles/ceph-crash/tasks/main.yml
@@ -40,6 +40,7 @@
         owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
         mode: "{{ ceph_keyring_permissions }}"
+      no_log: true
 
 - name: start ceph-crash daemon
   when: containerized_deployment | bool

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -25,6 +25,7 @@
   when:
     - cephx | bool
     - copy_admin_key | bool
+  no_log: true
 
 - name: add mgr ip address to trusted list with dashboard - ipv4
   set_fact:

--- a/roles/ceph-mds/tasks/common.yml
+++ b/roles/ceph-mds/tasks/common.yml
@@ -40,3 +40,5 @@
   when:
     - cephx | bool
     - item.item.copy_key | bool
+  no_log: true
+

--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -81,6 +81,7 @@
         - cephx | bool
         - item is not skipped
         - item.item.copy_key | bool
+      no_log: true
 
 - name: set mgr key permissions
   file:

--- a/roles/ceph-nfs/tasks/main.yml
+++ b/roles/ceph-nfs/tasks/main.yml
@@ -75,6 +75,7 @@
       when:
         - not item.0.get('skipped', False)
         - item.0.item.name == 'client.' + ceph_nfs_ceph_user or item.0.item.name == rgw_client_name
+      no_log: true
 
 - name: include start_nfs.yml
   import_tasks: start_nfs.yml

--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -39,6 +39,7 @@
       when:
         - cephx | bool
         - item.item.copy_key | bool
+      no_log: true
   when: groups.get(mon_group_name, []) | length > 0
 
 - name: dbus related tasks

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container.yml
@@ -74,6 +74,7 @@
       when:
         - cephx | bool
         - item.item.copy_key | bool
+      no_log: true
 
     - name: nfs object gateway related tasks
       when: nfs_obj_gw | bool

--- a/roles/ceph-osd/tasks/common.yml
+++ b/roles/ceph-osd/tasks/common.yml
@@ -42,3 +42,5 @@
     - cephx | bool
     - item is not skipped
     - item.item.copy_key | bool
+  no_log: true
+

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -60,6 +60,7 @@
         - "{{ _osp_keys.results }}"
         - "{{ groups[mon_group_name] }}"
       delegate_to: "{{ item.1 }}"
+      no_log: true
   when:
     - cephx | bool
     - openstack_config | bool

--- a/roles/ceph-rbd-mirror/tasks/common.yml
+++ b/roles/ceph-rbd-mirror/tasks/common.yml
@@ -29,6 +29,7 @@
   when:
     - cephx | bool
     - item.item.copy_key | bool
+  no_log: true
 
 - name: create rbd-mirror keyring
   ceph_key:

--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -39,6 +39,7 @@
     - cephx | bool
     - item is not skipped
     - item.item.copy_key | bool
+  no_log: true
 
 - name: copy SSL certificate & key data to certificate path
   copy:


### PR DESCRIPTION
Set **no_log: true** for all the updated files , so that sensitive information are not logged out in the ansible output, thereby increasing security and privacy.

Fixes: #6529

Signed-off-by: Neelaksh Singh <neelaksh48@gmail.com>