### PR TITLE
container: conditionnally disable lvmetad

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -342,6 +342,7 @@ dummy:
 
 ## OSD options
 #
+#lvmetad_disabled: false
 #is_hci: false
 #hci_safety_factor: 0.2
 #non_hci_safety_factor: 0.7

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -342,6 +342,7 @@ ceph_iscsi_config_dev: false
 
 ## OSD options
 #
+#lvmetad_disabled: false
 #is_hci: false
 #hci_safety_factor: 0.2
 #non_hci_safety_factor: 0.7

--- a/roles/ceph-container-common/tasks/prerequisites.yml
+++ b/roles/ceph-container-common/tasks/prerequisites.yml
@@ -1,4 +1,22 @@
 ---
+- name: lvmetad tasks related
+  when:
+    - inventory_hostname in groups.get(osd_group_name, [])
+    - lvmetad_disabled | default(False) | bool
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] | int == 7
+  block:
+    - name: stop lvmetad
+      service:
+        name: lvmetad
+        state: stopped
+
+    - name: disable and mask lvmetad service
+      service:
+        name: lvmetad
+        enabled: no
+        masked: yes
+
 - name: remove ceph udev rules
   file:
     path: "{{ item }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -334,6 +334,7 @@ cephfs_pools:
 
 ## OSD options
 #
+lvmetad_disabled: false
 is_hci: false
 hci_safety_factor: 0.2
 non_hci_safety_factor: 0.7


### PR DESCRIPTION
Enabling lvmetad in containerized deployments on el7 based OS might
cause issues.
This commit make it possible to disable this service if needed.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1955040

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>