### PR TITLE
cephadm-adopt: purge grafana db

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -1155,6 +1155,11 @@
             enabled: false
           failed_when: false
 
+        - name: purge old grafana db in /var/lib/grafana
+          file:
+            path: /var/lib/grafana/grafana.db
+            state: absent
+
         - name: adopt grafana daemon
           cephadm_adopt:
             name: "grafana.{{ ansible_facts['hostname'] }}"


### PR DESCRIPTION
ceph-ansible leaves /var/lib/grafana content so it overrides the
datasource that cephadm writes. It causes a 502 error "bad gateway".

The idea here is basically removing the grafana content in
/var/lib/grafana which should fix this issue.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1963849

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>