### PR TITLE
prometheus: enforce osd nodes in templates

### DIFF
--- a/roles/ceph-prometheus/templates/prometheus.yml.j2
+++ b/roles/ceph-prometheus/templates/prometheus.yml.j2
@@ -19,7 +19,7 @@ scrape_configs:
 {% endfor %}
   - job_name: 'node'
     static_configs:
-{% for host in (groups['all'] | difference(groups[monitoring_group_name] | union(groups.get(client_group_name, [])))) %}
+{% for host in (groups['all'] | difference(groups[monitoring_group_name] | union(groups.get(client_group_name, []))) | union(groups.get(osd_group_name, []))) %}
       - targets: ['{{ host }}:{{ node_exporter_port }}']
         labels:
           instance: "{{ hostvars[host]['ansible_facts']['nodename'] }}"


### PR DESCRIPTION
When osd nodes are collocated in the clients group (HCI context for
instance), the current logic will exclude osd nodes since they are
present in the client group.

The best fix would be to exclude clients node only when they are not
member of another group but for now, as a workaround, we can enforce
the addition of osd nodes to fix this specific case.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1947695

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>