### PR TITLE
tests: pull images from cloud.centos.org

### DIFF
--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+vagrant box remove --force --provider libvirt --box-version 0 centos/8 || true
+vagrant box add --provider libvirt --name centos/8 https://cloud.centos.org/centos/8/vagrant/x86_64/images/CentOS-8-Vagrant-8.3.2011-20201204.2.x86_64.vagrant-libvirt.box || true
+
 retries=0
 until [ $retries -ge 5 ]
 do


### PR DESCRIPTION
temporary work around vagrant cloud issue which seems broken at the time
of pushing this commit.
Let's pull images from cloud.centos.org for now since vagrant cloud
hosted images return a 403 error.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>