### PR TITLE
vagrant_up: fix bash legacy syntax

### DIFF
--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -5,7 +5,7 @@ until [ $retries -ge 5 ]
 do
   echo "Attempting to start VMs. Attempts: $retries"
   timeout 10m time vagrant up "$@" && break
-  retries=$[$retries+1]
+  retries=$((retries+1))
   sleep 5
 done
 


### PR DESCRIPTION
This commit rewrites the deprecated syntax used in vagrant_up.sh

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>