### PR TITLE
[skip ci] fs2bs: fix wrong filter when setting osd_ids

### DIFF
--- a/infrastructure-playbooks/filestore-to-bluestore.yml
+++ b/infrastructure-playbooks/filestore-to-bluestore.yml
@@ -48,7 +48,7 @@
       set_fact:
         osd_ids: "{{ osd_ids | default([]) | union(item) }}"
       with_items:
-        - "{{ ((osd_tree.stdout | default('{}') | trim | from_json).nodes | selectattr('name', 'match', '^' + inventory_hostname + '$') | map(attribute='children') | list) }}"
+        - "{{ ((osd_tree.stdout | default('{}') | trim | from_json).nodes | selectattr('name', 'equalto', inventory_hostname) | map(attribute='children') | list) }}"
 
     - name: get osd metadata
       command: "{{ ceph_cmd }} --cluster {{ cluster }} osd metadata osd.{{ item }} -f json"
@@ -355,7 +355,7 @@
           set_fact:
             osd_ids: "{{ osd_ids | default([]) + [item] }}"
           with_items:
-            - "{{ ((osd_tree.stdout | default('{}') | from_json).nodes | selectattr('name', 'match', inventory_hostname) | map(attribute='children') | list) }}"
+            - "{{ ((osd_tree.stdout | default('{}') | from_json).nodes | selectattr('name', 'equalto', inventory_hostname) | map(attribute='children') | list) }}"
 
         - name: purge osd(s) from the cluster
           ceph_osd:


### PR DESCRIPTION
using 'match' filter in that task will lead to bad behavior if I have
the following node names for instance:

- node1
- node11
- node111

with `selectattr('name', 'match', inventory_hostname)` it will match
'node1' along with 'node11' and 'node111'.

using 'equalto' filter will make sure we only match the target node.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1963066

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>