### PR TITLE
fs2bs: use match filter in selectattr()

### DIFF
--- a/infrastructure-playbooks/filestore-to-bluestore.yml
+++ b/infrastructure-playbooks/filestore-to-bluestore.yml
@@ -48,7 +48,7 @@
       set_fact:
         osd_ids: "{{ osd_ids | default([]) | union(item) }}"
       with_items:
-        - "{{ ((osd_tree.stdout | default('{}') | trim | from_json).nodes | selectattr('name', 'equalto', inventory_hostname) | map(attribute='children') | list) }}"
+        - "{{ ((osd_tree.stdout | default('{}') | trim | from_json).nodes | selectattr('name', 'match', '^' + inventory_hostname + '$') | map(attribute='children') | list) }}"
 
     - name: get osd metadata
       command: "{{ ceph_cmd }} --cluster {{ cluster }} osd metadata osd.{{ item }} -f json"
@@ -355,7 +355,7 @@
           set_fact:
             osd_ids: "{{ osd_ids | default([]) + [item] }}"
           with_items:
-            - "{{ ((osd_tree.stdout | default('{}') | from_json).nodes | selectattr('name', 'equalto', inventory_hostname) | map(attribute='children') | list) }}"
+            - "{{ ((osd_tree.stdout | default('{}') | from_json).nodes | selectattr('name', 'match', '^' + inventory_hostname + '$') | map(attribute='children') | list) }}"
 
         - name: purge osd(s) from the cluster
           ceph_osd:


### PR DESCRIPTION
0990ae41099d8b9d678f546fc8790033f421711f changed the filter in
selectattr() from 'match' to 'equalto' but due to an incompatibility with
the Jinja2 version for python 2.7 on el7 we must stick to using 'match'
filter.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>