### PR TITLE
crash: fix --limit deployments (containers)

### DIFF
--- a/roles/ceph-crash/tasks/main.yml
+++ b/roles/ceph-crash/tasks/main.yml
@@ -20,6 +20,21 @@
       delegate_to: "{{ groups.get(mon_group_name, [])[0] }}"
       run_once: True
 
+    - name: enforce container_binary on first monitor
+      import_role:
+        name: ceph-facts
+        tasks_from: container_binary.yml
+      delegate_to: "{{ groups.get(mon_group_name, [])[0] }}"
+      delegate_facts: true
+
+    - name: set_fact container_exec_cmd
+      set_fact:
+        container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_facts']['hostname'] if not rolling_update | bool else hostvars[mon_host | default(groups[mon_group_name][0])]['ansible_facts']['hostname'] }}"
+      delegate_to: "{{ groups.get(mon_group_name, [])[0] }}"
+      delegate_facts: true
+      when:
+        - containerized_deployment | bool
+
     - name: get keys from monitors
       command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} auth get client.crash"
       register: _crash_keys


### PR DESCRIPTION
ceph-crash deployments is broken when ceph-ansible playbook is called
with --limit in containerized contexts since we don't set
`container_exec_cmd` on the first monitor.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1964835

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 10ed26f14dc38211d4c77cbeeeb681d215a351b7)