### PR TITLE
dashboard: fix typo introduced during backport

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -969,7 +969,7 @@
     - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
-    - "{{ monitoring_group_name|default('monitoring') }}"
+    - "{{ grafana_server_group_name|default('grafana-server') }}"
   gather_facts: false
   become: true
   tasks:

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
@@ -12,4 +12,4 @@
 - name: enable red hat storage tools repository
   rhsm_repository:
     name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms"
-  when: (mgr_group_name in group_names or rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names or monitoring_group_name in group_names)
+  when: (mgr_group_name in group_names or rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names or grafana_server_group_name in group_names)


### PR DESCRIPTION
during backport of c8b92deba10c0b6e0ebcb0e31315b1e6174fdc0c the pattern
should have been s/monitoring_group_name/grafana_server_group_name/

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1964907

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>