### PR TITLE
dashboard: fix rgw user creation

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -296,7 +296,7 @@
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
       when:
-        - not rgw_multisite | bool or rgw_zonemaster | bool
+        - not rgw_multisite | bool or (true in (rgw_instances | selectattr('rgw_zonemaster', 'defined') | map(attribute='rgw_zonemaster') | list) if rgw_instances is defined else rgw_zonemaster | default(false))
         - get_rgw_user.rc == 22
 
     - name: get the rgw access and secret keys


### PR DESCRIPTION
When deploying dashboard in a cluster with rgw multisite deployed.
Due to the last rgw multisite refactor, we now expect the variable
`rgw_zonemaster` to be defined in the dict `rgw_instances`.
The idea here is to create that user on the cluster as soon as we have 1
`rgw_zonemaster` set to `true` in `rgw_instances`.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1964995

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>