### PR TITLE
ceph_key: handle error in a better way

### DIFF
--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -619,10 +619,6 @@ def run_module():
     elif state == "info":
         rc, cmd, out, err = exec_commands(
             module, info_key(cluster, name, user, user_key_path, output_format, container_image))  # noqa E501
-        if rc != 0:
-            result["stdout"] = "skipped, since {0} does not exist".format(name)
-            result['rc'] = 0
-            module.exit_json(**result)
 
     elif state == "list":
         rc, cmd, out, err = exec_commands(

--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -16,6 +16,7 @@
       register: initial_mon_key
       run_once: True
       delegate_to: "{{ running_mon }}"
+      failed_when: initial_mon_key.rc not in [0, 2]
       when: running_mon is defined
 
     - name: generate monitor initial keyring
@@ -25,11 +26,18 @@
       delegate_to: localhost
       become: false
       run_once: true
-      when: initial_mon_key.skipped is defined
+      when:
+        - initial_mon_key is skipped
+          or
+          initial_mon_key is not succeeded
+
+    - name: set_fact _initial_mon_key_success
+      set_fact:  # when initial_mon_key is registered above, `rc: 2` is considered success.
+        _initial_mon_key_success: "{{ initial_mon_key is not skipped and initial_mon_key.rc == 0 }}"
 
     - name: get initial keyring when it already exists
       set_fact:
-        monitor_keyring: "{{ (initial_mon_key.stdout | from_json)[0]['key'] if initial_mon_key is not skipped else monitor_keyring.stdout }}"
+        monitor_keyring: "{{ (initial_mon_key.stdout | from_json)[0]['key'] if _initial_mon_key_success | bool else monitor_keyring.stdout }}"
       when: initial_mon_key.stdout|default('')|length > 0 or monitor_keyring is not skipped
 
     - name: create monitor initial keyring


### PR DESCRIPTION
When calling the `ceph_key` module with `state: info`, if the ceph
command called fails, the actual error is hidden by the module which
makes it pretty difficult to troubleshoot.

The current code always states that if rc is not equal to 0 the keyring
doesn't exist.

`state: info` should always return the actual rc, stdout and stderr.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1964889

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>