### PR TITLE
rolling_update: fix mon+rgw/multisite collocation

### DIFF
--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: set_fact radosgw_adm_cmd
+  set_fact:
+    radosgw_adm_cmd: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph:/var/lib/ceph:z --entrypoint=radosgw-admin ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'radosgw-admin' }} --cluster {{ cluster }}"
+
 - name: include common.yml
   include_tasks: common.yml
 

--- a/roles/ceph-rgw/tasks/multisite/master.yml
+++ b/roles/ceph-rgw/tasks/multisite/master.yml
@@ -81,7 +81,7 @@
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: update period for zone creation
-  command: "{{ container_exec_cmd }} radosgw-admin --cluster={{ cluster }} --rgw-realm={{ item.realm }} --rgw-zonegroup={{ item.zonegroup }} --rgw-zone={{ item.zone }} period update --commit"
+  command: "{{ radosgw_adm_cmd }} --rgw-realm={{ item.realm }} --rgw-zonegroup={{ item.zonegroup }} --rgw-zone={{ item.zone }} period update --commit"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   loop: "{{ zone_endpoints_list }}"

--- a/roles/ceph-rgw/tasks/multisite/secondary.yml
+++ b/roles/ceph-rgw/tasks/multisite/secondary.yml
@@ -37,7 +37,7 @@
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: get the period(s)
-  command: "{{ container_exec_cmd }} radosgw-admin period get --cluster={{ cluster }} --rgw-realm={{ item.realm }}"
+  command: "{{ radosgw_adm_cmd }} radosgw-admin period get --rgw-realm={{ item.realm }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   loop: "{{ secondary_realms }}"
@@ -81,7 +81,7 @@
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
 - name: update period for zone creation
-  command: "{{ container_exec_cmd }} radosgw-admin --cluster={{ cluster }} --rgw-realm={{ item.realm }} --rgw-zonegroup={{ item.zonegroup }} --rgw-zone={{ item.zone }} period update --commit"
+  command: "{{ radosgw_adm_cmd }} --rgw-realm={{ item.realm }} --rgw-zonegroup={{ item.zonegroup }} --rgw-zone={{ item.zone }} period update --commit"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   loop: "{{ zone_endpoints_list }}"


### PR DESCRIPTION
When monitors and rgw are collocated with multisite enabled, the
rolling_update playbook fails because during the workflow, we run some
radosgw-admin commands very early on the first mon even though this is
the monitor being upgraded, it means the container doesn't exist since
it was stopped.
With this commit we now run an ephemeral container instead for running
those radosgw-admin commands so we don't need to care if the mon container
is running.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1970232

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>