### PR TITLE
rolling_update: fix mon+rgw/multisite collocation

### DIFF
--- a/roles/ceph-handler/tasks/main.yml
+++ b/roles/ceph-handler/tasks/main.yml
@@ -52,6 +52,7 @@
 - name: rgw multi-instances related tasks
   when:
     - not docker2podman | default(false) | bool
+    - not rolling_update | default(false) | bool
     - inventory_hostname in groups.get(rgw_group_name, [])
     - handler_rgw_status | bool
   block:


### PR DESCRIPTION
When monitors and rgw are collocated with multisite enabled, the
rolling_update playbook fails because during the workflow, we run some
radosgw-admin commands very early on the first mon even though this is
the monitor being upgraded, it means the container doesn't exist since
it was stopped.

This block is relevant only for scaling out rgw daemons or initial
deployment. In rolling_update workflow, it is not needed so let's skip
it.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1970232

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>