### PR TITLE
tests: allocate more memory for all_in_one job

### DIFF
--- a/tests/functional/all-in-one/container/vagrant_variables.yml
+++ b/tests/functional/all-in-one/container/vagrant_variables.yml
@@ -21,7 +21,7 @@ cluster_subnet: 192.168.20
 
 # MEMORY
 # set 1024 for CentOS
-memory: 1024
+memory: 4096
 
 # Disks
 # For libvirt use disks: "[ '/dev/vdb', '/dev/vdc' ]"

--- a/tests/functional/all-in-one/vagrant_variables.yml
+++ b/tests/functional/all-in-one/vagrant_variables.yml
@@ -17,7 +17,7 @@ cluster_subnet: 192.168.18
 
 # MEMORY
 # set 1024 for CentOS
-memory: 1024
+memory: 8192
 
 # Disks
 # For libvirt use disks: "[ '/dev/vdb', '/dev/vdc' ]"


### PR DESCRIPTION
Since we fire up much less VMs than other job, we can affoard allocating
more memory here for this job.
Each VM hosts more daemon so 1024Mb can be too few.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>