### PR TITLE
update: block upgrade when nfs+rgw is deployed

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -14,6 +14,24 @@
 #   - if you use an ISO, you have to change the ceph_rhcs_iso_path to the directory containing the new Ceph version
 #
 
+- name: block upgrade if nfs+rgw deployed
+  hosts: "{{ nfs_group_name | default('nfss') }}"
+  serial: 1
+  become: True
+  tasks:
+    - name: import_role ceph-defaults
+      import_role:
+        name: ceph-defaults
+
+    - name: block upgrade if nfs+rgw deployed
+      fail:
+        msg: >
+          Upgrading to Ceph Pacific isn't supported with nfs+rgw.
+          This will be supported soon in a new release of Ceph Pacific.
+      when:
+        - groups.get(nfs_group_name, []) | length > 0
+        - nfs_obj_gw | bool
+
 - name: confirm whether user really meant to upgrade the cluster
   hosts: localhost
   become: false
@@ -27,6 +45,10 @@
       private: no
 
   tasks:
+    - name: import_role ceph-defaults
+      import_role:
+        name: ceph-defaults
+
     - name: exit playbook, if user did not mean to upgrade cluster
       fail:
         msg: >
@@ -35,10 +57,6 @@
            use `-e ireallymeanit=yes` on the command line when
            invoking the playbook"
       when: ireallymeanit != 'yes'
-
-    - name: import_role ceph-defaults
-      import_role:
-        name: ceph-defaults
 
     - name: check if a legacy grafana-server group exists
       import_role:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,9 @@ def node(host, request):
     if request.node.get_closest_marker("dashboard") and group_names == ['clients']:
         pytest.skip('Not a valid test for client node')
 
+    if request.node.get_closest_marker("no_rolling_update") and rolling_update:
+        pytest.skip('Not a valid test when testing rolling_update')
+
     data = dict(
         vars=ansible_vars,
         docker=docker,

--- a/tests/functional/tests/nfs/test_nfs_ganesha.py
+++ b/tests/functional/tests/nfs/test_nfs_ganesha.py
@@ -4,6 +4,7 @@ import pytest
 
 class TestNFSs(object):
 
+    @pytest.mark.no_rolling_update
     @pytest.mark.no_docker
     @pytest.mark.parametrize('pkg', [
         'nfs-ganesha',
@@ -23,6 +24,7 @@ class TestNFSs(object):
         assert host.file(
             "/etc/ganesha/ganesha.conf").contains("Entries_HWMark")
 
+    @pytest.mark.no_rolling_update
     def test_nfs_is_up(self, node, host, setup):
         hostname = node["vars"]["inventory_hostname"]
         cluster = setup['cluster_name']

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -48,6 +48,8 @@ commands=
   bash -c 'ANSIBLE_CONFIG={envdir}/tmp/ceph-ansible/ansible.cfg ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/hosts {envdir}/tmp/ceph-ansible/tests/functional/lvm_setup.yml --extra-vars "osd_scenario=lvm"'
 
   # deploy the cluster
+  # passing ceph_nfs_rgw_access_key and ceph_nfs_rgw_secret_key because of a weird behavior in the CI:
+  # When rendering the ganesha.conf.j2 template, it complains because of undefined variables in the block "{% if nfs_obj_gw | bool %}" although we explicitly set this variable to false (see below).
   bash -c 'ANSIBLE_CONFIG={envdir}/tmp/ceph-ansible/ansible.cfg ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/hosts {envdir}/tmp/ceph-ansible/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
       ceph_stable_release=octopus \
@@ -57,6 +59,10 @@ commands=
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
+      nfs_file_gw=True \
+      nfs_obj_gw=False \
+      ceph_nfs_rgw_access_key=fake_access_key \
+      ceph_nfs_rgw_secret_key=fake_secret_key \
   "'
 
   non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup=True change_dir={changedir} ceph_dev_branch=pacific ceph_dev_sha1=latest setup_nfs_dev_repo=false" --tags "vagrant_setup"
@@ -66,6 +72,8 @@ commands=
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
+      nfs_file_gw=True \
+      nfs_obj_gw=False \
   "
 
   bash -c "CEPH_STABLE_RELEASE=pacific py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests"


### PR DESCRIPTION
This is an unsupported configuration.
There are issues with RGW+NFS upgraded from Nautilus to Pacific.
This approach might be seen as a bit aggressive but it is preferable
to wait before upgrading in that case.
    
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1970003
    
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>