### PR TITLE
tests: use nfs/mds instead of nfs/rgw

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -13,7 +13,7 @@
       command: "{{ hostvars[groups.get(mon_group_name)[0]]['container_exec_cmd'] }} ceph --cluster {{ cluster }} auth get {{ item.name }}"
       register: _rgw_keys
       with_items:
-        - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
+        - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: "{{ nfs_obj_gw }}" }
         - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
       run_once: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,8 @@ def node(host, request):
     group_names = ansible_vars["group_names"]
     docker = ansible_vars.get("docker")
     dashboard = ansible_vars.get("dashboard_enabled", True)
+    nfs_file_gw = ansible_vars.get("nfs_file_gw")
+    nfs_obj_gw = ansible_vars.get("nfs_obj_gw")
     radosgw_num_instances = ansible_vars.get("radosgw_num_instances", 1)
     ceph_release_num = {
         'jewel': 10,
@@ -146,6 +148,12 @@ def node(host, request):
     if request.node.get_closest_marker("dashboard") and group_names == ['clients']:
         pytest.skip('Not a valid test for client node')
 
+    if request.node.get_closest_marker("no_nfs_file_gw") and nfs_file_gw:
+        pytest.skip('Not a valid test for nfs+cephfs node')
+
+    if request.node.get_closest_marker("no_nfs_obj_gw") and nfs_obj_gw:
+        pytest.skip('Not a valid test for nfs+rgw node')
+
     data = dict(
         vars=ansible_vars,
         docker=docker,
@@ -153,6 +161,8 @@ def node(host, request):
         ceph_release_num=ceph_release_num,
         rolling_update=rolling_update,
         radosgw_num_instances=radosgw_num_instances,
+        nfs_file_gw=nfs_file_gw,
+        nfs_obj_gw=nfs_obj_gw,
     )
     return data
 

--- a/tests/functional/all_daemons/container/group_vars/nfss
+++ b/tests/functional/all_daemons/container/group_vars/nfss
@@ -1,0 +1,4 @@
+---
+copy_admin_key: true
+nfs_file_gw: true
+nfs_obj_gw: false

--- a/tests/functional/all_daemons/group_vars/nfss
+++ b/tests/functional/all_daemons/group_vars/nfss
@@ -1,6 +1,6 @@
 copy_admin_key: true
-nfs_file_gw: false
-nfs_obj_gw: true
+nfs_file_gw: true
+nfs_obj_gw: false
 ganesha_conf_overrides: |
     CACHEINODE {
             Entries_HWMark = 100000;

--- a/tests/functional/tests/nfs/test_nfs_ganesha.py
+++ b/tests/functional/tests/nfs/test_nfs_ganesha.py
@@ -5,11 +5,21 @@ import pytest
 class TestNFSs(object):
 
     @pytest.mark.no_docker
+    @pytest.mark.no_nfs_file_gw
     @pytest.mark.parametrize('pkg', [
         'nfs-ganesha',
         'nfs-ganesha-rgw'
     ])
-    def test_nfs_ganesha_package_is_installed(self, node, host, pkg):
+    def test_nfs_ganesha_rgw_package_is_installed(self, node, host, pkg):
+        assert host.package(pkg).is_installed
+
+    @pytest.mark.no_docker
+    @pytest.mark.no_nfs_obj_gw
+    @pytest.mark.parametrize('pkg', [
+        'nfs-ganesha-ceph',
+        'nfs-ganesha-rados-grace'
+    ])
+    def test_nfs_ganesha_fs_package_is_installed(self, node, host, pkg):
         assert host.package(pkg).is_installed
 
     @pytest.mark.no_docker
@@ -23,6 +33,7 @@ class TestNFSs(object):
         assert host.file(
             "/etc/ganesha/ganesha.conf").contains("Entries_HWMark")
 
+    @pytest.mark.no_nfs_file_gw
     def test_nfs_is_up(self, node, host, setup):
         hostname = node["vars"]["inventory_hostname"]
         cluster = setup['cluster_name']


### PR DESCRIPTION
needed for the update job in stable-6.0 branch.
the upgrade from either nautilus or octopus to pacific isnt supported
when nfs/rgw is deployed.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>