### PR TITLE
multisite: fix bug during switch2containers

### DIFF
--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -81,4 +81,5 @@
   run_once: true
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])
+    - hostvars[item]["rgw_instances_host"] is defined
     - hostvars[item]["rgw_multisite"] | default(False) | bool


### PR DESCRIPTION
When running the switch-to-containers playbook with multisite enabled,
the fact "rgw_instances" is only set for the node being processed
(serial: 1), the consequence of that is that the set_fact of
'rgw_instances_all' can't iterate over all rgw node in order to look up
each 'rgw_instances_host'.

Adding a condition checking whether hostvars[item]["rgw_instances_host"]
is defined fixes this issue.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1967926

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>