### PR TITLE
Don't create RGW pools on upgrade

### DIFF
--- a/roles/ceph-rgw/tasks/main.yml
+++ b/roles/ceph-rgw/tasks/main.yml
@@ -9,7 +9,9 @@
 - name: rgw pool creation tasks
   include_tasks: rgw_create_pools.yml
   run_once: true
-  when: rgw_create_pools is defined
+  when:
+    - rgw_create_pools is defined
+    - not rolling_update | default(False) | bool
 
 - name: include_tasks openstack-keystone.yml
   include_tasks: openstack-keystone.yml


### PR DESCRIPTION
Skip the RGW pool creation tasks on upgrade. The same is already
done for OpenStack pools.

When upgrading from an older version which may have created a different
set of pools or pools with different parameters, creating the pools
could create unneeded new pools or cause pool parameters to change.