### PR TITLE
Support binding RGW to multiple interfaces

### DIFF
--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -106,12 +106,16 @@ osd memory target = {{ _osd_memory_target | default(osd_memory_target) }}
 host = {{ _rgw_hostname }}
 keyring = /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ _rgw_hostname + '.' + instance['instance_name'] }}/keyring
 log file = /var/log/ceph/{{ cluster }}-rgw-{{ hostvars[inventory_hostname]['ansible_facts']['hostname'] + '.' + instance['instance_name'] }}.log
-{% set _rgw_binding_socket = instance['radosgw_address'] | default(_radosgw_address) | string + ':' + instance['radosgw_frontend_port'] | default(radosgw_frontend_port) | string %}
+{% set _rgw_binding_address = instance['radosgw_address'] | default(_radosgw_address) %}
+{% set _rgw_binding_socket = [] %}
+{% for addr in _rgw_binding_address %}
+{% set _ = _rgw_binding_socket.append(addr | string + ':' + instance['radosgw_frontend_port'] | default(radosgw_frontend_port) | string) %}
+{% endfor %}
 {%- macro frontend_line(frontend_type) -%}
 {%- if frontend_type == 'civetweb' -%}
-{{ radosgw_frontend_type }} port={{ _rgw_binding_socket }}{{ 's ssl_certificate='+radosgw_frontend_ssl_certificate if radosgw_frontend_ssl_certificate else '' }}
+{{ frontend_type }} port={% for socket in _rgw_binding_socket %}{{ socket }}{{ 's' if radosgw_frontend_ssl_certificate else '' }}{{ '+' if not loop.last else '' }}{% endfor %}{{ ' ssl_certificate='+radosgw_frontend_ssl_certificate if radosgw_frontend_ssl_certificate else '' }}
 {%- elif frontend_type == 'beast' -%}
-{{ radosgw_frontend_type }} {{ 'ssl_' if radosgw_frontend_ssl_certificate else '' }}endpoint={{ _rgw_binding_socket }}{{ ' ssl_certificate='+radosgw_frontend_ssl_certificate if radosgw_frontend_ssl_certificate else '' }}
+{{ frontend_type }} {% for socket in _rgw_binding_socket %}{{ 'ssl_' if radosgw_frontend_ssl_certificate else '' }}endpoint={{ socket }} {% endfor %}{{ 'ssl_certificate='+radosgw_frontend_ssl_certificate if radosgw_frontend_ssl_certificate else '' }}
 {%- endif -%}
 {%- endmacro -%}
 rgw frontends = {{ frontend_line(radosgw_frontend_type) }} {{ radosgw_frontend_options }}

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -252,7 +252,7 @@
       changed_when: false
 
     - name: set the rgw host
-      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-host {{ hostvars[groups[rgw_group_name][0]]['rgw_instances'][0]['radosgw_address'] }}"
+      command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-rgw-api-host {{ hostvars[groups[rgw_group_name][0]]['rgw_instances'][0]['radosgw_address'] | first }}"
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
 

--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -1,7 +1,7 @@
 ---
 - name: set_fact _radosgw_address to radosgw_address_block ipv4
   set_fact:
-    _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(hostvars[inventory_hostname]['radosgw_address_block'].split(',')) | first }}"
+    _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(hostvars[inventory_hostname]['radosgw_address_block'].split(',')) }}"
   when:
     - radosgw_address_block is defined
     - radosgw_address_block != 'subnet'
@@ -9,7 +9,7 @@
 
 - name: set_fact _radosgw_address to radosgw_address_block ipv6
   set_fact:
-    _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[inventory_hostname]['radosgw_address_block'].split(',')) | last | ipwrap }}"
+    _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[inventory_hostname]['radosgw_address_block'].split(',')) | ipwrap }}"
   when:
     - radosgw_address_block is defined
     - radosgw_address_block != 'subnet'
@@ -17,7 +17,7 @@
 
 - name: set_fact _radosgw_address to radosgw_address
   set_fact:
-    _radosgw_address: "{{ radosgw_address | ipwrap }}"
+    _radosgw_address: "{{ (radosgw_address if radosgw_address is sequence else [radosgw_address]) | ipwrap }}"
   when:
     - radosgw_address is defined
     - radosgw_address != 'x.x.x.x'
@@ -34,12 +34,12 @@
 
     - name: set_fact _radosgw_address to radosgw_interface - ipv4
       set_fact:
-        _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts'][_interface][ip_version]['address'] }}"
+        _radosgw_address: "{{ [hostvars[inventory_hostname]['ansible_facts'][_interface][ip_version]['address']] }}"
       when: ip_version == 'ipv4'
 
     - name: set_fact _radosgw_address to radosgw_interface - ipv6
       set_fact:
-        _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts'][_interface][ip_version][0]['address'] | ipwrap }}"
+        _radosgw_address: "{{ [hostvars[inventory_hostname]['ansible_facts'][_interface][ip_version][0]['address'] | ipwrap] }}"
       when: ip_version == 'ipv6'
 
 - name: set_fact rgw_instances without rgw multisite

--- a/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
@@ -11,7 +11,7 @@ else
     RGW_PROTOCOL=http
 fi
 INSTANCES_NAME=({% for i in rgw_instances %}{{ i.instance_name }} {% endfor %})
-RGW_IPS=({% for i in rgw_instances %}{{ i.radosgw_address }} {% endfor %})
+RGW_IPS=({% for i in rgw_instances %}{{ i.radosgw_address | first }} {% endfor %})
 RGW_PORTS=({% for i in rgw_instances %}{{ i.radosgw_frontend_port }} {% endfor %})
 declare -a DOCKER_EXECS
 declare -a SOCKET_PREFIX


### PR DESCRIPTION
Allow a single RGW instance to be configured to bind to multiple
interfaces. The "rgw_address" variable can either be an IP address as a
string or a list of IP addresses.

Signed-off-by: Gaudenz Steinlin <gaudenz.steinlin@cloudscale.ch>