### PR TITLE
Create radosgw key on mon host

### DIFF
--- a/roles/ceph-rgw/tasks/common.yml
+++ b/roles/ceph-rgw/tasks/common.yml
@@ -8,37 +8,32 @@
     mode: "{{ ceph_directories_mode }}"
   with_items: "{{ rbd_client_admin_socket_path }}"
 
-- name: get keys from monitors
+- name: get admin key from monitors
   ceph_key:
-    name: "{{ item.name }}"
+    name: "client.admin"
     cluster: "{{ cluster }}"
     output_format: plain
     state: info
   environment:
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-  register: _rgw_keys
-  with_items:
-    - { name: "client.bootstrap-rgw", path: "/var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring", copy_key: true }
-    - { name: "client.admin", path: "/etc/ceph/{{ cluster }}.client.admin.keyring", copy_key: "{{ copy_admin_key }}" }
+  register: _rgw_admin_key
   delegate_to: "{{ groups.get(mon_group_name)[0] }}"
   run_once: true
   when:
     - cephx | bool
-    - item.copy_key | bool
+    - copy_admin_key | bool
 
-- name: copy ceph key(s) if needed
+- name: copy ceph admin key if needed
   copy:
-    dest: "{{ item.item.path }}"
-    content: "{{ item.stdout + '\n' }}"
-    owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
-    group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
+    dest: "/etc/ceph/{{ cluster }}.client.admin.keyring"
+    content: "{{ _rgw_admin_key.stdout + '\n' }}"
+    owner: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
+    group: "{{ ceph_uid if containerized_deployment else 'ceph' }}"
     mode: "{{ ceph_keyring_permissions }}"
-  with_items: "{{ _rgw_keys.results }}"
   when:
     - cephx | bool
-    - item is not skipped
-    - item.item.copy_key | bool
+    - copy_admin_key | bool
   no_log: true
 
 - name: copy SSL certificate & key data to certificate path

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -1,20 +1,40 @@
 ---
-- name: create rgw keyrings
+- name: create rados gateway instance key
   ceph_key:
     name: "client.rgw.{{ ansible_facts['hostname'] }}.{{ item.instance_name }}"
-    cluster: "{{ cluster }}"
-    user: "client.bootstrap-rgw"
-    user_key: /var/lib/ceph/bootstrap-rgw/{{ cluster }}.keyring
-    dest: "/var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_facts['hostname'] }}.{{ item.instance_name }}/keyring"
-    caps:
-      osd: 'allow rwx'
-      mon: 'allow rw'
-    import_key: False
-    owner: "ceph"
-    group: "ceph"
-    mode: "0600"
+    state: present
+    # The value below must be valid JSON starting with "{" to be automatically
+    # converted to a dict by Ansible
+    caps: >-
+      {% if rgw_create_pools -%}
+      {"mon": "allow r",
+       "osd": "{% for name in rgw_create_pools %}allow rwx pool={{ name }}{% if not loop.last %}, {% endif %}{% endfor %}"}
+      {% else -%}
+      {"osd": "allow rwx",
+       "mon": "allow rw"}
+      {% endif %}
   environment:
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-  with_items: "{{ rgw_instances }}"
+  loop: "{{ rgw_instances }}"
+  when: cephx | bool
+  delegate_to: '{{ groups[mon_group_name][0] }}'
+
+- name: get rados gateway keys from monitors
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} auth get client.rgw.{{ ansible_facts['hostname'] }}.{{ item.instance_name }}"
+  register: _rgw_keys
+  loop: "{{ rgw_instances }}"
+  delegate_to: '{{ groups[mon_group_name][0] }}'
+  check_mode: false
+  changed_when: false
+  when: cephx | bool
+
+- name: put rados gateway keys
+  copy:
+    dest: /var/lib/ceph/radosgw/{{ cluster }}-rgw.{{ ansible_facts['hostname'] }}.{{ item.item.instance_name }}/keyring
+    content: "{{ item.stdout }}\n"
+    owner: "ceph"
+    group: "ceph"
+    mode: "0600"
+  loop: "{{ _rgw_keys.results }}"
   when: cephx | bool

--- a/tests/functional/add-rgws/group_vars/rgws
+++ b/tests/functional/add-rgws/group_vars/rgws
@@ -1,9 +1,25 @@
 copy_admin_key: true
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:
-    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/all-in-one/container/group_vars/all
+++ b/tests/functional/all-in-one/container/group_vars/all
@@ -24,17 +24,27 @@ ceph_conf_overrides:
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 rgw_create_pools:
-  foo:
+  .rgw.root:
     pg_num: 16
-    type: replicated
-  bar:
+  default.rgw.log:
     pg_num: 16
-  ec:
+  default.rgw.control:
     pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
     type: ec
     ec_profile: myecprofile
     ec_k: 2
     ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
+    pg_num: 16
+    type: replicated
 osd_objectstore: "bluestore"
 lvm_volumes:
   - data: data-lv1

--- a/tests/functional/all-in-one/group_vars/all
+++ b/tests/functional/all-in-one/group_vars/all
@@ -29,14 +29,24 @@ lvm_volumes:
     db: journal1
     db_vg: journals
 rgw_create_pools:
-  foo:
+  .rgw.root:
     pg_num: 16
-    type: replicated
-  bar:
+  default.rgw.log:
     pg_num: 16
-  ec:
+  default.rgw.control:
     pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
     type: ec
     ec_profile: myecprofile
     ec_k: 2
     ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
+    pg_num: 16
+    type: replicated

--- a/tests/functional/all_daemons/container/group_vars/rgws
+++ b/tests/functional/all_daemons/container/group_vars/rgws
@@ -1,8 +1,24 @@
 ---
 copy_admin_key: True
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:
-    pg_num: 16

--- a/tests/functional/all_daemons/group_vars/rgws
+++ b/tests/functional/all_daemons/group_vars/rgws
@@ -1,9 +1,25 @@
 copy_admin_key: true
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:
-    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/collocation/container/group_vars/rgws
+++ b/tests/functional/collocation/container/group_vars/rgws
@@ -1,7 +1,23 @@
 ---
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:
-    pg_num: 16

--- a/tests/functional/collocation/group_vars/rgws
+++ b/tests/functional/collocation/group_vars/rgws
@@ -1,7 +1,23 @@
 ---
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:
-    pg_num: 16

--- a/tests/functional/docker2podman/group_vars/rgws
+++ b/tests/functional/docker2podman/group_vars/rgws
@@ -1,7 +1,24 @@
 ---
 copy_admin_key: True
 rgw_create_pools:
-  foo:
+  .rgw.root:
     pg_num: 16
-  bar:
+  default.rgw.log:
     pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
+    pg_num: 16
+    type: replicated

--- a/tests/functional/external_clients/container/inventory/group_vars/all
+++ b/tests/functional/external_clients/container/inventory/group_vars/all
@@ -23,10 +23,27 @@ ceph_conf_overrides:
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 rgw_create_pools:
-  foo:
+  .rgw.root:
     pg_num: 16
-  bar:
+  default.rgw.log:
     pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
+    pg_num: 16
+    type: replicated
 osd_objectstore: "bluestore"
 lvm_volumes:
   - data: data-lv1

--- a/tests/functional/external_clients/inventory/group_vars/all
+++ b/tests/functional/external_clients/inventory/group_vars/all
@@ -28,9 +28,26 @@ lvm_volumes:
     db: journal1
     db_vg: journals
 rgw_create_pools:
-  foo:
+  .rgw.root:
     pg_num: 16
-  bar:
+  default.rgw.log:
     pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
+    pg_num: 16
+    type: replicated
 fsid: 40358a87-ab6e-4bdc-83db-1d909147861c
 generate_fsid: false

--- a/tests/functional/podman/group_vars/rgws
+++ b/tests/functional/podman/group_vars/rgws
@@ -1,7 +1,24 @@
 ---
 copy_admin_key: True
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:

--- a/tests/functional/rgw-multisite/container/group_vars/rgws
+++ b/tests/functional/rgw-multisite/container/group_vars/rgws
@@ -4,10 +4,26 @@ copy_admin_key: true
 rgw_multisite: true
 rgw_multisite_proto: http
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:
-    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/rgw-multisite/container/secondary/group_vars/rgws
+++ b/tests/functional/rgw-multisite/container/secondary/group_vars/rgws
@@ -3,10 +3,26 @@
 rgw_multisite: true
 rgw_multisite_proto: http
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:
-    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/rgw-multisite/group_vars/rgws
+++ b/tests/functional/rgw-multisite/group_vars/rgws
@@ -4,10 +4,26 @@ copy_admin_key: true
 rgw_multisite: true
 rgw_multisite_proto: http
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:
-    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/rgw-multisite/secondary/group_vars/rgws
+++ b/tests/functional/rgw-multisite/secondary/group_vars/rgws
@@ -3,10 +3,26 @@
 rgw_multisite: true
 rgw_multisite_proto: http
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:
-    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/shrink_rgw/container/group_vars/rgws
+++ b/tests/functional/shrink_rgw/container/group_vars/rgws
@@ -1,10 +1,26 @@
 ---
 copy_admin_key: true
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:
-    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/shrink_rgw/group_vars/rgws
+++ b/tests/functional/shrink_rgw/group_vars/rgws
@@ -1,10 +1,26 @@
 ---
 copy_admin_key: true
 rgw_create_pools:
-  foo:
+  .rgw.root:
+    pg_num: 16
+  default.rgw.log:
+    pg_num: 16
+  default.rgw.control:
+    pg_num: 16
+  default.rgw.meta:
+    pg_num: 16
+  default.rgw.otp:
+    pg_num: 16
+  default.rgw.buckets.data:
+    pg_num: 32
+    type: ec
+    ec_profile: myecprofile
+    ec_k: 2
+    ec_m: 1
+  default.rgw.buckets.index:
+    pg_num: 16
+  default.rgw.buckets.non-ec:
     pg_num: 16
     type: replicated
-  bar:
-    pg_num: 16
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400

--- a/tests/functional/tests/rgw/test_rgw.py
+++ b/tests/functional/tests/rgw/test_rgw.py
@@ -30,7 +30,7 @@ class TestRGWs(object):
                 hostname=hostname, container_binary=container_binary)
         else:
             container_exec_cmd = ''
-        cmd = "sudo {container_exec_cmd} ceph --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/{cluster}.keyring --cluster={cluster} --connect-timeout 5 -f json -s".format(  # noqa E501
+        cmd = "sudo {container_exec_cmd} ceph --cluster={cluster} --connect-timeout 5 -f json -s".format(  # noqa E501
             container_exec_cmd=container_exec_cmd,
             hostname=hostname,
             cluster=cluster


### PR DESCRIPTION
Instead of copying the bootstrap key to the rgw host, create the key on
the first mon host and just copy over the resulting key. The bootstrap
key basically gives full permissions to create keys on the cluster and
should be tightly secured and not be on a rgw host which might be
directly connected to the Internet.

If the pools are created by the Ansible playbook, the key permissions are
restricted to just allow the operations needed for radosgw and do not
allow pool manipulation.

Signed-off-by: Gaudenz Steinlin <gaudenz.steinlin@cloudscale.ch>