### PR TITLE
Update 'validate ceph_repository_community'

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -19,11 +19,11 @@
 
     - name: validate ceph_repository_community
       fail:
-        msg: "ceph_stable_release must be 'quincy'"
+        msg: "ceph_stable_release must be 'pacific' or 'octopus'"
       when:
         - ceph_origin == 'repository'
         - ceph_repository == 'community'
-        - ceph_stable_release not in ['quincy']
+        - ceph_stable_release not in ['pacific','octopus']
 
     - name: validate ceph_repository_type
       fail:


### PR DESCRIPTION
https://docs.ceph.com/en/latest/releases/index.html

In 2021-06, Current active release is 'pacific' or 'octopus'