### PR TITLE
alertmanager: remove warning about untrusted certs

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -47,43 +47,6 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: "{{ monitoring_group_name }}"
-  gather_facts: false
-  become: true
-  pre_tasks:
-    - name: set ceph grafana install 'In Progress'
-      run_once: true
-      set_stats:
-        data:
-          installer_phase_ceph_grafana:
-            status: "In Progress"
-            start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
-
-  tasks:
-    - import_role:
-        name: ceph-defaults
-      tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-facts
-      tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-facts
-        tasks_from: grafana
-      tags: ['ceph_update_config']
-    - import_role:
-        name: ceph-prometheus
-    - import_role:
-        name: ceph-grafana
-
-  post_tasks:
-    - name: set ceph grafana install 'Complete'
-      run_once: true
-      set_stats:
-        data:
-          installer_phase_ceph_grafana:
-            status: "Complete"
-            end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
-
 # using groups[] here otherwise it can't fallback to the mon if there's no mgr group.
 # adding an additional | default(omit) in case where no monitors are present (external ceph cluster)
 - hosts: "{{ groups[mgr_group_name] | default(groups[mon_group_name]) | default(omit) }}"
@@ -118,5 +81,42 @@
       set_stats:
         data:
           installer_phase_ceph_dashboard:
+            status: "Complete"
+            end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+
+- hosts: "{{ monitoring_group_name }}"
+  gather_facts: false
+  become: true
+  pre_tasks:
+    - name: set ceph grafana install 'In Progress'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_grafana:
+            status: "In Progress"
+            start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
+
+  tasks:
+    - import_role:
+        name: ceph-defaults
+      tags: ['ceph_update_config']
+    - import_role:
+        name: ceph-facts
+      tags: ['ceph_update_config']
+    - import_role:
+        name: ceph-facts
+        tasks_from: grafana
+      tags: ['ceph_update_config']
+    - import_role:
+        name: ceph-prometheus
+    - import_role:
+        name: ceph-grafana
+
+  post_tasks:
+    - name: set ceph grafana install 'Complete'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_grafana:
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"

--- a/roles/ceph-prometheus/tasks/setup_container.yml
+++ b/roles/ceph-prometheus/tasks/setup_container.yml
@@ -1,4 +1,15 @@
 ---
+- name: copy dashboard SSL certificate file
+  copy:
+    src: "{{ '/etc/ceph/ceph-dashboard.crt' if not dashboard_tls_external | bool else dashboard_crt }}"
+    dest: "/etc/ceph/ceph-dashboard.crt"
+    owner: root
+    group: root
+    mode: 0440
+    remote_src: true
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  when: dashboard_protocol == 'https'
+
 - name: include_tasks systemd.yml
   include_tasks: systemd.yml
 

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -23,6 +23,9 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=alertmanager \
 {% endif %}
   -v "{{ alertmanager_conf_dir }}:/etc/alertmanager:Z" \
   -v "{{ alertmanager_data_dir }}:/alertmanager:Z" \
+{% if dashboard_protocol == 'https' %}
+  -v "/etc/ceph/ceph-dashboard.crt:/etc/ssl/certs/ceph-dashboard.crt:Z" \
+{% endif %}
   --net=host \
   --cpu-period={{ alertmanager_container_cpu_period }} \
   --cpu-quota={{ alertmanager_container_cpu_period * alertmanager_container_cpu_cores }} \

--- a/roles/ceph-prometheus/templates/alertmanager.yml.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.yml.j2
@@ -12,4 +12,9 @@ receivers:
   webhook_configs:
 {% for host in groups['mgrs'] | default(groups['mons']) %}
   - url: '{{ dashboard_protocol }}://{{ hostvars[host]['ansible_facts']['fqdn'] }}:{{ dashboard_port }}/api/prometheus_receiver'
+{% if dashboard_protocol == 'https' %}
+    http_config:
+      tls_config:
+        ca_file: /etc/ssl/certs/ceph-dashboard.crt
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
When using self-signed/untrusted CA certificates, alertmanager displays
an error in logs. With this commit this should make those messages
disappear.
    
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1936299

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>