### PR TITLE
[skip ci] cephadm_adopt: add any_errors_fatal on play

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -45,6 +45,7 @@
     - "{{ iscsi_gw_group_name|default('iscsigws') }}"
     - "{{ monitoring_group_name|default('monitoring') }}"
   become: true
+  any_errors_fatal: True
   gather_facts: false
   vars:
     delegate_facts_host: true
@@ -346,6 +347,7 @@
   serial: 1
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -393,6 +395,7 @@
   serial: 1
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -428,6 +431,7 @@
   hosts: "{{ osd_group_name|default('osds') }}"
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -451,6 +455,7 @@
   serial: 1
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -538,6 +543,7 @@
   hosts: "{{ osd_group_name|default('osds') }}"
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -560,6 +566,7 @@
   hosts: "{{ mds_group_name|default('mdss') }}"
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -577,6 +584,7 @@
   serial: 1
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -622,6 +630,7 @@
   hosts: "{{ rgw_group_name|default('rgws') }}"
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -696,6 +705,7 @@
   serial: 1
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -754,6 +764,7 @@
   serial: 1
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -892,6 +903,7 @@
   hosts: "{{ rbdmirror_group_name|default('rbdmirrors') }}"
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -909,6 +921,7 @@
   serial: 1
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -949,6 +962,7 @@
   hosts: "{{ iscsi_gw_group_name|default('iscsigws') }}"
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -966,6 +980,7 @@
   serial: 1
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -1011,6 +1026,7 @@
     - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -1035,6 +1051,7 @@
   serial: 1
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -1201,6 +1218,7 @@
     - "{{ monitoring_group_name|default('monitoring') }}"
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -1233,6 +1251,7 @@
   hosts: "{{ mon_group_name|default('mons') }}[0]"
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults
@@ -1282,6 +1301,7 @@
   hosts: "{{ mon_group_name|default('mons') }}[0]"
   become: true
   gather_facts: false
+  any_errors_fatal: True
   tasks:
     - import_role:
         name: ceph-defaults


### PR DESCRIPTION
Add any_errors_fatal: true in cephadm-adopt playbook.
We should stop the playbook execution when a task throws an error.
Otherwise, it can lead to unexpected behavior.
    
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1976179

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>