### PR TITLE
[skip ci] switch2container: run ceph-validate role

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -58,6 +58,11 @@
       when: delegate_facts_host | bool
       tags: always
 
+    - import_role:
+        name: ceph-facts
+    - import_role:
+        name: ceph-validate
+
 - name: switching from non-containerized to containerized ceph mon
   vars:
     containerized_deployment: true


### PR DESCRIPTION
This adds the ceph-validate role before starting the switch to a containerized
deployment.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1968177

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>