### PR TITLE
[skip ci] shrink-mgr: modify existing mgr check

### DIFF
--- a/infrastructure-playbooks/shrink-mgr.yml
+++ b/infrastructure-playbooks/shrink-mgr.yml
@@ -74,14 +74,6 @@
               manager each time the playbook runs."
       when: mgr_to_kill is not defined
 
-    - name: exit playbook, if the manager is not part of the inventory
-      fail:
-        msg: "It seems that the host given is not part of your inventory,
-              please make sure it is."
-      when:
-        - mgr_to_kill not in active_mgr
-        - mgr_to_kill not in standbys_mgr
-
     - name: exit playbook, if user did not mean to shrink cluster
       fail:
         msg: "Exiting shrink-mgr playbook, no manager was removed.
@@ -93,6 +85,13 @@
     - name: set_fact mgr_to_kill_hostname
       set_fact:
         mgr_to_kill_hostname: "{{ hostvars[mgr_to_kill]['ansible_facts']['hostname'] }}"
+
+    - name: exit playbook, if the selected manager is not present in the cluster
+      fail:
+        msg: "It seems that the host given is not present in the cluster."
+      when:
+        - mgr_to_kill_hostname not in active_mgr
+        - mgr_to_kill_hostname not in standbys_mgr
 
   tasks:
     - name: stop manager services and verify it

--- a/tests/functional/shrink_mgr/hosts-2
+++ b/tests/functional/shrink_mgr/hosts-2
@@ -1,8 +1,0 @@
-[mons]
-mon0
-
-[osds]
-osd0
-
-[mgrs]
-mgr0


### PR DESCRIPTION
Do not rely on the inventory aliases in order to check if the selected
manager to be removed is present.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1967897

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>