### PR TITLE
container: set tcmalloc value by default

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -550,7 +550,7 @@ dummy:
 # For Debian & Red Hat/CentOS installs set TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES
 # Set this to a byte value (e.g. 134217728)
 # A value of 0 will leave the package default.
-#ceph_tcmalloc_max_total_thread_cache: 0
+#ceph_tcmalloc_max_total_thread_cache: 134217728
 
 
 ##########

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -550,7 +550,7 @@ ceph_iscsi_config_dev: false
 # For Debian & Red Hat/CentOS installs set TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES
 # Set this to a byte value (e.g. 134217728)
 # A value of 0 will leave the package default.
-#ceph_tcmalloc_max_total_thread_cache: 0
+#ceph_tcmalloc_max_total_thread_cache: 134217728
 
 
 ##########

--- a/roles/ceph-common/tasks/configure_memory_allocator.yml
+++ b/roles/ceph-common/tasks/configure_memory_allocator.yml
@@ -9,7 +9,13 @@
   when:
     - ansible_facts['os_family'] == 'Debian'
     - etc_default_ceph.stat.exists
-  notify: restart ceph osds
+  notify:
+    - restart ceph mons
+    - restart ceph mgrs
+    - restart ceph osds
+    - restart ceph mdss
+    - restart ceph rgws
+    - restart ceph rbdmirrors
 
 - name: configure TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES for redhat
   lineinfile:
@@ -19,4 +25,10 @@
     regexp: "^TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES="
     line: "TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }}"
   when: ansible_facts['os_family'] == 'RedHat'
-  notify: restart ceph osds
+  notify:
+    - restart ceph mons
+    - restart ceph mgrs
+    - restart ceph osds
+    - restart ceph mdss
+    - restart ceph rgws
+    - restart ceph rbdmirrors

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -542,7 +542,7 @@ os_tuning_params:
 # For Debian & Red Hat/CentOS installs set TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES
 # Set this to a byte value (e.g. 134217728)
 # A value of 0 will leave the package default.
-ceph_tcmalloc_max_total_thread_cache: 0
+ceph_tcmalloc_max_total_thread_cache: 134217728
 
 
 ##########

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -32,6 +32,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=MDS \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
+  -e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }} \
   {{ ceph_mds_docker_extra_env }} \
   --name=ceph-mds-{{ ansible_facts['hostname'] }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -31,6 +31,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=MGR \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
+  -e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }} \
   {{ ceph_mgr_docker_extra_env }} \
   --name=ceph-mgr-{{ ansible_facts['hostname'] }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -46,6 +46,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
   -e CEPH_PUBLIC_NETWORK={{ public_network | regex_replace(' ', '') }} \
   -e CEPH_DAEMON=MON \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
+  -e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }} \
   {{ ceph_mon_docker_extra_env }} \
   {{ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 {% if container_binary == 'podman' %}

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -54,9 +54,7 @@ numactl \
   {% endif -%}
   {{ container_env_args }} \
   -e CLUSTER={{ cluster }} \
-  {% if (ceph_tcmalloc_max_total_thread_cache | int) > 0 -%}
   -e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }} \
-  {% endif -%}
   -v /run/lvm/:/run/lvm/ \
   -e CEPH_DAEMON=OSD_CEPH_VOLUME_ACTIVATE \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -31,6 +31,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -e CLUSTER={{ cluster }} \
   -e CEPH_DAEMON=RBD_MIRROR \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
+  -e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }} \
   --name=ceph-rbd-mirror-{{ ansible_facts['hostname'] }} \
   {{ ceph_rbd_mirror_docker_extra_env }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -45,6 +45,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -e CLUSTER={{ cluster }} \
   -e RGW_NAME={{ ansible_facts['hostname'] }}.${INST_NAME} \
   -e CONTAINER_IMAGE={{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} \
+  -e TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES={{ ceph_tcmalloc_max_total_thread_cache }} \
   --name=ceph-rgw-{{ ansible_facts['hostname'] }}-${INST_NAME} \
   {{ ceph_rgw_docker_extra_env }} \
   {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -69,6 +69,8 @@
     - import_role:
         name: ceph-facts
     - import_role:
+        name: ceph-handler
+    - import_role:
         name: ceph-validate
     - import_role:
         name: ceph-infra


### PR DESCRIPTION
All ceph daemons need to have the TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES
environment variable set to 128MB by default in container setup.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1970913

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>