### PR TITLE
[skip ci] purge: add monitoring group in final cleanup play

### DIFF
--- a/infrastructure-playbooks/purge-container-cluster.yml
+++ b/infrastructure-playbooks/purge-container-cluster.yml
@@ -557,6 +557,7 @@
     - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
     - "{{ nfs_group_name|default('nfss') }}"
     - "{{ mgr_group_name|default('mgrs') }}"
+    - "{{ monitoring_group_name|default('monitoring') }}"
 
   become: true
 


### PR DESCRIPTION
This adds the monitoring group in the "final cleanup play" so any cid
files generated are well removed when purging the cluster.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1974536

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>