### PR TITLE
[skip ci] ceph-crash: add install checkpoint

### DIFF
--- a/plugins/callback/installer_checkpoint.py
+++ b/plugins/callback/installer_checkpoint.py
@@ -34,6 +34,7 @@ class CallbackModule(CallbackBase):
             'installer_phase_ceph_dashboard',
             'installer_phase_ceph_grafana',
             'installer_phase_ceph_node_exporter',
+            'installer_phase_ceph_crash',
         ]
 
         # Define the attributes of the installer phases
@@ -89,6 +90,10 @@ class CallbackModule(CallbackBase):
             'installer_phase_ceph_node_exporter': {
                 'title': 'Install Ceph Node Exporter',
                 'playbook': 'roles/ceph-node-exporter/tasks/main.yml'
+            },
+            'installer_phase_ceph_crash': {
+                'title': 'Install Ceph Crash',
+                'playbook': 'roles/ceph-crash/tasks/main.yml'
             },
         }
 

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -450,6 +450,14 @@
   gather_facts: false
   become: True
   any_errors_fatal: true
+  pre_tasks:
+    - name: set ceph crash install 'In Progress'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_crash:
+            status: "In Progress"
+            start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
   tasks:
     - import_role:
@@ -462,6 +470,14 @@
     - import_role:
         name: ceph-crash
 
+  post_tasks:
+    - name: set ceph crash install 'Complete'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_crash:
+            status: "Complete"
+            end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
 - hosts: mons
   gather_facts: false

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -473,6 +473,14 @@
   gather_facts: false
   become: True
   any_errors_fatal: true
+  pre_tasks:
+    - name: set ceph crash install 'In Progress'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_crash:
+            status: "In Progress"
+            start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
   tasks:
     - import_role:
@@ -484,6 +492,15 @@
         name: ceph-handler
     - import_role:
         name: ceph-crash
+
+  post_tasks:
+    - name: set ceph crash install 'Complete'
+      run_once: true
+      set_stats:
+        data:
+          installer_phase_ceph_crash:
+            status: "Complete"
+            end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
 - hosts: mons
   gather_facts: false


### PR DESCRIPTION
The ceph crash insatll checkpoint callback was missing in the main
playbooks.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>