### PR TITLE
switch2containers: remove ceph packages

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -107,6 +107,10 @@ dummy:
 #ceph_use_distro_backports: false # DEBIAN ONLY
 #ceph_directories_mode: "0755"
 
+## Container migration
+# set this variable to `true` when you want the playbook to remove any ceph RPM after the migration to container is complete.
+#remove_pkg_post_container_migration: false
+
 ###########
 # INSTALL #
 ###########

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -107,6 +107,10 @@ dummy:
 #ceph_use_distro_backports: false # DEBIAN ONLY
 #ceph_directories_mode: "0755"
 
+## Container migration
+# set this variable to `true` when you want the playbook to remove any ceph RPM after the migration to container is complete.
+#remove_pkg_post_container_migration: false
+
 ###########
 # INSTALL #
 ###########

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -679,6 +679,55 @@
     - import_role:
         name: ceph-crash
 
+- name: remove all ceph rpms
+  vars:
+    ceph_packages:
+      - ceph
+      - ceph-base
+      - ceph-common
+      - ceph-fuse
+      - ceph-mds
+      - ceph-mgr
+      - ceph-mon
+      - ceph-osd
+      - ceph-release
+      - ceph-radosgw
+      - ceph-grafana-dashboards
+      - rbd-mirror
+      - libcephfs2
+      - librados2
+      - libradosstriper1
+      - librbd1
+      - librgw2
+      - python3-ceph-argparse
+      - python3-cephfs
+      - python3-rados
+      - python3-rbd
+      - python3-rgw
+      - ceph-iscsi
+      - tcmu-runner
+      - nfs-ganesha
+      - nfs-ganesha-selinux
+  hosts:
+    - "{{ mon_group_name|default('mons') }}"
+    - "{{ osd_group_name|default('osds') }}"
+    - "{{ mds_group_name|default('mdss') }}"
+    - "{{ rgw_group_name|default('rgws') }}"
+    - "{{ rbdmirror_group_name|default('rbdmirrors') }}"
+    - "{{ nfs_group_name|default('nfss') }}"
+    - "{{ client_group_name|default('clients') }}"
+    - "{{ mgr_group_name|default('mgrs') }}"
+    - "{{ monitoring_group_name|default('monitoring') }}"
+    - "{{ iscsi_gw_group_name|default('iscsigws') }}"
+  become: true
+  gather_facts: false
+  tasks:
+    - name: remove ceph packages
+      package:
+        name: "{{ ceph_packages }}"
+        state: absent
+      when: remove_pkg_post_container_migration | bool
+
 - name: final task
   hosts:
     - "{{ mon_group_name|default('mons') }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -99,6 +99,10 @@ upgrade_ceph_packages: False
 ceph_use_distro_backports: false # DEBIAN ONLY
 ceph_directories_mode: "0755"
 
+## Container migration
+# set this variable to `true` when you want the playbook to remove any ceph RPM after the migration to container is complete.
+remove_pkg_post_container_migration: false
+
 ###########
 # INSTALL #
 ###########

--- a/tox.ini
+++ b/tox.ini
@@ -135,6 +135,7 @@ commands=
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml --extra-vars "\
       ireallymeanit=yes \
+      remove_pkg_post_container_migration=true \
       ceph_docker_image_tag=latest-master-devel \
       ceph_docker_registry=quay.ceph.io \
       ceph_docker_image=ceph-ci/daemon \


### PR DESCRIPTION
Once the migration to containers is done we can make the playbook remove
any ceph rpms if the user set `remove_pkg_post_container_migration` to
`true`

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1976986