### PR TITLE
[skip ci] dashboard: support dedicated network for the dashboard

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -645,6 +645,8 @@ dummy:
 # then we will autogenerate a cert and keyfile
 #dashboard_protocol: https
 #dashboard_port: 8443
+# set this variable to the network you want the dashboard to listen on. (Default to public_network)
+#dashboard_network: "{{ public_network }}"
 #dashboard_admin_user: admin
 #dashboard_admin_user_ro: false
 # This variable must be set with a strong custom password when dashboard_enabled is True

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -645,6 +645,8 @@ containerized_deployment: true
 # then we will autogenerate a cert and keyfile
 #dashboard_protocol: https
 #dashboard_port: 8443
+# set this variable to the network you want the dashboard to listen on. (Default to public_network)
+#dashboard_network: "{{ public_network }}"
 #dashboard_admin_user: admin
 #dashboard_admin_user_ro: false
 # This variable must be set with a strong custom password when dashboard_enabled is True

--- a/roles/ceph-dashboard/tasks/configure_dashboard_backends.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard_backends.yml
@@ -1,16 +1,16 @@
 ---
 - name: get current mgr backend - ipv4
   set_fact:
-    mgr_server_addr: "{{ hostvars[dashboard_backend]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}"
+    dashboard_server_addr: "{{ hostvars[dashboard_backend]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(dashboard_network.split(',')) | first }}"
   when: ip_version == 'ipv4'
 
 - name: get current mgr backend - ipv6
   set_fact:
-    mgr_server_addr: "{{ hostvars[dashboard_backend]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last }}"
+    dashboard_server_addr: "{{ hostvars[dashboard_backend]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(dashboard_network.split(',')) | last }}"
   when: ip_version == 'ipv6'
 
 - name: config the current dashboard backend
-  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} config set mgr mgr/dashboard/{{ hostvars[dashboard_backend]['ansible_facts']['hostname'] }}/server_addr {{ mgr_server_addr }}"
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} config set mgr mgr/dashboard/{{ hostvars[dashboard_backend]['ansible_facts']['hostname'] }}/server_addr {{ dashboard_server_addr }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   changed_when: false
   run_once: true

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -637,6 +637,8 @@ dashboard_enabled: True
 # then we will autogenerate a cert and keyfile
 dashboard_protocol: https
 dashboard_port: 8443
+# set this variable to the network you want the dashboard to listen on. (Default to public_network)
+dashboard_network: "{{ public_network }}"
 dashboard_admin_user: admin
 dashboard_admin_user_ro: false
 # This variable must be set with a strong custom password when dashboard_enabled is True


### PR DESCRIPTION
This introduces a new variable `dashboard_network` in order to support
deploying the dashboard on a different subnet.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1927574

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>