### PR TITLE
[skip ci] update: convert straw bucket

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -1033,6 +1033,43 @@
         - import_role:
             name: ceph-dashboard
 
+- name: switch any existing crush buckets to straw2
+  hosts: "{{ mon_group_name | default('mons') }}[0]"
+  become: true
+  any_errors_fatal: true
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: ceph-defaults
+
+    - import_role:
+        name: ceph-facts
+        tasks_from: container_binary.yml
+
+    - name: set_fact ceph_cmd
+      set_fact:
+        ceph_cmd: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z --entrypoint=ceph ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph' }}"
+
+    - name: backup the crushmap
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} osd getcrushmap -o /etc/ceph/{{ cluster }}-crushmap"
+      changed_when: false
+
+    - block:
+        - name: switch crush buckets to straw2
+          command: "{{ ceph_cmd }} --cluster {{ cluster }} crush set-all-straw-buckets-to-straw2"
+          changed_when: false
+      rescue:
+        - name: restore the crushmap
+          command: "{{ ceph_cmd }} --cluster {{ cluster }} osd setcrushmap -i /etc/ceph/{{ cluster }}-crushmap"
+          changed_when: false
+
+        - name: switching to straw2 buckets failed
+          debug:
+            msg: >
+              "An attempt to switch to straw2 bucket was made but failed.
+               Check the cluster status."
+
+
 - name: show ceph status
   hosts: "{{ mon_group_name|default('mons') }}"
   become: True


### PR DESCRIPTION
After an upgrade, the presence of straw buckets will produce the
following warning (HEALTH_WARN):

```
crush map has legacy tunables (require firefly, min is hammer)
```

because straw bucket is a firefly feature it needs to be converted to
straw2.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1967964

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>