### PR TITLE
lib/ceph-volume: support zapping by osd_id

### DIFF
--- a/tests/library/test_ceph_volume.py
+++ b/tests/library/test_ceph_volume.py
@@ -113,6 +113,21 @@ class TestCephVolumeModule(object):
         result = ceph_volume.zap_devices(fake_module, fake_container_image)
         assert result == expected_command_list
 
+    def test_zap_osd_id(self):
+        fake_module = MagicMock()
+        fake_module.params = {'osd_id': '123'}
+        fake_container_image = None
+        expected_command_list = ['ceph-volume',
+                                 '--cluster',
+                                 'ceph',
+                                 'lvm',
+                                 'zap',
+                                 '--destroy',
+                                 '--osd-id',
+                                 '123']
+        result = ceph_volume.zap_devices(fake_module, fake_container_image)
+        assert result == expected_command_list
+
     def test_activate_osd(self):
         expected_command_list = ['ceph-volume',
                                  '--cluster',


### PR DESCRIPTION
This commit adds the support for zapping an osd by osd_id in the
ceph_volume module.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>