### PR TITLE
[skip ci] cephadm-adopt: enable osd memory autotune for HCI

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -283,6 +283,13 @@
           changed_when: false
           delegate_to: '{{ groups[mon_group_name][0] }}'
 
+    - name: enable the osd memory autotune for hci environment
+      command: "{{ ceph_cmd }} config set osd osd_memory_target_autotune true"
+      changed_when: false
+      run_once: true
+      delegate_to: '{{ groups[mon_group_name][0] }}'
+      when: is_hci | bool
+
     - name: manage nodes with cephadm
       command: "{{ ceph_cmd }} orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['default_ipv4']['address'] }} {{ group_names | join(' ') }}"
       changed_when: false


### PR DESCRIPTION
This enables the osd_memory_target_autotune option on HCI environment.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1973149

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>