### PR TITLE
[skip ci] ceph-mgr: move mgr module list to common

### DIFF
--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -90,3 +90,8 @@
     group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     mode: "{{ ceph_keyring_permissions }}"
   when: cephx | bool
+
+- name: append dashboard modules to ceph_mgr_modules
+  set_fact:
+    ceph_mgr_modules: "{{ ceph_mgr_modules | union(['dashboard', 'prometheus']) }}"
+  when: dashboard_enabled | bool

--- a/roles/ceph-mgr/tasks/main.yml
+++ b/roles/ceph-mgr/tasks/main.yml
@@ -21,6 +21,6 @@
 - name: include mgr_modules.yml
   include_tasks: mgr_modules.yml
   when:
-    - ceph_mgr_modules | length > 0 or dashboard_enabled | bool
+    - ceph_mgr_modules | length > 0
     - ((groups[mgr_group_name] | default([]) | length == 0 and inventory_hostname == groups[mon_group_name] | last) or
       (groups[mgr_group_name] | default([]) | length > 0 and inventory_hostname == groups[mgr_group_name] | last))

--- a/roles/ceph-mgr/tasks/mgr_modules.yml
+++ b/roles/ceph-mgr/tasks/mgr_modules.yml
@@ -1,9 +1,4 @@
 ---
-- name: append dashboard modules to ceph_mgr_modules
-  set_fact:
-    ceph_mgr_modules: "{{ ceph_mgr_modules | union(['dashboard', 'prometheus']) }}"
-  when: dashboard_enabled | bool
-
 - name: wait for all mgr to be up
   command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} mgr dump -f json"
   register: mgr_dump


### PR DESCRIPTION
Populating the ceph_mgr_modules list in the mgr_modules doesn't make sense
since that file is only executed if the list isn't empty or we're using the
dashboard.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>