### PR TITLE
[skip ci] ceph-nfs: allow overriding NFS_CORE_PARAM

### DIFF
--- a/group_vars/nfss.yml.sample
+++ b/group_vars/nfss.yml.sample
@@ -110,6 +110,7 @@ dummy:
 #        #Entries_HWMark = 100000;
 #}
 #
+#ganesha_core_param_overrides:
 #ganesha_ceph_export_overrides:
 #ganesha_rgw_export_overrides:
 #ganesha_rgw_section_overrides:

--- a/roles/ceph-nfs/defaults/main.yml
+++ b/roles/ceph-nfs/defaults/main.yml
@@ -102,6 +102,7 @@ rgw_client_name: client.rgw.{{ ansible_facts['hostname'] }}
         #Entries_HWMark = 100000;
 #}
 #
+#ganesha_core_param_overrides:
 #ganesha_ceph_export_overrides:
 #ganesha_rgw_export_overrides:
 #ganesha_rgw_section_overrides:

--- a/roles/ceph-nfs/templates/ganesha.conf.j2
+++ b/roles/ceph-nfs/templates/ganesha.conf.j2
@@ -10,6 +10,7 @@ NFS_Core_Param
 {% if ceph_nfs_bind_addr is defined %}
        Bind_Addr={{ ceph_nfs_bind_addr }};
 {% endif %}
+{{ ganesha_core_param_overrides | default(None) }}
 }
 
 {% if ceph_nfs_disable_caching | bool or nfs_file_gw | bool %}


### PR DESCRIPTION
We already have config override variables for existing block (like
ganesha_ceph_export_overrides, ganesha_log_overrides, etc...) or a
global one (ganesha_conf_overrides) but redefining the NFS_CORE_PARAM
block in that variable will erase all previous values (currently only
Bind_Addr).

```yaml
ganesha_core_param_overrides: |
        Enable_UDP = false;
        NFS_Port = 2050;
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1941775

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>