### PR TITLE
ceph-mgr: don't install dashboard pkg by default

### DIFF
--- a/group_vars/mgrs.yml.sample
+++ b/group_vars/mgrs.yml.sample
@@ -31,7 +31,6 @@ dummy:
 # Ceph mgr packages to install, ceph-mgr + extra module packages.
 #ceph_mgr_packages:
 #  - ceph-mgr
-#  - ceph-mgr-dashboard
 #  - ceph-mgr-diskprediction-local
 
 

--- a/roles/ceph-mgr/defaults/main.yml
+++ b/roles/ceph-mgr/defaults/main.yml
@@ -23,7 +23,6 @@ ceph_mgr_modules: []
 # Ceph mgr packages to install, ceph-mgr + extra module packages.
 ceph_mgr_packages:
   - ceph-mgr
-  - ceph-mgr-dashboard
   - ceph-mgr-diskprediction-local
 
 

--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -6,6 +6,11 @@
     - dashboard_enabled | bool
     - ansible_facts['distribution'] == 'RedHat'
 
+- name: set_fact ceph_mgr_packages for dashboard
+  set_fact:
+    ceph_mgr_packages: "{{ ceph_mgr_packages | union(['ceph-mgr-dashboard']) }}"
+  when: dashboard_enabled | bool
+
 - name: install ceph-mgr packages on RedHat or SUSE
   package:
     name: '{{ ceph_mgr_packages }}'


### PR DESCRIPTION
This is a partial backport of 2547ab60.

We are currently installing the ceph-mgr-dashboard package even if the
dashboard_enabled variable is set to false.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>