### PR TITLE
ceph-handler: remove _xxx_handler_called facts

### DIFF
--- a/roles/ceph-handler/tasks/handler_crash.yml
+++ b/roles/ceph-handler/tasks/handler_crash.yml
@@ -1,8 +1,4 @@
 ---
-- name: set _crash_handler_called before restart
-  set_fact:
-    _crash_handler_called: True
-
 - name: restart the ceph-crash service
   systemd:
     name: ceph-crash@{{ ansible_facts['hostname'] }}
@@ -11,8 +7,3 @@
     masked: no
     daemon_reload: yes
   ignore_errors: true
-  when: hostvars[inventory_hostname]['_crash_handler_called'] | default(False) | bool
-
-- name: set _crash_handler_called after restart
-  set_fact:
-    _crash_handler_called: False

--- a/roles/ceph-handler/tasks/handler_mdss.yml
+++ b/roles/ceph-handler/tasks/handler_mdss.yml
@@ -1,8 +1,4 @@
 ---
-- name: set _mds_handler_called before restart
-  set_fact:
-    _mds_handler_called: True
-
 - name: copy mds restart script
   template:
     src: restart_mds_daemon.sh.j2
@@ -13,13 +9,7 @@
 
 - name: restart ceph mds daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_mds_daemon.sh
-  when:
-    - hostvars[item]['handler_mds_status'] | default(False) | bool
-    - hostvars[item]['_mds_handler_called'] | default(False) | bool
+  when: hostvars[item]['handler_mds_status'] | default(False) | bool
   with_items: "{{ groups[mds_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True
-
-- name: set _mds_handler_called after restart
-  set_fact:
-    _mds_handler_called: False

--- a/roles/ceph-handler/tasks/handler_mgrs.yml
+++ b/roles/ceph-handler/tasks/handler_mgrs.yml
@@ -1,8 +1,4 @@
 ---
-- name: set _mgr_handler_called before restart
-  set_fact:
-    _mgr_handler_called: True
-
 - name: copy mgr restart script
   template:
     src: restart_mgr_daemon.sh.j2
@@ -13,13 +9,7 @@
 
 - name: restart ceph mgr daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_mgr_daemon.sh
-  when:
-    - hostvars[item]['handler_mgr_status'] | default(False) | bool
-    - hostvars[item]['_mgr_handler_called'] | default(False) | bool
+  when: hostvars[item]['handler_mgr_status'] | default(False) | bool
   with_items: "{{ groups[mgr_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True
-
-- name: set _mgr_handler_called after restart
-  set_fact:
-    _mgr_handler_called: False

--- a/roles/ceph-handler/tasks/handler_mons.yml
+++ b/roles/ceph-handler/tasks/handler_mons.yml
@@ -1,11 +1,4 @@
 ---
-# We only want to restart on hosts that have called the handler.
-# This var is set when he handler is called, and unset after the
-# restart to ensure only the correct hosts are restarted.
-- name: set _mon_handler_called before restart
-  set_fact:
-    _mon_handler_called: True
-
 - name: copy mon restart script
   template:
     src: restart_mon_daemon.sh.j2
@@ -16,14 +9,7 @@
 
 - name: restart ceph mon daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_mon_daemon.sh
-  when:
-    # We do not want to run these checks on initial deployment (`socket.rc == 0`)
-    - hostvars[item]['handler_mon_status'] | default(False) | bool
-    - hostvars[item]['_mon_handler_called'] | default(False) | bool
+  when: hostvars[item]['handler_mon_status'] | default(False) | bool
   with_items: "{{ groups[mon_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True
-
-- name: set _mon_handler_called after restart
-  set_fact:
-    _mon_handler_called: False

--- a/roles/ceph-handler/tasks/handler_nfss.yml
+++ b/roles/ceph-handler/tasks/handler_nfss.yml
@@ -1,8 +1,4 @@
 ---
-- name: set _nfs_handler_called before restart
-  set_fact:
-    _nfs_handler_called: True
-
 - name: copy nfs restart script
   template:
     src: restart_nfs_daemon.sh.j2
@@ -13,13 +9,7 @@
 
 - name: restart ceph nfs daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_nfs_daemon.sh
-  when:
-    - hostvars[item]['handler_nfs_status'] | default(False) | bool
-    - hostvars[item]['_nfs_handler_called'] | default(False) | bool
+  when: hostvars[item]['handler_nfs_status'] | default(False) | bool
   with_items: "{{ groups[nfs_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True
-
-- name: set _nfs_handler_called after restart
-  set_fact:
-    _nfs_handler_called: False

--- a/roles/ceph-handler/tasks/handler_osds.yml
+++ b/roles/ceph-handler/tasks/handler_osds.yml
@@ -9,10 +9,6 @@
 - name: osd handler
   when: trigger_restart | default(False) | bool
   block:
-    - name: set _osd_handler_called before restart
-      set_fact:
-        _osd_handler_called: True
-
     - name: unset noup flag
       ceph_osd_flag:
         name: noup
@@ -85,14 +81,9 @@
       when:
         - hostvars[item]['handler_osd_status'] | default(False) | bool
         - handler_health_osd_check | bool
-        - hostvars[item]['_osd_handler_called'] | default(False) | bool
       with_items: "{{ groups[osd_group_name] | intersect(ansible_play_batch) }}"
       delegate_to: "{{ item }}"
       run_once: True
-
-    - name: set _osd_handler_called after restart
-      set_fact:
-        _osd_handler_called: False
 
     - name: re-enable pg autoscale on pools
       ceph_pool:

--- a/roles/ceph-handler/tasks/handler_rbd_target_api_gw.yml
+++ b/roles/ceph-handler/tasks/handler_rbd_target_api_gw.yml
@@ -1,27 +1,14 @@
 ---
-- name: set _rbd_target_api_handler_called before restart
-  set_fact:
-    _rbd_target_api_handler_called: True
-
 - name: restart rbd-target-api
   service:
     name: rbd-target-api
     state: restarted
   when:
     - ceph_rbd_target_api_stat.get('rc') == 0
-    - hostvars[item]['_rbd_target_api_handler_called'] | default(False) | bool
     - ceph_rbd_target_api_stat.get('stdout_lines', [])|length != 0
   with_items: "{{ groups[iscsi_gw_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True
-
-- name: set _rbd_target_api_handler_called after restart
-  set_fact:
-    _rbd_target_api_handler_called: False
-
-- name: set _rbd_target_gw_handler_called before restart
-  set_fact:
-    _rbd_target_gw_handler_called: True
 
 - name: restart rbd-target-gw
   service:
@@ -29,12 +16,7 @@
     state: restarted
   when:
     - ceph_rbd_target_gw_stat.get('rc') == 0
-    - hostvars[item]['_rbd_target_gw_handler_called'] | default(False) | bool
     - ceph_rbd_target_gw_stat.get('stdout_lines', [])|length != 0
   with_items: "{{ groups[iscsi_gw_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True
-
-- name: set _rbd_target_gw_handler_called after restart
-  set_fact:
-    _rbd_target_gw_handler_called: False

--- a/roles/ceph-handler/tasks/handler_rbdmirrors.yml
+++ b/roles/ceph-handler/tasks/handler_rbdmirrors.yml
@@ -1,8 +1,4 @@
 ---
-- name: set _rbdmirror_handler_called before restart
-  set_fact:
-    _rbdmirror_handler_called: True
-
 - name: copy rbd mirror restart script
   template:
     src: restart_rbd_mirror_daemon.sh.j2
@@ -13,13 +9,7 @@
 
 - name: restart ceph rbd mirror daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_rbd_mirror_daemon.sh
-  when:
-    - hostvars[item]['handler_rbd_mirror_status'] | default(False) | bool
-    - hostvars[item]['_rbdmirror_handler_called'] | default(False) | bool
+  when: hostvars[item]['handler_rbd_mirror_status'] | default(False) | bool
   with_items: "{{ groups[rbdmirror_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True
-
-- name: set _rbdmirror_handler_called after restart
-  set_fact:
-    _rbdmirror_handler_called: False

--- a/roles/ceph-handler/tasks/handler_rgws.yml
+++ b/roles/ceph-handler/tasks/handler_rgws.yml
@@ -1,8 +1,4 @@
 ---
-- name: set _rgw_handler_called before restart
-  set_fact:
-    _rgw_handler_called: True
-
 - name: copy rgw restart script
   template:
     src: restart_rgw_daemon.sh.j2
@@ -13,13 +9,7 @@
 
 - name: restart ceph rgw daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_rgw_daemon.sh
-  when:
-    - hostvars[item]['handler_rgw_status'] | default(False) | bool
-    - hostvars[item]['_rgw_handler_called'] | default(False) | bool
+  when: hostvars[item]['handler_rgw_status'] | default(False) | bool
   with_items: "{{ groups[rgw_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True
-
-- name: set _rgw_handler_called after restart
-  set_fact:
-    _rgw_handler_called: False

--- a/roles/ceph-handler/tasks/handler_tcmu_runner.yml
+++ b/roles/ceph-handler/tasks/handler_tcmu_runner.yml
@@ -1,20 +1,11 @@
 ---
-- name: set _tcmu_runner_handler_called before restart
-  set_fact:
-    _tcmu_runner_handler_called: True
-
 - name: restart tcmu-runner
   service:
     name: tcmu-runner
     state: restarted
   when:
     - ceph_tcmu_runner_stat.get('rc') == 0
-    - hostvars[item]['_tcmu_runner_handler_called'] | default(False) | bool
     - ceph_tcmu_runner_stat.get('stdout_lines', [])|length != 0
   with_items: "{{ groups[iscsi_gw_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True
-
-- name: set _tcmu_runner_handler_called after restart
-  set_fact:
-    _tcmu_runner_handler_called: False


### PR DESCRIPTION
We don't really need to set/unset those variables before and after the
restart task.
We already rely on the daemon/container status.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>