### PR TITLE
[skip ci] common: remove unnecessary run_once statements

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -401,18 +401,15 @@
     - name: get balancer module status
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer status -f json"
       register: balancer_status
-      run_once: true
       changed_when: false
 
     - name: set_fact pools_pgautoscaler_mode
       set_fact:
         pools_pgautoscaler_mode: "{{ pools_pgautoscaler_mode | default([]) | union([{'name': item.pool_name, 'mode': item.pg_autoscale_mode}]) }}"
-      run_once: true
       with_items: "{{ (pool_list.stdout | default('{}') | from_json)['pools'] }}"
 
     - name: disable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer off"
-      run_once: true
       changed_when: false
       when: (balancer_status.stdout | from_json)['active'] | bool
 
@@ -422,7 +419,6 @@
         cluster: "{{ cluster }}"
         pg_autoscale_mode: false
       with_items: "{{ pools_pgautoscaler_mode }}"
-      run_once: true
       when:
         - pools_pgautoscaler_mode is defined
         - item.mode == 'on'
@@ -537,7 +533,6 @@
         name: "{{ item.name }}"
         cluster: "{{ cluster }}"
         pg_autoscale_mode: true
-      run_once: true
       with_items: "{{ pools_pgautoscaler_mode }}"
       when:
         - pools_pgautoscaler_mode is defined
@@ -560,7 +555,6 @@
 
     - name: re-enable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer on"
-      run_once: true
       changed_when: false
       when: (balancer_status.stdout | from_json)['active'] | bool
 

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -218,24 +218,20 @@
     - name: get pool list
       command: "{{ ceph_cmd }} --cluster {{ cluster }} osd dump -f json"
       register: pool_list
-      run_once: true
       changed_when: false
 
     - name: get balancer module status
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer status -f json"
       register: balancer_status
-      run_once: true
       changed_when: false
 
     - name: set_fact pools_pgautoscaler_mode
       set_fact:
         pools_pgautoscaler_mode: "{{ pools_pgautoscaler_mode | default([]) | union([{'name': item.pool_name, 'mode': item.pg_autoscale_mode}]) }}"
-      run_once: true
       with_items: "{{ (pool_list.stdout | default('{}') | from_json)['pools'] }}"
 
     - name: disable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer off"
-      run_once: true
       changed_when: false
       when: (balancer_status.stdout | from_json)['active'] | bool
 
@@ -245,7 +241,6 @@
         cluster: "{{ cluster }}"
         pg_autoscale_mode: false
       with_items: "{{ pools_pgautoscaler_mode }}"
-      run_once: true
       when:
         - pools_pgautoscaler_mode is defined
         - item.mode == 'on'
@@ -410,7 +405,6 @@
         cluster: "{{ cluster }}"
         pg_autoscale_mode: true
       with_items: "{{ pools_pgautoscaler_mode }}"
-      run_once: true
       when:
         - pools_pgautoscaler_mode is defined
         - item.mode == 'on'
@@ -432,7 +426,6 @@
 
     - name: re-enable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer on"
-      run_once: true
       changed_when: false
       when: (balancer_status.stdout | from_json)['active'] | bool
 


### PR DESCRIPTION
1303611 introduced tasks for disabling the pg_autoscaler on pools and
the balancer but thoses tasks are already executed on the first monitor
node so we don't need to add the `run_once` statement.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>