### PR TITLE
common: fix py2 pool_list from_json when skipped

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -461,7 +461,7 @@
       set_fact:
         pools_pgautoscaler_mode: "{{ pools_pgautoscaler_mode | default([]) | union([{'name': item.pool_name, 'mode': item.pg_autoscale_mode}]) }}"
       run_once: true
-      with_items: "{{ (pool_list.stdout | from_json)['pools'] }}"
+      with_items: "{{ (pool_list.stdout | default('{}') | from_json)['pools'] }}"
 
     - name: disable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer off"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -408,7 +408,7 @@
       set_fact:
         pools_pgautoscaler_mode: "{{ pools_pgautoscaler_mode | default([]) | union([{'name': item.pool_name, 'mode': item.pg_autoscale_mode}]) }}"
       run_once: true
-      with_items: "{{ (pool_list.stdout | from_json)['pools'] }}"
+      with_items: "{{ (pool_list.stdout | default('{}') | from_json)['pools'] }}"
 
     - name: disable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer off"

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -231,7 +231,7 @@
       set_fact:
         pools_pgautoscaler_mode: "{{ pools_pgautoscaler_mode | default([]) | union([{'name': item.pool_name, 'mode': item.pg_autoscale_mode}]) }}"
       run_once: true
-      with_items: "{{ (pool_list.stdout | from_json)['pools'] }}"
+      with_items: "{{ (pool_list.stdout | default('{}') | from_json)['pools'] }}"
 
     - name: disable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer off"

--- a/roles/ceph-handler/tasks/handler_osds.yml
+++ b/roles/ceph-handler/tasks/handler_osds.yml
@@ -56,7 +56,7 @@
       set_fact:
         pools_pgautoscaler_mode: "{{ pools_pgautoscaler_mode | default([]) | union([{'name': item.pool_name, 'mode': item.pg_autoscale_mode}]) }}"
       run_once: true
-      with_items: "{{ (pool_list.stdout | from_json)['pools'] }}"
+      with_items: "{{ (pool_list.stdout | default('{}') | from_json)['pools'] }}"
 
     - name: disable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer off"


### PR DESCRIPTION
When using python 2 and the task with a loop is skipped then it generates
an error.

Unexpected templating type error occurred on
({{ (pool_list.stdout | from_json)['pools'] }}): expected string or buffer

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>