### PR TITLE
[skip ci] alertmanager: allow disable dashboard tls verify

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -723,6 +723,7 @@ dummy:
 #alertmanager_port: 9093
 #alertmanager_cluster_port: 9094
 #alertmanager_conf_overrides: {}
+#alertmanager_dashboard_api_no_ssl_verify: "{{ true if dashboard_protocol == 'https' and not dashboard_crt and not dashboard_key else false }}"
 # igw
 #
 # `igw_network` variable is intended for allowing dashboard deployment with iSCSI node not residing in the same subnet than what is defined in `public_network`.

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -723,6 +723,7 @@ alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alert
 #alertmanager_port: 9093
 #alertmanager_cluster_port: 9094
 #alertmanager_conf_overrides: {}
+#alertmanager_dashboard_api_no_ssl_verify: "{{ true if dashboard_protocol == 'https' and not dashboard_crt and not dashboard_key else false }}"
 # igw
 #
 # `igw_network` variable is intended for allowing dashboard deployment with iSCSI node not residing in the same subnet than what is defined in `public_network`.

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -715,6 +715,7 @@ alertmanager_conf_dir: /etc/alertmanager
 alertmanager_port: 9093
 alertmanager_cluster_port: 9094
 alertmanager_conf_overrides: {}
+alertmanager_dashboard_api_no_ssl_verify: "{{ true if dashboard_protocol == 'https' and not dashboard_crt and not dashboard_key else false }}"
 # igw
 #
 # `igw_network` variable is intended for allowing dashboard deployment with iSCSI node not residing in the same subnet than what is defined in `public_network`.

--- a/roles/ceph-prometheus/templates/alertmanager.yml.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.yml.j2
@@ -12,4 +12,9 @@ receivers:
   webhook_configs:
 {% for host in groups['mgrs'] | default(groups['mons']) %}
   - url: '{{ dashboard_protocol }}://{{ hostvars[host]['ansible_facts']['fqdn'] }}:{{ dashboard_port }}/api/prometheus_receiver'
+{% if dashboard_protocol == 'https' and alertmanager_dashboard_api_no_ssl_verify | bool %}
+    http_config:
+      tls_config:
+        insecure_skip_verify: true
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
When using self-signed/untrusted CA certificates, alertmanager displays
an error in logs. With this commit this should make those messages
disappear.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1936299

Co-authored-by: Guillaume Abrioux <gabrioux@redhat.com>

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>