### PR TITLE
[skip ci] update: check the ceph release

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -113,6 +113,21 @@
         - (containerized_deployment | bool) or (dashboard_enabled | bool)
         - ceph_docker_registry_auth | bool
 
+    - name: check ceph release in container image
+      when: containerized_deployment | bool
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
+      block:
+        - name: get the ceph release being deployed
+          command: "{{ ceph_cmd }} --cluster {{ cluster }} --version"
+          register: ceph_version
+          changed_when: false
+
+        - name: check ceph release being deployed
+          fail:
+            msg: "This version of ceph-ansible is intended for upgrading to Ceph Quincy only."
+          when: "'quincy' not in ceph_version.stdout.split()"
+
     - name: set_fact rolling_update
       set_fact:
         rolling_update: true


### PR DESCRIPTION
Check early which Ceph release is going to be deployed and fail if it
doesn't correspond to the ceph-ansible version being used.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1978643

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>