### PR TITLE
[skip ci] ceph-handler: Fix osd handler in check mode

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -449,6 +449,7 @@
       run_once: true
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
+      check_mode: false
 
     - name: get balancer module status
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer status -f json"
@@ -456,6 +457,7 @@
       run_once: true
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
+      check_mode: false
 
     - name: set_fact pools_pgautoscaler_mode
       set_fact:

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -397,11 +397,13 @@
       register: pool_list
       run_once: true
       changed_when: false
+      check_mode: false
 
     - name: get balancer module status
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer status -f json"
       register: balancer_status
       changed_when: false
+      check_mode: false
 
     - name: set_fact pools_pgautoscaler_mode
       set_fact:

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -219,11 +219,13 @@
       command: "{{ ceph_cmd }} --cluster {{ cluster }} osd dump -f json"
       register: pool_list
       changed_when: false
+      check_mode: false
 
     - name: get balancer module status
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer status -f json"
       register: balancer_status
       changed_when: false
+      check_mode: false
 
     - name: set_fact pools_pgautoscaler_mode
       set_fact:

--- a/roles/ceph-handler/tasks/handler_osds.yml
+++ b/roles/ceph-handler/tasks/handler_osds.yml
@@ -44,6 +44,7 @@
       delegate_to: "{{ groups.get(mon_group_name, [])[0] }}"
       run_once: true
       changed_when: false
+      check_mode: false
 
     - name: get balancer module status
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer status -f json"
@@ -51,6 +52,7 @@
       run_once: true
       delegate_to: "{{ groups[mon_group_name][0] }}"
       changed_when: false
+      check_mode: false
 
     - name: set_fact pools_pgautoscaler_mode
       set_fact:


### PR DESCRIPTION
Run the Ceph commands that only gather information (without making any changes
to the cluster) when running Ansible in check mode.

This allows the tasks that depend on the variables set by those tasks to
succeed in check mode.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>