### PR TITLE
[skip ci] ceph-defaults: add missing grafana dashboards

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -693,6 +693,8 @@ dummy:
 #  - pool-overview.json
 #  - radosgw-detail.json
 #  - radosgw-overview.json
+#  - radosgw-sync-overview.json
+#  - rbd-details.json
 #  - rbd-overview.json
 #grafana_plugins:
 #  - vonage-status-panel

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -693,6 +693,8 @@ grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
 #  - pool-overview.json
 #  - radosgw-detail.json
 #  - radosgw-overview.json
+#  - radosgw-sync-overview.json
+#  - rbd-details.json
 #  - rbd-overview.json
 #grafana_plugins:
 #  - vonage-status-panel

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -685,6 +685,8 @@ grafana_dashboard_files:
   - pool-overview.json
   - radosgw-detail.json
   - radosgw-overview.json
+  - radosgw-sync-overview.json
+  - rbd-details.json
   - rbd-overview.json
 grafana_plugins:
   - vonage-status-panel


### PR DESCRIPTION
The radosgw-sync-overview and rbd-details grafana dashboars were missing
from the list.

Closes: #6758

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>