### PR TITLE
[skip ci][stable-5.0] ceph-defaults: update grafana dashboards source

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -685,7 +685,7 @@ dummy:
 #grafana_uid: 472
 #grafana_datasource: Dashboard
 #grafana_dashboards_path: "/etc/grafana/dashboards/ceph-dashboard"
-#grafana_dashboard_version: master
+#grafana_dashboard_version: octopus
 #grafana_dashboard_files:
 #  - ceph-cluster.json
 #  - cephfs-overview.json

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -685,7 +685,7 @@ grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
 #grafana_uid: 472
 #grafana_datasource: Dashboard
 #grafana_dashboards_path: "/etc/grafana/dashboards/ceph-dashboard"
-#grafana_dashboard_version: master
+#grafana_dashboard_version: octopus
 #grafana_dashboard_files:
 #  - ceph-cluster.json
 #  - cephfs-overview.json

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -677,7 +677,7 @@ grafana_container_memory: 4
 grafana_uid: 472
 grafana_datasource: Dashboard
 grafana_dashboards_path: "/etc/grafana/dashboards/ceph-dashboard"
-grafana_dashboard_version: master
+grafana_dashboard_version: octopus
 grafana_dashboard_files:
   - ceph-cluster.json
   - cephfs-overview.json


### PR DESCRIPTION
We currently download the grafana dashboars from the ceph@master branch
for all ceph releases.
We should use the right ceph branch according to the ceph release.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>