### PR TITLE
cephadm-adopt: use cephadm_ssh_user for ssh user

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -236,10 +236,16 @@
       register: cephadm_pubpkey
       delegate_to: '{{ groups[mon_group_name][0] }}'
 
-    - name: allow cephadm key for root account
+    - name: allow cephadm key for {{ cephadm_ssh_user | default('root') }} account
       authorized_key:
-        user: root
+        user: "{{ cephadm_ssh_user | default('root') }}"
         key: '{{ cephadm_pubpkey.stdout }}'
+
+    - name: set cephadm ssh user to {{ cephadm_ssh_user | default('root') }}
+      command: "{{ ceph_cmd }} cephadm set-user {{ cephadm_ssh_user | default('root') }}"
+      changed_when: false
+      run_once: true
+      delegate_to: "{{ groups[mon_group_name][0] }}"
 
     - name: run cephadm prepare-host
       command: cephadm prepare-host


### PR DESCRIPTION
Use cephadm_ssh_user to set custom user (not root) for cephadm to ssh to the hosts

Signed-off-by: Seena Fallah <seenafallah@gmail.com>