### PR TITLE
[skip ci] library: exit on user creation failure

### DIFF
--- a/library/ceph_dashboard_user.py
+++ b/library/ceph_dashboard_user.py
@@ -20,9 +20,10 @@ try:
     from ansible.module_utils.ca_common import generate_ceph_cmd, \
                                                is_containerized, \
                                                exec_command, \
-                                               exit_module
+                                               exit_module, \
+                                               fatal
 except ImportError:
-    from module_utils.ca_common import generate_ceph_cmd, is_containerized, exec_command, exit_module  # noqa: E501
+    from module_utils.ca_common import generate_ceph_cmd, is_containerized, exec_command, exit_module, fatal  # noqa: E501
 
 import datetime
 import json
@@ -260,6 +261,8 @@ def run_module():
             rc, cmd, out, err = exec_command(module, set_password(module, container_image=container_image), stdin=password)  # noqa: E501
         else:
             rc, cmd, out, err = exec_command(module, create_user(module, container_image=container_image), stdin=password)  # noqa: E501
+            if rc != 0:
+                fatal(err, module)
             rc, cmd, out, err = exec_command(module, set_roles(module, container_image=container_image))  # noqa: E501
             changed = True
 


### PR DESCRIPTION
When the ceph dashboard user creation fails then the issue is hidden
as we don't check the return code and don't print the error message
in the module output.

This ends up with a failure on the ceph dashboard set roles command saying
that the user doesn't exist.

By failing on the user creation, we will have an explicit explaination of
the issue (like weak password).

Closes: #6197

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>