### PR TITLE
[skip ci] osds: use osd pool ls instead of osd dump command

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -444,7 +444,7 @@
         name: ceph-defaults
 
     - name: get pool list
-      command: "{{ ceph_cmd }} --cluster {{ cluster }} osd dump -f json"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} osd pool ls detail -f json"
       register: pool_list
       run_once: true
       delegate_to: "{{ groups[mon_group_name][0] }}"
@@ -463,7 +463,7 @@
       set_fact:
         pools_pgautoscaler_mode: "{{ pools_pgautoscaler_mode | default([]) | union([{'name': item.pool_name, 'mode': item.pg_autoscale_mode}]) }}"
       run_once: true
-      with_items: "{{ (pool_list.stdout | default('{}') | from_json)['pools'] }}"
+      with_items: "{{ pool_list.stdout | default('{}') | from_json }}"
 
     - name: disable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer off"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -408,7 +408,7 @@
         tasks_from: container_binary.yml
 
     - name: get pool list
-      command: "{{ ceph_cmd }} --cluster {{ cluster }} osd dump -f json"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} osd pool ls detail -f json"
       register: pool_list
       run_once: true
       changed_when: false
@@ -423,7 +423,7 @@
     - name: set_fact pools_pgautoscaler_mode
       set_fact:
         pools_pgautoscaler_mode: "{{ pools_pgautoscaler_mode | default([]) | union([{'name': item.pool_name, 'mode': item.pg_autoscale_mode}]) }}"
-      with_items: "{{ (pool_list.stdout | default('{}') | from_json)['pools'] }}"
+      with_items: "{{ pool_list.stdout | default('{}') | from_json }}"
 
     - name: disable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer off"

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -216,7 +216,7 @@
         tasks_from: container_binary.yml
 
     - name: get pool list
-      command: "{{ ceph_cmd }} --cluster {{ cluster }} osd dump -f json"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} osd pool ls detail -f json"
       register: pool_list
       changed_when: false
       check_mode: false
@@ -230,7 +230,7 @@
     - name: set_fact pools_pgautoscaler_mode
       set_fact:
         pools_pgautoscaler_mode: "{{ pools_pgautoscaler_mode | default([]) | union([{'name': item.pool_name, 'mode': item.pg_autoscale_mode}]) }}"
-      with_items: "{{ (pool_list.stdout | default('{}') | from_json)['pools'] }}"
+      with_items: "{{ pool_list.stdout | default('{}') | from_json }}"
 
     - name: disable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer off"

--- a/roles/ceph-handler/tasks/handler_osds.yml
+++ b/roles/ceph-handler/tasks/handler_osds.yml
@@ -39,7 +39,7 @@
         mode: 0750
 
     - name: get pool list
-      command: "{{ ceph_cmd }} --cluster {{ cluster }} osd dump -f json"
+      command: "{{ ceph_cmd }} --cluster {{ cluster }} osd pool ls detail -f json"
       register: pool_list
       delegate_to: "{{ groups.get(mon_group_name, [])[0] }}"
       run_once: true
@@ -58,7 +58,7 @@
       set_fact:
         pools_pgautoscaler_mode: "{{ pools_pgautoscaler_mode | default([]) | union([{'name': item.pool_name, 'mode': item.pg_autoscale_mode}]) }}"
       run_once: true
-      with_items: "{{ (pool_list.stdout | default('{}') | from_json)['pools'] }}"
+      with_items: "{{ pool_list.stdout | default('{}') | from_json }}"
 
     - name: disable balancer
       command: "{{ ceph_cmd }} --cluster {{ cluster }} balancer off"


### PR DESCRIPTION
The ceph osd pool ls detail command is a subset of the ceph osd dump
command.

```console
$ ceph osd dump --format json|wc -c
10117
$ ceph osd pool ls detail --format json|wc -c
4740
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>