### PR TITLE
[skip ci] adopt: import rgw ssl certificate into kv store

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -699,8 +699,8 @@
         path: "/var/lib/ceph/mds/{{ cluster }}-{{ ansible_facts['hostname'] }}"
         state: absent
 
-- name: rgw realm/zonegroup/zone requirements
-  hosts: "{{ rgw_group_name|default('rgws') }}"
+- name: redeploy rgw daemons
+  hosts: "{{ rgw_group_name | default('rgws') }}"
   become: true
   gather_facts: false
   any_errors_fatal: True
@@ -712,63 +712,65 @@
         name: ceph-facts
         tasks_from: set_radosgw_address.yml
 
-    - name: for non multisite setup
-      when: not rgw_multisite | bool
-      run_once: true
-      delegate_to: "{{ groups[mon_group_name][0] }}"
+    - name: import rgw ssl certificate into kv store
+      when: radosgw_frontend_ssl_certificate | length > 0
       block:
-        - name: create a default realm
-          radosgw_realm:
-            cluster: "{{ cluster }}"
-            name: default
-            default: true
-          environment:
-            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+        - name: slurp rgw ssl certificate
+          slurp:
+            src: "{{ radosgw_frontend_ssl_certificate }}"
+          register: rgw_ssl_cert
 
-        - name: modify the default zonegroup
-          radosgw_zonegroup:
-            cluster: "{{ cluster }}"
-            name: default
-            realm: default
-            master: true
-            default: true
-          environment:
-            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-
-        - name: modify the default zone
-          radosgw_zone:
-            cluster: "{{ cluster }}"
-            name: default
-            realm: default
-            zonegroup: default
-            master: true
-            default: true
-          environment:
-            CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-            CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-
-        - name: commit the period
-          command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- radosgw-admin --cluster {{ cluster }} period update --commit"
+        - name: store ssl certificate in kv store (not multisite)
+          command: >
+            {{ container_binary }} run --rm -i -v /etc/ceph:/etc/ceph:z --entrypoint=ceph {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} --cluster {{ cluster }}
+            config-key set rgw/cert/rgw.{{ ansible_facts['hostname'] }} -i -
+          args:
+            stdin: "{{ rgw_ssl_cert.content | b64decode }}"
+            stdin_add_newline: no
           changed_when: false
-          environment:
-            CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
-
-        - name: update the placement of radosgw hosts
-          command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} orch apply rgw {{ cluster }} {{ rgw_realm | default('default') }} {{ rgw_zone | default('default') }} --placement='count-per-host:{{ radosgw_num_instances }} label:{{ rgw_group_name }}' --port={{ radosgw_frontend_port }} {{ '--ssl' if radosgw_frontend_ssl_certificate else '' }}"
-          run_once: true
-          changed_when: false
+          when: not rgw_multisite | bool
           delegate_to: "{{ groups[mon_group_name][0] }}"
           environment:
             CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
-    - name: update the placement of radosgw multisite hosts
-      command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} orch apply rgw {{ item.host }}.{{ item.rgw_realm }}.{{ item.rgw_zone }}.{{ item.radosgw_frontend_port }} --realm={{ item.rgw_realm }} --zone={{ item.rgw_zone }} --port={{ item.radosgw_frontend_port }} --placement={{ item.host }}"
+        - name: store ssl certificate in kv store (multisite)
+          command: >
+            {{ container_binary }} run --rm -i -v /etc/ceph:/etc/ceph:z --entrypoint=ceph {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} --cluster {{ cluster }}
+            config-key set rgw/cert/rgw.{{ ansible_facts['hostname'] }}.{{ item.rgw_realm }}.{{ item.rgw_zone }}.{{ item.radosgw_frontend_port }} -i -
+          args:
+            stdin: "{{ rgw_ssl_cert.content | b64decode }}"
+            stdin_add_newline: no
+          changed_when: false
+          loop: "{{ rgw_instances }}"
+          when: rgw_multisite | bool
+          delegate_to: "{{ groups[mon_group_name][0] }}"
+          environment:
+            CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+
+    - name: update the placement of radosgw hosts
+      command: >
+        {{ cephadm_cmd }} shell --fsid {{ fsid }} --
+        ceph --cluster {{ cluster }} orch apply rgw {{ ansible_facts['hostname'] }}
+        --placement='count-per-host:{{ radosgw_num_instances }} {{ ansible_facts['hostname'] }}'
+        --port={{ radosgw_frontend_port }}
+        {{ '--ssl' if radosgw_frontend_ssl_certificate else '' }}
       changed_when: false
-      with_items: "{{ rgw_instances_all }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      when: not rgw_multisite | bool
+      environment:
+        CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+
+    - name: update the placement of radosgw multisite hosts
+      command: >
+        {{ cephadm_cmd }} shell --fsid {{ fsid }} --
+        ceph --cluster {{ cluster }} orch apply rgw {{ ansible_facts['hostname'] }}.{{ item.rgw_realm }}.{{ item.rgw_zone }}.{{ item.radosgw_frontend_port }}
+        --placement={{ ansible_facts['hostname'] }}
+        --realm={{ item.rgw_realm }} --zone={{ item.rgw_zone }}
+        --port={{ item.radosgw_frontend_port }}
+        {{ '--ssl' if radosgw_frontend_ssl_certificate else '' }}
+      changed_when: false
+      loop: "{{ rgw_instances }}"
       when: rgw_multisite | bool
-      run_once: true
       delegate_to: "{{ groups[mon_group_name][0] }}"
       environment:
         CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'


### PR DESCRIPTION
Without this, when rgw is managed by cephadm, it fails to start because
the ssl certificate isn't present in the kv store.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1987010
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1988404

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>