### PR TITLE
[skip ci] cephadm-adopt: use --realm and --zone for RGW

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -756,7 +756,7 @@
             CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
         - name: update the placement of radosgw hosts
-          command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} orch apply rgw {{ cluster }} {{ rgw_realm | default('default') }} {{ rgw_zone | default('default') }} --placement='count-per-host:{{ radosgw_num_instances }} label:{{ rgw_group_name }}' --port={{ radosgw_frontend_port }} {{ '--ssl' if radosgw_frontend_ssl_certificate else '' }}"
+          command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} orch apply rgw {{ cluster }} --realm={{ rgw_realm | default('default') }} --zone={{ rgw_zone | default('default') }} --placement='count-per-host:{{ radosgw_num_instances }} label:{{ rgw_group_name }}' --port={{ radosgw_frontend_port }} {{ '--ssl' if radosgw_frontend_ssl_certificate else '' }}"
           run_once: true
           changed_when: false
           delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
Historically, ceph orch apply rgw was using:
 - 1st arg as service id
 - 2nd arg as realm value
 - 3rd arg as zone value

There's now dedicated parameters for that (even if the current implementation
is still working) but we have now the same parameters used for both multisite
and non multisite setup.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>