### PR TITLE
[skip ci] container: add pids limit parameter

### DIFF
--- a/roles/ceph-crash/templates/ceph-crash.service.j2
+++ b/roles/ceph-crash/templates/ceph-crash.service.j2
@@ -17,6 +17,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-crash-%i \
 {% if container_binary == 'podman' %}
 -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+--pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
 --net=host \
 -v /var/lib/ceph:/var/lib/ceph:z \
 -v /etc/localtime:/etc/localtime:ro \

--- a/roles/ceph-grafana/templates/grafana-server.service.j2
+++ b/roles/ceph-grafana/templates/grafana-server.service.j2
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=grafana-server \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   -v /etc/grafana:/etc/grafana:Z \
   -v /var/lib/grafana:/var/lib/grafana:Z \
   --net=host \

--- a/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-api.service.j2
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --memory={{ ceph_rbd_target_api_docker_memory_limit }} \
   --cpus={{ ceph_rbd_target_api_docker_cpu_limit }} \
   -v /etc/localtime:/etc/localtime:ro \

--- a/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
+++ b/roles/ceph-iscsi-gw/templates/rbd-target-gw.service.j2
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --memory={{ ceph_rbd_target_gw_docker_memory_limit }} \
   --cpus={{ ceph_rbd_target_gw_docker_cpu_limit }} \
   -v /etc/localtime:/etc/localtime:ro \

--- a/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
+++ b/roles/ceph-iscsi-gw/templates/tcmu-runner.service.j2
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --memory={{ ceph_tcmu_runner_docker_memory_limit }} \
   --cpus={{ ceph_tcmu_runner_docker_cpu_limit }} \
   -v /etc/localtime:/etc/localtime:ro \

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --memory={{ ceph_mds_docker_memory_limit }} \
   --cpus={{ cpu_limit }} \
   -v /var/lib/ceph:/var/lib/ceph:z \

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --memory={{ ceph_mgr_docker_memory_limit }} \
   --cpus={{ ceph_mgr_docker_cpu_limit }} \
   -v /var/lib/ceph:/var/lib/ceph:z,rshared \

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --memory={{ ceph_mon_docker_memory_limit }} \
   --cpus={{ ceph_mon_docker_cpu_limit }} \
   -v /var/lib/ceph:/var/lib/ceph:z,rshared \

--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   -v /var/lib/ceph:/var/lib/ceph:z \
   -v /etc/ceph:/etc/ceph:z \
   -v /var/lib/nfs/ganesha:/var/lib/nfs/ganesha:z \

--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --privileged \
   -v /proc:/host/proc:ro -v /sys:/host/sys:ro \
   --net=host \

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -27,6 +27,7 @@ numactl \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --rm \
   --net=host \
   --privileged=true \

--- a/roles/ceph-prometheus/templates/alertmanager.service.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.service.j2
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=alertmanager \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   -v "{{ alertmanager_conf_dir }}:/etc/alertmanager:Z" \
   -v "{{ alertmanager_data_dir }}:/alertmanager:Z" \
   --net=host \

--- a/roles/ceph-prometheus/templates/prometheus.service.j2
+++ b/roles/ceph-prometheus/templates/prometheus.service.j2
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=prometheus \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   -v "{{ prometheus_conf_dir }}:/etc/prometheus:Z" \
   -v "{{ prometheus_data_dir }}:/prometheus:Z" \
   --net=host \

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --memory={{ ceph_rbd_mirror_docker_memory_limit }} \
   --cpus={{ ceph_rbd_mirror_docker_cpu_limit }} \
   -v /var/lib/ceph:/var/lib/ceph:z \

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
 {% if container_binary == 'podman' %}
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
+  --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --memory={{ ceph_rgw_docker_memory_limit }} \
   --cpus={{ cpu_limit }} \
   {% if ceph_rgw_docker_cpuset_cpus is defined -%}


### PR DESCRIPTION
Description of problem:

RGW container fails to start (on a RHEL8 setup) with:

```console
Jul 15 14:20:43 servera kernel: cgroup: fork rejected by pids controller in /machine.slice/libpod-54832992fcbbbf92b0d10d0491f7ff987728bec87c1c55b79cb3921c6f503f49.scope
Jul 15 14:20:43 servera conmon[34853]: terminate called after throwing an instance of 'std::system_error'
Jul 15 14:20:43 servera conmon[34853]:  what():  Resource temporarily unavailable
Jul 15 14:20:43 servera conmon[34853]: *** Caught signal (Aborted) **
Jul 15 14:20:43 servera conmon[34853]: in thread 7f5d605e1280 
```

The podman default pids-limit is set to 2048. 

```console
$ grep . sys/fs/cgroup/pids/machine.slice/libpod-*/pids.max
sys/fs/cgroup/pids/machine.slice/libpod-9336707e04da464b9128b7c57a0ee9b70efc5acb5207ea03ab413583c2264283.scope/pids.max:2048
sys/fs/cgroup/pids/machine.slice/libpod-d0eb2257c2fb371e015af9b68c716ed280399d9d2e88925aad9323ac26f659f3.scope/pids.max:2048
```

While this value of 2048 is more than sufficient when the rgw thread pool size uses its default value of 512, when rgw thread pool size is increased up to a value near to the pids-limit value, it does not leave place for the other processes to spawn and run within the container and the container crashes.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1987041