### PR TITLE
ceph-defaults: remove radosgw_civetweb_ variables

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -367,18 +367,11 @@ dummy:
 #
 #radosgw_frontend_type: beast # For additional frontends see: https://docs.ceph.com/en/latest/radosgw/frontends/
 
-#radosgw_civetweb_port: 8080
-#radosgw_civetweb_num_threads: 512
-#radosgw_civetweb_options: "num_threads={{ radosgw_civetweb_num_threads }}"
-# For additional civetweb configuration options available such as logging,
-# keepalive, and timeout settings, please see the civetweb docs at
-# https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md
-
-#radosgw_frontend_port: "{{ radosgw_civetweb_port if radosgw_frontend_type == 'civetweb' else '8080' }}"
+#radosgw_frontend_port: 8080
 # The server private key, public certificate and any other CA or intermediate certificates should be in one file, in PEM format.
 #radosgw_frontend_ssl_certificate: ""
 #radosgw_frontend_ssl_certificate_data: "" # certificate contents to be written to path defined by radosgw_frontend_ssl_certificate
-#radosgw_frontend_options: "{{ radosgw_civetweb_options if radosgw_frontend_type == 'civetweb' else '' }}"
+#radosgw_frontend_options: ""
 #radosgw_thread_pool_size: 512
 
 

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -367,18 +367,11 @@ ceph_iscsi_config_dev: false
 #
 #radosgw_frontend_type: beast # For additional frontends see: https://docs.ceph.com/en/latest/radosgw/frontends/
 
-#radosgw_civetweb_port: 8080
-#radosgw_civetweb_num_threads: 512
-#radosgw_civetweb_options: "num_threads={{ radosgw_civetweb_num_threads }}"
-# For additional civetweb configuration options available such as logging,
-# keepalive, and timeout settings, please see the civetweb docs at
-# https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md
-
-#radosgw_frontend_port: "{{ radosgw_civetweb_port if radosgw_frontend_type == 'civetweb' else '8080' }}"
+#radosgw_frontend_port: 8080
 # The server private key, public certificate and any other CA or intermediate certificates should be in one file, in PEM format.
 #radosgw_frontend_ssl_certificate: ""
 #radosgw_frontend_ssl_certificate_data: "" # certificate contents to be written to path defined by radosgw_frontend_ssl_certificate
-#radosgw_frontend_options: "{{ radosgw_civetweb_options if radosgw_frontend_type == 'civetweb' else '' }}"
+#radosgw_frontend_options: ""
 #radosgw_thread_pool_size: 512
 
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -359,18 +359,11 @@ mds_max_mds: 1
 #
 radosgw_frontend_type: beast # For additional frontends see: https://docs.ceph.com/en/latest/radosgw/frontends/
 
-radosgw_civetweb_port: 8080
-radosgw_civetweb_num_threads: 512
-radosgw_civetweb_options: "num_threads={{ radosgw_civetweb_num_threads }}"
-# For additional civetweb configuration options available such as logging,
-# keepalive, and timeout settings, please see the civetweb docs at
-# https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md
-
-radosgw_frontend_port: "{{ radosgw_civetweb_port if radosgw_frontend_type == 'civetweb' else '8080' }}"
+radosgw_frontend_port: 8080
 # The server private key, public certificate and any other CA or intermediate certificates should be in one file, in PEM format.
 radosgw_frontend_ssl_certificate: ""
 radosgw_frontend_ssl_certificate_data: "" # certificate contents to be written to path defined by radosgw_frontend_ssl_certificate
-radosgw_frontend_options: "{{ radosgw_civetweb_options if radosgw_frontend_type == 'civetweb' else '' }}"
+radosgw_frontend_options: ""
 radosgw_thread_pool_size: 512
 
 

--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -185,13 +185,6 @@
   include_tasks: check_iscsi.yml
   when: iscsi_gw_group_name in group_names
 
-- name: warn about radosgw_civetweb_num_threads option deprecation
-  debug:
-    msg: "WARNING: radosgw_civetweb_num_threads variable is deprecated. Please use radosgw_thread_pool_size instead"
-  when:
-    - radosgw_frontend_type == 'civetweb'
-    - radosgw_civetweb_num_threads is defined
-
 - name: include check_nfs.yml
   include_tasks: check_nfs.yml
   when: inventory_hostname in groups.get(nfs_group_name, [])


### PR DESCRIPTION
`radosgw_civetweb_xxx` variables are legacy variables and users should
have switched to `radosgw_frontend_xxx` variables instead.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>