### PR TITLE
[skip ci] rolling_update: get ceph version when mons exist

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -114,7 +114,9 @@
         - ceph_docker_registry_auth | bool
 
     - name: check ceph release in container image
-      when: containerized_deployment | bool
+      when:
+        - groups.get(mon_group_name, []) | length > 0
+        - containerized_deployment | bool
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: true
       block:


### PR DESCRIPTION
eec3878 introduced a regression for upgrade scenarios where there's no
monitor nodes at all (like ganesha standalone, external clients, etc..)

```console
TASK [get the ceph release being deployed] ************************************
task path: infrastructure-playbooks/rolling_update.yml:121
Thursday 29 July 2021  15:55:29 +0000 (0:00:00.484)       0:00:15.802 *********
fatal: [client0]: FAILED! =>
  msg: '''dict object'' has no attribute ''mons'''
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>