### PR TITLE
[skip ci] Fixes typo in rgw-add-users-buckets playbook

### DIFF
--- a/infrastructure-playbooks/rgw-add-users-buckets.yml
+++ b/infrastructure-playbooks/rgw-add-users-buckets.yml
@@ -2,7 +2,7 @@
 #
 # This example is run on your local machine
 #
-# Ensure that your local machine cant connect to rgw of your cluster
+# Ensure that your local machine can connect to rgw of your cluster
 #
 # You will need to update the following vars
 #


### PR DESCRIPTION
Fixes typo in infrastructure-playbooks/rgw-add-users-buckets.yml  playbook