### PR TITLE
add-osd: use container_exec_cmd fact from mon host

### DIFF
--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -113,7 +113,7 @@
         add_osd: True
 
     - name: set noup flag
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd set noup"
+      command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd set noup"
       delegate_to: "{{ groups['mons'][0] }}"
       run_once: True
       changed_when: False
@@ -133,7 +133,7 @@
 
   post_tasks:
     - name: unset noup flag
-      command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd unset noup"
+      command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd unset noup"
       delegate_to: "{{ groups['mons'][0] }}"
       run_once: True
       changed_when: False


### PR DESCRIPTION
Because we're delegating the task to the first monitor node, we need to be
sure that the container_exec_cmd fact is the one from that node too otherwise
we could have a mismatch on the ceph-mon container name.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1990772

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>