### PR TITLE
tests: add pytest-timeout

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -16,3 +16,4 @@ markers =
   rbdmirrors: for rbdmirror nodes
   rgws: for rgw nodes
   grafanas: for grafana nodes
+timeout = 300

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,3 +9,4 @@ mock
 jmespath
 pytest-rerunfailures<9.0
 pytest-cov
+pytest-timeout


### PR DESCRIPTION
There's no global timeout on pytest meaning if one test hang then the
CI job will only timeout after 3h instead of failing earlier.
Adding a global timeout to 300s.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>