### PR TITLE
tests: rename grafana to monitoring

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,8 +177,8 @@ def pytest_collection_modifyitems(session, config, items):
             item.add_marker(pytest.mark.nfss)
         elif "iscsi" in test_path:
             item.add_marker(pytest.mark.iscsigws)
-        elif "grafana" in test_path:
-            item.add_marker(pytest.mark.grafanas)
+        elif "monitoring" in test_path:
+            item.add_marker(pytest.mark.monitoring)
         else:
             item.add_marker(pytest.mark.all)
 

--- a/tests/functional/tests/monitoring/test_monitoring.py
+++ b/tests/functional/tests/monitoring/test_monitoring.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-class TestGrafanas(object):
+class TestMonitoring(object):
 
     @pytest.mark.dashboard
     @pytest.mark.no_docker


### PR DESCRIPTION
Since the grafana-server group has been renamed to monitoring then
changing the associated tests.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>