### PR TITLE
[skip ci] roles: remove leftover from pr #4319

### DIFF
--- a/roles/ceph-iscsi-gw/tasks/systemd.yml
+++ b/roles/ceph-iscsi-gw/tasks/systemd.yml
@@ -1,6 +1,5 @@
 ---
 - name: generate systemd unit files for tcmu-runner, rbd-target-api and rbd-target-gw
-  become: true
   template:
     src: "{{ role_path }}/templates/{{ item }}.service.j2"
     dest: /etc/systemd/system/{{ item }}.service

--- a/roles/ceph-mds/tasks/systemd.yml
+++ b/roles/ceph-mds/tasks/systemd.yml
@@ -1,6 +1,5 @@
 ---
 - name: generate systemd unit file
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-mds.service.j2"
     dest: /etc/systemd/system/ceph-mds@.service

--- a/roles/ceph-mgr/tasks/systemd.yml
+++ b/roles/ceph-mgr/tasks/systemd.yml
@@ -1,6 +1,5 @@
 ---
 - name: generate systemd unit file
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-mgr.service.j2"
     dest: /etc/systemd/system/ceph-mgr@.service

--- a/roles/ceph-mon/tasks/systemd.yml
+++ b/roles/ceph-mon/tasks/systemd.yml
@@ -1,6 +1,5 @@
 ---
 - name: generate systemd unit file for mon container
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-mon.service.j2"
     dest: /etc/systemd/system/ceph-mon@.service

--- a/roles/ceph-nfs/tasks/systemd.yml
+++ b/roles/ceph-nfs/tasks/systemd.yml
@@ -1,6 +1,5 @@
 ---
 - name: generate systemd unit file
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-nfs.service.j2"
     dest: /etc/systemd/system/ceph-nfs@.service

--- a/roles/ceph-rbd-mirror/tasks/systemd.yml
+++ b/roles/ceph-rbd-mirror/tasks/systemd.yml
@@ -1,6 +1,5 @@
 ---
 - name: generate systemd unit file
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-rbd-mirror.service.j2"
     dest: /etc/systemd/system/ceph-rbd-mirror@.service

--- a/roles/ceph-rgw/tasks/systemd.yml
+++ b/roles/ceph-rgw/tasks/systemd.yml
@@ -1,6 +1,5 @@
 ---
 - name: generate systemd unit file
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-radosgw.service.j2"
     dest: /etc/systemd/system/ceph-radosgw@.service


### PR DESCRIPTION
pr #4319 introduced some uesless `become: true` on systemd tasks.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>