### PR TITLE
[skip ci] Vagrantfile: fallback on 'varant_variables.yml.sample'

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,13 @@
 require 'yaml'
 VAGRANTFILE_API_VERSION = '2'
 
-config_file=File.expand_path(File.join(File.dirname(__FILE__), 'vagrant_variables.yml'))
+if File.file?(File.join(File.dirname(__FILE__), 'vagrant_variables.yml')) then
+  vagrant_variables_file = 'vagrant_variables.yml'
+else
+  vagrant_variables_file = 'vagrant_variables.yml.sample'
+end
+
+config_file=File.expand_path(File.join(File.dirname(__FILE__), vagrant_variables_file))
 
 settings=YAML.load_file(config_file)
 


### PR DESCRIPTION
When using a vagrant command from the root directory of the repo, it
throws an error if no 'vagrant_variables.yml' file is present.

```
Message: Errno::ENOENT: No such file or directory @ rb_sysopen - /home/guits/workspaces/ceph-ansible/vagrant_variables.yml
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>