### PR TITLE
tests: auth_allow_insecure_global_id_reclaim false

### DIFF
--- a/tests/functional/all_daemons/ceph-override.json
+++ b/tests/functional/all_daemons/ceph-override.json
@@ -1,6 +1,7 @@
 {
   "ceph_conf_overrides": {
     "global": {
+      "auth_allow_insecure_global_id_reclaim": false,
       "osd_pool_default_pg_num": 12,
       "osd_pool_default_size": 1,
       "mon_allow_pool_size_one": true,

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -13,6 +13,7 @@ rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
+    auth_allow_insecure_global_id_reclaim: false
     mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -6,6 +6,7 @@ cluster_network: "192.168.2.0/24"
 radosgw_interface: "{{ 'eth1' if ansible_facts['distribution'] == 'CentOS' else 'ens6' }}"
 ceph_conf_overrides:
   global:
+    auth_allow_insecure_global_id_reclaim: false
     mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -14,6 +14,7 @@ rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
+    auth_allow_insecure_global_id_reclaim: false
     osd_pool_default_pg_num: 8
     mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -11,6 +11,7 @@ rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
+    auth_allow_insecure_global_id_reclaim: false
     osd_pool_default_pg_num: 8
     mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false


### PR DESCRIPTION
Otherwise the clients won't be able to reconnect after the reboot in the
all_daemons and collocation jobs.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>