### PR TITLE
[skip ci] containers: introduce target systemd unit

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -374,17 +374,14 @@
       failed_when: false
       when: containerized_deployment | bool
 
-    - name: remove ceph-mon systemd unit file
+    - name: remove ceph-mon systemd files
       file:
-        path: /etc/systemd/system/ceph-mon@.service
+        path: "{{ item }}"
         state: absent
-      when: containerized_deployment | bool
-
-    - name: remove ceph-mon systemd override directory
-      file:
-        path: /etc/systemd/system/ceph-mon@.service.d
-        state: absent
-      when: not containerized_deployment | bool
+      loop:
+        - /etc/systemd/system/ceph-mon@.service
+        - /etc/systemd/system/ceph-mon@.service.d
+        - /etc/systemd/system/ceph-mon.target
 
     - name: waiting for the monitor to join the quorum...
       command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} quorum_status --format json"
@@ -422,17 +419,15 @@
       failed_when: false
       when: containerized_deployment | bool
 
-    - name: remove ceph-mgr systemd unit file
+    - name: remove ceph-mgr systemd files
       file:
-        path: /etc/systemd/system/ceph-mgr@.service
+        path: "{{ item }}"
         state: absent
-      when: containerized_deployment | bool
+      loop:
+        - /etc/systemd/system/ceph-mgr@.service
+        - /etc/systemd/system/ceph-mgr@.service.d
+        - /etc/systemd/system/ceph-mgr.target
 
-    - name: remove ceph-mgr systemd override directory
-      file:
-        path: /etc/systemd/system/ceph-mgr@.service.d
-        state: absent
-      when: not containerized_deployment | bool
 
 - name: set osd flags
   hosts: "{{ osd_group_name|default('osds') }}"
@@ -555,20 +550,15 @@
         firewalld: "{{ true if configure_firewall | bool else false }}"
       loop: '{{ (osd_list.stdout | from_json).keys() | list }}'
 
-    - name: remove ceph-osd systemd unit and ceph-osd-run.sh files
+    - name: remove ceph-osd systemd and ceph-osd-run.sh files
       file:
-        path: '{{ item }}'
+        path: "{{ item }}"
         state: absent
       loop:
         - /etc/systemd/system/ceph-osd@.service
+        - /etc/systemd/system/ceph-osd@.service.d
+        - /etc/systemd/system/ceph-osd.target
         - "{{ ceph_osd_docker_run_script_path | default('/usr/share') }}/ceph-osd-run.sh"
-      when: containerized_deployment | bool
-
-    - name: remove ceph-osd systemd override directory
-      file:
-        path: /etc/systemd/system/ceph-osd@.service.d
-        state: absent
-      when: not containerized_deployment | bool
 
     - name: remove osd directory
       file:
@@ -674,7 +664,7 @@
         name: ceph-mds.target
         state: stopped
         enabled: false
-      when: not containerized_deployment | bool
+      failed_when: false
 
     - name: reset failed ceph-mds systemd unit
       command: "systemctl reset-failed ceph-mds@{{ ansible_facts['hostname'] }}"  # noqa 303
@@ -682,17 +672,14 @@
       failed_when: false
       when: containerized_deployment | bool
 
-    - name: remove ceph-mds systemd unit file
+    - name: remove ceph-mds systemd files
       file:
-        path: /etc/systemd/system/ceph-mds@.service
+        path: "{{ item }}"
         state: absent
-      when: containerized_deployment | bool
-
-    - name: remove ceph-mds systemd override directory
-      file:
-        path: /etc/systemd/system/ceph-mds@.service.d
-        state: absent
-      when: not containerized_deployment | bool
+      loop:
+        - /etc/systemd/system/ceph-mds@.service
+        - /etc/systemd/system/ceph-mds@.service.d
+        - /etc/systemd/system/ceph-mds.target
 
     - name: remove legacy ceph mds data
       file:
@@ -799,10 +786,10 @@
 
     - name: stop and disable ceph-radosgw systemd target
       service:
-        name: ceph-rgw.target
+        name: ceph-radosgw.target
         state: stopped
         enabled: false
-      when: not containerized_deployment | bool
+      failed_when: false
 
     - name: reset failed ceph-radosgw systemd unit
       command: "systemctl reset-failed ceph-radosgw@rgw.{{ ansible_facts['hostname'] }}.{{ item.instance_name }}"  # noqa 303
@@ -811,17 +798,14 @@
       loop: '{{ rgw_instances }}'
       when: containerized_deployment | bool
 
-    - name: remove ceph-radosgw systemd unit file
+    - name: remove ceph-radosgw systemd files
       file:
-        path: /etc/systemd/system/ceph-radosgw@.service
+        path: "{{ item }}"
         state: absent
-      when: containerized_deployment | bool
-
-    - name: remove ceph-radosgw systemd override directory
-      file:
-        path: /etc/systemd/system/ceph-radosgw@.service.d
-        state: absent
-      when: not containerized_deployment | bool
+      loop:
+        - /etc/systemd/system/ceph-radosgw@.service
+        - /etc/systemd/system/ceph-radosgw@.service.d
+        - /etc/systemd/system/ceph-radosgw.target
 
     - name: remove legacy ceph radosgw data
       file:
@@ -868,17 +852,13 @@
       failed_when: false
       when: containerized_deployment | bool
 
-    - name: remove ceph-nfs systemd unit file
+    - name: remove ceph-nfs systemd unit files
       file:
-        path: /etc/systemd/system/ceph-nfs@.service
+        path: "{{ item }}"
         state: absent
-      when: containerized_deployment | bool
-
-    - name: remove ceph-nfs systemd override directory
-      file:
-        path: /etc/systemd/system/ceph-nfs@.service.d
-        state: absent
-      when: not containerized_deployment | bool
+      loop:
+        - /etc/systemd/system/ceph-nfs@.service
+        - /etc/systemd/system/ceph-nfs@.service.d
 
     - name: remove legacy ceph radosgw directory
       file:
@@ -1014,7 +994,7 @@
         name: ceph-rbd-mirror.target
         state: stopped
         enabled: false
-      when: not containerized_deployment | bool
+      failed_when: false
 
     - name: reset failed rbd-mirror systemd unit
       command: "systemctl reset-failed ceph-rbd-mirror@rbd-mirror.{{ ansible_facts['hostname'] }}"  # noqa 303
@@ -1022,17 +1002,15 @@
       failed_when: false
       when: containerized_deployment | bool
 
-    - name: remove rbd-mirror systemd unit file
+    - name: remove rbd-mirror systemd files
       file:
-        path: /etc/systemd/system/ceph-rbd-mirror@.service
+        path: "{{ item }}"
         state: absent
-      when: containerized_deployment | bool
+      loop:
+        - /etc/systemd/system/ceph-rbd-mirror@.service
+        - /etc/systemd/system/ceph-rbd-mirror@.service.d
+        - /etc/systemd/system/ceph-rbd-mirror.target
 
-    - name: remove rbd-mirror systemd override directory
-      file:
-        path: /etc/systemd/system/ceph-rbd-mirror@.service.d
-        state: absent
-      when: not containerized_deployment | bool
 
 - name: redeploy iscsigw daemons
   hosts: "{{ iscsi_gw_group_name|default('iscsigws') }}"
@@ -1092,6 +1070,7 @@
         - tcmu-runner
       when: containerized_deployment | bool
 
+
 - name: redeploy ceph-crash daemons
   hosts:
     - "{{ mon_group_name|default('mons') }}"
@@ -1114,6 +1093,11 @@
         enabled: false
       failed_when: false
 
+    - name: remove ceph-crash systemd unit file
+      file:
+        path: /etc/systemd/system/ceph-crash@.service
+        state: absent
+
     - name: update the placement of ceph-crash hosts
       command: "{{ cephadm_cmd }} shell --fsid {{ fsid }} -- ceph --cluster {{ cluster }} orch apply crash --placement='label:ceph'"
       run_once: true
@@ -1121,6 +1105,7 @@
       delegate_to: '{{ groups[mon_group_name][0] }}'
       environment:
         CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+
 
 - name: redeploy alertmanager/grafana/prometheus daemons
   hosts: "{{ monitoring_group_name|default('monitoring') }}"

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -248,8 +248,11 @@
 
     - name: remove ceph mds service
       file:
-        path: /etc/systemd/system/ceph-mds@.service
+        path: /etc/systemd/system/ceph-mds{{ item }}
         state: absent
+      loop:
+        - '@.service'
+        - '.target'
 
 
 - name: purge ceph mgr cluster
@@ -267,9 +270,11 @@
 
     - name: remove ceph mgr service
       file:
-        path: /etc/systemd/system/ceph-mgr@.service
+        path: /etc/systemd/system/ceph-mgr{{ item }}
         state: absent
-
+      loop:
+        - '@.service'
+        - '.target'
 
 - name: purge rgwloadbalancer cluster
   hosts: rgwloadbalancers
@@ -304,6 +309,14 @@
       failed_when: false
       with_items: "{{ rgw_instances }}"
 
+    - name: remove ceph rgw service
+      file:
+        path: /etc/systemd/system/ceph-radosgw{{ item }}
+        state: absent
+      loop:
+        - '@.service'
+        - '.target'
+
 
 - name: purge ceph rbd-mirror cluster
   hosts: rbdmirrors
@@ -316,6 +329,14 @@
         state: stopped
         enabled: no
       failed_when: false
+
+    - name: remove ceph rbd-mirror service
+      file:
+        path: /etc/systemd/system/ceph-rbd-mirror{{ item }}
+        state: absent
+      loop:
+        - '@.service'
+        - '.target'
 
 
 - name: purge ceph osd cluster
@@ -599,9 +620,11 @@
 
     - name: remove ceph osd service
       file:
-        path: /etc/systemd/system/ceph-osd@.service
+        path: /etc/systemd/system/ceph-osd{{ item }}
         state: absent
-      when: containerized_deployment | bool
+      loop:
+        - '@.service'
+        - '.target'
 
 - name: purge ceph mon cluster
   hosts: mons
@@ -633,11 +656,9 @@
 
     - name: remove ceph mon and mgr service
       file:
-        path: "/etc/systemd/system/ceph-{{ item }}@.service"
+        path: "/etc/systemd/system/ceph-{{ item.0 }}{{ item.1 }}"
         state: absent
-      with_items:
-        - mon
-        - mgr
+      loop: "{{ ['mon', 'mgr'] | product(['@.service', '.target']) | list }}"
 
 
 - name: purge ceph-crash daemons

--- a/roles/ceph-container-common/files/ceph.target
+++ b/roles/ceph-container-common/files/ceph.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph*@.service instances at once
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/ceph-container-common/tasks/main.yml
+++ b/roles/ceph-container-common/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: generate systemd ceph-mon target file
+  copy:
+    src: ceph.target
+    dest: /etc/systemd/system/ceph.target
+
+- name: enable ceph.target
+  service:
+    name: ceph.target
+    enabled: yes
+    daemon_reload: yes
+
 - name: include prerequisites.yml
   include_tasks: prerequisites.yml
 

--- a/roles/ceph-crash/templates/ceph-crash.service.j2
+++ b/roles/ceph-crash/templates/ceph-crash.service.j2
@@ -41,4 +41,4 @@ TimeoutStartSec=120
 TimeoutStopSec=10
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=ceph.target

--- a/roles/ceph-mds/files/ceph-mds.target
+++ b/roles/ceph-mds/files/ceph-mds.target
@@ -1,0 +1,9 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph-mds@.service instances at once
+PartOf=ceph.target
+After=ceph-mon.target
+Before=ceph.target
+Wants=ceph.target ceph-mon.target
+
+[Install]
+WantedBy=multi-user.target ceph.target

--- a/roles/ceph-mds/tasks/containerized.yml
+++ b/roles/ceph-mds/tasks/containerized.yml
@@ -2,6 +2,13 @@
 - name: include_tasks systemd.yml
   include_tasks: systemd.yml
 
+- name: enable ceph-mds.target
+  service:
+    name: ceph-mds.target
+    enabled: yes
+    daemon_reload: yes
+  when: containerized_deployment | bool
+
 - name: systemd start mds container
   systemd:
     name: ceph-mds@{{ ansible_facts['hostname'] }}

--- a/roles/ceph-mds/tasks/systemd.yml
+++ b/roles/ceph-mds/tasks/systemd.yml
@@ -8,3 +8,9 @@
     group: "root"
     mode: "0644"
   notify: restart ceph mdss
+
+- name: generate systemd ceph-mds target file
+  copy:
+    src: ceph-mds.target
+    dest: /etc/systemd/system/ceph-mds.target
+  when: containerized_deployment | bool

--- a/roles/ceph-mds/templates/ceph-mds.service.j2
+++ b/roles/ceph-mds/templates/ceph-mds.service.j2
@@ -1,5 +1,6 @@
 [Unit]
 Description=Ceph MDS
+PartOf=ceph-mds.target
 {% if container_binary == 'docker' %}
 After=docker.service
 Requires=docker.service
@@ -53,4 +54,4 @@ PIDFile=/%t/%n-pid
 {% endif %}
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=ceph.target

--- a/roles/ceph-mgr/files/ceph-mgr.target
+++ b/roles/ceph-mgr/files/ceph-mgr.target
@@ -1,0 +1,9 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph-mgr@.service instances at once
+PartOf=ceph.target
+After=ceph-mon.target
+Before=ceph.target
+Wants=ceph.target ceph-mon.target
+
+[Install]
+WantedBy=multi-user.target ceph.target

--- a/roles/ceph-mgr/tasks/start_mgr.yml
+++ b/roles/ceph-mgr/tasks/start_mgr.yml
@@ -21,6 +21,13 @@
   include_tasks: systemd.yml
   when: containerized_deployment | bool
 
+- name: enable ceph-mgr.target
+  service:
+    name: ceph-mgr.target
+    enabled: yes
+    daemon_reload: yes
+  when: containerized_deployment | bool
+
 - name: systemd start mgr
   systemd:
     name: ceph-mgr@{{ ansible_facts['hostname'] }}

--- a/roles/ceph-mgr/tasks/systemd.yml
+++ b/roles/ceph-mgr/tasks/systemd.yml
@@ -8,3 +8,9 @@
     group: "root"
     mode: "0644"
   notify: restart ceph mgrs
+
+- name: generate systemd ceph-mgr target file
+  copy:
+    src: ceph-mgr.target
+    dest: /etc/systemd/system/ceph-mgr.target
+  when: containerized_deployment | bool

--- a/roles/ceph-mgr/templates/ceph-mgr.service.j2
+++ b/roles/ceph-mgr/templates/ceph-mgr.service.j2
@@ -1,5 +1,6 @@
 [Unit]
 Description=Ceph Manager
+PartOf=ceph-mgr.target
 {% if container_binary == 'docker' %}
 After=docker.service
 Requires=docker.service
@@ -52,4 +53,4 @@ PIDFile=/%t/%n-pid
 {% endif %}
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=ceph.target

--- a/roles/ceph-mon/files/ceph-mon.target
+++ b/roles/ceph-mon/files/ceph-mon.target
@@ -1,0 +1,8 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph-mon@.service instances at once
+PartOf=ceph.target
+Before=ceph.target
+Wants=ceph.target
+
+[Install]
+WantedBy=multi-user.target ceph.target

--- a/roles/ceph-mon/tasks/systemd.yml
+++ b/roles/ceph-mon/tasks/systemd.yml
@@ -1,6 +1,5 @@
 ---
 - name: generate systemd unit file for mon container
-  become: true
   template:
     src: "{{ role_path }}/templates/ceph-mon.service.j2"
     dest: /etc/systemd/system/ceph-mon@.service
@@ -8,3 +7,16 @@
     group: "root"
     mode: "0644"
   notify: restart ceph mons
+
+- name: generate systemd ceph-mon target file
+  copy:
+    src: ceph-mon.target
+    dest: /etc/systemd/system/ceph-mon.target
+  when: containerized_deployment | bool
+
+- name: enable ceph-mon.target
+  service:
+    name: ceph-mon.target
+    enabled: yes
+    daemon_reload: yes
+  when: containerized_deployment | bool

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -1,5 +1,6 @@
 [Unit]
 Description=Ceph Monitor
+PartOf=ceph-mon.target
 {% if container_binary == 'docker' %}
 After=docker.service
 Requires=docker.service
@@ -67,4 +68,4 @@ PIDFile=/%t/%n-pid
 {% endif %}
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=ceph.target

--- a/roles/ceph-osd/files/ceph-osd.target
+++ b/roles/ceph-osd/files/ceph-osd.target
@@ -1,0 +1,9 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph-osd@.service instances at once
+PartOf=ceph.target
+After=ceph-mon.target
+Before=ceph.target
+Wants=ceph.target ceph-mon.target
+
+[Install]
+WantedBy=multi-user.target ceph.target

--- a/roles/ceph-osd/tasks/systemd.yml
+++ b/roles/ceph-osd/tasks/systemd.yml
@@ -7,3 +7,16 @@
     group: "root"
     mode: "0644"
   notify: restart ceph osds
+
+- name: generate systemd ceph-osd target file
+  copy:
+    src: ceph-osd.target
+    dest: /etc/systemd/system/ceph-osd.target
+  when: containerized_deployment | bool
+
+- name: enable ceph-osd.target
+  service:
+    name: ceph-osd.target
+    enabled: yes
+    daemon_reload: yes
+  when: containerized_deployment | bool

--- a/roles/ceph-osd/templates/ceph-osd.service.j2
+++ b/roles/ceph-osd/templates/ceph-osd.service.j2
@@ -1,6 +1,7 @@
 # {{ ansible_managed }}
 [Unit]
 Description=Ceph OSD
+PartOf=ceph-osd.target
 {% if container_binary == 'docker' %}
 After=docker.service
 Requires=docker.service
@@ -79,4 +80,4 @@ PIDFile=/%t/%n-pid
 {% endif %}
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=ceph.target

--- a/roles/ceph-rbd-mirror/files/ceph-rbd-mirror.target
+++ b/roles/ceph-rbd-mirror/files/ceph-rbd-mirror.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph-rbd-mirror@.service instances at once
+PartOf=ceph.target
+Before=ceph.target
+
+[Install]
+WantedBy=multi-user.target ceph.target

--- a/roles/ceph-rbd-mirror/tasks/systemd.yml
+++ b/roles/ceph-rbd-mirror/tasks/systemd.yml
@@ -8,3 +8,16 @@
     group: "root"
     mode: "0644"
   notify: restart ceph rbdmirrors
+
+- name: generate systemd ceph-rbd-mirror target file
+  copy:
+    src: ceph-rbd-mirror.target
+    dest: /etc/systemd/system/ceph-rbd-mirror.target
+  when: containerized_deployment | bool
+
+- name: enable ceph-rbd-mirror.target
+  service:
+    name: ceph-rbd-mirror.target
+    enabled: yes
+    daemon_reload: yes
+  when: containerized_deployment | bool

--- a/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
+++ b/roles/ceph-rbd-mirror/templates/ceph-rbd-mirror.service.j2
@@ -1,5 +1,6 @@
 [Unit]
 Description=Ceph RBD mirror
+PartOf=ceph-rbd-mirror.target
 {% if container_binary == 'docker' %}
 After=docker.service
 Requires=docker.service
@@ -52,4 +53,4 @@ PIDFile=/%t/%n-pid
 {% endif %}
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=ceph.target

--- a/roles/ceph-rgw/files/ceph-radosgw.target
+++ b/roles/ceph-rgw/files/ceph-radosgw.target
@@ -1,0 +1,9 @@
+[Unit]
+Description=ceph target allowing to start/stop all ceph-radosgw@.service instances at once
+PartOf=ceph.target
+After=ceph-mon.target
+Before=ceph.target
+Wants=ceph.target ceph-mon.target
+
+[Install]
+WantedBy=multi-user.target ceph.target

--- a/roles/ceph-rgw/tasks/systemd.yml
+++ b/roles/ceph-rgw/tasks/systemd.yml
@@ -8,3 +8,16 @@
     group: "root"
     mode: "0644"
   notify: restart ceph rgws
+
+- name: generate systemd ceph-radosgw target file
+  copy:
+    src: ceph-radosgw.target
+    dest: /etc/systemd/system/ceph-radosgw.target
+  when: containerized_deployment | bool
+
+- name: enable ceph-radosgw.target
+  service:
+    name: ceph-radosgw.target
+    enabled: yes
+    daemon_reload: yes
+  when: containerized_deployment | bool

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -1,5 +1,6 @@
 [Unit]
 Description=Ceph RGW
+PartOf=ceph-radosgw.target
 {% if container_binary == 'docker' %}
 After=docker.service
 Requires=docker.service
@@ -66,4 +67,4 @@ PIDFile=/%t/%n-pid
 {% endif %}
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=ceph.target


### PR DESCRIPTION
This adds ceph-*.target systemd unit files support for containerized
deployments.
This also fixes a regression introduced by PR #6719 (rgw and nfs systemd
units not getting purged)

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1962748

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>