### PR TITLE
[skip ci] ceph-mon: do not log monitor keyring

### DIFF
--- a/roles/ceph-mon/tasks/deploy_monitors.yml
+++ b/roles/ceph-mon/tasks/deploy_monitors.yml
@@ -41,6 +41,7 @@
       set_fact:
         monitor_keyring: "{{ (initial_mon_key.stdout | from_json)[0]['key'] if _initial_mon_key_success | bool else monitor_keyring.stdout }}"
       when: initial_mon_key.stdout|default('')|length > 0 or monitor_keyring is not skipped
+      no_log: "{{ no_log_on_ceph_key_tasks }}"
 
     - name: create monitor initial keyring
       ceph_key:


### PR DESCRIPTION
We don't want to display the keyring in the ansible log.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>