### PR TITLE
tests: use old build of ceph@master

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -297,6 +297,7 @@ setenv=
   ANSIBLE_KEEP_REMOTE_FILES = 1
   ANSIBLE_CACHE_PLUGIN = memory
   ANSIBLE_GATHERING = implicit
+  CEPH_DEV_SHA1 = 6436cc5e13174b8b206301b0a073b8a776eea490
   # only available for ansible >= 2.5
   ANSIBLE_STDOUT_CALLBACK = yaml
   non_container: DEV_SETUP = True


### PR DESCRIPTION
for unlocking the ci.
this is intended to be reverted.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>