### PR TITLE
[skip ci] purge: add container_binary needed for zap osds

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -368,6 +368,10 @@
     - import_role:
         name: ceph-defaults
 
+    - import_role:
+        name: ceph-facts
+        tasks_from: container_binary
+
     - name: default lvm_volumes if not defined
       set_fact:
         lvm_volumes: []


### PR DESCRIPTION
`container_binary` isn't set anymore in the purge osd play because of a
regression introduced by 60aa70a.
The CI didn't catch it because the play purging node-exporter sets this
variable for all nodes before we run the purge osd play.

This commit fixes this regression.

Signed-off-by: Seena Fallah <seenafallah@gmail.com>