### PR TITLE
[skip ci] iscsi: don't set default value for trusted_ip_list

### DIFF
--- a/group_vars/iscsigws.yml.sample
+++ b/group_vars/iscsigws.yml.sample
@@ -30,7 +30,9 @@ dummy:
 #api_port: 5000
 #api_secure: false
 #loop_delay: 1
-#trusted_ip_list: 192.168.122.1
+# set the variable below with a comma separated list of IPs
+# in order to restrict the access to the iSCSI API
+# trusted_ip_list: 192.168.122.1
 
 
 ##########

--- a/roles/ceph-iscsi-gw/defaults/main.yml
+++ b/roles/ceph-iscsi-gw/defaults/main.yml
@@ -22,7 +22,9 @@ api_password: admin
 api_port: 5000
 api_secure: false
 loop_delay: 1
-trusted_ip_list: 192.168.122.1
+# set the variable below with a comma separated list of IPs
+# in order to restrict the access to the iSCSI API
+# trusted_ip_list: 192.168.122.1
 
 
 ##########

--- a/roles/ceph-iscsi-gw/tasks/common.yml
+++ b/roles/ceph-iscsi-gw/tasks/common.yml
@@ -30,7 +30,7 @@
 
 - name: add mgr ip address to trusted list with dashboard - ipv4
   set_fact:
-    trusted_ip_list: '{{ trusted_ip_list }},{{ hostvars[item]["ansible_facts"]["all_ipv4_addresses"] | ips_in_ranges(public_network.split(",")) | first }}'
+    trusted_ip_list: '{{ trusted_ip_list | default("") }}{{ "," if trusted_ip_list is defined else "" }}{{ hostvars[item]["ansible_facts"]["all_ipv4_addresses"] | ips_in_ranges(public_network.split(",")) | first }}'
   with_items: '{{ groups[mgr_group_name] | default(groups[mon_group_name]) }}'
   when:
     - dashboard_enabled | bool
@@ -38,7 +38,7 @@
 
 - name: add mgr ip address to trusted list with dashboard - ipv6
   set_fact:
-    trusted_ip_list: '{{ trusted_ip_list }},{{ hostvars[item]["ansible_facts"]["all_ipv6_addresses"] | ips_in_ranges(public_network.split(",")) | last }}'
+    trusted_ip_list: '{{ trusted_ip_list | default("") }}{{ "," if trusted_ip_list is defined else "" }}{{ hostvars[item]["ansible_facts"]["all_ipv6_addresses"] | ips_in_ranges(public_network.split(",")) | last }}'
   with_items: '{{ groups[mgr_group_name] | default(groups[mon_group_name]) }}'
   when:
     - dashboard_enabled | bool

--- a/roles/ceph-iscsi-gw/templates/iscsi-gateway.cfg.j2
+++ b/roles/ceph-iscsi-gw/templates/iscsi-gateway.cfg.j2
@@ -25,4 +25,6 @@ api_user = {{ api_user }}
 api_password = {{ api_password }}
 api_port = {{ api_port }}
 loop_delay = {{ loop_delay }}
+{% if trusted_ip_list is defined %}
 trusted_ip_list = {{ trusted_ip_list }}
+{% endif %}


### PR DESCRIPTION
It restricts access to the iSCSI API.
It can be left empty if the API isn't going to be access from outside the
gateway node

Even though this seems to be a limited use case, it's better to leave it
empty by default than having a meaningless default value.

We could make this variable mandatory but that would be a breaking
change. Let's just add a logic in the template in order to set this
variable in the configuration file only if it was specified by users.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1994930

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>