### PR TITLE
[skip ci] cephadm-adopt: remove ceph-nfs.target

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -845,13 +845,6 @@
         enabled: false
       failed_when: false
 
-    - name: stop and disable ceph-nfs systemd target
-      service:
-        name: ceph-nfs.target
-        state: stopped
-        enabled: false
-      when: not containerized_deployment | bool
-
     - name: reset failed ceph-nfs systemd unit
       command: "systemctl reset-failed ceph-nfs@{{ ansible_facts['hostname'] }}"  # noqa 303
       changed_when: false


### PR DESCRIPTION
This systemd target doesn't exist at all.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>