### PR TITLE
[skip ci] container: explicitly pull monitoring images

### DIFF
--- a/roles/ceph-container-common/tasks/fetch_image.yml
+++ b/roles/ceph-container-common/tasks/fetch_image.yml
@@ -209,6 +209,48 @@
     HTTPS_PROXY: "{{ ceph_docker_https_proxy | default('') }}"
     NO_PROXY: "{{ ceph_docker_no_proxy }}"
 
+- name: "pulling alertmanager/prometheus/grafana container images"
+  command: "{{ timeout_command }} {{ container_binary }} pull {{ item }}"
+  changed_when: false
+  register: monitoring_images
+  until: monitoring_images.rc == 0
+  retries: "{{ docker_pull_retry }}"
+  delay: 10
+  loop:
+    - "{{ alertmanager_container_image }}"
+    - "{{ prometheus_container_image }}"
+    - "{{ grafana_container_image }}"
+  when:
+    - dashboard_enabled | bool
+    - inventory_hostname in groups.get(monitoring_group_name, [])
+  environment:
+    HTTP_PROXY: "{{ ceph_docker_http_proxy | default('') }}"
+    HTTPS_PROXY: "{{ ceph_docker_https_proxy | default('') }}"
+    NO_PROXY: "{{ ceph_docker_no_proxy }}"
+
+- name: "pulling node-exporter container image"
+  command: "{{ timeout_command }} {{ container_binary }} pull {{ node_exporter_container_image }}"
+  changed_when: false
+  register: node_exporter_image
+  until: node_exporter_image.rc == 0
+  retries: "{{ docker_pull_retry }}"
+  delay: 10
+  when:
+    - dashboard_enabled | bool
+    - inventory_hostname in groups.get(mon_group_name, []) or
+      inventory_hostname in groups.get(osd_group_name, []) or
+      inventory_hostname in groups.get(mds_group_name, []) or
+      inventory_hostname in groups.get(rgw_group_name, []) or
+      inventory_hostname in groups.get(mgr_group_name, []) or
+      inventory_hostname in groups.get(rbdmirror_group_name, []) or
+      inventory_hostname in groups.get(nfs_group_name, []) or
+      inventory_hostname in groups.get(iscsi_gw_group_name, []) or
+      inventory_hostname in groups.get(monitoring_group_name, [])
+  environment:
+    HTTP_PROXY: "{{ ceph_docker_http_proxy | default('') }}"
+    HTTPS_PROXY: "{{ ceph_docker_https_proxy | default('') }}"
+    NO_PROXY: "{{ ceph_docker_no_proxy }}"
+
 - name: "inspecting {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }} image after pulling"
   command: "{{ container_binary }} inspect {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
   changed_when: false


### PR DESCRIPTION
We don't pull the monitoring container images (alertmanager, prometheus,
node-exporter and grafana) in a dedicated task like we're doing for the
ceph container image.
This means that the container image pull is done during the start of the
systemd service.
By doing this, pulling the image behind a proxy isn't working with podman.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1995574

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>