### PR TITLE
Revert "tests: use old build of ceph@master"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -297,7 +297,6 @@ setenv=
   ANSIBLE_KEEP_REMOTE_FILES = 1
   ANSIBLE_CACHE_PLUGIN = memory
   ANSIBLE_GATHERING = implicit
-  CEPH_DEV_SHA1 = 6436cc5e13174b8b206301b0a073b8a776eea490
   # only available for ansible >= 2.5
   ANSIBLE_STDOUT_CALLBACK = yaml
   non_container: DEV_SETUP = True


### PR DESCRIPTION
This reverts commit 47a451426a8308a4ea80e0a1e4d867e9dd290fe5.

This build isn't available on shaman anymore.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>