### PR TITLE
add symlink to infrastructure-playbooks, clarify steps

### DIFF
--- a/infrastructure-playbooks/group_vars
+++ b/infrastructure-playbooks/group_vars
@@ -1,0 +1,1 @@
+../group_vars

--- a/infrastructure-playbooks/take-over-existing-cluster.yml
+++ b/infrastructure-playbooks/take-over-existing-cluster.yml
@@ -8,7 +8,7 @@
 # 1. Install Ansible and add your monitors and osds hosts in it. For more detailed information you can read the [Ceph Ansible Wiki](https://github.com/ceph/ceph-ansible/wiki)
 # 2. Set  `generate_fsid: false` in `group_vars`
 # 3. Get your current cluster fsid with `ceph fsid` and set `fsid` accordingly in `group_vars`
-# 4. Run the playbook called: `take-over-existing-cluster.yml` like this `ansible-playbook take-over-existing-cluster.yml`.
+# 4. Run the playbook called: `take-over-existing-cluster.yml` like this `ansible-playbook infrastructure-playbooks/take-over-existing-cluster.yml`.
 # 5. Eventually run Ceph Ansible to validate everything by doing: `ansible-playbook site.yml`.
 
 - hosts: mons


### PR DESCRIPTION
I would suggest a symlink to group_vars because at the moment playbooks like take-over-existing-cluster.yml are not runnable out of the box. see #6852

the readme in infrastructure-playbooks says:

To use them, run ansible-playbook infrastructure-playbooks/<playbook>.

So playbooks should run this way. 