### PR TITLE
[skip ci] ceph-defaults: set quay.io as the default registry

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -543,7 +543,7 @@ dummy:
 ##########
 #ceph_docker_image: "ceph/daemon"
 #ceph_docker_image_tag: latest-master
-#ceph_docker_registry: docker.io
+#ceph_docker_registry: quay.io
 #ceph_docker_registry_auth: false
 #ceph_docker_registry_username:
 #ceph_docker_registry_password:

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -535,7 +535,7 @@ ceph_tcmalloc_max_total_thread_cache: 134217728
 ##########
 ceph_docker_image: "ceph/daemon"
 ceph_docker_image_tag: latest-master
-ceph_docker_registry: docker.io
+ceph_docker_registry: quay.io
 ceph_docker_registry_auth: false
 #ceph_docker_registry_username:
 #ceph_docker_registry_password:


### PR DESCRIPTION
Because the ceph container images are now only pushed to the quay.io
registry then this updates the default registry value.
The docker.io registry can still be used but doesn't receive updated
container images.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>