### PR TITLE
[skip ci] Revert "tests: rename grafana to monitoring"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,8 +177,8 @@ def pytest_collection_modifyitems(session, config, items):
             item.add_marker(pytest.mark.nfss)
         elif "iscsi" in test_path:
             item.add_marker(pytest.mark.iscsigws)
-        elif "monitoring" in test_path:
-            item.add_marker(pytest.mark.monitoring)
+        elif "grafana" in test_path:
+            item.add_marker(pytest.mark.grafanas)
         else:
             item.add_marker(pytest.mark.all)
 

--- a/tests/functional/tests/grafana/test_grafana.py
+++ b/tests/functional/tests/grafana/test_grafana.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-class TestMonitoring(object):
+class TestGrafanas(object):
 
     @pytest.mark.dashboard
     @pytest.mark.no_docker


### PR DESCRIPTION
This reverts commit a36586a7777dc34cb977f81dc2d5bdfa2bebd4b6.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>