### PR TITLE
[skip ci] tests: fix container-cephadm job

### DIFF
--- a/tests/functional/cephadm/group_vars/all
+++ b/tests/functional/cephadm/group_vars/all
@@ -6,3 +6,4 @@ dashboard_admin_password: $sX!cD$rYU6qR^B!
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon-base
 ceph_docker_image_tag: latest-master-devel
+containerized_deployment: true


### PR DESCRIPTION
add missing variable `containerized_deployment` in group_vars

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>