### PR TITLE
ceph-defaults: set ceph_stable_release default to the stable branch release

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -215,7 +215,6 @@ An example configuration that deploys the upstream ``octopus`` version of Ceph w
 
    ceph_origin: repository
    ceph_repository: community
-   ceph_stable_release: octopus
    public_network: "192.168.3.0/24"
    cluster_network: "192.168.4.0/24"
    monitor_interface: eth1
@@ -227,7 +226,6 @@ The following config options are required to be changed on all installations but
 selection or other aspects of your cluster.
 
 - ``ceph_origin``
-- ``ceph_stable_release``
 - ``public_network``
 - ``monitor_interface`` or ``monitor_address``
 

--- a/docs/source/installation/containerized.rst
+++ b/docs/source/installation/containerized.rst
@@ -12,7 +12,7 @@ To deploy ceph in containers, you will need to set the ``containerized_deploymen
 
    containerized_deployment: true
 
-The ``ceph_origin``, ``ceph_repository`` and ``ceph_stable_release`` variables aren't needed anymore in containerized deployment and are ignored.
+The ``ceph_origin`` and ``ceph_repository`` variables aren't needed anymore in containerized deployment and are ignored.
 
 .. code-block:: console
 

--- a/docs/source/installation/non-containerized.rst
+++ b/docs/source/installation/non-containerized.rst
@@ -24,8 +24,6 @@ Community repository
 ~~~~~~~~~~~~~~~~~~~~
 
 If ``ceph_repository`` is set to ``community``, packages you will be by default installed from http://download.ceph.com, this can be changed by tweaking ``ceph_mirror``.
-Final step is to select which Ceph release you want to install, for this you have to set ``ceph_stable_release`` accordingly.
-For example, ``ceph_stable_release: luminous``.
 
 RHCS repository
 ~~~~~~~~~~~~~~~

--- a/docs/source/testing/tox.rst
+++ b/docs/source/testing/tox.rst
@@ -21,12 +21,6 @@ runs of ``ceph-ansible``.
 
 The following environent variables are available for use:
 
-* ``CEPH_STABLE_RELEASE``: (default: ``jewel``) This would configure the ``ceph-ansible`` variable ``ceph_stable_relese``. This is set
-  automatically when using the ``jewel-*`` or ``kraken-*`` testing scenarios.
-
-* ``UPDATE_CEPH_STABLE_RELEASE``: (default: ``kraken``) This would configure the ``ceph-ansible`` variable ``ceph_stable_relese`` during an ``update``
-  scenario. This is set automatically when using the ``jewel-*`` or ``kraken-*`` testing scenarios.
-
 * ``CEPH_DOCKER_REGISTRY``: (default: ``quay.ceph.io``) This would configure the ``ceph-ansible`` variable ``ceph_docker_registry``.
 
 * ``CEPH_DOCKER_IMAGE``: (default: ``ceph-ci/daemon``) This would configure the ``ceph-ansible`` variable ``ceph_docker_image``.

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -140,7 +140,7 @@ dummy:
 #
 #ceph_mirror: https://download.ceph.com
 #ceph_stable_key: https://download.ceph.com/keys/release.asc
-#ceph_stable_release: dummy
+#ceph_stable_release: quincy
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -140,7 +140,7 @@ ceph_repository: rhcs
 #
 #ceph_mirror: https://download.ceph.com
 #ceph_stable_key: https://download.ceph.com/keys/release.asc
-#ceph_stable_release: dummy
+#ceph_stable_release: quincy
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -132,7 +132,7 @@ valid_ceph_repository:
 #
 ceph_mirror: https://download.ceph.com
 ceph_stable_key: https://download.ceph.com/keys/release.asc
-ceph_stable_release: dummy
+ceph_stable_release: quincy
 ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 nfs_ganesha_stable: true # use stable repos for nfs-ganesha

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ def node(host, request):
     # tox will pass in this environment variable. we need to do it this way
     # because testinfra does not collect and provide ansible config passed in
     # from using --extra-vars
-    ceph_stable_release = os.environ.get("CEPH_STABLE_RELEASE", "luminous")
+    ceph_stable_release = os.environ.get("CEPH_STABLE_RELEASE", "quincy")
     rolling_update = os.environ.get("ROLLING_UPDATE", "False")
     group_names = ansible_vars["group_names"]
     docker = ansible_vars.get("docker")

--- a/tox-filestore_to_bluestore.ini
+++ b/tox-filestore_to_bluestore.ini
@@ -31,7 +31,6 @@ setenv=
   non_container: DEV_SETUP = True
 
   CEPH_DOCKER_IMAGE_TAG = latest-master
-  CEPH_STABLE_RELEASE = octopus
 
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/filestore-to-bluestore{env:CONTAINER_DIR:}
@@ -49,7 +48,6 @@ commands=
   # deploy the cluster
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:octopus} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
@@ -58,11 +56,10 @@ commands=
   "
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/filestore-to-bluestore.yml --limit osds --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      ceph_stable_release={env:CEPH_STABLE_RELEASE:octopus} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
   "
 
-  bash -c "CEPH_STABLE_RELEASE={env:UPDATE_CEPH_STABLE_RELEASE:octopus} py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests"
+  bash -c "CEPH_STABLE_RELEASE=quincy py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests"
 
   vagrant destroy --force

--- a/tox-podman.ini
+++ b/tox-podman.ini
@@ -26,7 +26,6 @@ setenv=
   # Set the ansible inventory host file to be used according to which distrib we are running on
   INVENTORY = {env:_INVENTORY:hosts}
   PLAYBOOK = site-container.yml.sample
-  CEPH_STABLE_RELEASE = nautilus
 
 deps= -r{toxinidir}/tests/requirements.txt
 changedir= {toxinidir}/tests/functional/podman

--- a/tox-shrink_osd.ini
+++ b/tox-shrink_osd.ini
@@ -72,7 +72,6 @@ setenv=
   CEPH_DOCKER_IMAGE_TAG = latest-master
   CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-master
   UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
-  CEPH_STABLE_RELEASE = pacific
 
 deps= -r{toxinidir}/tests/requirements.txt
 changedir=

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -62,6 +62,6 @@ commands=
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
   "
 
-  bash -c "CEPH_STABLE_RELEASE={env:UPDATE_CEPH_STABLE_RELEASE:octopus} py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests"
+  bash -c "CEPH_STABLE_RELEASE=quincy py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests"
 
   vagrant destroy --force

--- a/tox.ini
+++ b/tox.ini
@@ -318,7 +318,6 @@ setenv=
   CEPH_DOCKER_IMAGE_TAG = latest-master
   CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-master
   UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
-  CEPH_STABLE_RELEASE = pacific
 
   switch_to_containers: CEPH_DOCKER_IMAGE_TAG = latest-master-devel
 


### PR DESCRIPTION
ceph_stable_release is a legacy from the time where a single branch of ceph-ansible supported more than one release of ceph

Signed-off-by: Seena Fallah <seenafallah@gmail.com>