### PR TITLE
[skip ci] cephadm-adopt: add no_log: true

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -358,6 +358,7 @@
     - name: set container registry info
       command: "{{ ceph_cmd }} cephadm registry-login {{ ceph_docker_registry }} {{ ceph_docker_registry_username }} {{ ceph_docker_registry_password }}"
       changed_when: false
+      no_log: true
       run_once: true
       delegate_to: '{{ groups[mon_group_name][0] }}'
       when: ceph_docker_registry_auth | bool


### PR DESCRIPTION
Let's add a `no_log: true` on the `cephadm registry-login` task.


Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>