### PR TITLE
dashboard: allow disabling of unused features

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -654,6 +654,7 @@ dummy:
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
 #dashboard_frontend_vip: ''
+#dashboard_disabled_features: []
 #prometheus_frontend_vip: ''
 #alertmanager_frontend_vip: ''
 #node_exporter_container_image: "docker.io/prom/node-exporter:v0.17.0"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -654,6 +654,7 @@ containerized_deployment: true
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: False
 #dashboard_frontend_vip: ''
+#dashboard_disabled_features: []
 #prometheus_frontend_vip: ''
 #alertmanager_frontend_vip: ''
 node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -188,6 +188,13 @@
     CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
 
+- name: disable unused dashboard features
+  command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard feature disable {{ item }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  run_once: true
+  changed_when: false
+  with_items: "{{ dashboard_disabled_features }}"
+
 - name: set grafana api user
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} dashboard set-grafana-api-username {{ grafana_admin_user }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -646,6 +646,7 @@ dashboard_rgw_api_user_id: ceph-dashboard
 dashboard_rgw_api_admin_resource: ''
 dashboard_rgw_api_no_ssl_verify: False
 dashboard_frontend_vip: ''
+dashboard_disabled_features: []
 prometheus_frontend_vip: ''
 alertmanager_frontend_vip: ''
 node_exporter_container_image: "docker.io/prom/node-exporter:v0.17.0"


### PR DESCRIPTION
Unconfigured dashboard features can lead to empty tabs in the dashboard
containing no meaningful content. Allow users to disable dashboard features
they know will not be used.

A list of features to be disabled allows the user to define a streamlined
dashboard as standard across deployments. Defaults to disabling no features,
ensuring that users are sure they do not need the dashboard feature before
disabling it.

Signed-off-by: Alex Lambert <lamberta@microsoft.com>