### PR TITLE
common: ensure ceph-aliases.sh is absent

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -82,6 +82,11 @@
         - osd_group_name in group_names
         - osd_objectstore == 'filestore'
 
+    - name: ensure legacy ceph aliases file is absent
+      file:
+        path: /etc/profile.d/ceph-aliases.sh
+        state: absent
+
     - import_role:
         name: ceph-facts
         tasks_from: container_binary.yml

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -135,6 +135,12 @@
       set_fact:
         rolling_update: true
 
+    - name: ensure legacy ceph aliases file is absent
+      file:
+        path: /etc/profile.d/ceph-aliases.sh
+        state: absent
+
+
 - name: upgrade ceph mon cluster
   vars:
     health_mon_check_retries: 5

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -63,6 +63,11 @@
     - import_role:
         name: ceph-validate
 
+    - name: ensure legacy ceph aliases file is absent
+      file:
+        path: /etc/profile.d/ceph-aliases.sh
+        state: absent
+
 - name: switching from non-containerized to containerized ceph mon
   vars:
     containerized_deployment: true


### PR DESCRIPTION
For pre-existing cluster where this fail was already deployed we need to
ensure it is removed.
See https://github.com/ceph/ceph-ansible/pull/3447#issue-390617983

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>