### PR TITLE
tests: set rgw_instances in collect-logs.yml

### DIFF
--- a/tests/functional/collect-logs.yml
+++ b/tests/functional/collect-logs.yml
@@ -11,6 +11,10 @@
         name: ceph-facts
         tasks_from: container_binary.yml
 
+    - import_role:
+        name: ceph-facts
+        tasks_from: set_radosgw_address.yml
+
     - name: set_fact ceph_cmd
       set_fact:
         ceph_cmd: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph:/var/lib/ceph:z -v /var/run/ceph:/var/run/ceph:z --entrypoint=ceph ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph' }}"


### PR DESCRIPTION
in order to gather rgw logs, we need rgw_instances to be set.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>