### PR TITLE
[skip ci] shrink-osd: check osd id format

### DIFF
--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -54,6 +54,12 @@
            -e osd_to_kill=0,1,2,3 argument."
       when: osd_to_kill is not defined
 
+    - name: check the osd ids passed have the correct format
+      fail:
+        msg: "The id {{ item }} has wrong format, please pass the number only"
+      with_items: "{{ osd_to_kill.split(',') }}"
+      when: not item is regex("^\d$")
+
   tasks:
     - import_role:
         name: ceph-defaults


### PR DESCRIPTION
This adds a check early in order to ensure the format of osd ids passed
is correct.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2005734

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>