### PR TITLE
nfs/rgw: support enforcing keys

### DIFF
--- a/roles/ceph-nfs/tasks/create_rgw_nfs_user.yml
+++ b/roles/ceph-nfs/tasks/create_rgw_nfs_user.yml
@@ -14,7 +14,7 @@
   when: nfs_obj_gw | bool
 
 - name: create rgw nfs user "{{ ceph_nfs_rgw_user }}"
-  command: "{{ container_exec_cmd_nfs | default('') }} radosgw-admin --cluster {{ cluster }} user create --uid={{ ceph_nfs_rgw_user }} --display-name='RGW NFS User'"
+  command: "{{ container_exec_cmd_nfs | default('') }} radosgw-admin --cluster {{ cluster }} user create --uid={{ ceph_nfs_rgw_user }} --display-name='RGW NFS User' {{ '--access-key=' + ceph_nfs_rgw_access_key if ceph_nfs_rgw_access_key is defined else '' }} {{ '--secret-key=' + ceph_nfs_rgw_secret_key if ceph_nfs_rgw_secret_key is defined else '' }}"
   run_once: true
   register: rgwuser
   changed_when: false


### PR DESCRIPTION
if one sets `ceph_nfs_rgw_access_key` and/or `ceph_nfs_rgw_secret_key`,
the nfs/rgw user creation won't take those variables into account and it
will generate a user with automatically generated credentials.
It ends up with a mismatch between what will be set in ganesha.conf and
the created user.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2010754

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>