### PR TITLE
[skip ci] shrink-osd: fix regression because of a wrong regex

### DIFF
--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -58,7 +58,7 @@
       fail:
         msg: "The id {{ item }} has wrong format, please pass the number only"
       with_items: "{{ osd_to_kill.split(',') }}"
-      when: not item is regex("^\d$")
+      when: not item is regex("^\d+$")
 
   tasks:
     - import_role:


### PR DESCRIPTION
shrink-osd: fix regression because of a wrong regex

968891f4498da9625acfdd34bfb01fe445d1eef2 introduced a regression.
The regex is wrong because it doesn't allow to shrink osds with id
greater than 9

Fixes: #6950

Signed-off-by: Per Abildgaard Toft <per@minfejl.dk>
