### PR TITLE
regex to allow shrinking multi-digit osds

### DIFF
--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -58,7 +58,7 @@
       fail:
         msg: "The id {{ item }} has wrong format, please pass the number only"
       with_items: "{{ osd_to_kill.split(',') }}"
-      when: not item is regex("^\d$")
+      when: not item is regex("^\d{1,23}$")
 
   tasks:
     - import_role:


### PR DESCRIPTION
When I wanted to delete a multi-digit OSD *(for example osd.11)* with the ``infrastructure-playbooks/shrink-osd.yml  -e osd_to_kill=11`` playbook, I noticed that the regex in the task "check the osd ids passed have the correct format" does not allow this. :disappointed: 
I am not an expert in writing regex and I don't know what a good maximum size for osd numbers is. But osds longer than one digit is a realistic scenario, I think. :wink: 

:rocket:  This pull request now also allows significantly larger numbers than just single-digit osds. *BTW I used https://regex101.com/ to test the regex.*