### PR TITLE
[skip ci] rolling_update: modify default health_osd_check_*

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -468,8 +468,8 @@
 
 - name: upgrade ceph osds cluster
   vars:
-    health_osd_check_retries: 40
-    health_osd_check_delay: 30
+    health_osd_check_retries: 600
+    health_osd_check_delay: 2
     upgrade_ceph_packages: True
   hosts: "{{ osd_group_name|default('osds') }}"
   tags: osds


### PR DESCRIPTION
let's do more retries with a shorter delay.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>