### PR TITLE
make grafana network configurable option

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -695,6 +695,7 @@ dummy:
 #  - grafana-piechart-panel
 #grafana_allow_embedding: True
 #grafana_port: 3000
+#grafana_network: "{{ public_network }}"
 #grafana_conf_overrides: {}
 #prometheus_container_image: "docker.io/prom/prometheus:v2.7.2"
 #prometheus_container_cpu_period: 100000

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -695,6 +695,7 @@ grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
 #  - grafana-piechart-panel
 #grafana_allow_embedding: True
 #grafana_port: 3000
+#grafana_network: "{{ public_network }}"
 #grafana_conf_overrides: {}
 prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
 #prometheus_container_cpu_period: 100000

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -687,6 +687,7 @@ grafana_plugins:
   - grafana-piechart-panel
 grafana_allow_embedding: True
 grafana_port: 3000
+grafana_network: "{{ public_network }}"
 grafana_conf_overrides: {}
 prometheus_container_image: "docker.io/prom/prometheus:v2.7.2"
 prometheus_container_cpu_period: 100000

--- a/roles/ceph-facts/tasks/grafana.yml
+++ b/roles/ceph-facts/tasks/grafana.yml
@@ -1,6 +1,6 @@
 - name: set grafana_server_addr fact - ipv4
   set_fact:
-    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first }}"
+    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(grafana_network.split(',')) | first }}"
   when:
     - groups.get(monitoring_group_name, []) | length > 0
     - ip_version == 'ipv4'
@@ -9,7 +9,7 @@
 
 - name: set grafana_server_addr fact - ipv6
   set_fact:
-    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}"
+    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ipwrap }}"
   when:
     - groups.get(monitoring_group_name, []) | length > 0
     - ip_version == 'ipv6'
@@ -18,7 +18,7 @@
 
 - name: set grafana_server_addrs fact - ipv4
   set_fact:
-    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | first]) | unique }}"
+    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(grafana_network.split(',')) | first]) | unique }}"
   with_items: "{{ groups.get(monitoring_group_name, []) }}"
   when:
     - groups.get(monitoring_group_name, []) | length > 0
@@ -27,7 +27,7 @@
 
 - name: set grafana_server_addrs fact - ipv6
   set_fact:
-    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap]) | unique }}"
+    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ipwrap]) | unique }}"
   with_items: "{{ groups.get(monitoring_group_name, []) }}"
   when:
     - groups.get(monitoring_group_name, []) | length > 0


### PR DESCRIPTION
currently the grafana server is implicitly tied to the public network, this should be a separate configurable variable in case a user wants to have it on another interface /  network.