### PR TITLE
update: support --limit on monitor nodes

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -273,6 +273,13 @@
           when: inventory_hostname in groups[mgr_group_name] | default([])
                 or groups[mgr_group_name] | default([]) | length == 0
 
+        - name: import_role ceph-facts
+          import_role:
+            name: ceph-facts
+            tasks_from: set_monitor_address.yml
+          delegate_to: "{{ groups[mon_group_name][0] }}"
+          delegate_facts: true
+
         - name: non container | waiting for the monitor to join the quorum...
           command: ceph --cluster "{{ cluster }}" -m "{{ hostvars[groups[mon_group_name][0]]['_current_monitor_address'] }}" quorum_status --format json
           register: ceph_health_raw

--- a/roles/ceph-facts/tasks/set_monitor_address.yml
+++ b/roles/ceph-facts/tasks/set_monitor_address.yml
@@ -54,4 +54,6 @@
   set_fact:
     _current_monitor_address: "{{ item.addr }}"
   with_items: "{{ _monitor_addresses }}"
-  when: inventory_hostname == item.name
+  when:
+    - (inventory_hostname == item.name and not rolling_update | default(False) | bool)
+      or (rolling_update | default(False) | bool and item.name == groups.get(mon_group_name, [])[0])

--- a/tox-subset_update.ini
+++ b/tox-subset_update.ini
@@ -51,7 +51,17 @@ commands=
   "
 
 # upgrade mons
-  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --tags=mons --extra-vars "\
+# mon1
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --limit mon1 --tags=mons --extra-vars "\
+      ireallymeanit=yes \
+      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
+      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
+      ceph_docker_registry_auth=True \
+      ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
+      ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
+  "
+# mon0 and mon2
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --limit 'mons:!mon1' --tags=mons --extra-vars "\
       ireallymeanit=yes \
       ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
       ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \


### PR DESCRIPTION
Change needed in order to support --limit on mon nodes.
Otherwise, a call to `hostvars[groups[mon_group_name][0]]['_current_monitor_address']`
throws an error:

```
"The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute '_current_monitor_address'"
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2014304#c28

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>