### PR TITLE
[skip ci] update: move a set_fact

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -91,6 +91,10 @@
       run_once: true
       when: delegate_facts_host | bool
 
+    - name: set_fact rolling_update
+      set_fact:
+        rolling_update: true
+
     - import_role:
         name: ceph-facts
 
@@ -131,9 +135,6 @@
             msg: "This version of ceph-ansible is intended for upgrading to Ceph Quincy only."
           when: "'quincy' not in ceph_version.stdout.split()"
 
-    - name: set_fact rolling_update
-      set_fact:
-        rolling_update: true
 
 - name: upgrade ceph mon cluster
   tags: mons


### PR DESCRIPTION
ceph-facts roles makes decisions based on the fact `rolling_update` so
it must be called before we run this role.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2014304

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>