### PR TITLE
library/ceph_ec_profile.py: Support CRUSH device class

### DIFF
--- a/library/ceph_ec_profile.py
+++ b/library/ceph_ec_profile.py
@@ -121,7 +121,7 @@ def get_profile(module, name, cluster='ceph', container_image=None):
     return cmd
 
 
-def create_profile(module, name, k, m, stripe_unit, cluster='ceph', force=False, container_image=None):  # noqa: E501
+def create_profile(module, name, k, m, stripe_unit, crush_device_class, cluster='ceph', force=False, container_image=None):  # noqa: E501
     '''
     Create a profile
     '''
@@ -129,6 +129,8 @@ def create_profile(module, name, k, m, stripe_unit, cluster='ceph', force=False,
     args = ['set', name, 'k={}'.format(k), 'm={}'.format(m)]
     if stripe_unit:
         args.append('stripe_unit={}'.format(stripe_unit))
+    if crush_device_class:
+        args.append('crush-device-class={}'.format(crush_device_class))
     if force:
         args.append('--force')
 
@@ -164,6 +166,7 @@ def run_module():
         stripe_unit=dict(type='str', required=False),
         k=dict(type='str', required=False),
         m=dict(type='str', required=False),
+        crush_device_class=dict(type='str', required=False, default=''),
     )
 
     module = AnsibleModule(
@@ -179,6 +182,7 @@ def run_module():
     stripe_unit = module.params.get('stripe_unit')
     k = module.params.get('k')
     m = module.params.get('m')
+    crush_device_class = module.params.get('crush_device_class')
 
     if module.check_mode:
         module.exit_json(
@@ -205,13 +209,15 @@ def run_module():
             current_profile = json.loads(out)
             if current_profile['k'] != k or \
                current_profile['m'] != m or \
-               current_profile.get('stripe_unit', stripe_unit) != stripe_unit:
+               current_profile.get('stripe_unit', stripe_unit) != stripe_unit or \
+               current_profile.get('crush-device-class', crush_device_class) != crush_device_class:
                 rc, cmd, out, err = exec_command(module,
                                                  create_profile(module,
                                                                 name,
                                                                 k,
                                                                 m,
                                                                 stripe_unit,
+                                                                crush_device_class,  # noqa: E501
                                                                 cluster,
                                                                 force=True, container_image=container_image))  # noqa: E501
                 changed = True
@@ -222,6 +228,7 @@ def run_module():
                                                                     k,
                                                                     m,
                                                                     stripe_unit,  # noqa: E501
+                                                                    crush_device_class,  # noqa: E501
                                                                     cluster,
                                                                     container_image=container_image))  # noqa: E501
             if rc == 0:

--- a/roles/ceph-rgw/tasks/rgw_create_pools.yml
+++ b/roles/ceph-rgw/tasks/rgw_create_pools.yml
@@ -5,6 +5,7 @@
     cluster: "{{ cluster }}"
     k: "{{ item.value.ec_k }}"
     m: "{{ item.value.ec_m }}"
+    crush_device_class: "{{ item.value.ec_crush_device_class | default(omit) }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   loop: "{{ rgw_create_pools | dict2items }}"
   when:

--- a/tests/library/test_ceph_ec_profile.py
+++ b/tests/library/test_ceph_ec_profile.py
@@ -28,11 +28,15 @@ class TestCephEcProfile(object):
 
         assert ceph_ec_profile.get_profile(self.fake_module, self.fake_name) == expected_cmd
 
-    @pytest.mark.parametrize("stripe_unit,force", [(False, False),
-                                                   (32, True),
-                                                   (False, True),
-                                                   (32, False)])
-    def test_create_profile(self, stripe_unit, force):
+    @pytest.mark.parametrize("stripe_unit,crush_device_class,force", [(False, None, False),
+                                                                      (32, None, True),
+                                                                      (False, None, True),
+                                                                      (32, None, False),
+                                                                      (False, 'hdd', False),
+                                                                      (32, 'ssd', True),
+                                                                      (False, 'nvme', True),
+                                                                      (32, 'hdd', False)])
+    def test_create_profile(self, stripe_unit, crush_device_class, force):
         expected_cmd = [
             self.fake_binary,
             '-n', 'client.admin',
@@ -44,6 +48,8 @@ class TestCephEcProfile(object):
         ]
         if stripe_unit:
             expected_cmd.append('stripe_unit={}'.format(stripe_unit))
+        if crush_device_class:
+            expected_cmd.append('crush-device-class={}'.format(crush_device_class))
         if force:
             expected_cmd.append('--force')
 
@@ -52,6 +58,7 @@ class TestCephEcProfile(object):
                                               self.fake_k,
                                               self.fake_m,
                                               stripe_unit,
+                                              crush_device_class,
                                               self.fake_cluster,
                                               force) == expected_cmd
 


### PR DESCRIPTION
The `crush_device_class` option of the `ceph_ec_profile` module was documented
but not implemented.