### PR TITLE
[skip ci] update: speed up client play

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -980,6 +980,8 @@
         name: ceph-defaults
     - import_role:
         name: ceph-facts
+        tasks_from: container_binary.yml
+      when: containerized_deployment | bool
     - import_role:
         name: ceph-handler
     - import_role:
@@ -990,10 +992,7 @@
       when:
         - (group_names != ['clients']) or (inventory_hostname == groups.get('clients', [''])|first)
         - containerized_deployment | bool
-    - import_role:
-        name: ceph-config
-    - import_role:
-        name: ceph-client
+
 
 - name: upgrade ceph-crash daemons
   hosts:


### PR DESCRIPTION
There's no need to run this play.
The client role only deploys keys and creates pools.
On large cluster deployment, this is time consuming for nothing.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2019831

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>