### PR TITLE
mgr: append balancer module to ceph_mgr_modules

### DIFF
--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -92,6 +92,6 @@
     ceph_mgr_modules: "{{ ceph_mgr_modules | union(['dashboard', 'prometheus']) }}"
   when: dashboard_enabled | bool
 
-- name: append pg_autoscaler module to ceph_mgr_modules
+- name: append balancer, pg_autoscaler module to ceph_mgr_modules
   set_fact:
-    ceph_mgr_modules: "{{ ceph_mgr_modules | union(['pg_autoscaler']) }}"
+    ceph_mgr_modules: "{{ ceph_mgr_modules | union(['pg_autoscaler', 'balancer']) }}"


### PR DESCRIPTION
otherwise the osd play in rolling_update can fail when it tries to
disable it before upgrading osd nodes.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 45a1d634d850ad971c71dbe9191b97caa3068b5a)