### PR TITLE
validate: fix bug when using vault

### DIFF
--- a/roles/ceph-validate/tasks/main.yml
+++ b/roles/ceph-validate/tasks/main.yml
@@ -201,7 +201,7 @@
   when:
     - ceph_docker_registry_auth | bool
     - (ceph_docker_registry_username is not defined or ceph_docker_registry_password is not defined) or
-      (ceph_docker_registry_username | length == 0 or ceph_docker_registry_password | length == 0)
+      (ceph_docker_registry_username | string | length == 0 or ceph_docker_registry_password | string | length == 0)
 
 - name: validate container service and container package
   fail:


### PR DESCRIPTION
since a variable encrypted with vault is no longer a string but a
encrypted object we can't use the filter | length, we have to convert it
to a string before.

Fixes: #6991

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>