### PR TITLE
[skip ci] purge: remove ceph directories on client nodes

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -1057,6 +1057,7 @@
     - rbdmirrors
     - nfss
     - mgrs
+    - clients
   gather_facts: false # Already gathered previously
   become: true
   tasks:


### PR DESCRIPTION
Otherwise any ceph directories are left over on client nodes
after the purge.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2024815

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>