### PR TITLE
[skip ci] adopt: fix ceph_origin and ceph_repository defaults

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -147,10 +147,17 @@
 
     - name: configure repository for installing cephadm
       when: containerized_deployment | bool
-      vars:
-        ceph_origin: repository
-        ceph_repository: community
       block:
+        - name: set_fact ceph_origin
+          set_fact:
+            ceph_origin: repository
+          when: ceph_origin == 'dummy'
+
+        - name: set_fact ceph_repository
+          set_fact:
+            ceph_repository: community
+          when: ceph_repository == 'dummy'
+
         - name: validate repository variables
           import_role:
             name: ceph-validate


### PR DESCRIPTION
This is overriding those variables because the precedence at the 'block
var' level is greater than the group_vars/host_vars.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2026861

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>