### PR TITLE
[skip ci] cephadm-adopt: ensure /etc/ceph is present on monitoring node

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -1219,6 +1219,14 @@
         path: "/etc/ceph/{{ cluster }}.conf"
       register: ceph_config
 
+    - name: ensure /etc/ceph is present
+      file:
+        path: /etc/ceph
+        state: directory
+        owner: "{{ ceph_uid | int if containerized_deployment | bool else 'ceph' }}"
+        group: "{{ ceph_uid | int if containerized_deployment | bool else 'ceph' }}"
+        mode: "{{ ceph_directories_mode }}"
+
     - name: write a ceph.conf with minimal config
       copy:
         dest: "/etc/ceph/{{ cluster }}.conf"


### PR DESCRIPTION
When deploying the monitoring stack on a dedicated node, the directory
`/etc/ceph` has never been created. Therefore, the play for adopting the
monitoring stack fails because it can't write the minimal config file.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2029697

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>