### PR TITLE
Fix check mode in ceph-facts and ceph-osd

### DIFF
--- a/roles/ceph-facts/tasks/get_def_crush_rule_name.yml
+++ b/roles/ceph-facts/tasks/get_def_crush_rule_name.yml
@@ -14,6 +14,6 @@
 - name: get current default crush rule name
   set_fact:
     ceph_osd_pool_default_crush_rule_name: "{{ item.rule_name }}"
-  with_items: "{{ default_crush_rule_details.stdout | default('{}') | from_json }}"
+  with_items: "{{ default_crush_rule_details.stdout | default('{}', True) | from_json }}"
   run_once: True
   when: item.rule_id | int == osd_pool_default_crush_rule | int

--- a/roles/ceph-osd/tasks/crush_rules.yml
+++ b/roles/ceph-osd/tasks/crush_rules.yml
@@ -44,8 +44,8 @@
 # NOTE(leseb): we should actually fail if multiple rules are set as default
 - name: set_fact info_ceph_default_crush_rule_yaml, ceph_osd_pool_default_crush_rule_name
   set_fact:
-    info_ceph_default_crush_rule_yaml: "{{ item.stdout | from_json() }}"
-    ceph_osd_pool_default_crush_rule_name: "{{ (item.stdout | from_json).rule_name }}"
+    info_ceph_default_crush_rule_yaml: "{{ item.stdout | default('{}', True) | from_json() }}"
+    ceph_osd_pool_default_crush_rule_name: "{{ (item.stdout | default('{}', True) | from_json).get('rule_name') }}"
   with_items: "{{ info_ceph_default_crush_rule.results }}"
   run_once: true
   when: not item.get('skipped', false)

--- a/roles/ceph-osd/tasks/start_osds.yml
+++ b/roles/ceph-osd/tasks/start_osds.yml
@@ -46,7 +46,7 @@
     mode: "{{ ceph_directories_mode }}"
     owner: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
-  with_items: "{{ ((ceph_osd_ids.stdout | default('{}') | from_json).keys() | list) | union(osd_ids_non_container.stdout_lines | default([])) }}"
+  with_items: "{{ ((ceph_osd_ids.stdout | default('{}', True) | from_json).keys() | list) | union(osd_ids_non_container.stdout_lines | default([])) }}"
 
 - name: systemd start osd
   systemd:
@@ -55,4 +55,4 @@
     enabled: yes
     masked: no
     daemon_reload: yes
-  with_items: "{{ ((ceph_osd_ids.stdout | default('{}') | from_json).keys() | list) | union(osd_ids_non_container.stdout_lines | default([])) }}"
+  with_items: "{{ ((ceph_osd_ids.stdout | default('{}', True) | from_json).keys() | list) | union(osd_ids_non_container.stdout_lines | default([])) }}"


### PR DESCRIPTION
This construct doesn't work as intended since ansible/ansible#74212:

```
item.stdout | default('{}') | from_json
```

That PR made the `command` module return `stdout` even in check mode (setting
it to the empty string), so `default()` has no effect in that case and
`from_json()` fails to parse an empty string.

Instead, `default()` needs to be invoked with its second argument set to
`True`, so that it replaces any `False` value (such as an empty string) with
its first argument:

```
item.stdout | default('{}', True) | from_json
```

