### PR TITLE
[skip ci] common: remove legacy repositories

### DIFF
--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
@@ -1,14 +1,4 @@
 ---
-- name: enable red hat storage monitor repository
-  rhsm_repository:
-    name: "rhceph-{{ ceph_rhcs_version }}-mon-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms"
-  when: (mon_group_name in group_names or mgr_group_name in group_names)
-
-- name: enable red hat storage osd repository
-  rhsm_repository:
-    name: "rhceph-{{ ceph_rhcs_version }}-osd-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms"
-  when: osd_group_name in group_names
-
 - name: enable red hat storage tools repository
   rhsm_repository:
     name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms"


### PR DESCRIPTION
As of rhceph-5, those repositories don't longer exist.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2032790

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>