### PR TITLE
[skip ci] cephadm: set allow_overwrite at bootstrap step

### DIFF
--- a/library/cephadm_bootstrap.py
+++ b/library/cephadm_bootstrap.py
@@ -81,6 +81,11 @@ options:
             - Manage firewall rules with firewalld.
         required: false
         default: true
+    allow_overwrite:
+        description:
+            - allow overwrite of existing –output-* config/keyring/ssh files.
+        required: false
+        default: false
     registry_url:
         description:
             - URL for custom registry.
@@ -100,11 +105,11 @@ options:
         required: false
     ssh_user:
         description:
-            - SSH user used for cephadm ssh to the hosts
+            - SSH user used for cephadm ssh to the hosts.
         required: false
     ssh_config:
         description:
-            - SSH config file path for cephadm ssh client
+            - SSH config file path for cephadm ssh client.
         required: false
 author:
     - Dimitri Savineau <dsavinea@redhat.com>
@@ -147,6 +152,7 @@ def main():
             dashboard_password=dict(type='str', required=False, no_log=True),
             monitoring=dict(type='bool', required=False, default=True),
             firewalld=dict(type='bool', required=False, default=True),
+            allow_overwrite=dict(type='bool', required=False, default=False),
             registry_url=dict(type='str', require=False),
             registry_username=dict(type='str', require=False),
             registry_password=dict(type='str', require=False, no_log=True),
@@ -175,6 +181,7 @@ def main():
     dashboard_password = module.params.get('dashboard_password')
     monitoring = module.params.get('monitoring')
     firewalld = module.params.get('firewalld')
+    allow_overwrite = module.params.get('allow_overwrite')
     registry_url = module.params.get('registry_url')
     registry_username = module.params.get('registry_username')
     registry_password = module.params.get('registry_password')
@@ -213,6 +220,9 @@ def main():
 
     if not firewalld:
         cmd.append('--skip-firewalld')
+
+    if allow_overwrite:
+        cmd.append('--allow-overwrite')
 
     if registry_url and registry_username and registry_password:
         cmd.extend(['--registry-url', registry_url,


### PR DESCRIPTION
When you had ```ceph.conf``` and you want to overwrite your config  you'll get 
```stderr: 'ERROR: /etc/ceph/ceph.conf already exists; delete or pass --allow-overwrite to overwrite'```
Signed-off-by: yasinlachiny <yasin.lachiny@gmail.com>