### PR TITLE
ceph-handler: Fix check mode

### DIFF
--- a/roles/ceph-handler/handlers/main.yml
+++ b/roles/ceph-handler/handlers/main.yml
@@ -88,4 +88,4 @@
         - "restart ceph rbdmirrors"
         - "restart ceph mgrs"
       register: tmpdirpath
-      when: tmpdirpath is defined
+      when: tmpdirpath.path is defined

--- a/roles/ceph-handler/tasks/handler_mdss.yml
+++ b/roles/ceph-handler/tasks/handler_mdss.yml
@@ -10,12 +10,14 @@
     owner: root
     group: root
     mode: 0750
+  when: tmpdirpath.path is defined
 
 - name: restart ceph mds daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_mds_daemon.sh
   when:
     - hostvars[item]['handler_mds_status'] | default(False) | bool
     - hostvars[item]['_mds_handler_called'] | default(False) | bool
+    - hostvars[item].tmpdirpath.path is defined
   with_items: "{{ groups[mds_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True

--- a/roles/ceph-handler/tasks/handler_mgrs.yml
+++ b/roles/ceph-handler/tasks/handler_mgrs.yml
@@ -10,12 +10,14 @@
     owner: root
     group: root
     mode: 0750
+  when: tmpdirpath.path is defined
 
 - name: restart ceph mgr daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_mgr_daemon.sh
   when:
     - hostvars[item]['handler_mgr_status'] | default(False) | bool
     - hostvars[item]['_mgr_handler_called'] | default(False) | bool
+    - hostvars[item].tmpdirpath.path is defined
   with_items: "{{ groups[mgr_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True

--- a/roles/ceph-handler/tasks/handler_mons.yml
+++ b/roles/ceph-handler/tasks/handler_mons.yml
@@ -13,6 +13,7 @@
     owner: root
     group: root
     mode: 0750
+  when: tmpdirpath.path is defined
 
 - name: restart ceph mon daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_mon_daemon.sh
@@ -20,6 +21,7 @@
     # We do not want to run these checks on initial deployment (`socket.rc == 0`)
     - hostvars[item]['handler_mon_status'] | default(False) | bool
     - hostvars[item]['_mon_handler_called'] | default(False) | bool
+    - hostvars[item].tmpdirpath.path is defined
   with_items: "{{ groups[mon_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True

--- a/roles/ceph-handler/tasks/handler_nfss.yml
+++ b/roles/ceph-handler/tasks/handler_nfss.yml
@@ -10,12 +10,14 @@
     owner: root
     group: root
     mode: 0750
+  when: tmpdirpath.path is defined
 
 - name: restart ceph nfs daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_nfs_daemon.sh
   when:
     - hostvars[item]['handler_nfs_status'] | default(False) | bool
     - hostvars[item]['_nfs_handler_called'] | default(False) | bool
+    - hostvars[item].tmpdirpath.path is defined
   with_items: "{{ groups[nfs_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True

--- a/roles/ceph-handler/tasks/handler_osds.yml
+++ b/roles/ceph-handler/tasks/handler_osds.yml
@@ -37,6 +37,7 @@
         owner: root
         group: root
         mode: 0750
+      when: tmpdirpath.path is defined
 
     - name: get pool list
       command: "{{ ceph_cmd }} --cluster {{ cluster }} osd pool ls detail -f json"
@@ -88,6 +89,7 @@
         - hostvars[item]['handler_osd_status'] | default(False) | bool
         - handler_health_osd_check | bool
         - hostvars[item]['_osd_handler_called'] | default(False) | bool
+        - hostvars[item].tmpdirpath.path is defined
       with_items: "{{ groups[osd_group_name] | intersect(ansible_play_batch) }}"
       delegate_to: "{{ item }}"
       run_once: True

--- a/roles/ceph-handler/tasks/handler_rbdmirrors.yml
+++ b/roles/ceph-handler/tasks/handler_rbdmirrors.yml
@@ -10,12 +10,14 @@
     owner: root
     group: root
     mode: 0750
+  when: tmpdirpath.path is defined
 
 - name: restart ceph rbd mirror daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_rbd_mirror_daemon.sh
   when:
     - hostvars[item]['handler_rbd_mirror_status'] | default(False) | bool
     - hostvars[item]['_rbdmirror_handler_called'] | default(False) | bool
+    - hostvars[item].tmpdirpath.path is defined
   with_items: "{{ groups[rbdmirror_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True

--- a/roles/ceph-handler/tasks/handler_rgws.yml
+++ b/roles/ceph-handler/tasks/handler_rgws.yml
@@ -10,12 +10,14 @@
     owner: root
     group: root
     mode: 0750
+  when: tmpdirpath.path is defined
 
 - name: restart ceph rgw daemon(s)
   command: /usr/bin/env bash {{ hostvars[item]['tmpdirpath']['path'] }}/restart_rgw_daemon.sh
   when:
     - hostvars[item]['handler_rgw_status'] | default(False) | bool
     - hostvars[item]['_rgw_handler_called'] | default(False) | bool
+    - hostvars[item].tmpdirpath.path is defined
   with_items: "{{ groups[rgw_group_name] }}"
   delegate_to: "{{ item }}"
   run_once: True


### PR DESCRIPTION
When running in check mode with one or more Ceph daemons that need to be
restarted, the `tmpdirpath.path` variable that several handlers rely on is
undefined, leading to fatal errors.

This commit ensures the tasks that require `tmpdirpath.path` are skipped when
it's undefined.

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>