### PR TITLE
tests: temporarily disable nfs-ganesha

### DIFF
--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -23,8 +23,8 @@ rgw0
 client0
 client1
 
-[nfss]
-nfs0
+#[nfss]
+#nfs0
 
 [rbdmirrors]
 rbd-mirror0

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -8,7 +8,7 @@ mon_vms: 3
 osd_vms: 3
 mds_vms: 3
 rgw_vms: 1
-nfs_vms: 1
+nfs_vms: 0
 grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2


### PR DESCRIPTION
This commit [1] seems to have broken a selinux policy preventing nfs-ganesha from
starting properly.

Since we can't address the issue in ceph-ansible, let's disable temporarily nfs-ganesha testing.

[1] https://github.com/nfs-ganesha/nfs-ganesha/commit/dae2da63d58ae6bfe9ee813b5a59bc40102d7b8d

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>