### PR TITLE
Fix rich version for ansible-lint

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           python-version: '3.8'
           architecture: x64
-      - run: pip install -r <(grep ansible tests/requirements.txt) ansible-lint==4.3.7 netaddr
+      - run: pip install -r <(grep ansible tests/requirements.txt) ansible-lint==4.3.7 'rich>=9.5.1,<11.0.0' netaddr
       - run: ansible-lint -x 106,204,205,208 -v --force-color ./roles/*/ ./infrastructure-playbooks/*.yml site-container.yml.sample site-container.yml.sample dashboard.yml
       - run: ansible-playbook -i ./tests/functional/all_daemons/hosts site.yml.sample --syntax-check --list-tasks -vv
       - run: ansible-playbook -i ./tests/functional/all_daemons/hosts site-container.yml.sample --syntax-check --list-tasks -vv


### PR DESCRIPTION
Ansible-lint prior to v5.3.1 has issue with reach version >=11.0.0.
In order to cherry-pick fix to stable branches we fix rich version.

This should be reverted with ansible-lint version bump.

Signed-off-by: Dmitriy Rabotyagov <noonedeadpunk@ya.ru>