### PR TITLE
nfs-ganesha: fix debian based OS deployments

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -145,8 +145,10 @@ dummy:
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
 #nfs_ganesha_stable_branch: V3.5-stable
-#nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
-
+#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-3.0/ubuntu
+#nfs_ganesha_apt_keyserver: keyserver.ubuntu.com
+#nfs_ganesha_apt_key_id: EA914D611053D07BD332E18010353E8834DC57CA
+#libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-3.0/ubuntu
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -145,8 +145,10 @@ ceph_repository: rhcs
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
 #nfs_ganesha_stable_branch: V3.5-stable
-#nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
-
+#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-3.0/ubuntu
+#nfs_ganesha_apt_keyserver: keyserver.ubuntu.com
+#nfs_ganesha_apt_key_id: EA914D611053D07BD332E18010353E8834DC57CA
+#libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-3.0/ubuntu
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -137,8 +137,10 @@ ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 nfs_ganesha_stable: true # use stable repos for nfs-ganesha
 nfs_ganesha_stable_branch: V3.5-stable
-nfs_ganesha_stable_deb_repo: "{{ ceph_mirror }}/nfs-ganesha/deb-{{ nfs_ganesha_stable_branch }}/{{ ceph_stable_release }}"
-
+nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-3.0/ubuntu
+nfs_ganesha_apt_keyserver: keyserver.ubuntu.com
+nfs_ganesha_apt_key_id: EA914D611053D07BD332E18010353E8834DC57CA
+libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-3.0/ubuntu
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_debian.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_debian.yml
@@ -14,6 +14,22 @@
             update_cache: no
           register: add_ganesha_apt_repo
 
+        - name: add libntirpc stable repository
+          apt_repository:
+            repo: "deb {{ libntirpc_stable_deb_repo }} {{ ceph_stable_distro_source | default(ansible_facts['distribution_release']) }} main"
+            state: present
+            update_cache: no
+          register: add_libntirpc_apt_repo
+          when: libntirpc_stable_deb_repo is defined
+
+        - name: add nfs-ganesha ppa apt key
+          apt_key:
+            keyserver: "{{ nfs_ganesha_apt_keyserver }}"
+            id: "{{ nfs_ganesha_apt_key_id }}"
+          when:
+            - nfs_ganesha_apt_key_id is defined
+            - nfs_ganesha_apt_keyserver is defined
+
         - name: update apt cache
           apt:
             update_cache: yes
@@ -21,7 +37,7 @@
           retries: 5
           delay: 2
           until: update_ganesha_apt_cache is success
-          when: add_ganesha_apt_repo is changed
+          when: add_ganesha_apt_repo is changed or add_libntirpc_apt_repo is changed
 
     - name: debian based systems - dev repos specific tasks
       when:


### PR DESCRIPTION
Let's use ppa repositories in order to deploy nfs-ganesha on Debian based OS.

Fixes: #7031

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>