### PR TITLE
Allow containers to access files labeled as cert_t

### DIFF
--- a/roles/ceph-container-common/tasks/prerequisites.yml
+++ b/roles/ceph-container-common/tasks/prerequisites.yml
@@ -1,4 +1,22 @@
 ---
+- name: Install selinux modules
+  when:
+    - ansible_facts['distribution'] == 'RedHat'
+    - inventory_hostname in groups.get(mon_group_name, [])
+      or inventory_hostname in groups.get(rgw_group_name, [])
+  block:
+    - import_role:
+        name: ceph-common
+        tasks_from: configure_repository.yml
+
+    - name: install ceph-selinux package
+      package:
+        name: ceph-selinux
+        state: present
+
+    - name: restore certificates selinux context
+      command: /usr/sbin/restorecon -RF /etc/pki/ca-trust/extracted 
+
 - name: lvmetad tasks related
   when:
     - inventory_hostname in groups.get(osd_group_name, [])

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -33,7 +33,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
   -v /etc/localtime:/etc/localtime:ro \
   -v /var/log/ceph:/var/log/ceph:z \
 {% if ansible_facts['distribution'] == 'RedHat' -%}
-  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:z \
+  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:ro \
 {% endif -%}
 {% if mon_docker_privileged | bool -%}
   --privileged \

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -39,7 +39,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -v /etc/localtime:/etc/localtime:ro \
   -v /var/log/ceph:/var/log/ceph:z \
   {% if ansible_facts['distribution'] == 'RedHat' -%}
-  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:z \
+  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:ro \
   {% endif -%}
   {% if radosgw_frontend_ssl_certificate -%}
   -v {{ radosgw_frontend_ssl_certificate }}:{{ radosgw_frontend_ssl_certificate }}:ro \


### PR DESCRIPTION
Initially binding /etc/pki/ca-trust/extracted:z to mon/rgw containers
was done to solve an OSP TripleO issue on RHEL
(https://github.com/ceph/ceph-ansible/pull/3638) but by using the z flag it
brought other issues like https://bugzilla.redhat.com/show_bug.cgi?id=2026953
The z flag prevents local services (like sssd) running on the host accessing
the certificates/files in that folder.

Solving this requires to modify the ceph-selinux package to allow
container_t flagged processes to have access to files/folders labelled with
cert_t and use ro instead of z flag.

2 PR are created to solve this issue. One for ceph-selinux (https://github.com/ceph/ceph/pull/44802) and another one for
ceph-ansible (this one)

Signed-off-by: Teoman ONAY <tonay@redhat.com>