### PR TITLE
tests: use centos stream-8 instead of centos 8

### DIFF
--- a/tests/functional/cephadm/vagrant_variables.yml
+++ b/tests/functional/cephadm/vagrant_variables.yml
@@ -23,7 +23,7 @@ cluster_subnet: 192.168.31
 # set 1024 for CentOS
 memory: 2048
 
-vagrant_box: centos/8
+vagrant_box: centos/stream8
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync

--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-vagrant box remove --force --provider libvirt --box-version 0 centos/8 || true
-vagrant box add --provider libvirt --name centos/8 https://cloud.centos.org/centos/8/vagrant/x86_64/images/CentOS-8-Vagrant-8.4.2105-20210603.0.x86_64.vagrant-libvirt.box || true
+vagrant box remove --force --provider libvirt --box-version 0 centos/stream8 || true
+vagrant box add --provider libvirt --name centos/stream8 https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20220125.1.x86_64.vagrant-libvirt.box || true
 
 retries=0
 until [ $retries -ge 5 ]

--- a/tox-cephadm.ini
+++ b/tox-cephadm.ini
@@ -21,7 +21,7 @@ setenv=
   # only available for ansible >= 2.5
   ANSIBLE_STDOUT_CALLBACK = yaml
   # Set the vagrant box image to use
-  CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
 
 deps= -r{toxinidir}/tests/requirements.txt
 changedir= {toxinidir}/tests/functional/cephadm

--- a/tox-external_clients.ini
+++ b/tox-external_clients.ini
@@ -20,8 +20,8 @@ setenv=
   ANSIBLE_STDOUT_CALLBACK = yaml
 #  non_container: DEV_SETUP = True
   # Set the vagrant box image to use
-  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
-  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
+  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
 
   container: CONTAINER_DIR = /container
   container: PLAYBOOK = site-container.yml.sample

--- a/tox-filestore_to_bluestore.ini
+++ b/tox-filestore_to_bluestore.ini
@@ -20,8 +20,8 @@ setenv=
   ANSIBLE_STDOUT_CALLBACK = yaml
 #  non_container: DEV_SETUP = True
   # Set the vagrant box image to use
-  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
-  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
+  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
 
   # Set the ansible inventory host file to be used according to which distrib we are running on
   INVENTORY = {env:_INVENTORY:hosts}

--- a/tox-podman.ini
+++ b/tox-podman.ini
@@ -21,7 +21,7 @@ setenv=
   # only available for ansible >= 2.5
   ANSIBLE_STDOUT_CALLBACK = yaml
   # Set the vagrant box image to use
-  CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
 
   # Set the ansible inventory host file to be used according to which distrib we are running on
   INVENTORY = {env:_INVENTORY:hosts}

--- a/tox-shrink_osd.ini
+++ b/tox-shrink_osd.ini
@@ -61,8 +61,8 @@ setenv=
   ANSIBLE_STDOUT_CALLBACK = yaml
   non_container: DEV_SETUP = True
   # Set the vagrant box image to use
-  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
-  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
+  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
   INVENTORY = {env:_INVENTORY:hosts}
   container: CONTAINER_DIR = /container
   container: PLAYBOOK = site-container.yml.sample

--- a/tox-subset_update.ini
+++ b/tox-subset_update.ini
@@ -20,8 +20,8 @@ setenv=
   ANSIBLE_STDOUT_CALLBACK = yaml
 #  non_container: DEV_SETUP = True
   # Set the vagrant box image to use
-  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
-  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
+  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
 
   INVENTORY = {env:_INVENTORY:hosts}
   container: CONTAINER_DIR = /container

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -20,8 +20,8 @@ setenv=
   ANSIBLE_STDOUT_CALLBACK = yaml
 #  non_container: DEV_SETUP = True
   # Set the vagrant box image to use
-  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
-  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
+  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
 
   INVENTORY = {env:_INVENTORY:hosts}
   container: CONTAINER_DIR = /container

--- a/tox.ini
+++ b/tox.ini
@@ -303,8 +303,8 @@ setenv=
   ANSIBLE_STDOUT_CALLBACK = yaml
   non_container: DEV_SETUP = True
   # Set the vagrant box image to use
-  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
-  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  centos-non_container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
+  centos-container: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
   INVENTORY = {env:_INVENTORY:hosts}
   container: CONTAINER_DIR = /container
   container: PLAYBOOK = site-container.yml.sample


### PR DESCRIPTION
CentOS 8 is EOL as of December 2021.
Let's use CentOS stream 8 instead.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>