### PR TITLE
[skip ci] Update EPEL mock config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ NAME = ceph-ansible
 #  "ceph-ansible-2.2.0-1.el8"
 
 DIST ?= "el8"
-MOCK_CONFIG ?= "epel-8-x86_64"
+MOCK_CONFIG ?= "centos+epel-8-x86_64"
 TAG := $(shell git describe --tags --abbrev=0 --match 'v*')
 VERSION := $(shell echo $(TAG) | sed 's/^v//')
 COMMIT := $(shell git rev-parse HEAD)


### PR DESCRIPTION
CL8 is EOL since 31st January 2022 [1].
So the EPEL mock config needs to be switched to
new one supported [2][3].

[1] https://www.centos.org/centos-linux-eol/
[2] https://pagure.io/epel/issue/133
[3] https://github.com/rpm-software-management/mock/pull/817