### PR TITLE
library/ceph_pool: Fix potential null value when creating pools

### DIFF
--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -395,7 +395,8 @@ def create_pool(cluster,
         args.extend(['--pg_num',
                      user_pool_config['pg_num']['value'],
                      '--pgp_num',
-                     user_pool_config['pgp_num']['value']])
+                     user_pool_config['pgp_num']['value'] or
+                     user_pool_config['pg_num']['value']])
     elif user_pool_config['target_size_ratio']['value']:
         args.extend(['--target_size_ratio',
                      user_pool_config['target_size_ratio']['value']])


### PR DESCRIPTION
Before, creating a pool by providing *only* `pg_num` would result in an
error as it would produce `--pgp-num null`.

This commit fix this behavior by defaulting `pgp_num` value to `pg_num`.

As described in Ceph documentation, when creating a pool `pgp_num` and `pg_num` should be equal.