### PR TITLE
[skip ci] rpm: fix packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ NAME = ceph-ansible
 #  "ceph-ansible-2.2.0-1.el8"
 
 DIST ?= "el8"
-MOCK_CONFIG ?= "centos+epel-8-x86_64"
+MOCK_CONFIG ?= "centos-stream+epel-8-x86_64"
 TAG := $(shell git describe --tags --abbrev=0 --match 'v*')
 VERSION := $(shell echo $(TAG) | sed 's/^v//')
 COMMIT := $(shell git rev-parse HEAD)

--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -15,8 +15,8 @@ Obsoletes:      ceph-iscsi-ansible <= 1.5
 
 BuildArch:      noarch
 
-BuildRequires: ansible >= 2.10
-Requires: ansible >= 2.10
+BuildRequires: ansible >= 2.9
+Requires: ansible >= 2.9
 
 %if 0%{?rhel} == 7
 BuildRequires: python2-devel


### PR DESCRIPTION
This fixes a couple of issues:

- ansible 2.10 isn't packaged.
- MOCK_CONFIG variable is wrong (centos 8 is EOL)

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>