### PR TITLE
[skip ci] purge: ceph-crash purge fixes

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -686,9 +686,15 @@
         enabled: no
       failed_when: false
 
+    - name: systemctl reset-failed ceph-crash@{{ 'ceph-crash@' + ansible_facts['hostname'] }}  # noqa 303
+      command: "systemctl reset-failed ceph-crash@{{ 'ceph-crash@' + ansible_facts['hostname'] }}"
+      changed_when: false
+      failed_when: false
+      when: containerized_deployment | bool
+
     - name: remove service file
       file:
-        name: "/etc/systemd/system/ceph-crash.service"
+        name: "/etc/systemd/system/ceph-crash{{ '@' if containerized_deployment | bool else '' }}.service"
         state: absent
       failed_when: false
 


### PR DESCRIPTION
This fixes the service file removal and makes the playbook
call `systemctl reset-failed` on the service because in Ceph
Nautilus, ceph-crash doesn't handle `SIGTERM` signal.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2055992

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>