### PR TITLE
Turn off SELinux separation for containers MON and RGW

### DIFF
--- a/roles/ceph-container-common/tasks/prerequisites.yml
+++ b/roles/ceph-container-common/tasks/prerequisites.yml
@@ -34,3 +34,11 @@
     mode: 0644
     state: present
     create: yes
+
+- name: restore certificates selinux context
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - inventory_hostname in groups.get(mon_group_name, [])
+      or inventory_hostname in groups.get(rgw_group_name, [])
+  command: /usr/sbin/restorecon -RF /etc/pki/ca-trust/extracted
+  changed_when: false

--- a/roles/ceph-mon/templates/ceph-mon.service.j2
+++ b/roles/ceph-mon/templates/ceph-mon.service.j2
@@ -27,13 +27,14 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-mon-%i \
   --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --memory={{ ceph_mon_docker_memory_limit }} \
   --cpus={{ ceph_mon_docker_cpu_limit }} \
-  -v /var/lib/ceph:/var/lib/ceph:z,rshared \
-  -v /etc/ceph:/etc/ceph:z \
-  -v /var/run/ceph:/var/run/ceph:z \
-  -v /etc/localtime:/etc/localtime:ro \
-  -v /var/log/ceph:/var/log/ceph:z \
-{% if ansible_facts['distribution'] == 'RedHat' -%}
-  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:z \
+  --security-opt label=disable \
+  -v /var/lib/ceph:/var/lib/ceph:rshared \
+  -v /etc/ceph:/etc/ceph \
+  -v /var/run/ceph:/var/run/ceph \
+  -v /etc/localtime:/etc/localtime \
+  -v /var/log/ceph:/var/log/ceph \
+{% if ansible_facts['os_family'] == 'RedHat' -%}
+  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted \
 {% endif -%}
 {% if mon_docker_privileged | bool -%}
   --privileged \

--- a/roles/ceph-rgw/templates/ceph-radosgw.service.j2
+++ b/roles/ceph-rgw/templates/ceph-radosgw.service.j2
@@ -27,22 +27,23 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --memory={{ ceph_rgw_docker_memory_limit }} \
   --cpus={{ cpu_limit }} \
+  --security-opt label=disable \
   {% if ceph_rgw_docker_cpuset_cpus is defined -%}
   --cpuset-cpus="{{ ceph_rgw_docker_cpuset_cpus }}" \
   {% endif -%}
   {% if ceph_rgw_docker_cpuset_mems is defined -%}
   --cpuset-mems="{{ ceph_rgw_docker_cpuset_mems }}" \
   {% endif -%}
-  -v /var/lib/ceph:/var/lib/ceph:z \
-  -v /etc/ceph:/etc/ceph:z \
-  -v /var/run/ceph:/var/run/ceph:z \
-  -v /etc/localtime:/etc/localtime:ro \
-  -v /var/log/ceph:/var/log/ceph:z \
-  {% if ansible_facts['distribution'] == 'RedHat' -%}
-  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:z \
+  -v /var/lib/ceph:/var/lib/ceph \
+  -v /etc/ceph:/etc/ceph \
+  -v /var/run/ceph:/var/run/ceph \
+  -v /etc/localtime:/etc/localtime \
+  -v /var/log/ceph:/var/log/ceph \
+  {% if ansible_facts['os_family'] == 'RedHat' -%}
+  -v /etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted \
   {% endif -%}
   {% if radosgw_frontend_ssl_certificate -%}
-  -v {{ radosgw_frontend_ssl_certificate }}:{{ radosgw_frontend_ssl_certificate }}:ro \
+  -v {{ radosgw_frontend_ssl_certificate }}:{{ radosgw_frontend_ssl_certificate }} \
   {% endif -%}
   -e CEPH_DAEMON=RGW \
   -e CLUSTER={{ cluster }} \


### PR DESCRIPTION
Initially MONs and RGW binded /etc/pki/ca-trust/extracted using the :z flag
(introduced to solve an OSP TripleO issue on RHEL - #3638) but using
this flag prevents local services (like sssd) running on the host from accessing
the certificates/files in that folder.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2026953

Signed-off-by: Teoman ONAY <tonay@redhat.com>