### PR TITLE
[skip ci] validate: fix wrong conditions

### DIFF
--- a/infrastructure-playbooks/add-osd.yml
+++ b/infrastructure-playbooks/add-osd.yml
@@ -51,6 +51,16 @@
       set_fact:
         add_osd: True
 
+    - name: set_fact docker_exec_cmd
+      set_fact:
+        docker_exec_cmd: "docker exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      delegate_facts: true
+      run_once: true
+      when:
+        - containerized_deployment
+        - groups.get(mon_group_name, []) | length > 0
+
   roles:
     - role: ceph-defaults
     - role: ceph-facts

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -161,7 +161,7 @@
   with_items: "{{ devices }}"
   register: devices_prepare_canonicalize
   when:
-    - devices is defined
+    - devices | length > 0
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
 
@@ -170,7 +170,7 @@
     devices: "{{ devices | default([]) + [ item.stdout ] }}"
   with_items: "{{ devices_prepare_canonicalize.results }}"
   when:
-    - devices is defined
+    - devices | length > 0
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
 
@@ -178,7 +178,7 @@
   set_fact:
     devices: "{{ devices | reject('search','/dev/disk') | list | unique }}"
   when:
-    - devices is defined
+    - devices | length > 0
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
 

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -115,8 +115,8 @@
   changed_when: false
   delegate_to: "{{ groups[mon_group_name][0] }}"
   until:
-    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_osds"] | int > 0
-    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_up_osds"]
+    - (wait_for_all_osds_up.stdout | default('{}') | from_json)["osdmap"]["osdmap"]["num_osds"] | int > 0
+    - (wait_for_all_osds_up.stdout | default('{}') | from_json)["osdmap"]["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | default('{}') from_json)["osdmap"]["osdmap"]["num_up_osds"]
   when:
     - inventory_hostname == ansible_play_hosts_all | last
 

--- a/roles/ceph-validate/tasks/check_devices.yml
+++ b/roles/ceph-validate/tasks/check_devices.yml
@@ -65,7 +65,7 @@
       with_items: "{{ lvm_volumes | default(devices) }}"
       when:
         - inventory_hostname in groups.get(osd_group_name, [])
-        - (item.data is defined and item.data_vg is undefined) or devices is defined
+        - (item.data is defined and item.data_vg is undefined) or devices | length > 0
 
     - name: fail when gpt header found on osd devices
       fail:


### PR DESCRIPTION
`devices` has a default value set in `ceph-defaults` which is `[]`
it makes check_devices fail.
See details in corresponding BZ

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2068353

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>