### PR TITLE
validate: drop a check

### DIFF
--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -43,20 +43,6 @@
         msg: "Distribution not supported {{ ansible_facts['distribution_version'] }} by Red Hat Ceph Storage, only RHEL >= 8.2"
       when: ansible_facts['distribution_version'] is version('8.2', '<')
 
-    - name: subscription manager related tasks
-      block:
-        - name: determine if node is registered with subscription-manager
-          command: subscription-manager identity
-          register: subscription
-          changed_when: false
-          failed_when: false
-          check_mode: no
-
-        - name: fail on unregistered red hat rhcs linux
-          fail:
-            msg: "You must register your machine with subscription-manager"
-          when: subscription.rc != 0
-
 - name: fail on unsupported distribution for ubuntu cloud archive
   fail:
     msg: "Distribution not supported by Ubuntu Cloud Archive: {{ ansible_facts['distribution'] }}"


### PR DESCRIPTION
Since the ISO install method removal, ceph-ansible isn't able
to detect wheter the user is deploying in a 'disconnected environment'.
By the way, given that ceph-ansible is available only for upgrading to RHCS 5,
this check doesn't make sense anymore, let's drop it.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2062147

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>