### PR TITLE
[skip ci] validate: fix check_devices

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -161,7 +161,7 @@
   with_items: "{{ devices }}"
   register: devices_prepare_canonicalize
   when:
-    - devices | length > 0
+    - devices is defined
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
 
@@ -170,7 +170,7 @@
     devices: "{{ devices | default([]) + [ item.stdout ] }}"
   with_items: "{{ devices_prepare_canonicalize.results }}"
   when:
-    - devices | length > 0
+    - devices is defined
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
 
@@ -178,7 +178,7 @@
   set_fact:
     devices: "{{ devices | reject('search','/dev/disk') | list | unique }}"
   when:
-    - devices | length > 0
+    - devices is defined
     - inventory_hostname in groups.get(osd_group_name, [])
     - not osd_auto_discovery|default(False)
 

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -116,7 +116,7 @@
   delegate_to: "{{ groups[mon_group_name][0] }}"
   until:
     - (wait_for_all_osds_up.stdout | default('{}') | from_json)["osdmap"]["osdmap"]["num_osds"] | int > 0
-    - (wait_for_all_osds_up.stdout | default('{}') | from_json)["osdmap"]["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | default('{}') from_json)["osdmap"]["osdmap"]["num_up_osds"]
+    - (wait_for_all_osds_up.stdout | default('{}') | from_json)["osdmap"]["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | default('{}') | from_json)["osdmap"]["osdmap"]["num_up_osds"]
   when:
     - inventory_hostname == ansible_play_hosts_all | last
 

--- a/roles/ceph-validate/tasks/check_devices.yml
+++ b/roles/ceph-validate/tasks/check_devices.yml
@@ -65,7 +65,7 @@
       with_items: "{{ lvm_volumes | default(devices) }}"
       when:
         - inventory_hostname in groups.get(osd_group_name, [])
-        - (item.data is defined and item.data_vg is undefined) or devices | length > 0
+        - (item.data is defined and item.data_vg is undefined) or devices is defined
 
     - name: fail when gpt header found on osd devices
       fail:

--- a/roles/ceph-validate/tasks/check_devices.yml
+++ b/roles/ceph-validate/tasks/check_devices.yml
@@ -65,7 +65,7 @@
       with_items: "{{ lvm_volumes | default(devices) }}"
       when:
         - inventory_hostname in groups.get(osd_group_name, [])
-        - (item.data is defined and item.data_vg is undefined) or devices is defined
+        - (item.data is defined and item.data_vg is undefined) or devices | default([]) | length > 0
 
     - name: fail when gpt header found on osd devices
       fail:


### PR DESCRIPTION
This fixes a regression introduced in 3.2.57 and the check_devices step.
    
When lvm_volumes is defined with data and data_vg (vg/lv format) it goes
to the second part of the condition which throws an undefined error given
that `devices` isn't defined.
    
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2069491