### PR TITLE
do not update Debian cache when package-install is disabled

### DIFF
--- a/roles/ceph-infra/tasks/main.yml
+++ b/roles/ceph-infra/tasks/main.yml
@@ -5,6 +5,7 @@
   when: ansible_facts['os_family'] == "Debian"
   register: result
   until: result is succeeded
+  tags: package-install
 
 - name: include_tasks configure_firewall.yml
   include_tasks: configure_firewall.yml


### PR DESCRIPTION
When deploying with --skip-tags=package-install (when there is no access to a repository), the playbook is still trying to update the package cache, which makes the playbook fail.
This change prevents the playbook to try to update the cache when the package-install tag is skipped.