### PR TITLE
added AlmaLinux and Rocky for iscsi deploy

### DIFF
--- a/roles/ceph-validate/tasks/check_iscsi.yml
+++ b/roles/ceph-validate/tasks/check_iscsi.yml
@@ -2,7 +2,7 @@
 - name: fail on unsupported distribution for iscsi gateways
   fail:
     msg: "iSCSI gateways can only be deployed on Red Hat Enterprise Linux, CentOS or Fedora"
-  when: ansible_facts['distribution'] not in ['RedHat', 'CentOS', 'Fedora']
+  when: ansible_facts['distribution'] not in ['RedHat', 'CentOS', 'Fedora', 'AlmaLinux', 'Rocky']
 
 - name: make sure gateway_ip_list is configured
   fail:


### PR DESCRIPTION
As AlmaLinux and Rocky are EL Distros you can deploy the iscsi gateway with ceph-ansible

Signed-off-by: Ingo Ebel <ingo.ebel@desy.de>