### PR TITLE
ceph-facts: fix ansible templating error for auto osd discovery

### DIFF
--- a/roles/ceph-facts/tasks/devices.yml
+++ b/roles/ceph-facts/tasks/devices.yml
@@ -87,5 +87,5 @@
     - item.value.sectors != "0"
     - item.value.partitions|count == 0
     - item.value.holders|count == 0
-    - ansible_facts['mounts'] | selectattr('device', 'equalto', device) | length == 0
+    - ansible_facts['mounts'] | selectattr('device', 'equalto', device) | list | length == 0
     - item.key is not match osd_auto_discovery_exclude


### PR DESCRIPTION
This commit fixes templating error that occurs when using auto osd discovery. Getting the len before converting the result to a list causes "object of type generator has no len()" error in some conditions.

Signed-off-by: pinotelio <ahmadreza.mollapour@gmail.com>