### PR TITLE
facts: always set `docker_exec_cmd`

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -24,6 +24,8 @@
   set_fact:
     docker_exec_cmd: "docker exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_hostname'] }}"
   delegate_to: "{{ groups[mon_group_name][0] }}"
+  delegate_facts: true
+  run_once: true
   when:
     - containerized_deployment
     - groups.get(mon_group_name, []) | length > 0

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -36,7 +36,7 @@
   include_tasks: common.yml
 
 - name: set noup flag
-  command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd set noup"
+  command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd set noup"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: True
   changed_when: False
@@ -99,7 +99,7 @@
   include_tasks: start_osds.yml
 
 - name: unset noup flag
-  command: "{{ docker_exec_cmd | default('') }} ceph --cluster {{ cluster }} osd unset noup"
+  command: "{{ hostvars[groups[mon_group_name][0]]['docker_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd unset noup"
   delegate_to: "{{ groups[mon_group_name][0] }}"
   changed_when: False
   when:


### PR DESCRIPTION
This ensures `docker_exec_cmd` is always set on the first monitor.
Otherwise, when running the playbook with `--limit`, it fails on tasks
calling `docker_exec_cmd` with a delegate_to on the first monitor since
it was not set.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>