### PR TITLE
[skip ci] dashboard: allow collecting stats from the host

### DIFF
--- a/roles/ceph-node-exporter/templates/node_exporter.service.j2
+++ b/roles/ceph-node-exporter/templates/node_exporter.service.j2
@@ -23,11 +23,13 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name=node-exporter \
 {% endif %}
   --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
   --privileged \
-  -v /proc:/host/proc:ro -v /sys:/host/sys:ro \
+  --security-opt label=disable \
+  -v /:/rootfs:ro \
   --net=host \
   {{ node_exporter_container_image }} \
-  --path.procfs=/host/proc \
-  --path.sysfs=/host/sys \
+  --path.procfs=/rootfs/proc \
+  --path.sysfs=/rootfs/sys \
+  --path.rootfs=/rootfs \
   --no-collector.timex \
   --web.listen-address=:{{ node_exporter_port }}
 {% if container_binary == 'podman' %}


### PR DESCRIPTION
This commit makes podman bindmount `/:/rootfs:ro` so the container can
collect data from the host.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2028775

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>