### PR TITLE
dashboard: support --limit execution with rgw

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -24,6 +24,13 @@
   delegate_to: "{{ item }}"
   delegate_facts: True
 
+- include_role:
+    name: ceph-facts
+    tasks_from: set_radosgw_address.yml
+  loop: "{{ groups[rgw_group_name] }}"
+  loop_control:
+    loop_var: ceph_dashboard_call_item
+
 - name: disable SSL for dashboard
   when: dashboard_protocol == "http"
   delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -31,23 +31,34 @@
     - name: set_fact _interface
       set_fact:
         _interface: "{{ (radosgw_interface | replace('-', '_')) }}"
+      loop: "{{ groups.get(rgw_group_name, []) }}"
+      delegate_to: "{{ item }}"
 
     - name: set_fact _radosgw_address to radosgw_interface - ipv4
       set_fact:
-        _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts'][_interface][ip_version]['address'] }}"
+        _radosgw_address: "{{ hostvars[item]['ansible_facts'][_interface][ip_version]['address'] }}"
+      loop: "{{ groups.get(rgw_group_name, []) }}"
+      delegate_to: "{{ item }}"
+      delegate_facts: true
       when: ip_version == 'ipv4'
 
     - name: set_fact _radosgw_address to radosgw_interface - ipv6
       set_fact:
-        _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts'][_interface][ip_version][0]['address'] | ipwrap }}"
+        _radosgw_address: "{{ hostvars[item]['ansible_facts'][_interface][ip_version][0]['address'] | ipwrap }}"
+      loop: "{{ groups.get(rgw_group_name, []) }}"
+      delegate_to: "{{ item }}"
+      delegate_facts: true
       when: ip_version == 'ipv6'
 
 - name: set_fact rgw_instances without rgw multisite
   set_fact:
-    rgw_instances: "{{ rgw_instances|default([]) | union([{'instance_name': 'rgw' + item|string, 'radosgw_address': _radosgw_address, 'radosgw_frontend_port': radosgw_frontend_port|int + item|int }]) }}"
+    rgw_instances: "{{ rgw_instances|default([]) | union([{'instance_name': 'rgw' + item|string, 'radosgw_address': hostvars[ceph_dashboard_call_item | default(inventory_hostname)]['_radosgw_address'], 'radosgw_frontend_port': radosgw_frontend_port|int + item|int }]) }}"
   with_sequence: start=0 end={{ radosgw_num_instances|int - 1 }}
+  delegate_to: "{{ ceph_dashboard_call_item if ceph_dashboard_call_item is defined else inventory_hostname }}"
+  delegate_facts: "{{ true if ceph_dashboard_call_item is defined else false }}"
   when:
-    - inventory_hostname in groups.get(rgw_group_name, [])
+    - ceph_dashboard_call_item is defined or
+      inventory_hostname in groups.get(rgw_group_name, [])
     - not rgw_multisite | bool
 
 - name: set_fact is_rgw_instances_defined
@@ -59,10 +70,13 @@
 
 - name: set_fact rgw_instances with rgw multisite
   set_fact:
-    rgw_instances: "{{ rgw_instances|default([]) | union([{ 'instance_name': 'rgw' + item | string, 'radosgw_address': _radosgw_address, 'radosgw_frontend_port': radosgw_frontend_port | int + item|int, 'rgw_realm': rgw_realm | string, 'rgw_zonegroup': rgw_zonegroup | string, 'rgw_zone': rgw_zone | string, 'system_access_key': system_access_key, 'system_secret_key': system_secret_key, 'rgw_zone_user': rgw_zone_user, 'rgw_zone_user_display_name': rgw_zone_user_display_name, 'endpoint': (rgw_pull_proto + '://' + rgw_pullhost + ':' + rgw_pull_port | string) if not rgw_zonemaster | bool and rgw_zonesecondary | bool else omit }]) }}"
+    rgw_instances: "{{ rgw_instances|default([]) | union([{ 'instance_name': 'rgw' + item | string, 'radosgw_address': hostvars[ceph_dashboard_call_item | default(inventory_hostname)]['_radosgw_address'], 'radosgw_frontend_port': radosgw_frontend_port | int + item|int, 'rgw_realm': rgw_realm | string, 'rgw_zonegroup': rgw_zonegroup | string, 'rgw_zone': rgw_zone | string, 'system_access_key': system_access_key, 'system_secret_key': system_secret_key, 'rgw_zone_user': rgw_zone_user, 'rgw_zone_user_display_name': rgw_zone_user_display_name, 'endpoint': (rgw_pull_proto + '://' + rgw_pullhost + ':' + rgw_pull_port | string) if not rgw_zonemaster | bool and rgw_zonesecondary | bool else omit }]) }}"
   with_sequence: start=0 end={{ radosgw_num_instances|int - 1 }}
+  delegate_to: "{{ ceph_dashboard_call_item if ceph_dashboard_call_item is defined else inventory_hostname }}"
+  delegate_facts: "{{ true if ceph_dashboard_call_item is defined else false }}"
   when:
-    - inventory_hostname in groups.get(rgw_group_name, [])
+    - ceph_dashboard_call_item is defined or
+      inventory_hostname in groups.get(rgw_group_name, [])
     - rgw_multisite | bool
     - not is_rgw_instances_defined | default(False) | bool
 
@@ -78,7 +92,6 @@
   set_fact:
     rgw_instances_all: '{{ rgw_instances_all | default([]) | union(hostvars[item]["rgw_instances_host"]) }}'
   with_items: "{{ groups.get(rgw_group_name, []) }}"
-  run_once: true
   when:
     - inventory_hostname in groups.get(rgw_group_name, [])
     - hostvars[item]["rgw_instances_host"] is defined


### PR DESCRIPTION
When the following conditions are met:

- rgw is deployed,
- dashboard is deployed,
- playbook is called with --limit,
- a node being processed is collocated on either a mon or mgr.

The playbook fails because `rgw_instances` is undefined.
The idea here is to make sure this variable is always defined.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2063029

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>