### PR TITLE
common: support setting pg autoscaler to off

### DIFF
--- a/roles/ceph-client/tasks/create_users_keys.yml
+++ b/roles/ceph-client/tasks/create_users_keys.yml
@@ -114,7 +114,7 @@
       when: item.target_size_ratio is defined
 
     - name: set pg_autoscale_mode value on pool(s)
-      command: "{{ ceph_admin_command | default('') }} --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"
+      command: "{{ ceph_admin_command | default('') }} --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ 'on' if item.pg_autoscale_mode | default('off') | lower in ['on', 'yes', 'true'] else 'off' if item.pg_autoscale_mode | default('off') | lower in ['off', 'no', 'false'] else 'warn' }}"
       delegate_to: "{{ delegated_node }}"
       with_items: "{{ pools | unique }}"
 

--- a/roles/ceph-mds/tasks/create_mds_filesystems.yml
+++ b/roles/ceph-mds/tasks/create_mds_filesystems.yml
@@ -46,7 +46,7 @@
       when: item.target_size_ratio is defined
 
     - name: set pg_autoscale_mode value on pool(s)
-      command: "{{ ceph_run_cmd }} --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"
+      command: "{{ ceph_run_cmd }} --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ 'on' if item.pg_autoscale_mode | default('off') | lower in ['on', 'yes', 'true'] else 'off' if item.pg_autoscale_mode | default('off') | lower in ['off', 'no', 'false'] else 'warn' }}"
       with_items: "{{ cephfs_pools | unique }}"
 
     - name: customize pool size

--- a/roles/ceph-osd/tasks/openstack_config.yml
+++ b/roles/ceph-osd/tasks/openstack_config.yml
@@ -39,7 +39,7 @@
       when: item.target_size_ratio is defined
 
     - name: set pg_autoscale_mode value on pool(s)
-      command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ item.pg_autoscale_mode | default(False) | ternary('on', 'warn') }}"
+      command: "{{ hostvars[groups[mon_group_name][0]]['container_exec_cmd'] | default('') }} ceph --cluster {{ cluster }} osd pool set {{ item.name }} pg_autoscale_mode {{ 'on' if item.pg_autoscale_mode | default('off') | lower in ['on', 'yes', 'true'] else 'off' if item.pg_autoscale_mode | default('off') | lower in ['off', 'no', 'false'] else 'warn' }}"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       with_items: "{{ openstack_pools | unique }}"
 


### PR DESCRIPTION
The current implementation doesn't allow to disable the pg autoscaler
on created pools. This allows only 'on' or 'warn'.

With this commit, this is now possible to disable it.

Valid values would be ['on', 'yes', 'true', 'off', 'no', 'false']

```
openstack_glance_pool:
  name: "images"
  pg_num: 128
  pgp_num: 128
  rule_name: "replicated_rule"
  type: 1
  application: "rbd"
  size: 3
  pg_autoscale_mode: off
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2062621

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>