### PR TITLE
dashboard: fix regression

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -27,9 +27,10 @@
 - include_role:
     name: ceph-facts
     tasks_from: set_radosgw_address.yml
-  loop: "{{ groups[rgw_group_name] }}"
+  loop: "{{ groups.get(rgw_group_name, []) }}"
   loop_control:
     loop_var: ceph_dashboard_call_item
+  when: groups.get(rgw_group_name, []) | length > 0
 
 - name: disable SSL for dashboard
   when: dashboard_protocol == "http"

--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -184,6 +184,7 @@
   when:
     - (inventory_hostname in groups.get(rgw_group_name, []) or inventory_hostname in groups.get(nfs_group_name, []))
     - groups.get(mon_group_name, []) | length > 0
+    - handler_mgr_status | default(False)
   block:
     - name: get ceph current status
       command: "{{ timeout_command }} {{ _container_exec_cmd | default('') }} ceph --cluster {{ cluster }} service dump -f json"


### PR DESCRIPTION
introduced by ceph/ceph-ansible/pull/7150

when no rgw is present, it fails.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2076192

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 1a56fd6a21b3e39c8acd4d3d20451df9b96754d2)