### PR TITLE
ceph_pool: set target size ratio on both 'on' and 'warn' mode

### DIFF
--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -391,7 +391,7 @@ def create_pool(cluster,
     args = ['create', user_pool_config['pool_name']['value'],
             user_pool_config['type']['value']]
 
-    if user_pool_config['pg_autoscale_mode']['value'] != 'on':
+    if user_pool_config['pg_autoscale_mode']['value'] == 'off':
         args.extend(['--pg_num',
                      user_pool_config['pg_num']['value'],
                      '--pgp_num',


### PR DESCRIPTION
when we set target_size_ratio to warn it means that the administrator wants to get suggestion from the mgr module but apply it manually when he/she wants. So it's in the same approach as 'on' mode just triggered by hand.
So there is no need to set pg_num when target_size_ratio is 'warn' and the mgr module will calculate the correct pg_num and the administrator will adjust it whenever he/she wants.

It is the same approach that was in #6471

Signed-off-by: Seena Fallah <seenafallah@gmail.com>