### PR TITLE
[Grafana] Update Ceph grafana dashbroad URL

### DIFF
--- a/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -36,7 +36,7 @@
 
 - name: download ceph grafana dashboards
   get_url:
-    url: "https://raw.githubusercontent.com/ceph/ceph/{{ grafana_dashboard_version }}/monitoring/grafana/dashboards/{{ item }}"
+    url: "https://raw.githubusercontent.com/ceph/ceph/{{ grafana_dashboard_version }}/monitoring/ceph-mixin/dashboards_out/{{ item }}"
     dest: "/etc/grafana/dashboards/ceph-dashboard/{{ item }}"
   with_items: "{{ grafana_dashboard_files }}"
   when:


### PR DESCRIPTION
Commit https://github.com/ceph/ceph/commit/fd5ec3b51ce9500e36597ac39e486a5cd40cddc4 has updated grafana URL
