### PR TITLE
Warn about ceph-ansible deprecation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,11 @@
-ceph-ansible
+ceph-ansible -- DEPRECATED --
 ============
+
+**NOTE: cephadm is the new official installer, you should consider migrating to cephadm.**
+
 Ansible playbooks for Ceph, the distributed filesystem.
 
 Please refer to our hosted documentation here: https://docs.ceph.com/projects/ceph-ansible/en/latest/
 
 You can view documentation for our ``stable-*`` branches by substituting ``master`` in the link
-above for the name of the branch. For example: https://docs.ceph.com/projects/ceph-ansible/en/stable-5.0/
+above for the name of the branch. For example: https://docs.ceph.com/projects/ceph-ansible/en/stable-6.0/

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -1,5 +1,18 @@
 ---
 # Defines deployment design and assigns role to server groups
+- hosts: localhost
+  connection: local
+  tasks:
+    - name: Warn about ceph-ansible deprecation
+      debug:
+        msg: "cephadm is the new official installer. Please, consider migrating.
+              See https://docs.ceph.com/en/latest/cephadm/install for new deployments
+              or https://docs.ceph.com/en/latest/cephadm/adoption for migrating existing deployments."
+      retries: 9
+      delay: 2
+      until: false
+      ignore_errors: true
+      when: not skip_deprecation_warn | default(false) | bool
 
 - hosts:
   - mons

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -1,6 +1,20 @@
 ---
 # Defines deployment design and assigns role to server groups
 
+- hosts: localhost
+  connection: local
+  tasks:
+    - name: Warn about ceph-ansible deprecation
+      debug:
+        msg: "cephadm is the new official installer. Please, consider migrating.
+              See https://docs.ceph.com/en/latest/cephadm/install for new deployments
+              or https://docs.ceph.com/en/latest/cephadm/adoption for migrating existing deployments."
+      retries: 9
+      delay: 2
+      until: false
+      ignore_errors: true
+      when: not skip_deprecation_warn | default(false) | bool
+
 - hosts:
   - mons
   - osds


### PR DESCRIPTION
The official installer is now cephadm.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>