### PR TITLE
[Grafana] Update grafana URL

### DIFF
--- a/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -36,7 +36,7 @@
 
 - name: download ceph grafana dashboards
   get_url:
-    url: "https://raw.githubusercontent.com/ceph/ceph/{{ grafana_dashboard_version }}/monitoring/grafana/dashboards/{{ item }}"
+    url: "https://raw.githubusercontent.com/ceph/ceph/{{ grafana_dashboard_version }}/monitoring/ceph-mixin/dashboards_out/{{ item }}"
     dest: "/etc/grafana/dashboards/ceph-dashboard/{{ item }}"
   with_items: "{{ grafana_dashboard_files }}"
   when:


### PR DESCRIPTION
Update Grafana dashboards URL.
This update is referred to the following commit:
https://github.com/ceph/ceph/commit/98236e3a1d2855c95d86640645c2984efa83791f

Signed-off-by: Tan Le <molyhangrong@gmail.com>