### PR TITLE
cephadm_adopt: set autotune_memory_target_ratio

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -360,6 +360,14 @@
       delegate_to: '{{ groups[mon_group_name][0] }}'
       when: is_hci | bool
 
+    - name: set autotune_memory_target_ratio
+      command: "{{ ceph_cmd }} config set mgr mgr/cephadm/autotune_memory_target_ratio {{ '0.2' if is_hci | bool else '0.7' }}"
+      changed_when: false
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
+      environment:
+        CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+
     - name: manage nodes with cephadm - ipv4
       command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv4_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | first }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
       changed_when: false


### PR DESCRIPTION
This adds a task that sets `autotune_memory_target_ratio` depending on the
value of `is_hci`.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2028693

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>