### PR TITLE
Add python default path for debian/ubuntu

### DIFF
--- a/raw_install_python.yml
+++ b/raw_install_python.yml
@@ -45,7 +45,9 @@
       when: stat_dnf3.rc == 0 or stat_yum.rc == 0
 
     - name: install python for debian based OS
-      raw: apt-get -y install python-simplejson
+      raw: >
+         apt-get -y install python-simplejson
+         ln -sf /usr/bin/python3 /usr/bin/python
       register: result
       until: result is succeeded
       when: stat_apt.rc == 0


### PR DESCRIPTION
Since debian based OSes dropped supporting python version 2 which resided in /usr/bin/python we need to add a softlink or otherwise ansible would fail.

Signed-off-by: Aliakbar Naji dr.nadji@gmail.com