### PR TITLE
ansible: use ansible.utils.ipwrap instead of ansible.netcommon.ipwrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ ceph-ansible.spec
 !.travis.yml
 !.mergify.yml
 !raw_install_python.yml
+!requirements.yml

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -63,6 +63,16 @@ You can acquire Ansible on Ubuntu by using the `Ansible PPA <https://launchpad.n
    $ sudo apt update
    $ sudo apt install ansible
 
+Ansible collections
+-------------------
+
+In order to install third-party collections that are required for ceph-ansible,
+please run:
+
+.. code-block:: console
+
+   $ ansible-galaxy install -r requirements.yml
+
 
 Releases
 ========

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -752,7 +752,7 @@ dummy:
 # For example:
 # If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
 # at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
-# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.netcommon.ipwrap }}" will be empty.
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }}" will be empty.
 # As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
 # Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 #igw_network: "{{ public_network }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -752,7 +752,7 @@ alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alert
 # For example:
 # If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
 # at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
-# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.netcommon.ipwrap }}" will be empty.
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }}" will be empty.
 # As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
 # Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 #igw_network: "{{ public_network }}"

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -375,7 +375,7 @@
       when: ip_version == 'ipv4'
 
     - name: manage nodes with cephadm - ipv6
-      command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | last | ansible.netcommon.ipwrap }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
+      command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | last | ansible.utils.ipwrap }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
       when: ip_version == 'ipv6'

--- a/infrastructure-playbooks/cephadm.yml
+++ b/infrastructure-playbooks/cephadm.yml
@@ -249,7 +249,7 @@
       when: ip_version == 'ipv4'
 
     - name: manage nodes with cephadm - ipv6
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.netcommon.ipwrap }} {{ group_names | join(' ') }} {{ '_admin' if mon_group_name | default('mons') in group_names else '' }}"
+      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }} {{ group_names | join(' ') }} {{ '_admin' if mon_group_name | default('mons') in group_names else '' }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
       environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # These are Python requirements needed to run ceph-ansible master
-ansible>=3,<4
+ansible>=2.10,<2.11,!=2.9.10
 netaddr
 six

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,5 @@
+---
+# These are Ansible requirements needed to run ceph-ansible main
+collections:
+  - name: ansible.utils
+    version: '>=2.5.0'

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -368,7 +368,7 @@
     - name: add iscsi gateways - ipv6
       command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard iscsi-gateway-add -i -"
       args:
-        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(igw_network.split(',')) | last | ansible.netcommon.ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(igw_network.split(',')) | last | ansible.utils.ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
         stdin_add_newline: no
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -744,7 +744,7 @@ alertmanager_dashboard_api_no_ssl_verify: "{{ true if dashboard_protocol == 'htt
 # For example:
 # If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
 # at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
-# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.netcommon.ipwrap }}" will be empty.
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }}" will be empty.
 # As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
 # Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 igw_network: "{{ public_network }}"

--- a/roles/ceph-facts/tasks/grafana.yml
+++ b/roles/ceph-facts/tasks/grafana.yml
@@ -9,7 +9,7 @@
 
 - name: set grafana_server_addr fact - ipv6
   set_fact:
-    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ansible.netcommon.ipwrap }}"
+    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ansible.utils.ipwrap }}"
   when:
     - groups.get(monitoring_group_name, []) | length > 0
     - ip_version == 'ipv6'
@@ -27,7 +27,7 @@
 
 - name: set grafana_server_addrs fact - ipv6
   set_fact:
-    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ansible.netcommon.ipwrap]) | unique }}"
+    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ansible.utils.ipwrap]) | unique }}"
   with_items: "{{ groups.get(monitoring_group_name, []) }}"
   when:
     - groups.get(monitoring_group_name, []) | length > 0

--- a/roles/ceph-facts/tasks/set_monitor_address.yml
+++ b/roles/ceph-facts/tasks/set_monitor_address.yml
@@ -11,7 +11,7 @@
 
 - name: set_fact _monitor_addresses to monitor_address_block ipv6
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[item]['monitor_address_block'].split(',')) | last | ansible.netcommon.ipwrap }] }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[item]['monitor_address_block'].split(',')) | last | ansible.utils.ipwrap }] }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') |  map(attribute='name') | list"
@@ -21,7 +21,7 @@
 
 - name: set_fact _monitor_addresses to monitor_address
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['monitor_address'] | ansible.netcommon.ipwrap}] }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['monitor_address'] | ansible.utils.ipwrap}] }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
@@ -30,7 +30,7 @@
 
 - name: set_fact _monitor_addresses to monitor_interface - ipv4
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version]['address'] | ansible.netcommon.ipwrap }]  }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version]['address'] | ansible.utils.ipwrap }]  }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
@@ -41,7 +41,7 @@
 
 - name: set_fact _monitor_addresses to monitor_interface - ipv6
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version][0]['address'] | ansible.netcommon.ipwrap }] }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version][0]['address'] | ansible.utils.ipwrap }] }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"

--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -18,7 +18,7 @@
 
 - name: set_fact _radosgw_address to radosgw_address_block ipv6
   set_fact:
-    _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[inventory_hostname]['radosgw_address_block'].split(',')) | last | ansible.netcommon.ipwrap }}"
+    _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[inventory_hostname]['radosgw_address_block'].split(',')) | last | ansible.utils.ipwrap }}"
   when:
     - radosgw_address_block is defined
     - radosgw_address_block != 'subnet'
@@ -26,7 +26,7 @@
 
 - name: set_fact _radosgw_address to radosgw_address
   set_fact:
-    _radosgw_address: "{{ radosgw_address | ansible.netcommon.ipwrap }}"
+    _radosgw_address: "{{ radosgw_address | ansible.utils.ipwrap }}"
   when:
     - radosgw_address is defined
     - radosgw_address != 'x.x.x.x'
@@ -53,7 +53,7 @@
 
     - name: set_fact _radosgw_address to radosgw_interface - ipv6
       set_fact:
-        _radosgw_address: "{{ hostvars[item]['ansible_facts'][_interface][ip_version][0]['address'] | ansible.netcommon.ipwrap }}"
+        _radosgw_address: "{{ hostvars[item]['ansible_facts'][_interface][ip_version][0]['address'] | ansible.utils.ipwrap }}"
       loop: "{{ groups.get(rgw_group_name, []) }}"
       delegate_to: "{{ item }}"
       delegate_facts: true

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@
 testinfra
 pytest-xdist
 pytest
-ansible>=3,<4
+ansible>=2.10,<2.11,!=2.9.10
 Jinja2>=2.10
 netaddr
 mock

--- a/tox-external_clients.ini
+++ b/tox-external_clients.ini
@@ -30,6 +30,7 @@ setenv=
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/external_clients{env:CONTAINER_DIR:}
 commands=
+  ansible-galaxy install -r {toxinidir}/requirements.yml -v
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 

--- a/tox-subset_update.ini
+++ b/tox-subset_update.ini
@@ -56,6 +56,7 @@ commands=
 
   pip uninstall -y ansible
   pip install -r {toxinidir}/tests/requirements.txt
+  ansible-galaxy install -r {toxinidir}/requirements.yml -v
 # upgrade mons
 # mon1
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --limit mon1 --tags=mons --extra-vars "\

--- a/tox.ini
+++ b/tox.ini
@@ -326,6 +326,7 @@ changedir=
   cephadm_adopt: {toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
 
 commands=
+  ansible-galaxy install -r {toxinidir}/requirements.yml -v
   rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
 
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}


### PR DESCRIPTION
ansible.netcommon.ipwrap is deprecated and is not being redirected with ansible 2.9.*

Signed-off-by: Seena Fallah <seenafallah@gmail.com>