### PR TITLE
[skip ci] doc: update ansible version requirement

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -91,7 +91,7 @@ The ``main`` branch should be considered experimental and used with caution.
 
 - ``stable-5.0`` Supports Ceph version ``octopus``. This branch requires Ansible version ``2.9``.
 
-- ``stable-6.0`` Supports Ceph version ``pacific``. This branch requires Ansible version ``2.9``.
+- ``stable-6.0`` Supports Ceph version ``pacific``. This branch requires Ansible version ``2.10``.
 
 - ``main`` Supports the main branch of Ceph. This branch requires Ansible version ``2.10``.
 


### PR DESCRIPTION
This updates the documentation regarding the Ansible version
requirement for `stable-6.0` branch.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>