### PR TITLE
stable-7.0: support Ceph Quincy

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,7 +93,9 @@ The ``master`` branch should be considered experimental and used with caution.
 
 - ``stable-6.0`` Supports Ceph version ``pacific``. This branch requires Ansible version ``2.9``.
 
-- ``master`` Supports the master branch of Ceph. This branch requires Ansible version ``2.10``.
+- ``stable-7.0`` Supports Ceph version ``quincy``. This branch requires Ansible version ``2.12``.
+
+- ``main`` Supports the main (devel) branch of Ceph. This branch requires Ansible version ``2.12``.
 
 .. NOTE:: ``stable-3.0`` and ``stable-3.1`` branches of ceph-ansible are deprecated and no longer maintained.
 

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -746,7 +746,7 @@ dummy:
 # For example:
 # If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
 # at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
-# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}" will be empty.
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }}" will be empty.
 # As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
 # Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 #igw_network: "{{ public_network }}"

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -161,11 +161,11 @@ dummy:
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-#nfs_ganesha_stable_branch: V3.5-stable
-#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-3.0/ubuntu
+#centos_release_nfs: centos-release-nfs-ganesha4
+#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-4/ubuntu
 #nfs_ganesha_apt_keyserver: keyserver.ubuntu.com
 #nfs_ganesha_apt_key_id: EA914D611053D07BD332E18010353E8834DC57CA
-#libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-3.0/ubuntu
+#libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-4/ubuntu
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -561,7 +561,7 @@ dummy:
 # DOCKER #
 ##########
 #ceph_docker_image: "ceph/daemon"
-#ceph_docker_image_tag: latest-master
+#ceph_docker_image_tag: latest-quincy
 #ceph_docker_registry: quay.io
 #ceph_docker_registry_auth: false
 #ceph_docker_registry_username:

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -161,11 +161,11 @@ ceph_repository: rhcs
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-#nfs_ganesha_stable_branch: V3.5-stable
-#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-3.0/ubuntu
+#centos_release_nfs: centos-release-nfs-ganesha4
+#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-4/ubuntu
 #nfs_ganesha_apt_keyserver: keyserver.ubuntu.com
 #nfs_ganesha_apt_key_id: EA914D611053D07BD332E18010353E8834DC57CA
-#libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-3.0/ubuntu
+#libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-4/ubuntu
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -746,7 +746,7 @@ alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alert
 # For example:
 # If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
 # at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
-# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}" will be empty.
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }}" will be empty.
 # As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
 # Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 #igw_network: "{{ public_network }}"

--- a/infrastructure-playbooks/backup-and-restore-ceph-files.yml
+++ b/infrastructure-playbooks/backup-and-restore-ceph-files.yml
@@ -83,14 +83,14 @@
         - name: get a list of files to be restored
           find:
             paths:
-              - "{{ backup_dir }}/{{ hostvars[_node]['ansible_facts']['hostname'] }}"
+              - "{{ backup_dir }}/{{ hostvars[target_node]['ansible_facts']['hostname'] }}"
             recurse: yes
           register: file_to_restore
 
         - name: restore files
           copy:
             src: "{{ item.path }}"
-            dest: "{{ item.path | replace(backup_dir + '/' + hostvars[_node]['ansible_facts']['hostname'], '') }}"
+            dest: "{{ item.path | replace(backup_dir + '/' + hostvars[target_node]['ansible_facts']['hostname'], '') }}"
             mode: preserve
           loop: "{{ file_to_restore.files }}"
           delegate_to: "{{ target_node }}"

--- a/infrastructure-playbooks/backup-and-restore-ceph-files.yml
+++ b/infrastructure-playbooks/backup-and-restore-ceph-files.yml
@@ -1,0 +1,96 @@
+---
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+#
+# This playbook can help in order to backup some Ceph files and restore them later.
+#
+# Usage:
+#
+# ansible-playbook -i <inventory> backup-and-restore-ceph-files.yml -e backup_dir=<backup directory path> -e mode=<backup|restore> -e target_node=<inventory_name>
+#
+# Required run-time variables
+# ------------------
+# backup_dir : a path where files will be read|write.
+# mode : tell the playbook either to backup or restore files.
+# target_node : the name of the node being processed, it must match the name set in the inventory.
+#
+# Examples
+# --------
+# ansible-playbook -i hosts, backup-and-restore-ceph-files.yml -e backup_dir=/usr/share/ceph-ansible/backup-ceph-files -e mode=backup -e target_node=mon01
+# ansible-playbook -i hosts, backup-and-restore-ceph-files.yml -e backup_dir=/usr/share/ceph-ansible/backup-ceph-files -e mode=restore -e target_node=mon01
+
+- hosts: localhost
+  become: true
+  gather_facts: true
+  tasks:
+    - name: exit playbook, if user did not set the source node
+      fail:
+        msg: >
+          "You must pass the node name: -e target_node=<inventory_name>.
+          The name must match what is set in your inventory."
+      when: target_node is not defined
+
+    - name: exit playbook, if user did not set the backup directory
+      fail:
+        msg: >
+          "you must pass the backup directory path: -e backup_dir=<backup directory path>"
+      when: backup_dir is not defined
+
+    - name: exit playbook, if user did not set the playbook mode (backup|restore)
+      fail:
+        msg: >
+          "you must pass the mode: -e mode=<backup|restore>"
+      when:
+        - mode is not defined
+        - mode not in ['backup', 'restore']
+
+    - name: gather facts on source node
+      setup:
+      delegate_to: "{{ target_node }}"
+      delegate_facts: true
+
+    - name: backup mode
+      when: mode == 'backup'
+      block:
+        - name: find files
+          find:
+            paths:
+              - /etc/ceph
+              - /var/lib/ceph
+            recurse: yes
+          register: file_to_backup
+          delegate_to: "{{ target_node }}"
+
+        - name: backup files
+          fetch:
+            src: "{{ item.path }}"
+            dest: "{{ backup_dir }}/{{ hostvars[target_node]['ansible_facts']['hostname'] }}/{{ item.path }}"
+            flat: yes
+          loop: "{{ file_to_backup.files }}"
+          delegate_to: "{{ target_node }}"
+
+        - name: preserve mode
+          file:
+            path: "{{ backup_dir }}/{{ hostvars[target_node]['ansible_facts']['hostname'] }}/{{ item.path }}"
+            mode: "{{ item.mode }}"
+            owner: "{{ item.uid }}"
+            group: "{{ item.gid }}"
+          loop: "{{ file_to_backup.files }}"
+
+    - name: restore mode
+      when: mode == 'restore'
+      block:
+        - name: get a list of files to be restored
+          find:
+            paths:
+              - "{{ backup_dir }}/{{ hostvars[_node]['ansible_facts']['hostname'] }}"
+            recurse: yes
+          register: file_to_restore
+
+        - name: restore files
+          copy:
+            src: "{{ item.path }}"
+            dest: "{{ item.path | replace(backup_dir + '/' + hostvars[_node]['ansible_facts']['hostname'], '') }}"
+            mode: preserve
+          loop: "{{ file_to_restore.files }}"
+          delegate_to: "{{ target_node }}"

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -360,6 +360,14 @@
       delegate_to: '{{ groups[mon_group_name][0] }}'
       when: is_hci | bool
 
+    - name: set autotune_memory_target_ratio
+      command: "{{ ceph_cmd }} config set mgr mgr/cephadm/autotune_memory_target_ratio {{ '0.2' if is_hci | bool else '0.7' }}"
+      changed_when: false
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      run_once: true
+      environment:
+        CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
+
     - name: manage nodes with cephadm - ipv4
       command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv4_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | first }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
       changed_when: false

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -823,6 +823,11 @@
         state: absent
       loop: '{{ (osd_list.stdout | from_json).keys() | list }}'
 
+    - name: remove any legacy directories in /var/lib/ceph/mon (workaround)
+      file:
+        path: "/var/lib/ceph/mon/{{ cluster }}-{{ ansible_facts['hostname'] }}"
+        state: absent
+
     - name: waiting for clean pgs...
       command: "{{ cephadm_cmd }} shell -k /etc/ceph/{{ cluster }}.client.admin.keyring --fsid {{ fsid }} -- ceph pg stat --format json"
       changed_when: false

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -367,7 +367,7 @@
       when: ip_version == 'ipv4'
 
     - name: manage nodes with cephadm - ipv6
-      command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | last | ipwrap }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
+      command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | last | ansible.utils.ipwrap }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
       when: ip_version == 'ipv6'

--- a/infrastructure-playbooks/cephadm.yml
+++ b/infrastructure-playbooks/cephadm.yml
@@ -249,7 +249,7 @@
       when: ip_version == 'ipv4'
 
     - name: manage nodes with cephadm - ipv6
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }} {{ group_names | join(' ') }} {{ '_admin' if mon_group_name | default('mons') in group_names else '' }}"
+      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }} {{ group_names | join(' ') }} {{ '_admin' if mon_group_name | default('mons') in group_names else '' }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
       environment:

--- a/infrastructure-playbooks/filestore-to-bluestore.yml
+++ b/infrastructure-playbooks/filestore-to-bluestore.yml
@@ -138,7 +138,7 @@
               when: item.1.stdout == 'ceph data'
 
             - name: umount osd data
-              mount:
+              ansible.posix.mount:
                 path: "/var/lib/ceph/osd/{{ cluster }}-{{ (item.0.stdout | from_json).whoami }}"
                 state: unmounted
               with_together:
@@ -147,7 +147,7 @@
               when: item.1.stdout == 'ceph data'
 
             - name: umount osd lockbox
-              mount:
+              ansible.posix.mount:
                 path: "/var/lib/ceph/osd-lockbox/{{ (item.0.stdout | from_json).data.uuid }}"
                 state: unmounted
               with_together:

--- a/infrastructure-playbooks/lv-teardown.yml
+++ b/infrastructure-playbooks/lv-teardown.yml
@@ -40,7 +40,7 @@
     changed_when: false
 
   - name: tear down any existing osd filesystem
-    mount:
+    ansible.posix.mount:
       path: "{{ item }}"
       state: unmounted
     with_items: "{{ old_osd_filesystems.stdout_lines }}"

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -686,11 +686,10 @@
         enabled: no
       failed_when: false
 
-    - name: systemctl reset-failed ceph-crash@{{ 'ceph-crash@' + ansible_facts['hostname'] }}  # noqa 303
-      command: "systemctl reset-failed ceph-crash@{{ 'ceph-crash@' + ansible_facts['hostname'] }}"
+    - name: systemctl reset-failed ceph-crash  # noqa 303
+      command: "systemctl reset-failed {{ 'ceph-crash@' + ansible_facts['hostname'] if containerized_deployment | bool else 'ceph-crash.service' }}"
       changed_when: false
       failed_when: false
-      when: containerized_deployment | bool
 
     - name: remove service file
       file:

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -75,7 +75,7 @@
           with_items: "{{ groups[nfs_group_name] }}"
 
         - name: ensure nfs-ganesha mountpoint(s) are unmounted
-          mount:
+          ansible.posix.mount:
             path: "{{ item.split(' ')[1] }}"
             state: unmounted
           with_items:
@@ -434,7 +434,7 @@
         - (containerized_deployment | bool or ceph_volume_present.rc == 0)
 
     - name: umount osd data partition
-      mount:
+      ansible.posix.mount:
         path: "{{ item }}"
         state: unmounted
       with_items: "{{ mounted_osd.stdout_lines }}"
@@ -802,7 +802,7 @@
       listen: "remove data"
 
     - name: umount osd data partition
-      mount:
+      ansible.posix.mount:
         path: "{{ item }}"
         state: unmounted
       with_items: "{{ mounted_osd.stdout_lines }}"

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -151,6 +151,7 @@
 
     - import_role:
         name: ceph-infra
+      tags: ceph_infra
 
     - import_role:
         name: ceph-validate

--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -161,7 +161,7 @@
       delegate_to: "{{ item.0 }}"
 
     - name: umount osd lockbox
-      mount:
+      ansible.posix.mount:
         path: "/var/lib/ceph/osd-lockbox/{{ ceph_osd_data_json[item.2]['data']['uuid'] }}"
         state: absent
       loop: "{{ _osd_hosts }}"
@@ -173,7 +173,7 @@
         - ceph_osd_data_json[item.2]['data']['uuid'] is defined
 
     - name: umount osd data
-      mount:
+      ansible.posix.mount:
         path: "/var/lib/ceph/osd/{{ cluster }}-{{ item.2 }}"
         state: absent
       loop: "{{ _osd_hosts }}"

--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -391,7 +391,7 @@ def create_pool(cluster,
     args = ['create', user_pool_config['pool_name']['value'],
             user_pool_config['type']['value']]
 
-    if user_pool_config['pg_autoscale_mode']['value'] != 'on':
+    if user_pool_config['pg_autoscale_mode']['value'] == 'off':
         args.extend(['--pg_num',
                      user_pool_config['pg_num']['value'],
                      '--pgp_num',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# These are Python requirements needed to run ceph-ansible master
-ansible>=2.10,<2.11,!=2.9.10
+# These are Python requirements needed to run ceph-ansible main
+ansible-core>=2.12,<2.13
 netaddr
 six

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,3 +4,7 @@ collections:
   - name: https://opendev.org/openstack/ansible-config_template
     version: 1.2.1
     type: git
+  - name: ansible.utils
+    version: '>=2.5.0'
+  - name: community.general
+  - name: ansible.posix

--- a/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
+++ b/roles/ceph-common/tasks/installs/prerequisite_rhcs_cdn_install.yml
@@ -2,4 +2,14 @@
 - name: enable red hat storage tools repository
   rhsm_repository:
     name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms"
-  when: (mgr_group_name in group_names or rgw_group_name in group_names or mds_group_name in group_names or nfs_group_name in group_names or iscsi_gw_group_name in group_names or client_group_name in group_names or monitoring_group_name in group_names)
+  when:
+    - mon_group_name in group_names
+      of osd_group_name in group_names
+      or mgr_group_name in group_names
+      or rgw_group_name in group_names
+      or mds_group_name in group_names
+      or nfs_group_name in group_names
+      or iscsi_gw_group_name in group_names
+      or client_group_name in group_names
+      or rbdmirror_group_name in group_names
+      or monitoring_group_name in group_names

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -312,7 +312,7 @@
     - name: add iscsi gateways - ipv6
       command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard iscsi-gateway-add -i -"
       args:
-        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(igw_network.split(',')) | last | ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(igw_network.split(',')) | last | ansible.utils.ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
         stdin_add_newline: no
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -153,11 +153,11 @@ ceph_stable_release: quincy
 ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-nfs_ganesha_stable_branch: V3.5-stable
-nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-3.0/ubuntu
+centos_release_nfs: centos-release-nfs-ganesha4
+nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-4/ubuntu
 nfs_ganesha_apt_keyserver: keyserver.ubuntu.com
 nfs_ganesha_apt_key_id: EA914D611053D07BD332E18010353E8834DC57CA
-libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-3.0/ubuntu
+libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-4/ubuntu
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -738,7 +738,7 @@ alertmanager_dashboard_api_no_ssl_verify: "{{ true if dashboard_protocol == 'htt
 # For example:
 # If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
 # at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
-# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}" will be empty.
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }}" will be empty.
 # As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
 # Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 igw_network: "{{ public_network }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -553,7 +553,7 @@ ceph_tcmalloc_max_total_thread_cache: 134217728
 # DOCKER #
 ##########
 ceph_docker_image: "ceph/daemon"
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy
 ceph_docker_registry: quay.io
 ceph_docker_registry_auth: false
 #ceph_docker_registry_username:

--- a/roles/ceph-facts/tasks/grafana.yml
+++ b/roles/ceph-facts/tasks/grafana.yml
@@ -9,7 +9,7 @@
 
 - name: set grafana_server_addr fact - ipv6
   set_fact:
-    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ipwrap }}"
+    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ansible.utils.ipwrap }}"
   when:
     - groups.get(monitoring_group_name, []) | length > 0
     - ip_version == 'ipv6'
@@ -27,7 +27,7 @@
 
 - name: set grafana_server_addrs fact - ipv6
   set_fact:
-    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ipwrap]) | unique }}"
+    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ipansible.utils.ipwrapwrap]) | unique }}"
   with_items: "{{ groups.get(monitoring_group_name, []) }}"
   when:
     - groups.get(monitoring_group_name, []) | length > 0

--- a/roles/ceph-facts/tasks/set_monitor_address.yml
+++ b/roles/ceph-facts/tasks/set_monitor_address.yml
@@ -11,7 +11,7 @@
 
 - name: set_fact _monitor_addresses to monitor_address_block ipv6
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[item]['monitor_address_block'].split(',')) | last | ipwrap }] }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[item]['monitor_address_block'].split(',')) | last | ansible.utils.ipwrap }] }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') |  map(attribute='name') | list"
@@ -21,7 +21,7 @@
 
 - name: set_fact _monitor_addresses to monitor_address
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['monitor_address'] | ipwrap}] }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['monitor_address'] | ansible.utils.ipwrap}] }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
@@ -30,7 +30,7 @@
 
 - name: set_fact _monitor_addresses to monitor_interface - ipv4
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version]['address'] | ipwrap }]  }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version]['address'] | ansible.utils.ipwrap }]  }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
@@ -41,7 +41,7 @@
 
 - name: set_fact _monitor_addresses to monitor_interface - ipv6
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version][0]['address'] | ipwrap }] }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version][0]['address'] | ansible.utils.ipwrap }] }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"

--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -9,7 +9,7 @@
 
 - name: set_fact _radosgw_address to radosgw_address_block ipv6
   set_fact:
-    _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[inventory_hostname]['radosgw_address_block'].split(',')) | last | ipwrap }}"
+    _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[inventory_hostname]['radosgw_address_block'].split(',')) | last | ansible.utils.ipwrap }}"
   when:
     - radosgw_address_block is defined
     - radosgw_address_block != 'subnet'
@@ -17,7 +17,7 @@
 
 - name: set_fact _radosgw_address to radosgw_address
   set_fact:
-    _radosgw_address: "{{ radosgw_address | ipwrap }}"
+    _radosgw_address: "{{ radosgw_address | ansible.utils.ipwrap }}"
   when:
     - radosgw_address is defined
     - radosgw_address != 'x.x.x.x'
@@ -39,7 +39,7 @@
 
     - name: set_fact _radosgw_address to radosgw_interface - ipv6
       set_fact:
-        _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts'][_interface][ip_version][0]['address'] | ipwrap }}"
+        _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts'][_interface][ip_version][0]['address'] | ansible.utils.ipwrap }}"
       when: ip_version == 'ipv6'
 
 - name: set_fact rgw_instances without rgw multisite

--- a/roles/ceph-grafana/tasks/configure_grafana.yml
+++ b/roles/ceph-grafana/tasks/configure_grafana.yml
@@ -36,7 +36,7 @@
 
 - name: download ceph grafana dashboards
   get_url:
-    url: "https://raw.githubusercontent.com/ceph/ceph/{{ grafana_dashboard_version }}/monitoring/grafana/dashboards/{{ item }}"
+    url: "https://raw.githubusercontent.com/ceph/ceph/{{ grafana_dashboard_version }}/monitoring/ceph-mixin/dashboards_out/{{ item }}"
     dest: "/etc/grafana/dashboards/ceph-dashboard/{{ item }}"
   with_items: "{{ grafana_dashboard_files }}"
   when:

--- a/roles/ceph-handler/templates/restart_nfs_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_nfs_daemon.sh.j2
@@ -3,7 +3,7 @@
 RETRIES="{{ handler_health_nfs_check_retries }}"
 DELAY="{{ handler_health_nfs_check_delay }}"
 NFS_NAME="ceph-nfs@{{ ceph_nfs_service_suffix | default(ansible_facts['hostname']) }}"
-PID=/var/run/ganesha.pid
+PID=/var/run/ganesha/ganesha.pid
 {% if containerized_deployment | bool %}
 DOCKER_EXEC="{{ container_binary }} exec ceph-nfs-{{ ceph_nfs_service_suffix | default(ansible_facts['hostname']) }}"
 {% endif %}

--- a/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_non_container_red_hat.yml
@@ -8,24 +8,9 @@
         - ceph_repository == 'community'
       block:
         - name: add nfs-ganesha stable repository
-          yum_repository:
-            name: nfs_ganesha_stable
-            description: nfs-ganesha stable repo
-            gpgcheck: yes
+          package:
+            name: "{{ centos_release_nfs }}"
             state: present
-            gpgkey: "{{ ceph_stable_key }}"
-            baseurl: "{{ ceph_mirror }}/nfs-ganesha/rpm-{{ nfs_ganesha_stable_branch }}/{{ ceph_release }}/el$releasever/$basearch"
-            file: nfs_ganesha_stable
-
-        - name: add nfs-ganesha stable noarch repository
-          yum_repository:
-            name: nfs_ganesha_stable_noarch
-            description: nfs-ganesha stable noarch repo
-            gpgcheck: yes
-            state: present
-            gpgkey: "{{ ceph_stable_key }}"
-            baseurl: "{{ ceph_mirror }}/nfs-ganesha/rpm-{{ nfs_ganesha_stable_branch }}/{{ ceph_release }}/el$releasever/noarch"
-            file: nfs_ganesha_stable
 
     - name: red hat based systems - dev repo related tasks
       block:

--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -6,8 +6,8 @@
 
 - name: fail on unsupported ansible version
   fail:
-    msg: "Ansible version must be 2.10!"
-  when: ansible_version.minor|int != 10
+    msg: "Ansible version must be 2.12!"
+  when: ansible_version.minor|int != 12
 
 - name: fail on unsupported system
   fail:

--- a/tests/functional/add-mdss/container/group_vars/all
+++ b/tests/functional/add-mdss/container/group_vars/all
@@ -29,4 +29,4 @@ ceph_conf_overrides:
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/add-mdss/container/vagrant_variables.yml
+++ b/tests/functional/add-mdss/container/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/add-mdss/vagrant_variables.yml
+++ b/tests/functional/add-mdss/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/add-mgrs/container/group_vars/all
+++ b/tests/functional/add-mgrs/container/group_vars/all
@@ -29,4 +29,4 @@ ceph_conf_overrides:
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/add-mgrs/container/vagrant_variables.yml
+++ b/tests/functional/add-mgrs/container/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/add-mgrs/vagrant_variables.yml
+++ b/tests/functional/add-mgrs/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/add-mons/container/group_vars/all
+++ b/tests/functional/add-mons/container/group_vars/all
@@ -29,4 +29,4 @@ ceph_conf_overrides:
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/add-osds/container/group_vars/all
+++ b/tests/functional/add-osds/container/group_vars/all
@@ -29,4 +29,4 @@ ceph_conf_overrides:
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/add-osds/container/vagrant_variables.yml
+++ b/tests/functional/add-osds/container/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/add-osds/vagrant_variables.yml
+++ b/tests/functional/add-osds/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/add-rbdmirrors/container/group_vars/all
+++ b/tests/functional/add-rbdmirrors/container/group_vars/all
@@ -29,4 +29,4 @@ ceph_conf_overrides:
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/add-rbdmirrors/container/vagrant_variables.yml
+++ b/tests/functional/add-rbdmirrors/container/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/add-rbdmirrors/vagrant_variables.yml
+++ b/tests/functional/add-rbdmirrors/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/add-rgws/container/group_vars/all
+++ b/tests/functional/add-rgws/container/group_vars/all
@@ -31,4 +31,4 @@ rgw_bucket_default_quota_max_objects: 1638400
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/add-rgws/container/vagrant_variables.yml
+++ b/tests/functional/add-rgws/container/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/add-rgws/vagrant_variables.yml
+++ b/tests/functional/add-rgws/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/all-in-one/container/group_vars/all
+++ b/tests/functional/all-in-one/container/group_vars/all
@@ -45,4 +45,4 @@ lvm_volumes:
     db_vg: journals
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/all-in-one/container/vagrant_variables.yml
+++ b/tests/functional/all-in-one/container/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-# client_vagrant_box: centos/7
+# client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/all-in-one/vagrant_variables.yml
+++ b/tests/functional/all-in-one/vagrant_variables.yml
@@ -39,8 +39,8 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
-# client_vagrant_box: centos/7
+vagrant_box: centos/stream8
+# client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -38,7 +38,7 @@ dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy
 node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"

--- a/tests/functional/all_daemons/container/vagrant_variables.yml
+++ b/tests/functional/all_daemons/container/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-#client_vagrant_box: centos/7
+#client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/all_daemons/hosts
+++ b/tests/functional/all_daemons/hosts
@@ -23,8 +23,8 @@ rgw0
 client0
 client1
 
-#[nfss]
-#nfs0
+[nfss]
+nfs0
 
 [rbdmirrors]
 rbd-mirror0

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/all_daemons/vagrant_variables.yml
+++ b/tests/functional/all_daemons/vagrant_variables.yml
@@ -8,7 +8,7 @@ mon_vms: 3
 osd_vms: 3
 mds_vms: 3
 rgw_vms: 1
-nfs_vms: 0
+nfs_vms: 1
 grafana_server_vms: 0
 rbd_mirror_vms: 1
 client_vms: 2

--- a/tests/functional/cephadm/group_vars/all
+++ b/tests/functional/cephadm/group_vars/all
@@ -5,5 +5,5 @@ cluster_network: "192.168.31.0/24"
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon-base
-ceph_docker_image_tag: latest-master-devel
+ceph_docker_image_tag: latest-quincy-devel
 containerized_deployment: true

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -27,7 +27,7 @@ dashboard_admin_user_ro: true
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy
 node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"

--- a/tests/functional/collocation/container/vagrant_variables.yml
+++ b/tests/functional/collocation/container/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-# client_vagrant_box: centos/7
+# client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/collocation/vagrant_variables.yml
+++ b/tests/functional/collocation/vagrant_variables.yml
@@ -39,8 +39,8 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
-# client_vagrant_box: centos/7
+vagrant_box: centos/stream8
+# client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/docker2podman/group_vars/all
+++ b/tests/functional/docker2podman/group_vars/all
@@ -35,7 +35,7 @@ dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy
 node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"

--- a/tests/functional/docker2podman/vagrant_variables.yml
+++ b/tests/functional/docker2podman/vagrant_variables.yml
@@ -23,7 +23,7 @@ cluster_subnet: 192.168.59
 # set 1024 for CentOS
 memory: 2048
 
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 #vagrant_sync_dir: /home/vagrant/sync

--- a/tests/functional/external_clients/container/inventory/group_vars/all
+++ b/tests/functional/external_clients/container/inventory/group_vars/all
@@ -39,4 +39,4 @@ fsid: 40358a87-ab6e-4bdc-83db-1d909147861c
 generate_fsid: false
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/external_clients/container/vagrant_variables.yml
+++ b/tests/functional/external_clients/container/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-# client_vagrant_box: centos/7
+# client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/external_clients/vagrant_variables.yml
+++ b/tests/functional/external_clients/vagrant_variables.yml
@@ -39,8 +39,8 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
-# client_vagrant_box: centos/7
+vagrant_box: centos/stream8
+# client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/filestore-to-bluestore/container/group_vars/all
+++ b/tests/functional/filestore-to-bluestore/container/group_vars/all
@@ -25,4 +25,4 @@ handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/filestore-to-bluestore/vagrant_variables.yml
+++ b/tests/functional/filestore-to-bluestore/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/infra_lv_create/vagrant_variables.yml
+++ b/tests/functional/infra_lv_create/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/lvm-auto-discovery/container/group_vars/all
+++ b/tests/functional/lvm-auto-discovery/container/group_vars/all
@@ -29,4 +29,4 @@ handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/lvm-auto-discovery/vagrant_variables.yml
+++ b/tests/functional/lvm-auto-discovery/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/lvm-batch/container/group_vars/all
+++ b/tests/functional/lvm-batch/container/group_vars/all
@@ -31,4 +31,4 @@ handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/lvm-batch/vagrant_variables.yml
+++ b/tests/functional/lvm-batch/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/lvm-osds/container/group_vars/all
+++ b/tests/functional/lvm-osds/container/group_vars/all
@@ -39,4 +39,4 @@ openstack_pools:
   - "{{ openstack_cinder_pool }}"
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/lvm-osds/vagrant_variables.yml
+++ b/tests/functional/lvm-osds/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/migrate_ceph_disk_to_ceph_volume/vagrant_variables.yml
+++ b/tests/functional/migrate_ceph_disk_to_ceph_volume/vagrant_variables.yml
@@ -52,7 +52,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/ooo-collocation/hosts
+++ b/tests/functional/ooo-collocation/hosts
@@ -11,7 +11,7 @@ all:
         rgw_keystone_url: 'http://192.168.95.10:5000', rgw_s3_auth_use_keystone: 'true', rgw_keystone_revocation_interval: 0}
     cluster: mycluster
     ceph_docker_image: ceph-ci/daemon
-    ceph_docker_image_tag: latest-master
+    ceph_docker_image_tag: latest-quincy
     ceph_docker_registry: quay.ceph.io
     cephfs_data_pool:
       name: 'manila_data'

--- a/tests/functional/ooo-collocation/vagrant_variables.yml
+++ b/tests/functional/ooo-collocation/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb', '/dev/sdc' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-# client_vagrant_box: centos/7
+# client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/podman/group_vars/all
+++ b/tests/functional/podman/group_vars/all
@@ -34,7 +34,7 @@ dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy
 node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"

--- a/tests/functional/rgw-multisite/container/group_vars/all
+++ b/tests/functional/rgw-multisite/container/group_vars/all
@@ -30,4 +30,4 @@ ceph_conf_overrides:
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/rgw-multisite/container/secondary/group_vars/all
+++ b/tests/functional/rgw-multisite/container/secondary/group_vars/all
@@ -30,4 +30,4 @@ ceph_conf_overrides:
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/rgw-multisite/secondary/vagrant_variables.yml
+++ b/tests/functional/rgw-multisite/secondary/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/rgw-multisite/vagrant_variables.yml
+++ b/tests/functional/rgw-multisite/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -69,7 +69,7 @@
 
     # mount -o remount doesn't work on RHEL 8 for now
     - name: add mount options to /
-      mount:
+      ansible.posix.mount:
         path: '{{ rootmount.mount }}'
         src: '{{ rootmount.device }}'
         opts: "noatime,nodiratime{% if ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] | int < 8 %},nobarrier{% endif %}"

--- a/tests/functional/shrink_mds/container/group_vars/all
+++ b/tests/functional/shrink_mds/container/group_vars/all
@@ -18,4 +18,4 @@ dashboard_enabled: False
 copy_admin_key: True
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/shrink_mds/container/vagrant_variables.yml
+++ b/tests/functional/shrink_mds/container/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-#client_vagrant_box: centos/7
+#client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/shrink_mds/vagrant_variables.yml
+++ b/tests/functional/shrink_mds/vagrant_variables.yml
@@ -48,7 +48,7 @@ disks: [ '/dev/sdb', '/dev/sdc' ]
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant
 vagrant_sync_dir: /home/vagrant/sync

--- a/tests/functional/shrink_mgr/container/group_vars/all
+++ b/tests/functional/shrink_mgr/container/group_vars/all
@@ -17,4 +17,4 @@ openstack_config: False
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/shrink_mgr/container/vagrant_variables.yml
+++ b/tests/functional/shrink_mgr/container/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-#client_vagrant_box: centos/7
+#client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/shrink_mgr/vagrant_variables.yml
+++ b/tests/functional/shrink_mgr/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/shrink_mon/container/group_vars/all
+++ b/tests/functional/shrink_mon/container/group_vars/all
@@ -17,4 +17,4 @@ openstack_config: False
 dashboard_enabled: False
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/shrink_mon/container/vagrant_variables.yml
+++ b/tests/functional/shrink_mon/container/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-#client_vagrant_box: centos/7
+#client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/shrink_mon/vagrant_variables.yml
+++ b/tests/functional/shrink_mon/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/shrink_osd/container/group_vars/all
+++ b/tests/functional/shrink_osd/container/group_vars/all
@@ -18,4 +18,4 @@ dashboard_enabled: False
 copy_admin_key: True
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/shrink_osd/container/vagrant_variables.yml
+++ b/tests/functional/shrink_osd/container/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-#client_vagrant_box: centos/7
+#client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/shrink_osd/vagrant_variables.yml
+++ b/tests/functional/shrink_osd/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/shrink_rbdmirror/container/group_vars/all
+++ b/tests/functional/shrink_rbdmirror/container/group_vars/all
@@ -17,4 +17,4 @@ dashboard_enabled: False
 copy_admin_key: True
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/shrink_rbdmirror/container/vagrant_variables.yml
+++ b/tests/functional/shrink_rbdmirror/container/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-#client_vagrant_box: centos/7
+#client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/shrink_rbdmirror/vagrant_variables.yml
+++ b/tests/functional/shrink_rbdmirror/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/shrink_rgw/container/group_vars/all
+++ b/tests/functional/shrink_rgw/container/group_vars/all
@@ -19,4 +19,4 @@ dashboard_enabled: False
 copy_admin_key: True
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy

--- a/tests/functional/shrink_rgw/container/vagrant_variables.yml
+++ b/tests/functional/shrink_rgw/container/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-#client_vagrant_box: centos/7
+#client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/shrink_rgw/vagrant_variables.yml
+++ b/tests/functional/shrink_rgw/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/subset_update/container/group_vars/all
+++ b/tests/functional/subset_update/container/group_vars/all
@@ -29,7 +29,7 @@ dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.ceph.io
 ceph_docker_image: ceph-ci/daemon
-ceph_docker_image_tag: latest-master
+ceph_docker_image_tag: latest-quincy
 node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
 alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"

--- a/tests/functional/subset_update/container/vagrant_variables.yml
+++ b/tests/functional/subset_update/container/vagrant_variables.yml
@@ -44,7 +44,7 @@ disks: "[ '/dev/sda', '/dev/sdb' ]"
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
 vagrant_box: centos/atomic-host
-#client_vagrant_box: centos/7
+#client_vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/functional/subset_update/vagrant_variables.yml
+++ b/tests/functional/subset_update/vagrant_variables.yml
@@ -51,7 +51,7 @@ disks: "[ '/dev/sdb', '/dev/sdc' ]"
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/7
+vagrant_box: centos/stream8
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box
 # Set to /home/vagrant/sync for Centos/7, /home/{ user }/vagrant for openstack and defaults to /vagrant

--- a/tests/library/test_cephadm_bootstrap.py
+++ b/tests/library/test_cephadm_bootstrap.py
@@ -4,7 +4,7 @@ import ca_test_common
 import cephadm_bootstrap
 
 fake_fsid = '0f1e0605-db0b-485c-b366-bd8abaa83f3b'
-fake_image = 'quay.ceph.io/ceph/daemon-base:latest-master-devel'
+fake_image = 'quay.ceph.io/ceph/daemon-base:latest-quincy-devel'
 fake_ip = '192.168.42.1'
 fake_registry = 'quay.ceph.io'
 fake_registry_user = 'foo'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,8 @@
 # These are Python requirements needed to run the functional tests
-testinfra>=3,<4
-pytest-xdist==1.28.0
-pytest>=4.6,<5.0
-ansible>=2.10,<2.11,!=2.9.10
+testinfra
+pytest-xdist
+pytest
+ansible-core>=2.12,<2.13
 Jinja2>=2.10
 netaddr
 mock

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,5 +7,5 @@ Jinja2>=2.10
 netaddr
 mock
 jmespath
-pytest-rerunfailures<9.0
+pytest-rerunfailures
 pytest-cov

--- a/tox-external_clients.ini
+++ b/tox-external_clients.ini
@@ -38,11 +38,8 @@ commands=
   # configure lvm
   ansible-playbook -vv -i {changedir}/inventory/hosts {toxinidir}/tests/functional/lvm_setup.yml
 
-  non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup=True change_dir={changedir} ceph_dev_branch=master ceph_dev_sha1=latest" --tags "vagrant_setup"
   ansible-playbook -vv -i {changedir}/inventory/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --limit 'all:!clients' --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      ceph_dev_branch=master \
-      ceph_dev_sha1=latest \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -55,8 +52,6 @@ commands=
       fsid=40358a87-ab6e-4bdc-83db-1d909147861c \
       external_cluster_mon_ips=192.168.31.10,192.168.31.11,192.168.31.12 \
       generate_fsid=false \
-      ceph_dev_branch=master \
-      ceph_dev_sha1=latest \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -69,8 +64,6 @@ commands=
       fsid=40358a87-ab6e-4bdc-83db-1d909147861c \
       external_cluster_mon_ips=192.168.31.10,192.168.31.11,192.168.31.12 \
       generate_fsid=false \
-      ceph_dev_branch=master \
-      ceph_dev_sha1=latest \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \

--- a/tox-filestore_to_bluestore.ini
+++ b/tox-filestore_to_bluestore.ini
@@ -30,7 +30,7 @@ setenv=
   non_container: PLAYBOOK = site.yml.sample
   non_container: DEV_SETUP = True
 
-  CEPH_DOCKER_IMAGE_TAG = latest-master
+  CEPH_DOCKER_IMAGE_TAG = latest-quincy
 
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/filestore-to-bluestore{env:CONTAINER_DIR:}
@@ -40,25 +40,17 @@ commands=
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/setup.yml
 
-  ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
-
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml --limit 'osd0:osd1'
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml --limit 'osd3:osd4' --tags partitions
 
   # deploy the cluster
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
   "
-  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/filestore-to-bluestore.yml --limit osds --extra-vars "\
-      delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
-  "
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/filestore-to-bluestore.yml --limit osds --extra-vars "delegate_facts_host={env:DELEGATE_FACTS_HOST:True}"
 
   bash -c "CEPH_STABLE_RELEASE=quincy py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests"
 

--- a/tox-shrink_osd.ini
+++ b/tox-shrink_osd.ini
@@ -69,9 +69,9 @@ setenv=
   container: PURGE_PLAYBOOK = purge-container-cluster.yml
   non_container: PLAYBOOK = site.yml.sample
 
-  CEPH_DOCKER_IMAGE_TAG = latest-master
-  CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-master
-  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
+  CEPH_DOCKER_IMAGE_TAG = latest-quincy
+  CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-quincy
+  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-quincy
 
 deps= -r{toxinidir}/tests/requirements.txt
 changedir=
@@ -80,8 +80,6 @@ changedir=
 
 
 commands=
-  ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
-
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
@@ -92,8 +90,6 @@ commands=
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -101,7 +97,7 @@ commands=
 
   # test cluster state using ceph-ansible tests
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
-  
+
   shrink_osd_single: {[shrink-osd-single]commands}
   shrink_osd_multiple: {[shrink-osd-multiple]commands}
 
@@ -109,8 +105,6 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --limit osds --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \

--- a/tox-subset_update.ini
+++ b/tox-subset_update.ini
@@ -28,9 +28,7 @@ setenv=
   container: PLAYBOOK = site-container.yml.sample
   non_container: PLAYBOOK = site.yml.sample
 
-  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
-  UPDATE_CEPH_DEV_BRANCH = master
-  UPDATE_CEPH_DEV_SHA1 = latest
+  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-quincy
   ROLLING_UPDATE = True
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/subset_update{env:CONTAINER_DIR:}
@@ -40,11 +38,8 @@ commands=
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/setup.yml
 
-  non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup=True change_dir={changedir} ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -54,8 +49,6 @@ commands=
 # mon1
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --limit mon1 --tags=mons --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -63,8 +56,6 @@ commands=
 # mon0 and mon2
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --limit 'mons:!mon1' --tags=mons --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -72,8 +63,6 @@ commands=
 # upgrade mgrs
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --tags=mgrs --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -81,8 +70,6 @@ commands=
 # upgrade osd1
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --limit=osd1 --tags=osds --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -90,8 +77,6 @@ commands=
 # upgrade remaining osds (serially)
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --limit='osds:!osd1' --tags=osds --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -99,8 +84,6 @@ commands=
 # upgrade rgws
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --tags=rgws --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -108,8 +91,6 @@ commands=
 # post upgrade actions
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --tags=post_upgrade --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -28,35 +28,46 @@ setenv=
   container: PLAYBOOK = site-container.yml.sample
   non_container: PLAYBOOK = site.yml.sample
 
-  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
-  UPDATE_CEPH_DEV_BRANCH = master
-  UPDATE_CEPH_DEV_SHA1 = latest
+  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-quincy
   ROLLING_UPDATE = True
-deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
 commands=
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
-  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/setup.yml
+  # use the stable-6.0 branch to deploy an octopus cluster
+  git clone -b stable-6.0 --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
+  ansible-galaxy install -r {envdir}/tmp/ceph-ansible/requirements.yml -v
+
+
+  bash -c 'ANSIBLE_CONFIG={envdir}/tmp/ceph-ansible/ansible.cfg ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/hosts {envdir}/tmp/ceph-ansible/tests/functional/setup.yml'
 
   # configure lvm, we exclude osd2 given this node uses lvm batch scenario (see corresponding inventory host file)
-  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml --limit 'osds:!osd2'
+  bash -c 'ANSIBLE_CONFIG={envdir}/tmp/ceph-ansible/ansible.cfg ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/hosts {envdir}/tmp/ceph-ansible/tests/functional/lvm_setup.yml --extra-vars "osd_scenario=lvm" --limit "osds:!osd2"'
 
-  non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup=True change_dir={changedir} ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
-  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
+  # deploy the cluster
+  # passing ceph_nfs_rgw_access_key and ceph_nfs_rgw_secret_key because of a weird behavior in the CI:
+  # When rendering the ganesha.conf.j2 template, it complains because of undefined variables in the block "{% if nfs_obj_gw | bool %}" although we explicitly set this variable to false (see below).
+  bash -c 'ANSIBLE_CONFIG={envdir}/tmp/ceph-ansible/ansible.cfg ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/hosts {envdir}/tmp/ceph-ansible/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.ceph.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph-ci/daemon} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-pacific} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
-  "
+      nfs_file_gw=True \
+      nfs_obj_gw=False \
+      ceph_nfs_rgw_access_key=fake_access_key \
+      ceph_nfs_rgw_secret_key=fake_secret_key \
+  "'
 
+  pip uninstall -y ansible
+  pip install -r {toxinidir}/tests/requirements.txt
+  ansible-galaxy install -r {toxinidir}/requirements.yml -v -f
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:UPDATE_CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:UPDATE_CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -43,6 +43,13 @@ commands=
 
   bash -c 'ANSIBLE_CONFIG={envdir}/tmp/ceph-ansible/ansible.cfg ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/hosts {envdir}/tmp/ceph-ansible/tests/functional/setup.yml'
 
+#  # use the stable-7.0 branch to deploy an octopus cluster
+#  git clone -b stable-7.0 --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+#  pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
+#  bash -c 'ANSIBLE_CONFIG={envdir}/tmp/ceph-ansible/ansible.cfg ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/hosts {envdir}/tmp/ceph-ansible/tests/functional/setup.yml'
+#  # configure lvm, we exclude osd2 given this node uses lvm batch scenario (see corresponding inventory host file)
+#  bash -c 'ANSIBLE_CONFIG={envdir}/tmp/ceph-ansible/ansible.cfg ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/hosts {envdir}/tmp/ceph-ansible/tests/functional/lvm_setup.yml --extra-vars "osd_scenario=lvm"'
+
   # configure lvm, we exclude osd2 given this node uses lvm batch scenario (see corresponding inventory host file)
   bash -c 'ANSIBLE_CONFIG={envdir}/tmp/ceph-ansible/ansible.cfg ansible-playbook -vv -i {envdir}/tmp/ceph-ansible/tests/functional/all_daemons{env:CONTAINER_DIR:}/hosts {envdir}/tmp/ceph-ansible/tests/functional/lvm_setup.yml --extra-vars "osd_scenario=lvm" --limit "osds:!osd2"'
 

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/rbd_map_devices.yml --extra-vars "\
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.ceph.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph-ci/daemon} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-quincy} \
   "
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
@@ -53,7 +53,7 @@ commands=
       remove_packages=yes \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.ceph.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph-ci/daemon} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-quincy} \
   "
 
   # re-setup lvm, we exclude osd2 given this node uses lvm batch scenario (see corresponding inventory host file)
@@ -61,8 +61,6 @@ commands=
 
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars @ceph-override.json --extra-vars "\
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -76,13 +74,11 @@ commands=
       ireallymeanit=yes \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.ceph.io} \
       ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph-ci/daemon} \
-      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+      ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-quincy} \
   "
 
   # set up the cluster again
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars @ceph-override.json --extra-vars "\
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -103,10 +99,7 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml
 
   # set up the cluster again
-  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
-  "
+  ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample}
   # test that the cluster can be redeployed in a healthy state
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 
@@ -155,7 +148,7 @@ commands=
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml --extra-vars "\
       ireallymeanit=yes \
-      ceph_docker_image_tag=latest-master-devel \
+      ceph_docker_image_tag=latest-quincy-devel \
       ceph_docker_registry=quay.ceph.io \
       ceph_docker_image=ceph-ci/daemon \
       ceph_docker_registry_auth=True \
@@ -172,11 +165,7 @@ commands=
 [add-mons]
 commands=
   ansible-playbook -vv -i {changedir}/hosts-2 --limit mon1 {toxinidir}/tests/functional/setup.yml
-  ansible-playbook -vv -i {changedir}/hosts-2 {toxinidir}/infrastructure-playbooks/add-mon.yml --extra-vars "\
-      ireallymeanit=yes \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
-      "
+  ansible-playbook -vv -i {changedir}/hosts-2 {toxinidir}/infrastructure-playbooks/add-mon.yml --extra-vars "ireallymeanit=yes"
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts-2 --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 
 [add-mgrs]
@@ -184,8 +173,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts-2 --limit mgrs {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i {changedir}/hosts-2 --limit mgrs {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -197,8 +184,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts-2 --limit mdss {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i {changedir}/hosts-2 --limit mdss {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -210,8 +195,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts-2 --limit rbdmirrors {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i {changedir}/hosts-2 --limit rbdmirrors {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -223,8 +206,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts-2 --limit rgws {toxinidir}/tests/functional/setup.yml
   ansible-playbook -vv -i {changedir}/hosts-2 --limit rgws {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -236,22 +217,18 @@ commands=
   bash -c "cd {changedir}/secondary && bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}"
   bash -c "cd {changedir}/secondary && bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}/secondary"
   ansible-playbook --ssh-common-args='-F {changedir}/secondary/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/setup.yml
-  ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir}/secondary ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
+  ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir}/secondary" --tags "vagrant_setup"
   ansible-playbook --ssh-common-args='-F {changedir}/secondary/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey' -vv -i {changedir}/secondary/hosts {toxinidir}/tests/functional/lvm_setup.yml
   # ensure the rule isn't already present
   ansible -i localhost, all -c local -b -m iptables -a 'chain=FORWARD protocol=tcp source=192.168.0.0/16 destination=192.168.0.0/16 jump=ACCEPT action=insert rule_num=1 state=absent'
   ansible -i localhost, all -c local -b -m iptables -a 'chain=FORWARD protocol=tcp source=192.168.0.0/16 destination=192.168.0.0/16 jump=ACCEPT action=insert rule_num=1 state=present'
   ansible-playbook --ssh-common-args='-F {changedir}/secondary/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey' -vv -i {changedir}/secondary/hosts {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       ireallymeanit=yes \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
       "
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --limit rgws --extra-vars "\
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -267,7 +244,7 @@ commands=
 [storage-inventory]
 commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/infrastructure-playbooks/storage-inventory.yml --extra-vars "\
-    ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-master} \
+    ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-quincy} \
   "
 
 [cephadm-adopt]
@@ -317,11 +294,11 @@ setenv=
   shrink_rbdmirror: RBDMIRROR_TO_KILL = rbd-mirror0
   shrink_rgw: RGW_TO_KILL = rgw0.rgw0
 
-  CEPH_DOCKER_IMAGE_TAG = latest-master
-  CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-master
-  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-master
+  CEPH_DOCKER_IMAGE_TAG = latest-quincy
+  CEPH_DOCKER_IMAGE_TAG_BIS = latest-bis-quincy
+  UPDATE_CEPH_DOCKER_IMAGE_TAG = latest-quincy
 
-  switch_to_containers: CEPH_DOCKER_IMAGE_TAG = latest-master-devel
+  switch_to_containers: CEPH_DOCKER_IMAGE_TAG = latest-quincy-devel
 
 deps= -r{toxinidir}/tests/requirements.txt
 changedir=
@@ -355,7 +332,6 @@ changedir=
 commands=
   ansible-galaxy install -r {toxinidir}/requirements.yml -v
   rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
-  non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
 
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
@@ -370,8 +346,6 @@ commands=
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
       deploy_secondary_zones=False \
-      ceph_dev_branch={env:CEPH_DEV_BRANCH:master} \
-      ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -387,7 +361,7 @@ commands=
   all_daemons,collocation: py.test --reruns 20 --reruns-delay 3 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
 
   # handlers/idempotency test
-  all_daemons,all_in_one,collocation: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "delegate_facts_host={env:DELEGATE_FACTS_HOST:True} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-bis-master} ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --extra-vars @ceph-override.json
+  all_daemons,all_in_one,collocation: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "delegate_facts_host={env:DELEGATE_FACTS_HOST:True} ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG_BIS:latest-bis-quincy}" --extra-vars @ceph-override.json
 
   purge: {[purge]commands}
   purge_dashboard: {[purge-dashboard]commands}


### PR DESCRIPTION
This adds required changes in order to support Ceph Quincy
with `stable-7.0` branch.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>