### PR TITLE
[skip ci] facts: fix deployments with different net interface names

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -252,7 +252,7 @@
   when: groups.get(mon_group_name, []) | length > 0
 
 - name: import_tasks set_radosgw_address.yml
-  import_tasks: set_radosgw_address.yml
+  include_tasks: set_radosgw_address.yml
   when: inventory_hostname in groups.get(rgw_group_name, [])
 
 - name: set_fact use_new_ceph_iscsi package or old ceph-iscsi-config/cli

--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -30,16 +30,26 @@
   block:
     - name: set_fact _interface
       set_fact:
-        _interface: "{{ (radosgw_interface | replace('-', '_')) }}"
+        _interface: "{{ (hostvars[item]['radosgw_interface'] | replace('-', '_')) }}"
+      loop: "{{ groups.get(rgw_group_name, []) }}"
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      run_once: true
 
     - name: set_fact _radosgw_address to radosgw_interface - ipv4
       set_fact:
-        _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts'][_interface][ip_version]['address'] }}"
+        _radosgw_address: "{{ hostvars[item]['ansible_facts'][hostvars[item]['_interface']][ip_version]['address'] }}"
+      loop: "{{ groups.get(rgw_group_name, []) }}"
+      delegate_to: "{{ item }}"
+      delegate_facts: true
       when: ip_version == 'ipv4'
 
     - name: set_fact _radosgw_address to radosgw_interface - ipv6
       set_fact:
-        _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts'][_interface][ip_version][0]['address'] | ansible.utils.ipwrap }}"
+        _radosgw_address: "{{ hostvars[item]['ansible_facts'][hostvars[item]['_interface']][ip_version][0]['address'] | ipwrap }}"
+      loop: "{{ groups.get(rgw_group_name, []) }}"
+      delegate_to: "{{ item }}"
+      delegate_facts: true
       when: ip_version == 'ipv6'
 
 - name: set_fact rgw_instances without rgw multisite


### PR DESCRIPTION
Deployments when radosgws don't have the same names for
network interface.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2095605

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>