### PR TITLE
nfs: bump to nfs-ganesha-4

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -161,11 +161,11 @@ dummy:
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-#nfs_ganesha_stable_branch: V3.5-stable
-#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-3.0/ubuntu
+#centos_release_nfs: centos-release-nfs-ganesha4
+#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-4/ubuntu
 #nfs_ganesha_apt_keyserver: keyserver.ubuntu.com
 #nfs_ganesha_apt_key_id: EA914D611053D07BD332E18010353E8834DC57CA
-#libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-3.0/ubuntu
+#libntirpc_stable_deb_repo: https://ppa.launchpadcontent.net/nfs-ganesha/libntirpc-4/ubuntuu
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -161,11 +161,11 @@ ceph_repository: rhcs
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-#nfs_ganesha_stable_branch: V3.5-stable
-#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-3.0/ubuntu
+#centos_release_nfs: centos-release-nfs-ganesha4
+#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-4/ubuntu
 #nfs_ganesha_apt_keyserver: keyserver.ubuntu.com
 #nfs_ganesha_apt_key_id: EA914D611053D07BD332E18010353E8834DC57CA
-#libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-3.0/ubuntu
+#libntirpc_stable_deb_repo: https://ppa.launchpadcontent.net/nfs-ganesha/libntirpc-4/ubuntuu
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -153,11 +153,11 @@ ceph_stable_release: quincy
 ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-nfs_ganesha_stable_branch: V3.5-stable
-nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-3.0/ubuntu
+centos_release_nfs: centos-release-nfs-ganesha4
+nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-4/ubuntu
 nfs_ganesha_apt_keyserver: keyserver.ubuntu.com
 nfs_ganesha_apt_key_id: EA914D611053D07BD332E18010353E8834DC57CA
-libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-3.0/ubuntu
+libntirpc_stable_deb_repo: https://ppa.launchpadcontent.net/nfs-ganesha/libntirpc-4/ubuntuu
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/


### PR DESCRIPTION
So stable-7.0 will use nfs-ganesha4 by default.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>