### PR TITLE
[skip ci] backup-and-restore: fix check on 'mode' variable

### DIFF
--- a/infrastructure-playbooks/backup-and-restore-ceph-files.yml
+++ b/infrastructure-playbooks/backup-and-restore-ceph-files.yml
@@ -42,7 +42,7 @@
           "you must pass the mode: -e mode=<backup|restore>"
       when:
         - mode is not defined
-        - mode not in ['backup', 'restore']
+          or mode not in ['backup', 'restore']
 
     - name: gather facts on source node
       setup:


### PR DESCRIPTION
Typical failure:

```
fatal: [localhost]: FAILED! =>
  msg: |-
    The conditional check 'mode not in ['backup', 'restore']' failed. The error was: error while evaluating conditional (mode not in ['backup', 'restore']): 'mode' is undefined
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2051640

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>