### PR TITLE
[skip ci] backup-and-restore: fix check on 'target_node' variable

### DIFF
--- a/infrastructure-playbooks/backup-and-restore-ceph-files.yml
+++ b/infrastructure-playbooks/backup-and-restore-ceph-files.yml
@@ -28,7 +28,9 @@
         msg: >
           "You must pass the node name: -e target_node=<inventory_name>.
           The name must match what is set in your inventory."
-      when: target_node is not defined
+      when:
+        - target_node is not defined
+          or target_node not in groups.get('all', [])
 
     - name: exit playbook, if user did not set the backup directory
       fail:


### PR DESCRIPTION
If the user doesn't pass a valid name (present in the inventory)
the playbook will fail like following:

```
fatal: [localhost -> {{ target_node }}]: FAILED! =>
  msg: |-
    The task includes an option with an undefined variable. The error was: "hostvars['10.70.46.40']" is undefined
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2051640

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>