### PR TITLE
[skip ci] tests: drop shrink_osd from tox.ini

### DIFF
--- a/tox-shrink_osd.ini
+++ b/tox-shrink_osd.ini
@@ -91,6 +91,7 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/setup.yml
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --extra-vars "\
+      yes_i_know=true \
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:main} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \
@@ -101,13 +102,14 @@ commands=
 
   # test cluster state using ceph-ansible tests
   py.test --reruns 5 --reruns-delay 1 -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/{env:INVENTORY} --ssh-config={changedir}/vagrant_ssh_config {toxinidir}/tests/functional/tests
-  
+
   shrink_osd_single: {[shrink-osd-single]commands}
   shrink_osd_multiple: {[shrink-osd-multiple]commands}
 
   # configure lvm
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/{env:PLAYBOOK:site.yml.sample} --limit osds --extra-vars "\
+      yes_i_know=true \
       delegate_facts_host={env:DELEGATE_FACTS_HOST:True} \
       ceph_dev_branch={env:CEPH_DEV_BRANCH:main} \
       ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} \

--- a/tox.ini
+++ b/tox.ini
@@ -322,7 +322,6 @@ setenv=
   shrink_mds: MDS_TO_KILL = mds0
   shrink_mgr: MGR_TO_KILL = mgr1
   shrink_mon: MON_TO_KILL = mon2
-  shrink_osd: OSD_TO_KILL = 0
   shrink_rbdmirror: RBDMIRROR_TO_KILL = rbd-mirror0
   shrink_rgw: RGW_TO_KILL = rgw0.rgw0
 
@@ -338,7 +337,6 @@ changedir=
   cluster: {toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
   shrink_mon: {toxinidir}/tests/functional/shrink_mon{env:CONTAINER_DIR:}
   shrink_mgn: {toxinidir}/tests/functional/shrink_mon{env:CONTAINER_DIR:}
-  shrink_osd: {toxinidir}/tests/functional/shrink_osd{env:CONTAINER_DIR:}
   shrink_mgr: {toxinidir}/tests/functional/shrink_mgr{env:CONTAINER_DIR:}
   shrink_mds: {toxinidir}/tests/functional/shrink_mds{env:CONTAINER_DIR:}
   shrink_rbdmirror: {toxinidir}/tests/functional/shrink_rbdmirror{env:CONTAINER_DIR:}
@@ -403,7 +401,6 @@ commands=
   purge_dashboard: {[purge-dashboard]commands}
   switch_to_containers: {[switch-to-containers]commands}
   shrink_mon: {[shrink-mon]commands}
-  shrink_osd: {[shrink-osd]commands}
   shrink_mgr: {[shrink-mgr]commands}
   shrink_mds: {[shrink-mds]commands}
   shrink_rbdmirror: {[shrink-rbdmirror]commands}


### PR DESCRIPTION
Otherwise vgs/lvs are not created and ceph-validate complains as expected.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>