### PR TITLE
facts: fix set_radosgw_address.yml

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -252,7 +252,7 @@
   when: groups.get(mon_group_name, []) | length > 0
 
 - name: import_tasks set_radosgw_address.yml
-  import_tasks: set_radosgw_address.yml
+  include_tasks: set_radosgw_address.yml
   when: inventory_hostname in groups.get(rgw_group_name, [])
 
 - name: set_fact use_new_ceph_iscsi package or old ceph-iscsi-config/cli

--- a/roles/ceph-handler/templates/restart_nfs_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_nfs_daemon.sh.j2
@@ -3,7 +3,7 @@
 RETRIES="{{ handler_health_nfs_check_retries }}"
 DELAY="{{ handler_health_nfs_check_delay }}"
 NFS_NAME="ceph-nfs@{{ ceph_nfs_service_suffix | default(ansible_facts['hostname']) }}"
-PID=/var/run/ganesha.pid
+PID=/var/run/ganesha/ganesha.pid
 {% if containerized_deployment | bool %}
 DOCKER_EXEC="{{ container_binary }} exec ceph-nfs-{{ ceph_nfs_service_suffix | default(ansible_facts['hostname']) }}"
 {% endif %}


### PR DESCRIPTION
use `include_tasks` instead of `import_tasks`.
Given that with `import_tasks` statements are preprocessed
and the tasks that defines it hasn't been run yet, it will fail
and complain like following:

```
The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute '_interface'
```

Using `include_tasks` instead fixes this.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>