### PR TITLE
[skip ci] facts: follow up on f6b49f78

### DIFF
--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -46,7 +46,7 @@
 
     - name: set_fact _radosgw_address to radosgw_interface - ipv6
       set_fact:
-        _radosgw_address: "{{ hostvars[item]['ansible_facts'][hostvars[item]['_interface']][ip_version][0]['address'] | ipwrap }}"
+        _radosgw_address: "{{ hostvars[item]['ansible_facts'][hostvars[item]['_interface']][ip_version][0]['address'] | ansible.utils.ipwrap }}"
       loop: "{{ groups.get(rgw_group_name, []) }}"
       delegate_to: "{{ item }}"
       delegate_facts: true


### PR DESCRIPTION
f6b49f78a9f14c37b2ca81fa6172beba8f43adc4 changed a call back to `ipwrap`
This fixes this.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>