### PR TITLE
[skip ci] pytest: drop test against py <3.8

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9]
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
since the bump to ansible-core 2.12, we have to drop
testing against py36 and py37 given that ansible 2.12 requires python
>=3.8

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>