### PR TITLE
[skip ci] update: fix a typo

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -1044,7 +1044,7 @@
         name: ceph-facts
         tasks_from: container_binary.yml
 
-    - name: container | disallow pre-quincy OSDs and enable all new quincy-only functionality
+    - name: container | disallow pre-pacific OSDs and enable all new pacific-only functionality
       command: "{{ container_binary }} exec ceph-mon-{{ hostvars[groups[mon_group_name][0]]['ansible_facts']['hostname'] }} ceph --cluster {{ cluster }} osd require-osd-release pacific"
       delegate_to: "{{ groups[mon_group_name][0] }}"
       run_once: True


### PR DESCRIPTION
s/pre-quincy/pre-pacific
s/quincy-only/pacific-only

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>