### PR TITLE
config: followup on 8a5628b51

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -105,11 +105,6 @@
         - num_osds | default(0) | int > 0
         - ((ansible_facts['memtotal_mb'] * 1048576 * safety_factor | float) / num_osds | float) > osd_memory_target
 
-    - name: set osd_memory_target
-      command: "{{ ceph_cmd }} config set osd/host:{{ inventory_hostname }} osd_memory_target {{ _osd_memory_target | default(osd_memory_target) }}"
-      changed_when: false
-      delegate_to: "{{ groups[mon_group_name][0] }}"
-
 - name: create ceph conf directory
   file:
     path: "/etc/ceph"

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -113,3 +113,8 @@
     - openstack_config | bool
     - inventory_hostname == groups[osd_group_name] | last
   tags: wait_all_osds_up
+
+- name: set osd_memory_target
+  command: "{{ ceph_cmd }} --cluster {{ cluster }} config set osd/host:{{ inventory_hostname }} osd_memory_target {{ _osd_memory_target | default(osd_memory_target) }}"
+  changed_when: false
+  delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
Add missing `--cluster {{ cluster }}` on task
`set osd_memory_target` in the main.yml file of the
ceph-config role.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>