### PR TITLE
tests: isolate ansible collections

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -851,12 +851,18 @@
   become: True
   gather_facts: false
   tasks:
+    - name: check for ceph rbd mirror services
+      command: systemctl show --no-pager --property=Id --state=enabled ceph-rbd-mirror@*  # noqa 303
+      changed_when: false
+      register: rbdmirror_services
+
     - name: stop ceph rbd mirror
-      systemd:
-        name: "ceph-rbd-mirror@rbd-mirror.{{ ansible_facts['hostname'] }}"
+      service:
+        name: "{{ item.split('=')[1] }}"
         state: stopped
         enabled: no
         masked: yes
+      loop: "{{ rbdmirror_services.stdout_lines }}"
 
     - import_role:
         name: ceph-defaults

--- a/tox-cephadm.ini
+++ b/tox-cephadm.ini
@@ -13,8 +13,9 @@ passenv=*
 sitepackages=True
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
+  ANSIBLE_COLLECTIONS_PATH = {envdir}/ansible_collections
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
-  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  ANSIBLE_CALLBACK_ENABLED = profile_tasks
   ANSIBLE_KEEP_REMOTE_FILES = 1
   ANSIBLE_CACHE_PLUGIN = memory
   ANSIBLE_GATHERING = implicit
@@ -27,6 +28,7 @@ deps= -r{toxinidir}/tests/requirements.txt
 changedir= {toxinidir}/tests/functional/cephadm
 
 commands=
+  ansible-galaxy collection install -r {toxinidir}/requirements.yml -v -p {envdir}/ansible_collections
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 

--- a/tox-docker2podman.ini
+++ b/tox-docker2podman.ini
@@ -13,8 +13,9 @@ passenv=*
 sitepackages=True
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
+  ANSIBLE_COLLECTIONS_PATH = {envdir}/ansible_collections
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
-  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  ANSIBLE_CALLBACK_ENABLED = profile_tasks
   ANSIBLE_KEEP_REMOTE_FILES = 1
   ANSIBLE_CACHE_PLUGIN = memory
   ANSIBLE_GATHERING = implicit
@@ -27,6 +28,7 @@ deps= -r{toxinidir}/tests/requirements.txt
 changedir= {toxinidir}/tests/functional/docker2podman
 
 commands=
+  ansible-galaxy collection install -r {toxinidir}/requirements.yml -v -p {envdir}/ansible_collections
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 

--- a/tox-external_clients.ini
+++ b/tox-external_clients.ini
@@ -12,8 +12,9 @@ allowlist_externals =
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
+  ANSIBLE_COLLECTIONS_PATH = {envdir}/ansible_collections
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
-  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  ANSIBLE_CALLBACK_ENABLED = profile_tasks
   ANSIBLE_CACHE_PLUGIN = memory
   ANSIBLE_GATHERING = implicit
   # only available for ansible >= 2.5
@@ -30,7 +31,7 @@ setenv=
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/external_clients{env:CONTAINER_DIR:}
 commands=
-  ansible-galaxy install -r {toxinidir}/requirements.yml -v
+  ansible-galaxy collection install -r {toxinidir}/requirements.yml -v -p {envdir}/ansible_collections
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 

--- a/tox-filestore_to_bluestore.ini
+++ b/tox-filestore_to_bluestore.ini
@@ -12,8 +12,9 @@ allowlist_externals =
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
+  ANSIBLE_COLLECTIONS_PATH = {envdir}/ansible_collections
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
-  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  ANSIBLE_CALLBACK_ENABLED = profile_tasks
   ANSIBLE_CACHE_PLUGIN = memory
   ANSIBLE_GATHERING = implicit
   # only available for ansible >= 2.5
@@ -35,6 +36,7 @@ setenv=
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/filestore-to-bluestore{env:CONTAINER_DIR:}
 commands=
+  ansible-galaxy collection install -r {toxinidir}/requirements.yml -v -p {envdir}/ansible_collections
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 

--- a/tox-podman.ini
+++ b/tox-podman.ini
@@ -13,8 +13,9 @@ passenv=*
 sitepackages=True
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
+  ANSIBLE_COLLECTIONS_PATH = {envdir}/ansible_collections
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
-  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  ANSIBLE_CALLBACK_ENABLED = profile_tasks
   ANSIBLE_KEEP_REMOTE_FILES = 1
   ANSIBLE_CACHE_PLUGIN = memory
   ANSIBLE_GATHERING = implicit
@@ -31,6 +32,7 @@ deps= -r{toxinidir}/tests/requirements.txt
 changedir= {toxinidir}/tests/functional/podman
 
 commands=
+  ansible-galaxy collection install -r {toxinidir}/requirements.yml -v -p {envdir}/ansible_collections
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 

--- a/tox-shrink_osd.ini
+++ b/tox-shrink_osd.ini
@@ -52,8 +52,9 @@ passenv=*
 sitepackages=False
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
+  ANSIBLE_COLLECTIONS_PATH = {envdir}/ansible_collections
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
-  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  ANSIBLE_CALLBACK_ENABLED = profile_tasks
   ANSIBLE_KEEP_REMOTE_FILES = 1
   ANSIBLE_CACHE_PLUGIN = memory
   ANSIBLE_GATHERING = implicit
@@ -80,6 +81,7 @@ changedir=
 
 
 commands=
+  ansible-galaxy collection install -r {toxinidir}/requirements.yml -v -p {envdir}/ansible_collections
   ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:main} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
 
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}

--- a/tox-subset_update.ini
+++ b/tox-subset_update.ini
@@ -12,8 +12,9 @@ allowlist_externals =
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
+  ANSIBLE_COLLECTIONS_PATH = {envdir}/ansible_collections
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
-  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  ANSIBLE_CALLBACK_ENABLED = profile_tasks
   ANSIBLE_CACHE_PLUGIN = memory
   ANSIBLE_GATHERING = implicit
   # only available for ansible >= 2.5
@@ -35,7 +36,7 @@ setenv=
 deps= -r{toxinidir}/tests/requirements.txt
 changedir={toxinidir}/tests/functional/subset_update{env:CONTAINER_DIR:}
 commands=
-  ansible-galaxy install -r {toxinidir}/requirements.yml -v
+  ansible-galaxy collection install -r {toxinidir}/requirements.yml -v -p {envdir}/ansible_collections
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 

--- a/tox-update.ini
+++ b/tox-update.ini
@@ -12,8 +12,9 @@ allowlist_externals =
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
+  ANSIBLE_COLLECTIONS_PATH = {envdir}/ansible_collections
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
-  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  ANSIBLE_CALLBACK_ENABLED = profile_tasks
   ANSIBLE_CACHE_PLUGIN = memory
   ANSIBLE_GATHERING = implicit
   # only available for ansible >= 2.5
@@ -37,6 +38,8 @@ changedir={toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
 commands=
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
+
+  ansible-galaxy collection install -r {toxinidir}/requirements.yml -v -p {envdir}/ansible_collections
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/setup.yml
 
@@ -63,7 +66,7 @@ commands=
 
 #  pip uninstall -y ansible
 #  pip install -r {toxinidir}/tests/requirements.txt
-  ansible-galaxy install -r {toxinidir}/requirements.yml -v
+#  ansible-galaxy collection install -r {toxinidir}/requirements.yml -v -p {envdir}/ansible_collections
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/rolling_update.yml --extra-vars "\
       ireallymeanit=yes \

--- a/tox.ini
+++ b/tox.ini
@@ -304,10 +304,11 @@ sitepackages=False
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
-  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  ANSIBLE_CALLBACKS_ENABLED = profile_tasks
   ANSIBLE_KEEP_REMOTE_FILES = 1
   ANSIBLE_CACHE_PLUGIN = memory
   ANSIBLE_GATHERING = implicit
+  ANSIBLE_COLLECTIONS_PATH = {envdir}/ansible_collections
   # only available for ansible >= 2.5
   ANSIBLE_STDOUT_CALLBACK = yaml
   non_container: DEV_SETUP = True
@@ -360,7 +361,7 @@ changedir=
   cephadm_adopt: {toxinidir}/tests/functional/all_daemons{env:CONTAINER_DIR:}
 
 commands=
-  ansible-galaxy install -r {toxinidir}/requirements.yml -v
+  ansible-galaxy collection install -r {toxinidir}/requirements.yml -v -p {envdir}/ansible_collections
   rhcs: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "change_dir={changedir}" --tags "vagrant_setup"
   non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:main} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
 


### PR DESCRIPTION
When Ansible collections are installed, they should be isolated.
Otherwise, they will be shared in any scheduled job.
This might cause issues when running different branch versions for instance.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>