### PR TITLE
[skip ci] purge-dashboard: check for legacy group name 'grafana-server'

### DIFF
--- a/infrastructure-playbooks/purge-dashboard.yml
+++ b/infrastructure-playbooks/purge-dashboard.yml
@@ -31,6 +31,17 @@
            invoking the playbook"
       when: ireallymeanit != 'yes'
 
+    - name: import_role ceph-defaults
+      import_role:
+        name: ceph-defaults
+
+    - name: check if a legacy grafana-server group exists
+      import_role:
+        name: ceph-facts
+        tasks_from: convert_grafana_server_group_name.yml
+      when: groups.get((grafana_server_group_name | default('grafana-server')), []) | length > 0
+
+
 - name: gather facts on all hosts
   hosts:
     - "{{ mon_group_name|default('mons') }}"


### PR DESCRIPTION
When using the legacy group name 'grafana-server', this playbook will run but
won't remove properly all monitoring resources as expected.

Fixes: #7265

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>