### PR TITLE
[skip ci] doc: update readthedoc settings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.9"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -152,5 +152,4 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-
-
+master_doc = 'index'


### PR DESCRIPTION
This is needed to enforce the python version.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>