### PR TITLE
tests: update tox config file for rbd-mirror scenario

### DIFF
--- a/tox-rbdmirror.ini
+++ b/tox-rbdmirror.ini
@@ -42,8 +42,6 @@ commands=
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
-  non_container: ansible-playbook -vv -i "localhost," -c local {toxinidir}/tests/functional/dev_setup.yml --extra-vars "dev_setup={env:DEV_SETUP:False} change_dir={changedir} ceph_dev_branch={env:CEPH_DEV_BRANCH:main} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}" --tags "vagrant_setup"
-
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/setup.yml
 
   # configure lvm


### PR DESCRIPTION
do not call dev_setup.yml so we don't use dev repo

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>