### PR TITLE
config: do not always set _osd_memory_target

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -102,6 +102,8 @@
       set_fact:
         _osd_memory_target: "{{ ((ansible_facts['memtotal_mb'] * 1048576 * safety_factor | float) / num_osds | float) | int }}"
       when:
+        - not ceph_conf_overrides.get('osd', {}).get('osd_memory_target')
+        - not ceph_conf_overrides.get('osd', {}).get('osd memory target')
         - num_osds | default(0) | int > 0
         - ((ansible_facts['memtotal_mb'] * 1048576 * safety_factor | float) / num_osds | float) > osd_memory_target
 


### PR DESCRIPTION
When 'osd_memory_target' is overridden in ceph_conf_overrides.
The task that sets the fact `osd_memory_target` in the ceph-config role
should be skipped.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2056675#c11

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>