### PR TITLE
config: use osd_memory_target value from ceph_conf_overrides if defined

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -100,10 +100,19 @@
 
     - name: set_fact _osd_memory_target
       set_fact:
+        _osd_memory_target: "{{ item }}"
+      loop:
+        - "{{ ceph_conf_overrides.get('osd', {}).get('osd memory target', '') }}"
+        - "{{ ceph_conf_overrides.get('osd', {}).get('osd_memory_target', '') }}"
+      when:
+        - item
+        - item > osd_memory_target
+
+    - name: set_fact _osd_memory_target
+      set_fact:
         _osd_memory_target: "{{ ((ansible_facts['memtotal_mb'] * 1048576 * safety_factor | float) / num_osds | float) | int }}"
       when:
-        - not ceph_conf_overrides.get('osd', {}).get('osd_memory_target')
-        - not ceph_conf_overrides.get('osd', {}).get('osd memory target')
+        - _osd_memory_target is undefined
         - num_osds | default(0) | int > 0
         - ((ansible_facts['memtotal_mb'] * 1048576 * safety_factor | float) / num_osds | float) > osd_memory_target
 


### PR DESCRIPTION
otherwise it's impossible to override `osd_memory_target`
via `ceph_conf_overrides`.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2056675

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>