### PR TITLE
facts: set is_rgw_instances_defined from configure_dashboard

### DIFF
--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -75,9 +75,12 @@
 
 - name: set_fact is_rgw_instances_defined
   set_fact:
-    is_rgw_instances_defined: "{{ rgw_instances is defined }}"
+    is_rgw_instances_defined: "{{ hostvars[ceph_dashboard_call_item | default(inventory_hostname)]['rgw_instances'] is defined }}"
+    delegate_to: "{{ ceph_dashboard_call_item if ceph_dashboard_call_item is defined else inventory_hostname }}"
+    delegate_facts: "{{ true if ceph_dashboard_call_item is defined else false }}"
   when:
-    - inventory_hostname in groups.get(rgw_group_name, [])
+    - inventory_hostname in groups.get(rgw_group_name, []) or
+      ceph_dashboard_call_item is defined
     - rgw_multisite | bool
 
 - name: set_fact rgw_instances with rgw multisite


### PR DESCRIPTION
When we come from configure_dashboard.yml, this fact should be set if
`rgw_instances` is defined in group_vars/host_vars. Otherwise, the next
task that set the fact `rgw_instances` will be run as it will assume it
wasn't user defined.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2117294

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>