### PR TITLE
ceph-config: allow overriding osd_memory_target

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -98,23 +98,20 @@
       when:
         - devices | default([]) | length > 0
 
-    - name: set_fact _osd_memory_target
+    - name: set_fact osd_memory_target, override from ceph_conf_overrides
       set_fact:
-        _osd_memory_target: "{{ item }}"
+        osd_memory_target: "{{ item }}"
       loop:
         - "{{ ceph_conf_overrides.get('osd', {}).get('osd memory target', '') }}"
         - "{{ ceph_conf_overrides.get('osd', {}).get('osd_memory_target', '') }}"
-      when:
-        - item
-        - item > osd_memory_target
+      when: item
 
     - name: set_fact _osd_memory_target
       set_fact:
         _osd_memory_target: "{{ ((ansible_facts['memtotal_mb'] * 1048576 * safety_factor | float) / num_osds | float) | int }}"
       when:
-        - _osd_memory_target is undefined
         - num_osds | default(0) | int > 0
-        - ((ansible_facts['memtotal_mb'] * 1048576 * safety_factor | float) / num_osds | float) > osd_memory_target
+        - ((ansible_facts['memtotal_mb'] * 1048576 * safety_factor | float) / num_osds | float) > (osd_memory_target | float)
 
 - name: create ceph conf directory
   file:


### PR DESCRIPTION
Typical failure:

```
"    The conditional check 'item > osd_memory_target' failed. The error was: Unexpected templating type error occurred on ({% if item > osd_memory_target %} True {% else %} False {% endif %}): '>' not supported between instances of 'str' and 'int'"
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2118544

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>