### PR TITLE
ansible: require 2.9 for downstream

### DIFF
--- a/ceph-ansible.spec.in
+++ b/ceph-ansible.spec.in
@@ -15,8 +15,8 @@ Obsoletes:      ceph-iscsi-ansible <= 1.5
 
 BuildArch:      noarch
 
-BuildRequires: ansible >= 2.10
-Requires: ansible >= 2.10
+BuildRequires: ansible >= 2.9
+Requires: ansible >= 2.9
 
 %if 0%{?rhel} == 7
 BuildRequires: python2-devel

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -758,7 +758,7 @@ dummy:
 # For example:
 # If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
 # at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
-# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }}" will be empty.
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}" will be empty.
 # As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
 # Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 #igw_network: "{{ public_network }}"

--- a/group_vars/rhcs.yml.sample
+++ b/group_vars/rhcs.yml.sample
@@ -758,7 +758,7 @@ alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alert
 # For example:
 # If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
 # at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
-# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }}" will be empty.
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}" will be empty.
 # As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
 # Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 #igw_network: "{{ public_network }}"

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -375,7 +375,7 @@
       when: ip_version == 'ipv4'
 
     - name: manage nodes with cephadm - ipv6
-      command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | last | ansible.utils.ipwrap }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
+      command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | last | ipwrap }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
       when: ip_version == 'ipv6'

--- a/infrastructure-playbooks/cephadm.yml
+++ b/infrastructure-playbooks/cephadm.yml
@@ -249,7 +249,7 @@
       when: ip_version == 'ipv4'
 
     - name: manage nodes with cephadm - ipv6
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }} {{ group_names | join(' ') }} {{ '_admin' if mon_group_name | default('mons') in group_names else '' }}"
+      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }} {{ group_names | join(' ') }} {{ '_admin' if mon_group_name | default('mons') in group_names else '' }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
       environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # These are Python requirements needed to run ceph-ansible master
-ansible>=2.10,<2.11,!=2.9.10
+ansible>=2.9,<2.10,!=2.9.10
 netaddr
 six

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -374,7 +374,7 @@
     - name: add iscsi gateways - ipv6
       command: "{{ ceph_cmd }} --cluster {{ cluster }} dashboard iscsi-gateway-add -i -"
       args:
-        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(igw_network.split(',')) | last | ansible.utils.ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
+        stdin: "{{ 'https' if hostvars[item]['api_secure'] | default(false) | bool else 'http' }}://{{ hostvars[item]['api_user'] | default('admin') }}:{{ hostvars[item]['api_password'] | default('admin') }}@{{ hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(igw_network.split(',')) | last | ipwrap }}:{{ hostvars[item]['api_port'] | default(5000) }}"
         stdin_add_newline: no
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -750,7 +750,7 @@ alertmanager_dashboard_api_no_ssl_verify: "{{ true if dashboard_protocol == 'htt
 # For example:
 # If the ceph public network is 2a00:8a60:1:c301::/64 and the iSCSI Gateway resides
 # at a dedicated gateway network (2a00:8a60:1:c300::/64) (With routing between those networks).
-# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ansible.utils.ipwrap }}" will be empty.
+# It means "{{ hostvars[item]['ansible_facts']['all_ipv4_addresses'] | ips_in_ranges(public_network.split(',')) | last | ipwrap }}" will be empty.
 # As a consequence, this prevent from deploying dashboard with iSCSI node when it reside in a subnet different than `public_network`.
 # Using `igw_network` make it possible, set it with the subnet used by your iSCSI node.
 igw_network: "{{ public_network }}"

--- a/roles/ceph-facts/tasks/grafana.yml
+++ b/roles/ceph-facts/tasks/grafana.yml
@@ -9,7 +9,7 @@
 
 - name: set grafana_server_addr fact - ipv6
   set_fact:
-    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ansible.utils.ipwrap }}"
+    grafana_server_addr: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ipwrap }}"
   when:
     - groups.get(monitoring_group_name, []) | length > 0
     - ip_version == 'ipv6'
@@ -27,7 +27,7 @@
 
 - name: set grafana_server_addrs fact - ipv6
   set_fact:
-    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ansible.utils.ipwrap]) | unique }}"
+    grafana_server_addrs: "{{ (grafana_server_addrs | default([]) + [hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(grafana_network.split(',')) | last | ipwrap]) | unique }}"
   with_items: "{{ groups.get(monitoring_group_name, []) }}"
   when:
     - groups.get(monitoring_group_name, []) | length > 0

--- a/roles/ceph-facts/tasks/set_monitor_address.yml
+++ b/roles/ceph-facts/tasks/set_monitor_address.yml
@@ -11,7 +11,7 @@
 
 - name: set_fact _monitor_addresses to monitor_address_block ipv6
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[item]['monitor_address_block'].split(',')) | last | ansible.utils.ipwrap }] }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[item]['monitor_address_block'].split(',')) | last | ipwrap }] }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') |  map(attribute='name') | list"
@@ -21,7 +21,7 @@
 
 - name: set_fact _monitor_addresses to monitor_address
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['monitor_address'] | ansible.utils.ipwrap}] }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['monitor_address'] | ipwrap}] }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
@@ -30,7 +30,7 @@
 
 - name: set_fact _monitor_addresses to monitor_interface - ipv4
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version]['address'] | ansible.utils.ipwrap }]  }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version]['address'] | ipwrap }]  }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"
@@ -41,7 +41,7 @@
 
 - name: set_fact _monitor_addresses to monitor_interface - ipv6
   set_fact:
-    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version][0]['address'] | ansible.utils.ipwrap }] }}"
+    _monitor_addresses: "{{ _monitor_addresses | default([]) + [{ 'name': item, 'addr': hostvars[item]['ansible_facts'][(hostvars[item]['monitor_interface']|replace('-', '_'))][ip_version][0]['address'] | ipwrap }] }}"
   with_items: "{{ groups.get(mon_group_name, []) }}"
   when:
     - "item not in _monitor_addresses | default([]) | selectattr('name', 'defined') | map(attribute='name') | list"

--- a/roles/ceph-facts/tasks/set_radosgw_address.yml
+++ b/roles/ceph-facts/tasks/set_radosgw_address.yml
@@ -18,7 +18,7 @@
 
 - name: set_fact _radosgw_address to radosgw_address_block ipv6
   set_fact:
-    _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[inventory_hostname]['radosgw_address_block'].split(',')) | last | ansible.utils.ipwrap }}"
+    _radosgw_address: "{{ hostvars[inventory_hostname]['ansible_facts']['all_ipv6_addresses'] | ips_in_ranges(hostvars[inventory_hostname]['radosgw_address_block'].split(',')) | last | ipwrap }}"
   when:
     - radosgw_address_block is defined
     - radosgw_address_block != 'subnet'
@@ -26,7 +26,7 @@
 
 - name: set_fact _radosgw_address to radosgw_address
   set_fact:
-    _radosgw_address: "{{ radosgw_address | ansible.utils.ipwrap }}"
+    _radosgw_address: "{{ radosgw_address | ipwrap }}"
   when:
     - radosgw_address is defined
     - radosgw_address != 'x.x.x.x'
@@ -56,7 +56,7 @@
 
     - name: set_fact _radosgw_address to radosgw_interface - ipv6
       set_fact:
-        _radosgw_address: "{{ hostvars[item]['ansible_facts'][hostvars[item]['_interface']][ip_version][0]['address'] | ansible.utils.ipwrap }}"
+        _radosgw_address: "{{ hostvars[item]['ansible_facts'][hostvars[item]['_interface']][ip_version][0]['address'] | ipwrap }}"
       loop: "{{ groups.get(rgw_group_name, []) }}"
       delegate_to: "{{ item }}"
       delegate_facts: true

--- a/roles/ceph-validate/tasks/check_system.yml
+++ b/roles/ceph-validate/tasks/check_system.yml
@@ -6,8 +6,8 @@
 
 - name: fail on unsupported ansible version
   fail:
-    msg: "Ansible version must be 2.10!"
-  when: ansible_version.minor|int != 10
+    msg: "Ansible version must be 2.9!"
+  when: ansible_version.minor|int != 9
 
 - name: fail on unsupported system
   fail:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@
 testinfra
 pytest-xdist
 pytest
-ansible>=2.10,<2.11,!=2.9.10
+ansible>=2.9,<2.10,!=2.9.10
 Jinja2>=2.10
 netaddr
 mock


### PR DESCRIPTION
RHCS 5.3 supports 2.9 only.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2120187

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>