### PR TITLE
ceph-crash: add support cluster name

### DIFF
--- a/roles/ceph-crash/templates/ceph-crash.service.j2
+++ b/roles/ceph-crash/templates/ceph-crash.service.j2
@@ -20,6 +20,9 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-crash-%i \
 {% endif %}
 --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
 --net=host \
+{% if cluster != 'ceph' %}
+-e CEPH_ARGS="--cluster {{ cluster }}"
+{% endif %}
 -v /var/lib/ceph:/var/lib/ceph:z \
 -v /etc/localtime:/etc/localtime:ro \
 -v /etc/ceph:/etc/ceph:z \


### PR DESCRIPTION
add cluster name to CEPH_ARGS env var to support custom cluster name
this can change as an arg to ceph-crash when https://github.com/ceph/ceph/pull/47836 released

Signed-off-by: Seena Fallah <seenafallah@gmail.com>