### PR TITLE
[skip ci] rbd-mirror: fix multiple rbd-mirror daemon support

### DIFF
--- a/roles/ceph-rbd-mirror/tasks/configure_mirroring.yml
+++ b/roles/ceph-rbd-mirror/tasks/configure_mirroring.yml
@@ -71,7 +71,6 @@
         CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       register: _rbd_mirror_key
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
-      run_once: true
       no_log: "{{ no_log_on_ceph_key_tasks }}"
 
     - name: copy ceph key


### PR DESCRIPTION
This `run_once: true` breaks multiple rbd-mirror daemons support as it would make all rbd-mirror daemons use the same keyring. Each rbd-mirror daemon needs its own keyring in order to start.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2037646

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>