### PR TITLE
[skip ci] rbd-mirror: add rx peer only once

### DIFF
--- a/roles/ceph-rbd-mirror/tasks/configure_mirroring.yml
+++ b/roles/ceph-rbd-mirror/tasks/configure_mirroring.yml
@@ -158,6 +158,7 @@
       changed_when: false
       delegate_to: "{{ groups[mon_group_name][0] }}"
       loop: "{{ mirror_peer.results }}"
+      run_once: true
       when: ceph_rbd_mirror_remote_user not in item.stdout
 
     - name: rm temporary file


### PR DESCRIPTION
in order to avoid the following error:

```
multiple RX peers are not currently supported
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2037646

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>