### PR TITLE
Disable timesyncd using the service module instead of timedatectl

### DIFF
--- a/roles/ceph-infra/tasks/setup_ntp.yml
+++ b/roles/ceph-infra/tasks/setup_ntp.yml
@@ -1,14 +1,16 @@
 ---
-- name: set ntp service and chrony daemon name for Debian family
+- name: set ntp service, chrony and timesyncd daemon name for Debian family
   set_fact:
     chrony_daemon_name: chrony
     ntp_service_name: ntp
+    timesyncd_service_name: systemd-timesyncd
   when: ansible_facts['os_family'] == 'Debian'
 
-- name: set ntp service and chrony daemon name for RedHat and Suse family
+- name: set ntp service, chrony and timesyncd daemon name for RedHat and Suse family
   set_fact:
     chrony_daemon_name: chronyd
     ntp_service_name: ntpd
+    timesyncd_service_name: systemd-timesyncd
   when: ansible_facts['os_family'] in ['RedHat', 'Suse']
 
 # Installation of NTP daemons needs to be a separate task since installations
@@ -35,14 +37,20 @@
 - name: enable the ntp daemon and disable the rest
   block:
     - name: enable timesyncing on timesyncd
-      command: timedatectl set-ntp on
+      service:
+        name: "{{ timesyncd_service_name }}"
+        state: started
+        enabled: yes
       notify:
         - disable ntpd
         - disable chronyd
       when: ntp_daemon_type == "timesyncd"
 
     - name: disable time sync using timesyncd if we are not using it
-      command: timedatectl set-ntp no
+      service:
+        name: "{{ timesyncd_service_name }}"
+        state: stopped
+        enabled: no
       when: ntp_daemon_type != "timesyncd"
 
     - name: enable ntpd


### PR DESCRIPTION
The playbook currently disables timesyncd when the selected ntp daemon is ntp or chrony.
It executes 
`timedatectl set-ntp no`
for disabling the timesyncd service.

However, according to the official documentation, the "set-ntp [BOOL]" command has a different outcome based on the timedatectl version.

The older one disables the timesyncd service (which is what we want)
`Takes a boolean argument. Controls whether network time synchronization is active and enabled (if available). This enables and
           starts, or disables and stops the systemd-timesyncd.service unit. It does not affect the state of any other, unrelated network
           time synchronization services that might be installed on the system. This command is hence mostly equivalent to: systemctl
           enable --now systemd-timesyncd.service and systemctl disable --now systemd-timesyncd.service, but is protected by a different
           access policy.
Note that even if time synchronization is turned off with this command, another unrelated system service might still
           synchronize the clock with the network. Also note that, strictly speaking, systemd-timesyncd.service does more than just
           network time synchronization, as it ensures a monotonic clock on systems without RTC even if no network is available. See
           systemd-timesyncd.service(8) for details about this.`

however, the new version is disabling and stopping the ntp service (ntp or chrony)

`Takes a boolean argument. Controls whether network time synchronization is active and enabled (if available). If the argument
           is true, this enables and starts the first existing network synchronization service. If the argument is false, then this
           disables and stops the known network synchronization services. The way that the list of services is built is described below.`
So basically, the playbook is disabling and stopping the service we want to use, which is not the desired behavior.
In the end, since the playbook enables again ntp or chrony the service will be up and running, however, there is no reason for disabling the service before.

So these changes cover all the cases.