### PR TITLE
Update ceph_ec_profile.py

### DIFF
--- a/library/ceph_ec_profile.py
+++ b/library/ceph_ec_profile.py
@@ -76,11 +76,6 @@ options:
             - Compute coding chunks for each object and store them on different
               OSDs.
         required: true
-    crush_root:
-        description:
-            - The name of the crush bucket used for the first step of the CRUSH
-              rule.
-        required: false
     crush_device_class:
         description:
             - Restrict placement to devices of a specific class (hdd/ssd)


### PR DESCRIPTION
This parameters "crush_root" unsupported for (ceph_ec_profile) module: crush_root
Follow this issue: https://github.com/ceph/ceph-ansible/issues/7306