### PR TITLE
OSD memory target improvements/fixes

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -97,9 +97,9 @@
 - name: set osd related config facts
   when: inventory_hostname in groups.get(osd_group_name, [])
   block:
-    - name: set_fact osd_memory_target, override from ceph_conf_overrides
+    - name: set_fact _osd_memory_target, override from ceph_conf_overrides
       set_fact:
-        osd_memory_target: "{{ item }}"
+        _osd_memory_target: "{{ item }}"
       loop:
         - "{{ ceph_conf_overrides.get('osd', {}).get('osd memory target', '') }}"
         - "{{ ceph_conf_overrides.get('osd', {}).get('osd_memory_target', '') }}"
@@ -109,6 +109,7 @@
       set_fact:
         _osd_memory_target: "{{ ((ansible_facts['memtotal_mb'] * 1048576 * safety_factor | float) / num_osds | float) | int }}"
       when:
+        - _osd_memory_target is undefined
         - num_osds | default(0) | int > 0
         - ((ansible_facts['memtotal_mb'] * 1048576 * safety_factor | float) / num_osds | float) > (osd_memory_target | float)
 

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -98,6 +98,9 @@
       when:
         - devices | default([]) | length > 0
 
+- name: set osd related config facts
+  when: inventory_hostname in groups.get(osd_group_name, [])
+  block:
     - name: set_fact osd_memory_target, override from ceph_conf_overrides
       set_fact:
         osd_memory_target: "{{ item }}"

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -89,14 +89,10 @@
         CEPH_CONTAINER_BINARY: "{{ container_binary }}"
         PYTHONIOENCODING: utf-8
       changed_when: false
-      when:
-        - devices | default([]) | length > 0
 
     - name: set_fact num_osds (add existing osds)
       set_fact:
         num_osds: "{{ lvm_list.stdout | default('{}') | from_json | length | int + num_osds | default(0) | int }}"
-      when:
-        - devices | default([]) | length > 0
 
 - name: set osd related config facts
   when: inventory_hostname in groups.get(osd_group_name, [])

--- a/roles/ceph-config/templates/ceph.conf.j2
+++ b/roles/ceph-config/templates/ceph.conf.j2
@@ -80,7 +80,6 @@ filestore xattr use omap = true
 {% endif %}
 {% endif %}
 {% if osd_objectstore == 'bluestore' %}
-{% set _num_osds = num_osds | default(0) | int %}
 [osd]
 osd memory target = {{ _osd_memory_target | default(osd_memory_target) }}
 {% endif %}

--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -113,8 +113,3 @@
     - openstack_config | bool
     - inventory_hostname == groups[osd_group_name] | last
   tags: wait_all_osds_up
-
-- name: set osd_memory_target
-  command: "{{ ceph_cmd }} --cluster {{ cluster }} config set osd/host:{{ inventory_hostname }} osd_memory_target {{ _osd_memory_target | default(osd_memory_target) }}"
-  changed_when: false
-  delegate_to: "{{ groups[mon_group_name][0] }}"


### PR DESCRIPTION
- ceph-osd: remove unused ceph config set for osd_memory_target
    - As the conf is always being set in the config file there is no need to set it in with `ceph config`.
    - Also this will make it hard to run the playbook with the `ceph_update_config` tag as it won't run and will create an inconsistency between the config managements of the cluster
- ceph-config: fix overriding osd_memory_target
    - When the value is overriding in `ceph_conf_overrides`, there is no need to calculate and set `osd_memory_target` again as we wanted to override the conf by our desired value.
- ceph-config: don't check for devices on existing osds
    - When osd_auto_discovery is true the `devices` var will be empty (as the disks have holders).
    - Also in general there is no need to check for devices to list the devices with ceph-volume as we have `default({})` on the stdout in `num_osds` set fact in the next task
- ceph-config: always set _osd_memory_target
    - this should be set when rolling_update is true as well, otherwise, it will reset to default on the upgrade