### PR TITLE
[skip ci] Support CentOS Storage SIG repository

### DIFF
--- a/roles/ceph-common/tasks/installs/centos_sig_repository.yml
+++ b/roles/ceph-common/tasks/installs/centos_sig_repository.yml
@@ -1,0 +1,26 @@
+---
+- name: "install CentOS Storage SIG repository for ceph {{ ceph_stable_release }} packages"
+  yum:
+    name: "centos-release-ceph-{{ ceph_stable_release }}"
+    state: present
+    update_cache: true
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+  register: result
+  until: result is succeeded
+
+- name: "alter the ceph centos-stream-8 SIGs broken repository (CentOS-derivative)"
+  replace:
+    path: "/etc/yum.repos.d/CentOS-Ceph-{{ ceph_stable_release | capitalize }}.repo"
+    regexp:  "{{ item.regex }}"
+    replace: "{{ item.replace }}"
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_major_version'] == "8"
+    - ansible_facts['distribution'] != 'CentOS' and ansible_facts['distribution_release'] != "Stream"
+  register: result
+  until: result is succeeded
+  with_items:
+    - {  regex:  '\?release\=\$releasever', replace: '?release=8-stream' }
+    - {  regex:  '\$contentdir\/\$releasever', replace: 'centos/8-stream' }
+    - {  regex:  '^\=CentOS', replace: 'name=CentOS' }

--- a/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
+++ b/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
@@ -7,6 +7,10 @@
   include_tasks: redhat_rhcs_repository.yml
   when: ceph_repository == 'rhcs'
 
+- name: include centos_sig_repository.yml
+  include_tasks: centos_sig_repository.yml
+  when: ceph_repository == 'sig'
+
 - name: include redhat_dev_repository.yml
   include_tasks: redhat_dev_repository.yml
   when: ceph_repository == 'dev'

--- a/roles/ceph-container-engine/vars/AlmaLinux-8.yml
+++ b/roles/ceph-container-engine/vars/AlmaLinux-8.yml
@@ -1,0 +1,3 @@
+---
+container_package_name: podman
+container_service_name: podman

--- a/roles/ceph-container-engine/vars/Rocky-8.yml
+++ b/roles/ceph-container-engine/vars/Rocky-8.yml
@@ -1,0 +1,3 @@
+---
+container_package_name: podman
+container_service_name: podman

--- a/roles/ceph-container-engine/vars/Rocky-9.yml
+++ b/roles/ceph-container-engine/vars/Rocky-9.yml
@@ -1,0 +1,3 @@
+---
+container_package_name: podman
+container_service_name: podman

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -141,6 +141,7 @@ valid_ceph_repository:
   - uca
   - custom
   - obs
+  - sig
 
 
 # REPOSITORY: COMMUNITY VERSION

--- a/roles/ceph-validate/tasks/check_repository.yml
+++ b/roles/ceph-validate/tasks/check_repository.yml
@@ -5,10 +5,10 @@
 
 - name: validate ceph_repository
   fail:
-    msg: "ceph_repository must be either 'community', 'rhcs', 'obs', 'dev', 'custom' or 'uca'"
+    msg: "ceph_repository must be either 'community', 'rhcs', 'obs', 'dev', 'custom', 'uca' or 'sig'"
   when:
     - ceph_origin == 'repository'
-    - ceph_repository not in ['community', 'rhcs', 'obs', 'dev', 'custom', 'uca']
+    - ceph_repository not in ['community', 'rhcs', 'obs', 'dev', 'custom', 'uca', 'sig']
 
 - name: validate ceph_repository_community
   fail:


### PR DESCRIPTION
To declare this via all.yml, ie.

ceph_origin: **repository**
ceph_repository: **sig**

Note: Vagrant boxes got issues on the default scsi if using RHEL8/9 based need to change it to other types under the VirtualBox storage controller to get rid of issues in my test to work using virtio, [more info on this](https://access.redhat.com/solutions/3773611) . Alter line 522 in Vagrantfile, like the following.
          vb.customize ['storagectl', :id,
                        '--name', 'OSD Controller',
                        '--add', '**virtio**']
RHEL9-based distro got still issues few python modules with the CentOS SIG.