### PR TITLE
library/radosgw_user.py: fix user update

### DIFF
--- a/library/radosgw_user.py
+++ b/library/radosgw_user.py
@@ -265,8 +265,6 @@ def modify_user(module, container_image=None):
     cluster = module.params.get('cluster')
     name = module.params.get('name')
     display_name = module.params.get('display_name')
-    if not display_name:
-        display_name = name
     email = module.params.get('email', None)
     access_key = module.params.get('access_key', None)
     secret_key = module.params.get('secret_key', None)


### PR DESCRIPTION
Removes the case when display_name was defined prevously but was not provided when modifying. Without this change the module will change display_name to name even if display_name was not name originally. See #7296
