### PR TITLE
switch-to-containers: fix rbd-mirror migration

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -566,7 +566,7 @@
   become: true
   pre_tasks:
     - name: check for ceph rbd mirror services
-      command: systemctl show --no-pager --property=Id --state=enabled ceph-rbd-mirror@*  # noqa 303
+      command: systemctl show --no-pager --property=Id ceph-rbd-mirror@*  # noqa 303
       changed_when: false
       register: rbdmirror_services
 


### PR DESCRIPTION
`--state=enabled` isn't a valid filter so the unit from the packaging never gets removed.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2134917

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>