### PR TITLE
[skip ci] switch-to-containers: ignore errors when stopping service

### DIFF
--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -575,6 +575,7 @@
         name: "{{ item.split('=')[1] }}"
         state: stopped
         enabled: no
+      ignore_errors: true
       loop: "{{ rbdmirror_services.stdout_lines }}"
 
     - name: remove old systemd unit files


### PR DESCRIPTION
There might be cases where it can break idempotency.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>