### PR TITLE
Setting fact _radosgw_address fail when RGW is on a different network than other nodes

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -33,9 +33,10 @@
 - include_role:
     name: ceph-facts
     tasks_from: set_radosgw_address.yml
-  loop: "{{ groups[rgw_group_name] }}"
+  loop: "{{ groups.get(rgw_group_name, []) }}"
   loop_control:
     loop_var: ceph_dashboard_call_item
+  when: inventory_hostname in groups.get(rgw_group_name, [])
 
 - name: disable SSL for dashboard
   when: dashboard_protocol == "http"


### PR DESCRIPTION
Changed the when condition to only execute that fact setting on RGW nodes while before it was run on all nodes and failed if the node was not on the same network range as the RGW.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2131150

Signed-off-by: Teoman ONAY <tonay@redhat.com>