### PR TITLE
[skip ci] Setting fact _radosgw_address fail when RGW is on a different network

### DIFF
--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -36,7 +36,7 @@
   loop: "{{ groups.get(rgw_group_name, []) }}"
   loop_control:
     loop_var: ceph_dashboard_call_item
-  when: groups.get(rgw_group_name, []) | length > 0
+  when: inventory_hostname in groups.get(rgw_group_name, [])
 
 - name: disable SSL for dashboard
   command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} config set mgr mgr/dashboard/ssl false"


### PR DESCRIPTION
Changed the when condition to only execute that fact setting on RGW nodes while before it was run on all nodes and failed if the node was not on the same network range as the RGW.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2131150

Signed-off-by: Teoman ONAY <tonay@redhat.com>
(cherry picked from commit 590e57cc1b9a79ced7a9208db8bf8eaf43d3f320)