### PR TITLE
[skip ci] cephadm-adopt: fix rbd-mirror adoption

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -462,7 +462,9 @@
   gather_facts: true
   tasks:
     - name: store existing rbd mirror peers in monitor config store
-      when: ceph_rbd_mirror_configure | default(False) | bool
+      when:
+        - ceph_rbd_mirror_configure | default(True) | bool
+        - ceph_rbd_mirror_remote_user is undefined
       block:
         - name: import ceph-defaults
           import_role:


### PR DESCRIPTION
The recent rbdmirror refactor introduced a regression in the cephadm-adopt playbook.
Given that the rbd-mirror peer addition is now done by using the monitor config-key store method during the cluster deployment, we can drop this play from the cephadm-adopt.yml playbook.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2140569

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>