### PR TITLE
Initialize rbd pool at pool creation

### DIFF
--- a/library/ceph_crush_rule.py
+++ b/library/ceph_crush_rule.py
@@ -18,12 +18,12 @@ __metaclass__ = type
 from ansible.module_utils.basic import AnsibleModule
 try:
     from ansible.module_utils.ca_common import exit_module, \
-                                               generate_ceph_cmd, \
+                                               generate_cmd, \
                                                is_containerized, \
                                                exec_command
 except ImportError:
     from module_utils.ca_common import exit_module, \
-                                       generate_ceph_cmd, \
+                                       generate_cmd, \
                                        is_containerized, \
                                        exec_command
 import datetime
@@ -142,10 +142,10 @@ def create_rule(module, container_image=None):
         if profile:
             args.append(profile)
 
-    cmd = generate_ceph_cmd(['osd', 'crush', 'rule'],
-                            args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'crush', 'rule'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -160,10 +160,10 @@ def get_rule(module, container_image=None):
 
     args = ['dump', name, '--format=json']
 
-    cmd = generate_ceph_cmd(['osd', 'crush', 'rule'],
-                            args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'crush', 'rule'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -178,10 +178,10 @@ def remove_rule(module, container_image=None):
 
     args = ['rm', name]
 
-    cmd = generate_ceph_cmd(['osd', 'crush', 'rule'],
-                            args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'crush', 'rule'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 

--- a/library/ceph_dashboard_user.py
+++ b/library/ceph_dashboard_user.py
@@ -17,13 +17,13 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 try:
-    from ansible.module_utils.ca_common import generate_ceph_cmd, \
+    from ansible.module_utils.ca_common import generate_cmd, \
                                                is_containerized, \
                                                exec_command, \
                                                exit_module, \
                                                fatal
 except ImportError:
-    from module_utils.ca_common import generate_ceph_cmd, is_containerized, exec_command, exit_module, fatal  # noqa: E501
+    from module_utils.ca_common import generate_cmd, is_containerized, exec_command, exit_module, fatal  # noqa: E501
 
 import datetime
 import json
@@ -123,11 +123,11 @@ def create_user(module, container_image=None):
 
     args = ['ac-user-create', '-i', '-',  name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image,
-                            interactive=True)
+    cmd = generate_cmd(sub_cmd=['dashboard'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image,
+                       interactive=True)
 
     return cmd
 
@@ -145,10 +145,10 @@ def set_roles(module, container_image=None):
 
     args.extend(roles)
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['dashboard'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -163,11 +163,11 @@ def set_password(module, container_image=None):
 
     args = ['ac-user-set-password', '-i', '-', name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image,
-                            interactive=True)
+    cmd = generate_cmd(sub_cmd=['dashboard'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image,
+                       interactive=True)
 
     return cmd
 
@@ -182,10 +182,10 @@ def get_user(module, container_image=None):
 
     args = ['ac-user-show', name, '--format=json']
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['dashboard'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -200,10 +200,10 @@ def remove_user(module, container_image=None):
 
     args = ['ac-user-delete', name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['dashboard'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['dashboard'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 

--- a/library/ceph_ec_profile.py
+++ b/library/ceph_ec_profile.py
@@ -18,12 +18,12 @@ __metaclass__ = type
 from ansible.module_utils.basic import AnsibleModule
 try:
     from ansible.module_utils.ca_common import is_containerized, \
-                                               generate_ceph_cmd, \
+                                               generate_cmd, \
                                                exec_command, \
                                                exit_module
 except ImportError:
     from module_utils.ca_common import is_containerized, \
-                                            generate_ceph_cmd, \
+                                            generate_cmd, \
                                             exec_command, \
                                             exit_module
 import datetime
@@ -108,10 +108,10 @@ def get_profile(module, name, cluster='ceph', container_image=None):
 
     args = ['get', name, '--format=json']
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'erasure-code-profile'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -129,10 +129,10 @@ def create_profile(module, name, k, m, stripe_unit, crush_device_class, cluster=
     if force:
         args.append('--force')
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'erasure-code-profile'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -144,10 +144,10 @@ def delete_profile(module, name, cluster='ceph', container_image=None):
 
     args = ['rm', name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'erasure-code-profile'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -205,7 +205,7 @@ def run_module():
             if current_profile['k'] != k or \
                current_profile['m'] != m or \
                current_profile.get('stripe_unit', stripe_unit) != stripe_unit or \
-               current_profile.get('crush-device-class', crush_device_class) != crush_device_class:
+               current_profile.get('crush-device-class', crush_device_class) != crush_device_class:  # noqa: E501
                 rc, cmd, out, err = exec_command(module,
                                                  create_profile(module,
                                                                 name,

--- a/library/ceph_fs.py
+++ b/library/ceph_fs.py
@@ -19,12 +19,12 @@ from ansible.module_utils.basic import AnsibleModule
 try:
     from ansible.module_utils.ca_common import is_containerized, \
                                                exec_command, \
-                                               generate_ceph_cmd, \
+                                               generate_cmd, \
                                                exit_module
 except ImportError:
     from module_utils.ca_common import is_containerized, \
                                        exec_command, \
-                                       generate_ceph_cmd, \
+                                       generate_cmd, \
                                        exit_module
 
 import datetime
@@ -119,10 +119,10 @@ def create_fs(module, container_image=None):
 
     args = ['new', name, metadata, data]
 
-    cmd = generate_ceph_cmd(sub_cmd=['fs'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['fs'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -137,10 +137,10 @@ def get_fs(module, container_image=None):
 
     args = ['get', name, '--format=json']
 
-    cmd = generate_ceph_cmd(sub_cmd=['fs'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['fs'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -155,10 +155,10 @@ def remove_fs(module, container_image=None):
 
     args = ['rm', name, '--yes-i-really-mean-it']
 
-    cmd = generate_ceph_cmd(sub_cmd=['fs'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['fs'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -173,10 +173,10 @@ def fail_fs(module, container_image=None):
 
     args = ['fail', name]
 
-    cmd = generate_ceph_cmd(sub_cmd=['fs'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['fs'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 
@@ -192,10 +192,10 @@ def set_fs(module, container_image=None):
 
     args = ['set', name, 'max_mds', str(max_mds)]
 
-    cmd = generate_ceph_cmd(sub_cmd=['fs'],
-                            args=args,
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['fs'],
+                       args=args,
+                       cluster=cluster,
+                       container_image=container_image)
 
     return cmd
 

--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -19,12 +19,12 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 try:
-    from ansible.module_utils.ca_common import generate_ceph_cmd, \
+    from ansible.module_utils.ca_common import generate_cmd, \
                                                is_containerized, \
                                                container_exec, \
                                                fatal
 except ImportError:
-    from module_utils.ca_common import generate_ceph_cmd, \
+    from module_utils.ca_common import generate_cmd, \
                                        is_containerized, \
                                        container_exec, \
                                        fatal
@@ -304,12 +304,12 @@ def create_key(module, result, cluster, user, user_key, name, secret, caps, impo
         cluster, name, secret, caps, dest, container_image))
 
     if import_key or user != 'client.admin':
-        cmd_list.append(generate_ceph_cmd(sub_cmd=['auth'],
-                                          args=args,
-                                          cluster=cluster,
-                                          user=user,
-                                          user_key=user_key,
-                                          container_image=container_image))
+        cmd_list.append(generate_cmd(sub_cmd=['auth'],
+                                     args=args,
+                                     cluster=cluster,
+                                     user=user,
+                                     user_key=user_key,
+                                     container_image=container_image))
 
     return cmd_list
 
@@ -326,12 +326,12 @@ def delete_key(cluster, user, user_key, name, container_image=None):
         name,
     ]
 
-    cmd_list.append(generate_ceph_cmd(sub_cmd=['auth'],
-                                      args=args,
-                                      cluster=cluster,
-                                      user=user,
-                                      user_key=user_key,
-                                      container_image=container_image))
+    cmd_list.append(generate_cmd(sub_cmd=['auth'],
+                                 args=args,
+                                 cluster=cluster,
+                                 user=user,
+                                 user_key=user_key,
+                                 container_image=container_image))
 
     return cmd_list
 
@@ -350,12 +350,12 @@ def get_key(cluster, user, user_key, name, dest, container_image=None):
         dest,
     ]
 
-    cmd_list.append(generate_ceph_cmd(sub_cmd=['auth'],
-                                      args=args,
-                                      cluster=cluster,
-                                      user=user,
-                                      user_key=user_key,
-                                      container_image=container_image))
+    cmd_list.append(generate_cmd(sub_cmd=['auth'],
+                                 args=args,
+                                 cluster=cluster,
+                                 user=user,
+                                 user_key=user_key,
+                                 container_image=container_image))
 
     return cmd_list
 
@@ -374,12 +374,12 @@ def info_key(cluster, name, user, user_key, output_format, container_image=None)
         output_format,
     ]
 
-    cmd_list.append(generate_ceph_cmd(sub_cmd=['auth'],
-                                      args=args,
-                                      cluster=cluster,
-                                      user=user,
-                                      user_key=user_key,
-                                      container_image=container_image))
+    cmd_list.append(generate_cmd(sub_cmd=['auth'],
+                                 args=args,
+                                 cluster=cluster,
+                                 user=user,
+                                 user_key=user_key,
+                                 container_image=container_image))
 
     return cmd_list
 
@@ -397,12 +397,12 @@ def list_keys(cluster, user, user_key, container_image=None):
         'json',
     ]
 
-    cmd_list.append(generate_ceph_cmd(sub_cmd=['auth'],
-                                      args=args,
-                                      cluster=cluster,
-                                      user=user,
-                                      user_key=user_key,
-                                      container_image=container_image))
+    cmd_list.append(generate_cmd(sub_cmd=['auth'],
+                                 args=args,
+                                 cluster=cluster,
+                                 user=user,
+                                 user_key=user_key,
+                                 container_image=container_image))
 
     return cmd_list
 

--- a/library/ceph_mgr_module.py
+++ b/library/ceph_mgr_module.py
@@ -18,11 +18,11 @@ __metaclass__ = type
 from ansible.module_utils.basic import AnsibleModule
 try:
     from ansible.module_utils.ca_common import exit_module, \
-                                               generate_ceph_cmd, \
+                                               generate_cmd, \
                                                is_containerized
 except ImportError:
     from module_utils.ca_common import exit_module, \
-                                       generate_ceph_cmd, \
+                                       generate_cmd, \
                                        is_containerized
 import datetime
 
@@ -97,10 +97,10 @@ def main():
 
     container_image = is_containerized()
 
-    cmd = generate_ceph_cmd(['mgr', 'module'],
-                            [state, name],
-                            cluster=cluster,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['mgr', 'module'],
+                       args=[state, name],
+                       cluster=cluster,
+                       container_image=container_image)
 
     if module.check_mode:
         exit_module(

--- a/library/ceph_osd.py
+++ b/library/ceph_osd.py
@@ -17,9 +17,9 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 try:
-    from ansible.module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized  # noqa: E501
+    from ansible.module_utils.ca_common import exit_module, generate_cmd, is_containerized  # noqa: E501
 except ImportError:
-    from module_utils.ca_common import exit_module, generate_ceph_cmd, is_containerized  # noqa: E501
+    from module_utils.ca_common import exit_module, generate_cmd, is_containerized  # noqa: E501
 import datetime
 
 
@@ -111,7 +111,7 @@ def main():
 
     container_image = is_containerized()
 
-    cmd = generate_ceph_cmd(['osd', state], ids, cluster=cluster, container_image=container_image)  # noqa: E501
+    cmd = generate_cmd(sub_cmd=['osd', state], args=ids, cluster=cluster, container_image=container_image)  # noqa: E501
 
     if state in ['destroy', 'purge']:
         cmd.append('--yes-i-really-mean-it')

--- a/library/ceph_osd_flag.py
+++ b/library/ceph_osd_flag.py
@@ -18,11 +18,11 @@ __metaclass__ = type
 from ansible.module_utils.basic import AnsibleModule
 try:
     from ansible.module_utils.ca_common import exit_module, \
-                                               generate_ceph_cmd, \
+                                               generate_cmd, \
                                                is_containerized
 except ImportError:
     from module_utils.ca_common import exit_module, \
-                                       generate_ceph_cmd, \
+                                       generate_cmd, \
                                        is_containerized
 import datetime
 
@@ -99,9 +99,9 @@ def main():
     container_image = is_containerized()
 
     if state == 'present':
-        cmd = generate_ceph_cmd(['osd', 'set'], [name], cluster=cluster, container_image=container_image)  # noqa: E501
+        cmd = generate_cmd(sub_cmd=['osd', 'set'], args=[name], cluster=cluster, container_image=container_image)  # noqa: E501
     else:
-        cmd = generate_ceph_cmd(['osd', 'unset'], [name], cluster=cluster, container_image=container_image)  # noqa: E501
+        cmd = generate_cmd(sub_cmd=['osd', 'unset'], args=[name], cluster=cluster, container_image=container_image)  # noqa: E501
 
     if module.check_mode:
         exit_module(

--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -19,14 +19,14 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
 try:
-    from ansible.module_utils.ca_common import generate_ceph_cmd, \
-                                               pre_generate_ceph_cmd, \
+    from ansible.module_utils.ca_common import generate_cmd, \
+                                               pre_generate_cmd, \
                                                is_containerized, \
                                                exec_command, \
                                                exit_module
 except ImportError:
-    from module_utils.ca_common import generate_ceph_cmd, \
-                                       pre_generate_ceph_cmd, \
+    from module_utils.ca_common import generate_cmd, \
+                                       pre_generate_cmd, \
                                        is_containerized, \
                                        exec_command, \
                                        exit_module
@@ -167,12 +167,12 @@ def check_pool_exist(cluster,
 
     args = ['stats', name, '-f', output_format]
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -182,7 +182,7 @@ def generate_get_config_cmd(param,
                             user,
                             user_key,
                             container_image=None):
-    _cmd = pre_generate_ceph_cmd(container_image=container_image)
+    _cmd = pre_generate_cmd('ceph', container_image=container_image)
     args = [
         '-n',
         user,
@@ -211,12 +211,12 @@ def get_application_pool(cluster,
 
     args = ['application', 'get', name, '-f', output_format]
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -233,12 +233,34 @@ def enable_application_pool(cluster,
 
     args = ['application', 'enable', name, application]
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
+
+    return cmd
+
+
+def init_rbd_pool(cluster,
+                  name,
+                  user,
+                  user_key,
+                  container_image=None):
+    '''
+    Initialize a rbd pool
+    '''
+
+    args = [name]
+
+    cmd = generate_cmd(cmd='rbd',
+                       sub_cmd=['pool', 'init'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -256,12 +278,12 @@ def disable_application_pool(cluster,
     args = ['application', 'disable', name,
             application, '--yes-i-really-mean-it']
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -279,12 +301,12 @@ def get_pool_details(module,
 
     args = ['ls', 'detail', '-f', output_format]
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     rc, cmd, out, err = exec_command(module, cmd)
 
@@ -368,18 +390,17 @@ def list_pools(cluster,
 
     args.extend(['-f', output_format])
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
 
 def create_pool(cluster,
-                name,
                 user,
                 user_key,
                 user_pool_config,
@@ -423,12 +444,12 @@ def create_pool(cluster,
                      '--autoscale-mode',
                      user_pool_config['pg_autoscale_mode']['value']])
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -440,12 +461,12 @@ def remove_pool(cluster, name, user, user_key, container_image=None):
 
     args = ['rm', name, name, '--yes-i-really-really-mean-it']
 
-    cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                            args=args,
-                            cluster=cluster,
-                            user=user,
-                            user_key=user_key,
-                            container_image=container_image)
+    cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                       args=args,
+                       cluster=cluster,
+                       user=user,
+                       user_key=user_key,
+                       container_image=container_image)
 
     return cmd
 
@@ -465,12 +486,12 @@ def update_pool(module, cluster, name,
                     delta[key]['cli_set_opt'],
                     delta[key]['value']]
 
-            cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
-                                    args=args,
-                                    cluster=cluster,
-                                    user=user,
-                                    user_key=user_key,
-                                    container_image=container_image)
+            cmd = generate_cmd(sub_cmd=['osd', 'pool'],
+                               args=args,
+                               cluster=cluster,
+                               user=user,
+                               user_key=user_key,
+                               container_image=container_image)
 
             rc, cmd, out, err = exec_command(module, cmd)
             if rc != 0:
@@ -634,7 +655,6 @@ def run_module():
         else:
             rc, cmd, out, err = exec_command(module,
                                              create_pool(cluster,
-                                                         name,
                                                          user,
                                                          user_key,
                                                          user_pool_config=user_pool_config,  # noqa: E501
@@ -644,6 +664,13 @@ def run_module():
                                            enable_application_pool(cluster,
                                                                    name,
                                                                    user_pool_config['application']['value'],  # noqa: E501
+                                                                   user,
+                                                                   user_key,
+                                                                   container_image=container_image))  # noqa: E501
+                if rc == 0 and user_pool_config['application']['value'] == 'rbd':  # noqa: E501
+                    rc, cmd, out, err = exec_command(module,
+                                                     init_rbd_pool(cluster,
+                                                                   user_pool_config['pool_name']['value'],  # noqa: E501
                                                                    user,
                                                                    user_key,
                                                                    container_image=container_image))  # noqa: E501

--- a/module_utils/ca_common.py
+++ b/module_utils/ca_common.py
@@ -2,15 +2,22 @@ import os
 import datetime
 
 
-def generate_ceph_cmd(sub_cmd, args, user_key=None, cluster='ceph', user='client.admin', container_image=None, interactive=False):
+def generate_cmd(cmd='ceph',
+                 sub_cmd=None,
+                 args=None,
+                 user_key=None,
+                 cluster='ceph',
+                 user='client.admin',
+                 container_image=None,
+                 interactive=False):
     '''
     Generate 'ceph' command line to execute
     '''
 
-    if not user_key:
+    if user_key is None:
         user_key = '/etc/ceph/{}.{}.keyring'.format(cluster, user)
 
-    cmd = pre_generate_ceph_cmd(container_image=container_image, interactive=interactive)
+    cmd = pre_generate_cmd(cmd, container_image=container_image, interactive=interactive)  # noqa: E501
 
     base_cmd = [
         '-n',
@@ -20,8 +27,11 @@ def generate_ceph_cmd(sub_cmd, args, user_key=None, cluster='ceph', user='client
         '--cluster',
         cluster
     ]
-    base_cmd.extend(sub_cmd)
-    cmd.extend(base_cmd + args)
+
+    if sub_cmd is not None:
+        base_cmd.extend(sub_cmd)
+
+    cmd.extend(base_cmd) if args is None else cmd.extend(base_cmd + args)
 
     return cmd
 
@@ -59,14 +69,14 @@ def is_containerized():
     return container_image
 
 
-def pre_generate_ceph_cmd(container_image=None, interactive=False):
+def pre_generate_cmd(cmd, container_image=None, interactive=False):
     '''
-    Generate ceph prefix comaand
+    Generate ceph prefix command
     '''
     if container_image:
-        cmd = container_exec('ceph', container_image, interactive=interactive)
+        cmd = container_exec(cmd, container_image, interactive=interactive)
     else:
-        cmd = ['ceph']
+        cmd = [cmd]
 
     return cmd
 
@@ -84,7 +94,7 @@ def exec_command(module, cmd, stdin=None):
     return rc, cmd, out, err
 
 
-def exit_module(module, out, rc, cmd, err, startd, changed=False, diff=dict(before="", after="")):
+def exit_module(module, out, rc, cmd, err, startd, changed=False, diff=dict(before="", after="")):  # noqa: E501
     endd = datetime.datetime.now()
     delta = endd - startd
 

--- a/tests/library/test_ceph_key.py
+++ b/tests/library/test_ceph_key.py
@@ -62,7 +62,7 @@ class TestCephKeyModule(object):
             'auth',
             'arg'
         ]
-        result = ceph_key.generate_ceph_cmd(
+        result = ceph_key.generate_cmd(
             sub_cmd=['auth'],
             args=fake_args,
             cluster=fake_cluster,
@@ -93,7 +93,7 @@ class TestCephKeyModule(object):
                                  fake_cluster,
                                  'auth',
                                  'arg']
-        result = ceph_key.generate_ceph_cmd(
+        result = ceph_key.generate_cmd(
             sub_cmd=['auth'],
             args=fake_args,
             cluster=fake_cluster,

--- a/tests/library/test_ceph_pool.py
+++ b/tests/library/test_ceph_pool.py
@@ -2,6 +2,7 @@ import os
 import sys
 import ceph_pool
 from mock.mock import patch
+import pytest
 
 sys.path.append('./library')
 fake_user = 'client.admin'
@@ -282,6 +283,53 @@ class TestCephPoolModule(object):
 
         assert cmd == expected_command
 
+    @pytest.mark.parametrize("container_image", [None, fake_container_image_name])
+    def test_init_rbd_pool(self, container_image):
+        if container_image:
+            expected_command = [
+                    'podman',
+                    'run',
+                    '--rm',
+                    '--net=host',
+                    '-v',
+                    '/etc/ceph:/etc/ceph:z',
+                    '-v',
+                    '/var/lib/ceph/:/var/lib/ceph/:z',
+                    '-v',
+                    '/var/log/ceph/:/var/log/ceph/:z',
+                    '--entrypoint=rbd',
+                    fake_container_image_name,
+                    '-n',
+                    fake_user,
+                    '-k',
+                    fake_user_key,
+                    '--cluster',
+                    fake_cluster_name,
+                    'pool',
+                    'init',
+                    self.fake_user_pool_config['pool_name']['value']
+            ]
+        else:
+            expected_command = [
+                    'rbd',
+                    '-n',
+                    fake_user,
+                    '-k',
+                    fake_user_key,
+                    '--cluster',
+                    fake_cluster_name,
+                    'pool',
+                    'init',
+                    self.fake_user_pool_config['pool_name']['value']
+            ]
+
+        cmd = ceph_pool.init_rbd_pool(fake_cluster_name,
+                                      self.fake_user_pool_config['pool_name']['value'],
+                                      fake_user, fake_user_key,
+                                      container_image)
+
+        assert cmd == expected_command
+
     def test_disable_application_pool(self):
         expected_command = [
                 'podman',
@@ -442,7 +490,6 @@ class TestCephPoolModule(object):
         ]
 
         cmd = ceph_pool.create_pool(fake_cluster_name,
-                                    self.fake_user_pool_config['pool_name']['value'],
                                     fake_user, fake_user_key, self.fake_user_pool_config,
                                     container_image=fake_container_image_name)
 
@@ -489,7 +536,6 @@ class TestCephPoolModule(object):
         ]
 
         cmd = ceph_pool.create_pool(fake_cluster_name,
-                                    self.fake_user_pool_config['pool_name']['value'],
                                     fake_user, fake_user_key,
                                     self.fake_user_pool_config,
                                     container_image=fake_container_image_name)
@@ -535,7 +581,6 @@ class TestCephPoolModule(object):
         ]
 
         cmd = ceph_pool.create_pool(fake_cluster_name,
-                                    self.fake_user_pool_config['pool_name']['value'],
                                     fake_user, fake_user_key, self.fake_user_pool_config,
                                     container_image=fake_container_image_name)
 
@@ -583,7 +628,6 @@ class TestCephPoolModule(object):
         ]
 
         cmd = ceph_pool.create_pool(fake_cluster_name,
-                                    self.fake_user_pool_config['pool_name']['value'],
                                     fake_user, fake_user_key, self.fake_user_pool_config,
                                     container_image=fake_container_image_name)
 

--- a/tests/module_utils/test_ca_common.py
+++ b/tests/module_utils/test_ca_common.py
@@ -38,17 +38,17 @@ class TestCommon(object):
 
     @pytest.mark.parametrize('image', [None, fake_container_image])
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_pre_generate_ceph_cmd(self, image):
+    def test_pre_generate_cmd(self, image):
         if image:
             expected_cmd = self.fake_container_cmd
         else:
             expected_cmd = [self.fake_binary]
 
-        assert ca_common.pre_generate_ceph_cmd(image) == expected_cmd
+        assert ca_common.pre_generate_cmd(self.fake_binary, image) == expected_cmd  # noqa: E501
 
     @pytest.mark.parametrize('image', [None, fake_container_image])
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_ceph_cmd(self, image):
+    def test_generate_cmd(self, image):
         sub_cmd = ['osd', 'pool']
         args = ['create', 'foo']
         if image:
@@ -64,11 +64,11 @@ class TestCommon(object):
             'osd', 'pool',
             'create', 'foo'
         ])
-        assert ca_common.generate_ceph_cmd(sub_cmd, args, cluster=self.fake_cluster, container_image=image) == expected_cmd
+        assert ca_common.generate_cmd(sub_cmd=sub_cmd, args=args, cluster=self.fake_cluster, container_image=image) == expected_cmd  # noqa: E501
 
     @pytest.mark.parametrize('image', [None, fake_container_image])
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_ceph_cmd_different_cluster_name(self, image):
+    def test_generate_cmd_different_cluster_name(self, image):
         sub_cmd = ['osd', 'pool']
         args = ['create', 'foo']
         if image:
@@ -84,12 +84,12 @@ class TestCommon(object):
             'osd', 'pool',
             'create', 'foo'
         ])
-        result = ca_common.generate_ceph_cmd(sub_cmd, args, cluster='foo', container_image=image)
+        result = ca_common.generate_cmd(sub_cmd=sub_cmd, args=args, cluster='foo', container_image=image)  # noqa: E501
         assert result == expected_cmd
 
     @pytest.mark.parametrize('image', [None, fake_container_image])
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_ceph_cmd_different_cluster_name_and_user(self, image):
+    def test_generate_cmd_different_cluster_name_and_user(self, image):
         sub_cmd = ['osd', 'pool']
         args = ['create', 'foo']
         if image:
@@ -105,12 +105,12 @@ class TestCommon(object):
             'osd', 'pool',
             'create', 'foo'
         ])
-        result = ca_common.generate_ceph_cmd(sub_cmd, args, cluster='foo', user='client.foo', container_image=image)
+        result = ca_common.generate_cmd(sub_cmd=sub_cmd, args=args, cluster='foo', user='client.foo', container_image=image)  # noqa: E501
         assert result == expected_cmd
 
     @pytest.mark.parametrize('image', [None, fake_container_image])
     @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
-    def test_generate_ceph_cmd_different_user(self, image):
+    def test_generate_cmd_different_user(self, image):
         sub_cmd = ['osd', 'pool']
         args = ['create', 'foo']
         if image:
@@ -126,7 +126,7 @@ class TestCommon(object):
             'osd', 'pool',
             'create', 'foo'
         ])
-        result = ca_common.generate_ceph_cmd(sub_cmd, args, user='client.foo', container_image=image)
+        result = ca_common.generate_cmd(sub_cmd=sub_cmd, args=args, user='client.foo', container_image=image)  # noqa: E501
         assert result == expected_cmd
 
     @pytest.mark.parametrize('stdin', [None, 'foo'])
@@ -137,7 +137,7 @@ class TestCommon(object):
         stdout = 'ceph version 1.2.3'
         fake_module.run_command.return_value = 0, stdout, stderr
         expected_cmd = [self.fake_binary, '--version']
-        _rc, _cmd, _out, _err = ca_common.exec_command(fake_module, expected_cmd, stdin=stdin)
+        _rc, _cmd, _out, _err = ca_common.exec_command(fake_module, expected_cmd, stdin=stdin)  # noqa: E501
         assert _rc == rc
         assert _cmd == expected_cmd
         assert _err == stderr


### PR DESCRIPTION
When creating a RBD pool it needs to be initialized as per documentation[1] Modified (pre_)generate_ceph_cmd to make it usable with rbd command as well

[1]https://docs.ceph.com/en/latest/rbd/rados-rbd-cmds/#create-a-block-device-pool

Signed-off-by: Teoman ONAY <tonay@redhat.com>