### PR TITLE
[skip ci] Check first the OSD storage file rather than after created

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -523,9 +523,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
 
         (0..2).each do |d|
+          unless File.exist?("disk-#{i}-#{d}.vdi")
           vb.customize ['createhd',
                         '--filename', "disk-#{i}-#{d}",
-                        '--size', '11000'] unless File.exist?("disk-#{i}-#{d}.vdi")
+                        '--size', '11000']
+          end
           vb.customize ['storageattach', :id,
                         '--storagectl', 'OSD Controller',
                         '--port', 3 + d,


### PR DESCRIPTION
Signed-off-by: Mario Codeniera <M.Codeniera@massey.ac.nz>

Fix the issue on using vagrant - VirtualBox:

```
==> osd0: Importing base box 'bento/ubuntu-20.04'...
==> osd0: Matching MAC address for NAT networking...
==> osd0: Checking if box 'bento/ubuntu-20.04' version '202206.03.0' is up to date...
==> osd0: Setting the name of the VM: ceph-ansible_osd0_1667337717442_50613
==> osd0: Fixed port collision for 22 => 2222. Now on port 2204.
==> osd0: Clearing any previously set network interfaces...
==> osd0: Preparing network interfaces based on configuration...
    osd0: Adapter 1: nat
    osd0: Adapter 2: hostonly
    osd0: Adapter 3: hostonly
==> osd0: Forwarding ports...
    osd0: 22 (guest) => 2204 (host) (adapter 1)
==> osd0: Running 'pre-boot' VM customizations...
A customization command failed:

["createhd", "--filename", "disk-0-0", "--size", "11000"]

The following error was experienced:

#<Vagrant::Errors::VBoxManageError: There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["createhd", "--filename", "disk-0-0", "--size", "11000"]

Stderr: 0%...VBOX_E_FILE_ERROR
VBoxManage: error: Failed to create medium
VBoxManage: error: Could not create the medium storage unit '/home/tahder/alcatraz/ceph-ansible/disk-0-0.vdi'.
VBoxManage: error: VDI: cannot create image '/home/tahder/alcatraz/ceph-ansible/disk-0-0.vdi' (VERR_ALREADY_EXISTS)
VBoxManage: error: Details: code VBOX_E_FILE_ERROR (0x80bb0004), component MediumWrap, interface IMedium
VBoxManage: error: Context: "RTEXITCODE handleCreateMedium(HandlerArg*)" at line 632 of file VBoxManageDisk.cpp
>

Please fix this customization and try again.
```
Related to PR #7348 which points to the stable-7.0 which is not allowed. 