### PR TITLE
tests: use quay.io instead of quay.ceph.io

### DIFF
--- a/docs/source/installation/containerized.rst
+++ b/docs/source/installation/containerized.rst
@@ -29,8 +29,8 @@ You can configure your own container register, image and tag by using the ``ceph
 
 .. code-block:: yaml
 
-   ceph_docker_registry: quay.ceph.io
-   ceph_docker_image: ceph-ci/daemon
+   ceph_docker_registry: quay.io
+   ceph_docker_image: ceph/daemon
    ceph_docker_image_tag: latest
 
 .. note::

--- a/docs/source/testing/tox.rst
+++ b/docs/source/testing/tox.rst
@@ -21,9 +21,9 @@ runs of ``ceph-ansible``.
 
 The following environent variables are available for use:
 
-* ``CEPH_DOCKER_REGISTRY``: (default: ``quay.ceph.io``) This would configure the ``ceph-ansible`` variable ``ceph_docker_registry``.
+* ``CEPH_DOCKER_REGISTRY``: (default: ``quay.io``) This would configure the ``ceph-ansible`` variable ``ceph_docker_registry``.
 
-* ``CEPH_DOCKER_IMAGE``: (default: ``ceph-ci/daemon``) This would configure the ``ceph-ansible`` variable ``ceph_docker_image``.
+* ``CEPH_DOCKER_IMAGE``: (default: ``ceph/daemon``) This would configure the ``ceph-ansible`` variable ``ceph_docker_image``.
 
 * ``CEPH_DOCKER_IMAGE_TAG``: (default: ``latest``) This would configure the ``ceph-ansible`` variable ``ceph_docker_image_name``.
 

--- a/library/cephadm_adopt.py
+++ b/library/cephadm_adopt.py
@@ -84,7 +84,7 @@ EXAMPLES = '''
   cephadm_adopt:
     name: mon.foo
     style: legacy
-    image: quay.ceph.io/ceph/daemon-base:latest-main-devel
+    image: quay.io/ceph/daemon-base:latest-main-devel
     pull: false
     firewalld: false
 
@@ -93,7 +93,7 @@ EXAMPLES = '''
     name: mon.foo
     style: legacy
   environment:
-    CEPHADM_IMAGE: quay.ceph.io/ceph/daemon-base:latest-main-devel
+    CEPHADM_IMAGE: quay.io/ceph/daemon-base:latest-main-devel
 '''
 
 RETURN = '''#  '''

--- a/library/cephadm_bootstrap.py
+++ b/library/cephadm_bootstrap.py
@@ -124,7 +124,7 @@ EXAMPLES = '''
   cephadm_bootstrap:
     mon_ip: 192.168.42.1
     fsid: 3c9ba63a-c7df-4476-a1e7-317dfc711f82
-    image: quay.ceph.io/ceph/daemon-base:latest-main-devel
+    image: quay.io/ceph/daemon-base:latest-main-devel
     dashboard: false
     monitoring: false
     firewalld: false
@@ -133,7 +133,7 @@ EXAMPLES = '''
   cephadm_bootstrap:
     mon_ip: 192.168.42.1
   environment:
-    CEPHADM_IMAGE: quay.ceph.io/ceph/daemon-base:latest-main-devel
+    CEPHADM_IMAGE: quay.io/ceph/daemon-base:latest-main-devel
 '''
 
 RETURN = '''#  '''

--- a/tests/functional/add-mdss/container/group_vars/all
+++ b/tests/functional/add-mdss/container/group_vars/all
@@ -27,6 +27,6 @@ ceph_conf_overrides:
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/add-mgrs/container/group_vars/all
+++ b/tests/functional/add-mgrs/container/group_vars/all
@@ -27,6 +27,6 @@ ceph_conf_overrides:
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/add-mons/container/group_vars/all
+++ b/tests/functional/add-mons/container/group_vars/all
@@ -27,6 +27,6 @@ ceph_conf_overrides:
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/add-osds/container/group_vars/all
+++ b/tests/functional/add-osds/container/group_vars/all
@@ -27,6 +27,6 @@ ceph_conf_overrides:
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/add-rbdmirrors/container/group_vars/all
+++ b/tests/functional/add-rbdmirrors/container/group_vars/all
@@ -27,6 +27,6 @@ ceph_conf_overrides:
     mon_warn_on_pool_no_redundancy: false
     osd_pool_default_size: 1
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/add-rgws/container/group_vars/all
+++ b/tests/functional/add-rgws/container/group_vars/all
@@ -29,6 +29,6 @@ ceph_conf_overrides:
 rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/all-in-one/container/group_vars/all
+++ b/tests/functional/all-in-one/container/group_vars/all
@@ -43,6 +43,6 @@ lvm_volumes:
     data_vg: test_group
     db: journal1
     db_vg: journals
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -36,10 +36,10 @@ handler_health_osd_check_delay: 10
 mds_max_mds: 2
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main
-node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"
+node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/ceph/ceph-grafana:6.7.4"

--- a/tests/functional/all_daemons/group_vars/all
+++ b/tests/functional/all_daemons/group_vars/all
@@ -30,9 +30,9 @@ handler_health_osd_check_delay: 10
 mds_max_mds: 2
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
-ceph_docker_registry: quay.ceph.io
-node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"
+ceph_docker_registry: quay.io
+node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/ceph/ceph-grafana:6.7.4"
 grafana_server_group_name: ceph_monitoring

--- a/tests/functional/cephadm/group_vars/all
+++ b/tests/functional/cephadm/group_vars/all
@@ -3,7 +3,7 @@ monitor_interface: eth1
 public_network: "192.168.30.0/24"
 cluster_network: "192.168.31.0/24"
 dashboard_admin_password: $sX!cD$rYU6qR^B!
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon-base
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main-devel
 containerized_deployment: true

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -25,10 +25,10 @@ handler_health_osd_check_delay: 10
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 dashboard_admin_user_ro: true
 grafana_admin_password: +xFRe+RES@7vg24n
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main
-node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"
+node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/ceph/ceph-grafana:6.7.4"

--- a/tests/functional/collocation/group_vars/all
+++ b/tests/functional/collocation/group_vars/all
@@ -22,8 +22,8 @@ handler_health_osd_check_delay: 10
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 dashboard_admin_user_ro: true
 grafana_admin_password: +xFRe+RES@7vg24n
-ceph_docker_registry: quay.ceph.io
-node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"
+ceph_docker_registry: quay.io
+node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/ceph/ceph-grafana:6.7.4"

--- a/tests/functional/docker2podman/group_vars/all
+++ b/tests/functional/docker2podman/group_vars/all
@@ -33,10 +33,10 @@ handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main
-node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"
+node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/ceph/ceph-grafana:6.7.4"

--- a/tests/functional/external_clients/container/inventory/group_vars/all
+++ b/tests/functional/external_clients/container/inventory/group_vars/all
@@ -37,6 +37,6 @@ lvm_volumes:
     db_vg: journals
 fsid: 40358a87-ab6e-4bdc-83db-1d909147861c
 generate_fsid: false
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/filestore-to-bluestore/container/group_vars/all
+++ b/tests/functional/filestore-to-bluestore/container/group_vars/all
@@ -23,6 +23,6 @@ ceph_conf_overrides:
 dashboard_enabled: False
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/lvm-auto-discovery/container/group_vars/all
+++ b/tests/functional/lvm-auto-discovery/container/group_vars/all
@@ -27,6 +27,6 @@ ceph_conf_overrides:
 dashboard_enabled: False
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/lvm-batch/container/group_vars/all
+++ b/tests/functional/lvm-batch/container/group_vars/all
@@ -29,6 +29,6 @@ ceph_conf_overrides:
 dashboard_enabled: False
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/lvm-osds/container/group_vars/all
+++ b/tests/functional/lvm-osds/container/group_vars/all
@@ -37,6 +37,6 @@ openstack_cinder_pool:
 openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/ooo-collocation/hosts
+++ b/tests/functional/ooo-collocation/hosts
@@ -10,9 +10,9 @@ all:
         rgw_keystone_admin_user: swift, rgw_keystone_api_version: 3, rgw_keystone_implicit_tenants: 'true',
         rgw_keystone_url: 'http://192.168.95.10:5000', rgw_s3_auth_use_keystone: 'true', rgw_keystone_revocation_interval: 0}
     cluster: mycluster
-    ceph_docker_image: ceph-ci/daemon
+    ceph_docker_image: ceph/daemon
     ceph_docker_image_tag: latest-main
-    ceph_docker_registry: quay.ceph.io
+    ceph_docker_registry: quay.io
     cephfs_data_pool:
       name: 'manila_data'
       application: "cephfs"

--- a/tests/functional/podman/group_vars/all
+++ b/tests/functional/podman/group_vars/all
@@ -32,10 +32,10 @@ handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main
-node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"
+node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/ceph/ceph-grafana:6.7.4"

--- a/tests/functional/rbdmirror/container/group_vars/all
+++ b/tests/functional/rbdmirror/container/group_vars/all
@@ -27,6 +27,6 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
     mon_max_pg_per_osd: 512
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/rbdmirror/container/secondary/group_vars/all
+++ b/tests/functional/rbdmirror/container/secondary/group_vars/all
@@ -27,6 +27,6 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
     mon_max_pg_per_osd: 512
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/rgw-multisite/container/group_vars/all
+++ b/tests/functional/rgw-multisite/container/group_vars/all
@@ -28,6 +28,6 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
     mon_max_pg_per_osd: 512
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/rgw-multisite/container/secondary/group_vars/all
+++ b/tests/functional/rgw-multisite/container/secondary/group_vars/all
@@ -28,6 +28,6 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
     mon_max_pg_per_osd: 512
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_mds/container/group_vars/all
+++ b/tests/functional/shrink_mds/container/group_vars/all
@@ -16,6 +16,6 @@ ceph_conf_overrides:
 openstack_config: False
 dashboard_enabled: False
 copy_admin_key: True
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_mgr/container/group_vars/all
+++ b/tests/functional/shrink_mgr/container/group_vars/all
@@ -15,6 +15,6 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_mon/container/group_vars/all
+++ b/tests/functional/shrink_mon/container/group_vars/all
@@ -15,6 +15,6 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 openstack_config: False
 dashboard_enabled: False
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_osd/container/group_vars/all
+++ b/tests/functional/shrink_osd/container/group_vars/all
@@ -16,6 +16,6 @@ ceph_conf_overrides:
 openstack_config: False
 dashboard_enabled: False
 copy_admin_key: True
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_rbdmirror/container/group_vars/all
+++ b/tests/functional/shrink_rbdmirror/container/group_vars/all
@@ -15,6 +15,6 @@ ceph_conf_overrides:
 openstack_config: False
 dashboard_enabled: False
 copy_admin_key: True
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_rgw/container/group_vars/all
+++ b/tests/functional/shrink_rgw/container/group_vars/all
@@ -17,6 +17,6 @@ ceph_conf_overrides:
 openstack_config: False
 dashboard_enabled: False
 copy_admin_key: True
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main

--- a/tests/functional/subset_update/container/group_vars/all
+++ b/tests/functional/subset_update/container/group_vars/all
@@ -27,10 +27,10 @@ mds_max_mds: 2
 dashboard_enabled: false
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
-ceph_docker_registry: quay.ceph.io
-ceph_docker_image: ceph-ci/daemon
+ceph_docker_registry: quay.io
+ceph_docker_image: ceph/daemon
 ceph_docker_image_tag: latest-main
-node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"
+node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/ceph/ceph-grafana:6.7.4"

--- a/tests/functional/subset_update/group_vars/all
+++ b/tests/functional/subset_update/group_vars/all
@@ -19,9 +19,9 @@ mds_max_mds: 2
 dashboard_enabled: false
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
-ceph_docker_registry: quay.ceph.io
-node_exporter_container_image: "quay.ceph.io/prometheus/node-exporter:v0.17.0"
-prometheus_container_image: "quay.ceph.io/prometheus/prometheus:v2.7.2"
-alertmanager_container_image: "quay.ceph.io/prometheus/alertmanager:v0.16.2"
-grafana_container_image: "quay.ceph.io/app-sre/grafana:6.7.4"
+ceph_docker_registry: quay.io
+node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
+prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"
+alertmanager_container_image: "quay.io/prometheus/alertmanager:v0.16.2"
+grafana_container_image: "quay.io/ceph/ceph-grafana:6.7.4"
 grafana_server_group_name: ceph_monitoring

--- a/tests/library/test_ceph_crush_rule.py
+++ b/tests/library/test_ceph_crush_rule.py
@@ -6,7 +6,7 @@ import ceph_crush_rule
 
 fake_cluster = 'ceph'
 fake_container_binary = 'podman'
-fake_container_image = 'quay.ceph.io/ceph/daemon:latest'
+fake_container_image = 'quay.io/ceph/daemon:latest'
 fake_name = 'foo'
 fake_bucket_root = 'default'
 fake_bucket_type = 'host'

--- a/tests/library/test_ceph_key.py
+++ b/tests/library/test_ceph_key.py
@@ -75,7 +75,7 @@ class TestCephKeyModule(object):
         fake_args = ['arg']
         fake_user = "fake-user"
         fake_user_key = "/tmp/my-key"
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest-luminous"
+        fake_container_image = "quay.io/ceph/daemon:latest-luminous"
         expected_command_list = ['docker',
                                  'run',
                                  '--rm',
@@ -84,7 +84,7 @@ class TestCephKeyModule(object):
                                  '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
                                  '-v', '/var/log/ceph/:/var/log/ceph/:z',
                                  '--entrypoint=ceph',
-                                 'quay.ceph.io/ceph-ci/daemon:latest-luminous',
+                                 'quay.io/ceph/daemon:latest-luminous',
                                  '-n',
                                  "fake-user",
                                  '-k',
@@ -143,7 +143,7 @@ class TestCephKeyModule(object):
         fake_dest = "/fake/ceph"
         fake_keyring_filename = fake_cluster + "." + fake_name + ".keyring"
         fake_file_destination = os.path.join(fake_dest, fake_keyring_filename)
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest-luminous"
+        fake_container_image = "quay.io/ceph/daemon:latest-luminous"
         expected_command_list = ['docker',
                                  'run',
                                  '--rm',
@@ -152,7 +152,7 @@ class TestCephKeyModule(object):
                                  '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
                                  '-v', '/var/log/ceph/:/var/log/ceph/:z',
                                  '--entrypoint=ceph-authtool',
-                                 'quay.ceph.io/ceph-ci/daemon:latest-luminous',
+                                 'quay.io/ceph/daemon:latest-luminous',
                                  '--create-keyring',
                                  fake_file_destination,
                                  '--name',
@@ -211,7 +211,7 @@ class TestCephKeyModule(object):
         fake_import_key = True
         fake_keyring_filename = fake_cluster + "." + fake_name + ".keyring"
         fake_file_destination = os.path.join(fake_dest, fake_keyring_filename)
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest-luminous"
+        fake_container_image = "quay.io/ceph/daemon:latest-luminous"
         expected_command_list = [
             ['docker',
              'run',
@@ -221,7 +221,7 @@ class TestCephKeyModule(object):
              '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
              '-v', '/var/log/ceph/:/var/log/ceph/:z',
              '--entrypoint=ceph-authtool',
-             'quay.ceph.io/ceph-ci/daemon:latest-luminous',
+             'quay.io/ceph/daemon:latest-luminous',
              '--create-keyring', fake_file_destination,
              '--name', fake_name,
              '--add-key', fake_secret,
@@ -235,7 +235,7 @@ class TestCephKeyModule(object):
              '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
              '-v', '/var/log/ceph/:/var/log/ceph/:z',
              '--entrypoint=ceph',
-             'quay.ceph.io/ceph-ci/daemon:latest-luminous',
+             'quay.io/ceph/daemon:latest-luminous',
              '-n', 'client.admin',
              '-k', '/etc/ceph/fake.client.admin.keyring',
              '--cluster', fake_cluster,
@@ -298,7 +298,7 @@ class TestCephKeyModule(object):
         fake_keyring_filename = fake_cluster + "." + fake_name + ".keyring"
         fake_file_destination = os.path.join(fake_dest, fake_keyring_filename)
         # create_key passes (one for ceph-authtool and one for itself) itw own array so the expected result is an array within an array # noqa E501
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest-luminous"
+        fake_container_image = "quay.io/ceph/daemon:latest-luminous"
         expected_command_list = [['docker',   # noqa E128
                                   'run',
                                   '--rm',
@@ -307,7 +307,7 @@ class TestCephKeyModule(object):
                                   '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
                                   '-v', '/var/log/ceph/:/var/log/ceph/:z',
                                   '--entrypoint=ceph-authtool',
-                                  'quay.ceph.io/ceph-ci/daemon:latest-luminous',
+                                  'quay.io/ceph/daemon:latest-luminous',
                                   '--create-keyring',
                                   fake_file_destination,
                                   '--name',
@@ -341,7 +341,7 @@ class TestCephKeyModule(object):
         fake_user_key = '/etc/ceph/fake.client.admin.keyring'
         fake_cluster = "fake"
         fake_name = "client.fake"
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest-luminous"
+        fake_container_image = "quay.io/ceph/daemon:latest-luminous"
         expected_command_list = [['docker',
                                   'run',
                                   '--rm',
@@ -350,7 +350,7 @@ class TestCephKeyModule(object):
                                   '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
                                   '-v', '/var/log/ceph/:/var/log/ceph/:z',
                                   '--entrypoint=ceph',
-                                  'quay.ceph.io/ceph-ci/daemon:latest-luminous',
+                                  'quay.io/ceph/daemon:latest-luminous',
                                   '-n', 'client.admin',
                                   '-k', '/etc/ceph/fake.client.admin.keyring',
                                   '--cluster', fake_cluster,
@@ -380,7 +380,7 @@ class TestCephKeyModule(object):
         fake_name = "client.fake"
         fake_user = 'client.admin'
         fake_user_key = '/etc/ceph/fake.client.admin.keyring'
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest-luminous"
+        fake_container_image = "quay.io/ceph/daemon:latest-luminous"
         expected_command_list = [['docker',   # noqa E128
                                   'run',
                                   '--rm',
@@ -389,7 +389,7 @@ class TestCephKeyModule(object):
                                   '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
                                   '-v', '/var/log/ceph/:/var/log/ceph/:z',
                                   '--entrypoint=ceph',
-                                  'quay.ceph.io/ceph-ci/daemon:latest-luminous',
+                                  'quay.io/ceph/daemon:latest-luminous',
                                   '-n', fake_user,
                                   '-k', fake_user_key,
                                   '--cluster', fake_cluster,
@@ -415,7 +415,7 @@ class TestCephKeyModule(object):
         fake_user = 'client.admin'
         fake_user_key = '/etc/ceph/fake.client.admin.keyring'
         fake_name = "client.fake"
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest-luminous"
+        fake_container_image = "quay.io/ceph/daemon:latest-luminous"
         fake_dest = "/fake/ceph"
         fake_keyring_filename = fake_cluster + "." + fake_name + ".keyring"
         fake_file_destination = os.path.join(fake_dest, fake_keyring_filename)
@@ -427,7 +427,7 @@ class TestCephKeyModule(object):
                                   '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
                                   '-v', '/var/log/ceph/:/var/log/ceph/:z',
                                   '--entrypoint=ceph',
-                                  'quay.ceph.io/ceph-ci/daemon:latest-luminous',
+                                  'quay.io/ceph/daemon:latest-luminous',
                                   '-n', fake_user,
                                   '-k', fake_user_key,
                                   '--cluster', fake_cluster,
@@ -472,7 +472,7 @@ class TestCephKeyModule(object):
         fake_user = "mon."
         fake_keyring_dirname = fake_cluster + "-" + fake_hostname
         fake_key = os.path.join("/var/lib/ceph/mon/", fake_keyring_dirname, 'keyring')
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest-luminous"
+        fake_container_image = "quay.io/ceph/daemon:latest-luminous"
         expected_command_list = [['docker',
                                   'run',
                                   '--rm',
@@ -481,7 +481,7 @@ class TestCephKeyModule(object):
                                   '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
                                   '-v', '/var/log/ceph/:/var/log/ceph/:z',
                                   '--entrypoint=ceph',
-                                  'quay.ceph.io/ceph-ci/daemon:latest-luminous',
+                                  'quay.io/ceph/daemon:latest-luminous',
                                   '-n', "mon.",
                                   '-k', "/var/lib/ceph/mon/fake-mon01/keyring",
                                   '--cluster', fake_cluster,
@@ -494,7 +494,7 @@ class TestCephKeyModule(object):
         fake_cluster = "fake"
         fake_user = "fake-user"
         fake_key = "/tmp/my-key"
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest-luminous"
+        fake_container_image = "quay.io/ceph/daemon:latest-luminous"
         expected_command_list = [['docker',
                                   'run',
                                   '--rm',
@@ -503,7 +503,7 @@ class TestCephKeyModule(object):
                                   '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
                                   '-v', '/var/log/ceph/:/var/log/ceph/:z',
                                   '--entrypoint=ceph',
-                                  'quay.ceph.io/ceph-ci/daemon:latest-luminous',
+                                  'quay.io/ceph/daemon:latest-luminous',
                                   '-n', "fake-user",
                                   '-k', "/tmp/my-key",
                                   '--cluster', fake_cluster,

--- a/tests/library/test_ceph_mgr_module.py
+++ b/tests/library/test_ceph_mgr_module.py
@@ -6,7 +6,7 @@ import ceph_mgr_module
 
 fake_cluster = 'ceph'
 fake_container_binary = 'podman'
-fake_container_image = 'quay.ceph.io/ceph/daemon:latest'
+fake_container_image = 'quay.io/ceph/daemon:latest'
 fake_module = 'noup'
 fake_user = 'client.admin'
 fake_keyring = '/etc/ceph/{}.{}.keyring'.format(fake_cluster, fake_user)

--- a/tests/library/test_ceph_osd.py
+++ b/tests/library/test_ceph_osd.py
@@ -6,7 +6,7 @@ import ceph_osd
 
 fake_cluster = 'ceph'
 fake_container_binary = 'podman'
-fake_container_image = 'quay.ceph.io/ceph/daemon:latest'
+fake_container_image = 'quay.io/ceph/daemon:latest'
 fake_id = '42'
 fake_ids = ['0', '7', '13']
 fake_user = 'client.admin'

--- a/tests/library/test_ceph_osd_flag.py
+++ b/tests/library/test_ceph_osd_flag.py
@@ -6,7 +6,7 @@ import ceph_osd_flag
 
 fake_cluster = 'ceph'
 fake_container_binary = 'podman'
-fake_container_image = 'quay.ceph.io/ceph/daemon:latest'
+fake_container_image = 'quay.io/ceph/daemon:latest'
 fake_flag = 'noup'
 fake_user = 'client.admin'
 fake_keyring = '/etc/ceph/{}.{}.keyring'.format(fake_cluster, fake_user)

--- a/tests/library/test_ceph_pool.py
+++ b/tests/library/test_ceph_pool.py
@@ -8,7 +8,7 @@ fake_user = 'client.admin'
 fake_user_key = '/etc/ceph/ceph.client.admin.keyring'
 fake_pool_name = 'foo'
 fake_cluster_name = 'ceph'
-fake_container_image_name = 'quay.ceph.io/ceph-ci/daemon:latest-luminous'
+fake_container_image_name = 'quay.io/ceph/daemon:latest-luminous'
 
 
 @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': 'podman'})

--- a/tests/library/test_ceph_volume.py
+++ b/tests/library/test_ceph_volume.py
@@ -77,7 +77,7 @@ class TestCephVolumeModule(object):
 
     def test_container_exec(self):
         fake_binary = "ceph-volume"
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest"
+        fake_container_image = "quay.io/ceph/daemon:latest"
         expected_command_list = get_container_cmd() + [fake_container_image]
         result = ceph_volume.container_exec(fake_binary, fake_container_image)
         assert result == expected_command_list
@@ -85,7 +85,7 @@ class TestCephVolumeModule(object):
     def test_zap_osd_container(self):
         fake_module = MagicMock()
         fake_module.params = {'data': '/dev/sda'}
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest"
+        fake_container_image = "quay.io/ceph/daemon:latest"
         expected_command_list = get_container_cmd() + \
             [fake_container_image,
                 '--cluster',
@@ -168,7 +168,7 @@ class TestCephVolumeModule(object):
     def test_list_osd_container(self):
         fake_module = MagicMock()
         fake_module.params = {'cluster': 'ceph', 'data': '/dev/sda'}
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest"
+        fake_container_image = "quay.io/ceph/daemon:latest"
         expected_command_list = get_container_cmd(
                                 {
                                     '/var/lib/ceph': '/var/lib/ceph:ro'
@@ -197,7 +197,7 @@ class TestCephVolumeModule(object):
 
     def test_list_storage_inventory_container(self):
         fake_module = MagicMock()
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest"
+        fake_container_image = "quay.io/ceph/daemon:latest"
         expected_command_list = get_container_cmd() + \
             [fake_container_image,
                 '--cluster',
@@ -215,7 +215,7 @@ class TestCephVolumeModule(object):
                               'cluster': 'ceph', }
 
         fake_action = "create"
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest"
+        fake_container_image = "quay.io/ceph/daemon:latest"
         expected_command_list = get_container_cmd() + \
             [fake_container_image,
                 '--cluster',
@@ -258,7 +258,7 @@ class TestCephVolumeModule(object):
                               'cluster': 'ceph', }
 
         fake_action = "prepare"
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest"
+        fake_container_image = "quay.io/ceph/daemon:latest"
         expected_command_list = get_container_cmd() + \
             [fake_container_image,
                 '--cluster',
@@ -303,7 +303,7 @@ class TestCephVolumeModule(object):
                               'cluster': 'ceph',
                               'batch_devices': ["/dev/sda", "/dev/sdb"]}
 
-        fake_container_image = "quay.ceph.io/ceph-ci/daemon:latest"
+        fake_container_image = "quay.io/ceph/daemon:latest"
         expected_command_list = get_container_cmd() + \
             [fake_container_image,
                 '--cluster',

--- a/tests/library/test_ceph_volume_simple_activate.py
+++ b/tests/library/test_ceph_volume_simple_activate.py
@@ -6,7 +6,7 @@ import ceph_volume_simple_activate
 
 fake_cluster = 'ceph'
 fake_container_binary = 'podman'
-fake_container_image = 'quay.ceph.io/ceph/daemon:latest'
+fake_container_image = 'quay.io/ceph/daemon:latest'
 fake_id = '42'
 fake_uuid = '0c4a7eca-0c2a-4c12-beff-08a80f064c52'
 fake_path = '/etc/ceph/osd/{}-{}.json'.format(fake_id, fake_uuid)

--- a/tests/library/test_ceph_volume_simple_scan.py
+++ b/tests/library/test_ceph_volume_simple_scan.py
@@ -6,7 +6,7 @@ import ceph_volume_simple_scan
 
 fake_cluster = 'ceph'
 fake_container_binary = 'podman'
-fake_container_image = 'quay.ceph.io/ceph/daemon:latest'
+fake_container_image = 'quay.io/ceph/daemon:latest'
 fake_path = '/var/lib/ceph/osd/ceph-0'
 
 

--- a/tests/library/test_cephadm_adopt.py
+++ b/tests/library/test_cephadm_adopt.py
@@ -4,7 +4,7 @@ import ca_test_common
 import cephadm_adopt
 
 fake_cluster = 'ceph'
-fake_image = 'quay.ceph.io/ceph/daemon-base:latest'
+fake_image = 'quay.io/ceph/daemon-base:latest'
 fake_name = 'mon.foo01'
 
 

--- a/tests/library/test_cephadm_bootstrap.py
+++ b/tests/library/test_cephadm_bootstrap.py
@@ -4,9 +4,9 @@ import ca_test_common
 import cephadm_bootstrap
 
 fake_fsid = '0f1e0605-db0b-485c-b366-bd8abaa83f3b'
-fake_image = 'quay.ceph.io/ceph/daemon-base:latest-main-devel'
+fake_image = 'quay.io/ceph/daemon-base:latest-main-devel'
 fake_ip = '192.168.42.1'
-fake_registry = 'quay.ceph.io'
+fake_registry = 'quay.io'
 fake_registry_user = 'foo'
 fake_registry_pass = 'bar'
 fake_registry_json = 'registry.json'

--- a/tox.ini
+++ b/tox.ini
@@ -43,16 +43,16 @@ commands=
 [purge]
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/rbd_map_devices.yml --extra-vars "\
-      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.ceph.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph-ci/daemon} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-main} \
   "
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/{env:PURGE_PLAYBOOK:purge-cluster.yml} --extra-vars "\
       ireallymeanit=yes \
       remove_packages=yes \
-      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.ceph.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph-ci/daemon} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-main} \
   "
 
@@ -75,8 +75,8 @@ commands=
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/purge-dashboard.yml --extra-vars "\
       ireallymeanit=yes \
-      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.ceph.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph-ci/daemon} \
+      ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.io} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-main} \
   "
 
@@ -159,8 +159,8 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml --extra-vars "\
       ireallymeanit=yes \
       ceph_docker_image_tag=latest-main-devel \
-      ceph_docker_registry=quay.ceph.io \
-      ceph_docker_image=ceph-ci/daemon \
+      ceph_docker_registry=quay.io \
+      ceph_docker_image=ceph/daemon \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \
@@ -372,7 +372,7 @@ commands=
   !lvm_batch-!lvm_auto_discovery: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml --limit 'osds:!osd2'
   lvm_osds,all_in_one: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/lvm_setup.yml --limit osd2
 
-  rhcs: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.ceph.io} repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
+  rhcs: ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/rhcs_setup.yml --extra-vars "ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.io} repo_url={env:REPO_URL:} rhel7_repo_url={env:RHEL7_REPO_URL:}" --skip-tags "vagrant_setup"
 
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/setup.yml
 


### PR DESCRIPTION
This makes the CI use quay.io instead of quay.ceph.io

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>