### PR TITLE
ceph-config: make sure rgw_instances is set

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -122,6 +122,12 @@
     mode: "{{ ceph_directories_mode }}"
   when: not containerized_deployment | bool
 
+- name: import_role ceph-facts
+  import_role:
+    name: ceph-facts
+    tasks_from: set_radosgw_address.yml
+  when: inventory_hostname in groups.get(rgw_group_name, [])
+
 - name: "generate {{ cluster }}.conf configuration file"
   openstack.config_template.config_template:
     src: "ceph.conf.j2"


### PR DESCRIPTION
We need to make sure `rgw_instances` is set before `ceph.conf` is rendered. Otherwise, the `ceph-crash` play in the main playbook updates (via ceph-handler) the `ceph.conf` on rgw nodes and removes rgw instances sections.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2141604

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>