### PR TITLE
devices: exclude db disks on osd_auto_discovery enabled

### DIFF
--- a/roles/ceph-facts/tasks/devices.yml
+++ b/roles/ceph-facts/tasks/devices.yml
@@ -89,3 +89,5 @@
     - item.value.holders|count == 0
     - ansible_facts['mounts'] | selectattr('device', 'equalto', device) | list | length == 0
     - item.key is not match osd_auto_discovery_exclude
+    - device not in dedicated_devices | default([])
+    - device not in bluestore_wal_devices | default([])


### PR DESCRIPTION
Exclude disks were defined in dedicated_devices and bluestore_wal_devices on osd_auto_discovery enabled.

Signed-off-by: Seena Fallah <seenafallah@gmail.com>