### PR TITLE
devices: remove duplicated disks after the readlink resolve

### DIFF
--- a/roles/ceph-facts/tasks/devices.yml
+++ b/roles/ceph-facts/tasks/devices.yml
@@ -1,78 +1,51 @@
 ---
-- name: resolve device link(s)
-  command: readlink -f {{ item }}
-  changed_when: false
-  check_mode: no
-  with_items: "{{ devices }}"
-  register: devices_prepare_canonicalize
+- name: resolve devices
   when:
     - devices is defined
     - not osd_auto_discovery | default(False) | bool
+  block:
+    - name: resolve device link(s)
+      command: readlink -f {{ item }}
+      changed_when: false
+      check_mode: no
+      with_items: "{{ devices }}"
+      register: devices_prepare_canonicalize
 
-- name: set_fact build devices from resolved symlinks
-  set_fact:
-    devices: "{{ devices | default([]) + [ item.stdout ] }}"
-  with_items: "{{ devices_prepare_canonicalize.results }}"
-  when:
-    - devices is defined
-    - not osd_auto_discovery | default(False) | bool
+    - name: set_fact build devices from resolved symlinks
+      set_fact:
+        devices: "{{ devices_prepare_canonicalize.results | map(attribute='stdout') | reject('search','/dev/disk') | list | unique }}"
 
-- name: set_fact build final devices list
-  set_fact:
-    devices: "{{ devices | reject('search','/dev/disk') | list | unique }}"
-  when:
-    - devices is defined
-    - not osd_auto_discovery | default(False) | bool
-
-- name: resolve dedicated_device link(s)
-  command: readlink -f {{ item }}
-  changed_when: false
-  check_mode: no
-  with_items: "{{ dedicated_devices }}"
-  register: dedicated_devices_prepare_canonicalize
+- name: resolve dedicated_device
   when:
     - dedicated_devices is defined
     - not osd_auto_discovery | default(False) | bool
+  block:
+    - name: resolve dedicated_device link(s)
+      command: readlink -f {{ item }}
+      changed_when: false
+      check_mode: no
+      with_items: "{{ dedicated_devices }}"
+      register: dedicated_devices_prepare_canonicalize
 
-- name: set_fact build dedicated_devices from resolved symlinks
-  set_fact:
-    dedicated_devices: "{{ dedicated_devices | default([]) + [ item.stdout ] }}"
-  with_items: "{{ dedicated_devices_prepare_canonicalize.results }}"
-  when:
-    - dedicated_devices is defined
-    - not osd_auto_discovery | default(False) | bool
+    - name: set_fact build dedicated_devices from resolved symlinks
+      set_fact:
+        dedicated_devices: "{{ dedicated_devices_prepare_canonicalize.results | map(attribute='stdout') | reject('search','/dev/disk') | list | unique }}"
 
-- name: set_fact build final dedicated_devices list
-  set_fact:
-    dedicated_devices: "{{ dedicated_devices | reject('search','/dev/disk') | list | unique }}"
-  when:
-    - dedicated_devices is defined
-    - not osd_auto_discovery | default(False) | bool
-
-- name: resolve bluestore_wal_device link(s)
-  command: readlink -f {{ item }}
-  changed_when: false
-  check_mode: no
-  with_items: "{{ bluestore_wal_devices }}"
-  register: bluestore_wal_devices_prepare_canonicalize
+- name: resolve bluestore_wal_device
   when:
     - bluestore_wal_devices is defined
     - not osd_auto_discovery | default(False) | bool
+  block:
+    - name: resolve bluestore_wal_device link(s)
+      command: readlink -f {{ item }}
+      changed_when: false
+      check_mode: no
+      with_items: "{{ bluestore_wal_devices }}"
+      register: bluestore_wal_devices_prepare_canonicalize
 
-- name: set_fact build bluestore_wal_devices from resolved symlinks
-  set_fact:
-    bluestore_wal_devices: "{{ bluestore_wal_devices | default([]) + [ item.stdout ] }}"
-  with_items: "{{ bluestore_wal_devices_prepare_canonicalize.results }}"
-  when:
-    - bluestore_wal_devices is defined
-    - not osd_auto_discovery | default(False) | bool
-
-- name: set_fact build final bluestore_wal_devices list
-  set_fact:
-    bluestore_wal_devices: "{{ bluestore_wal_devices | reject('search','/dev/disk') | list | unique }}"
-  when:
-    - bluestore_wal_devices is defined
-    - not osd_auto_discovery | default(False) | bool
+    - name: set_fact build bluestore_wal_devices from resolved symlinks
+      set_fact:
+        bluestore_wal_devices: "{{ bluestore_wal_devices_prepare_canonicalize.results | map(attribute='stdout') | reject('search','/dev/disk') | list | unique }}"
 
 - name: set_fact devices generate device list when osd_auto_discovery
   vars:


### PR DESCRIPTION
If a disk has a symlink it will be re-added to the devices lists one with resolved path and the other with a defined path. We can rebuild the list from the readlink output cause readlink always return the correct path for all disks.

Signed-off-by: Seena Fallah <seenafallah@gmail.com>