### PR TITLE
devices: allow using lvm_volumes with devices 

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -92,7 +92,7 @@
 
     - name: set_fact num_osds (add existing osds)
       set_fact:
-        num_osds: "{{ lvm_list.stdout | default('{}') | from_json | length | int + num_osds | default(0) | int }}"
+        num_osds: "{{ num_osds | int + (lvm_list.stdout | default('{}') | from_json | dict2items | map(attribute='value') | flatten | map(attribute='devices') | sum(start=[]) | difference(lvm_volumes | default([]) | map(attribute='data')) | length | int) }}"
 
 - name: set osd related config facts
   when: inventory_hostname in groups.get(osd_group_name, [])

--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -20,7 +20,7 @@
 
     - name: count number of osds for lvm scenario
       set_fact:
-        num_osds: "{{ lvm_volumes | length | int }}"
+        num_osds: "{{ num_osds | int + (lvm_volumes | length | int) }}"
       when: lvm_volumes | default([]) | length > 0
 
     - block:
@@ -65,14 +65,14 @@
 
         - name: set_fact num_osds from the output of 'ceph-volume lvm batch --report' (legacy report)
           set_fact:
-            num_osds: "{{ ((lvm_batch_report.stdout | default('{}') | from_json).osds | default([]) | length | int) + (_rejected_devices | default([]) | length | int) }}"
+            num_osds: "{{ num_osds | int + ((lvm_batch_report.stdout | default('{}') | from_json).osds | default([]) | length | int) + (_rejected_devices | default([]) | length | int) }}"
           when:
             - (lvm_batch_report.stdout | default('{}') | from_json) is mapping
             - (lvm_batch_report.stdout | default('{}') | from_json).changed | default(true) | bool
 
         - name: set_fact num_osds from the output of 'ceph-volume lvm batch --report' (new report)
           set_fact:
-            num_osds: "{{ ((lvm_batch_report.stdout | default('{}') | from_json) | default([]) | length | int) + (_rejected_devices | default([]) | length | int) }}"
+            num_osds: "{{ num_osds | int + ((lvm_batch_report.stdout | default('{}') | from_json) | default([]) | length | int) + (_rejected_devices | default([]) | length | int) }}"
           when:
             - (lvm_batch_report.stdout | default('{}') | from_json) is not mapping
             - (lvm_batch_report.stdout | default('{}') | from_json).changed | default(true) | bool

--- a/roles/ceph-facts/tasks/devices.yml
+++ b/roles/ceph-facts/tasks/devices.yml
@@ -91,3 +91,4 @@
     - item.key is not match osd_auto_discovery_exclude
     - device not in dedicated_devices | default([])
     - device not in bluestore_wal_devices | default([])
+    - device not in (lvm_volumes | default([]) | map(attribute='data') | list)


### PR DESCRIPTION
* Exclude device from lvm_volumes while osd_auto_discovery is true
* Sum num_osds on both lvm_volumes and devices list
* Exclude lvm_volumes defined disks from existing osds while it has been counted by the "count number of osds for lvm scenario" task.