### PR TITLE
Fixes selinux relabeling issue for nfs container

### DIFF
--- a/roles/ceph-nfs/templates/ceph-nfs.service.j2
+++ b/roles/ceph-nfs/templates/ceph-nfs.service.j2
@@ -23,6 +23,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --net=host \
   -d --log-driver journald --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid \
 {% endif %}
   --pids-limit={{ 0 if container_binary == 'podman' else -1 }} \
+  --security-opt label=disable \
   -v /var/lib/ceph/bootstrap-rgw/:/var/lib/ceph/bootstrap-rgw:z \
   -v /etc/ceph:/etc/ceph:z \
   -v /var/lib/nfs/ganesha:/var/lib/nfs/ganesha:z \


### PR DESCRIPTION
Due to podman selinux relabeling issue,  added -security-opt label=disable to the nfs unit template