### PR TITLE
ceph-mgr: Fix reference to copy_admin_key variable

### DIFF
--- a/roles/ceph-mgr/tasks/common.yml
+++ b/roles/ceph-mgr/tasks/common.yml
@@ -52,7 +52,7 @@
     - name: set_fact _mgr_keys
       set_fact:
         _mgr_keys:
-          - { 'name': 'client.admin', 'path': "/etc/ceph/{{ cluster }}.client.admin.keyring", 'copy_key': copy_admin_key }
+          - { 'name': 'client.admin', 'path': "/etc/ceph/{{ cluster }}.client.admin.keyring", 'copy_key': "{{ copy_admin_key }}" }
           - { 'name': "mgr.{{ ansible_facts['hostname'] }}", 'path': "/var/lib/ceph/mgr/{{ cluster }}-{{ ansible_facts['hostname'] }}/keyring", 'copy_key': true }
 
     - name: get keys from monitors


### PR DESCRIPTION
Enabling installation of the admin key to mgr nodes by setting "copy_admin_key: true" is broken. This is because the variable is not referenced correctly (using inline Jinja2 templating).

This is an old bug. It exists in stable-6.0 and stable-7.0 and probably earlier versions as well.