### PR TITLE
tests: force rpm pkg upgrade

### DIFF
--- a/tests/functional/setup.yml
+++ b/tests/functional/setup.yml
@@ -58,6 +58,12 @@
           #        - ansible_facts['distribution_major_version'] | int > 7
           #        - not is_atomic | bool
 
+    - name: force rpm pkg upgrade
+      package:
+        name: rpm
+        state: latest
+      when: not is_atomic | bool
+
     - name: update the system
       command: dnf update -y
       changed_when: false


### PR DESCRIPTION
Due to a bug with the rpm version present in the current stream8 vagrant image, we have to make sure it is first upgraded to the latest version.