### PR TITLE
Replace ip_version check with ansible test

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -364,13 +364,13 @@
       command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv4_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | first }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
-      when: ip_version == 'ipv4'
+      when: cephadm_mgmt_network is ansible.utils.ipv4
 
     - name: manage nodes with cephadm - ipv6
       command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | last | ipwrap }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
-      when: ip_version == 'ipv6'
+      when: cephadm_mgmt_network is ansible.utils.ipv6
 
     - name: add ceph label for core component
       command: "{{ ceph_cmd }} orch host label add {{ ansible_facts['nodename'] }} ceph"


### PR DESCRIPTION
Instead of checking ip_version variable we should check the input address for ip version and select code path based on that.

This solves ceph adoption with mixed ipv6 and ipv4 networks.

Resolves: rhbz#2186226