### PR TITLE
check ip_version with built-in filters for ansible 2.9

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -372,13 +372,13 @@
       command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv4_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | first }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
-      when: ip_version == 'ipv4'
+      when: cephadm_mgmt_network | ipv4
 
     - name: manage nodes with cephadm - ipv6
       command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | last | ipwrap }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
-      when: ip_version == 'ipv6'
+      when: cephadm_mgmt_network | ipv6
 
     - name: add ceph label for core component
       command: "{{ ceph_cmd }} orch host label add {{ ansible_facts['nodename'] }} ceph"


### PR DESCRIPTION
Ansible 2.9's IP address filters are simply available as `ipv4` or `ipv6`.

https://docs.ansible.com/ansible/2.9/user_guide/playbooks_filters.html#ip-address-filter

In newer Ansible versions, these are `ansible.utils.ipv4` and `ansible.utils.ipv6`.