### PR TITLE
ceph-config: drop osd_memory_target from ceph_conf_overrides

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -104,6 +104,13 @@
         - "{{ ceph_conf_overrides.get('osd', {}).get('osd_memory_target', '') }}"
       when: item
 
+    - name: drop osd_memory_target from conf override
+      set_fact:
+        ceph_conf_overrides: "{{ ceph_conf_overrides | combine({'osd': {item: omit}}, recursive=true) }}"
+      loop:
+        - osd memory target
+        - osd_memory_target
+
     - name: set_fact _osd_memory_target
       set_fact:
         _osd_memory_target: "{{ ((ansible_facts['memtotal_mb'] * 1048576 * safety_factor | float) / num_osds | float) | int }}"


### PR DESCRIPTION
As it's always being set in ceph.conf template, it leads to having duplicated osd_memory_target keys in rendered ceph conf while defining one in ceph_conf_overrides.