### PR TITLE
tests: updates functional tests with new image

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -560,7 +560,7 @@ dummy:
 ##########
 # DOCKER #
 ##########
-#ceph_docker_image: "ceph/daemon"
+#ceph_docker_image: "ceph/daemon-base"
 #ceph_docker_image_tag: latest-main
 #ceph_docker_registry: quay.io
 #ceph_docker_registry_auth: false

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -552,7 +552,7 @@ ceph_tcmalloc_max_total_thread_cache: 134217728
 ##########
 # DOCKER #
 ##########
-ceph_docker_image: "ceph/daemon"
+ceph_docker_image: "ceph/daemon-base"
 ceph_docker_image_tag: latest-main
 ceph_docker_registry: quay.io
 ceph_docker_registry_auth: false

--- a/tests/functional/add-mdss/container/group_vars/all
+++ b/tests/functional/add-mdss/container/group_vars/all
@@ -28,5 +28,5 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/add-mgrs/container/group_vars/all
+++ b/tests/functional/add-mgrs/container/group_vars/all
@@ -28,5 +28,5 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/add-mons/container/group_vars/all
+++ b/tests/functional/add-mons/container/group_vars/all
@@ -28,5 +28,5 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/add-osds/container/group_vars/all
+++ b/tests/functional/add-osds/container/group_vars/all
@@ -28,5 +28,5 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/add-rbdmirrors/container/group_vars/all
+++ b/tests/functional/add-rbdmirrors/container/group_vars/all
@@ -28,5 +28,5 @@ ceph_conf_overrides:
     osd_pool_default_size: 1
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/add-rgws/container/group_vars/all
+++ b/tests/functional/add-rgws/container/group_vars/all
@@ -30,5 +30,5 @@ rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/all-in-one/container/group_vars/all
+++ b/tests/functional/all-in-one/container/group_vars/all
@@ -44,5 +44,5 @@ lvm_volumes:
     db: journal1
     db_vg: journals
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/all_daemons/container/group_vars/all
+++ b/tests/functional/all_daemons/container/group_vars/all
@@ -37,7 +37,7 @@ mds_max_mds: 2
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"

--- a/tests/functional/collocation/container/group_vars/all
+++ b/tests/functional/collocation/container/group_vars/all
@@ -26,7 +26,7 @@ dashboard_admin_password: $sX!cD$rYU6qR^B!
 dashboard_admin_user_ro: true
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"

--- a/tests/functional/docker2podman/group_vars/all
+++ b/tests/functional/docker2podman/group_vars/all
@@ -34,7 +34,7 @@ handler_health_osd_check_delay: 10
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"

--- a/tests/functional/external_clients/container/inventory/group_vars/all
+++ b/tests/functional/external_clients/container/inventory/group_vars/all
@@ -38,5 +38,5 @@ lvm_volumes:
 fsid: 40358a87-ab6e-4bdc-83db-1d909147861c
 generate_fsid: false
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/lvm-auto-discovery/container/group_vars/all
+++ b/tests/functional/lvm-auto-discovery/container/group_vars/all
@@ -28,5 +28,5 @@ dashboard_enabled: False
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/lvm-batch/container/group_vars/all
+++ b/tests/functional/lvm-batch/container/group_vars/all
@@ -28,5 +28,5 @@ dashboard_enabled: False
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/lvm-osds/container/group_vars/all
+++ b/tests/functional/lvm-osds/container/group_vars/all
@@ -37,5 +37,5 @@ openstack_pools:
   - "{{ openstack_glance_pool }}"
   - "{{ openstack_cinder_pool }}"
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/podman/group_vars/all
+++ b/tests/functional/podman/group_vars/all
@@ -33,7 +33,7 @@ handler_health_osd_check_delay: 10
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"

--- a/tests/functional/rbdmirror/container/group_vars/all
+++ b/tests/functional/rbdmirror/container/group_vars/all
@@ -28,5 +28,5 @@ ceph_conf_overrides:
     mon_max_pg_per_osd: 512
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/rbdmirror/container/secondary/group_vars/all
+++ b/tests/functional/rbdmirror/container/secondary/group_vars/all
@@ -28,5 +28,5 @@ ceph_conf_overrides:
     mon_max_pg_per_osd: 512
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/rgw-multisite/container/group_vars/all
+++ b/tests/functional/rgw-multisite/container/group_vars/all
@@ -29,5 +29,5 @@ ceph_conf_overrides:
     mon_max_pg_per_osd: 512
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/rgw-multisite/container/secondary/group_vars/all
+++ b/tests/functional/rgw-multisite/container/secondary/group_vars/all
@@ -29,5 +29,5 @@ ceph_conf_overrides:
     mon_max_pg_per_osd: 512
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_mds/container/group_vars/all
+++ b/tests/functional/shrink_mds/container/group_vars/all
@@ -17,5 +17,5 @@ openstack_config: False
 dashboard_enabled: False
 copy_admin_key: True
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_mgr/container/group_vars/all
+++ b/tests/functional/shrink_mgr/container/group_vars/all
@@ -16,5 +16,5 @@ ceph_conf_overrides:
 openstack_config: False
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_mon/container/group_vars/all
+++ b/tests/functional/shrink_mon/container/group_vars/all
@@ -16,5 +16,5 @@ ceph_conf_overrides:
 openstack_config: False
 dashboard_enabled: False
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_osd/container/group_vars/all
+++ b/tests/functional/shrink_osd/container/group_vars/all
@@ -17,5 +17,5 @@ openstack_config: False
 dashboard_enabled: False
 copy_admin_key: True
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_rbdmirror/container/group_vars/all
+++ b/tests/functional/shrink_rbdmirror/container/group_vars/all
@@ -16,5 +16,5 @@ openstack_config: False
 dashboard_enabled: False
 copy_admin_key: True
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/shrink_rgw/container/group_vars/all
+++ b/tests/functional/shrink_rgw/container/group_vars/all
@@ -18,5 +18,5 @@ openstack_config: False
 dashboard_enabled: False
 copy_admin_key: True
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main

--- a/tests/functional/subset_update/container/group_vars/all
+++ b/tests/functional/subset_update/container/group_vars/all
@@ -28,7 +28,7 @@ dashboard_enabled: false
 dashboard_admin_password: $sX!cD$rYU6qR^B!
 grafana_admin_password: +xFRe+RES@7vg24n
 ceph_docker_registry: quay.io
-ceph_docker_image: ceph/daemon
+ceph_docker_image: ceph/daemon-base
 ceph_docker_image_tag: latest-main
 node_exporter_container_image: "quay.io/prometheus/node-exporter:v0.17.0"
 prometheus_container_image: "quay.io/prometheus/prometheus:v2.7.2"

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands=
 commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/tests/functional/rbd_map_devices.yml --extra-vars "\
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon-base} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-main} \
   "
 
@@ -52,7 +52,7 @@ commands=
       ireallymeanit=yes \
       remove_packages=yes \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon-base} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-main} \
   "
 
@@ -76,7 +76,7 @@ commands=
   ansible-playbook -vv -i {changedir}/{env:INVENTORY} {toxinidir}/infrastructure-playbooks/purge-dashboard.yml --extra-vars "\
       ireallymeanit=yes \
       ceph_docker_registry={env:CEPH_DOCKER_REGISTRY:quay.io} \
-      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon} \
+      ceph_docker_image={env:CEPH_DOCKER_IMAGE:ceph/daemon-base} \
       ceph_docker_image_tag={env:CEPH_DOCKER_IMAGE_TAG:latest-main} \
   "
 
@@ -160,7 +160,7 @@ commands=
       ireallymeanit=yes \
       ceph_docker_image_tag=latest-main-devel \
       ceph_docker_registry=quay.io \
-      ceph_docker_image=ceph/daemon \
+      ceph_docker_image=ceph/daemon-base \
       ceph_docker_registry_auth=True \
       ceph_docker_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_docker_registry_password={env:DOCKER_HUB_PASSWORD} \


### PR DESCRIPTION
let's use quay.io/ceph/daemon-base in every tests instead of `ceph/daemon` since it's not supposed to be built anymore soon.