### PR TITLE
Specify the zone when requesting zonegroup information.

### DIFF
--- a/library/radosgw_zone.py
+++ b/library/radosgw_zone.py
@@ -313,6 +313,7 @@ def get_zonegroup(module, container_image=None):
     '''
 
     cluster = module.params.get('cluster')
+    name = module.params.get('name')
     realm = module.params.get('realm')
     zonegroup = module.params.get('zonegroup')
 
@@ -323,6 +324,7 @@ def get_zonegroup(module, container_image=None):
         cluster,
         'zonegroup',
         'get',
+        '--rgw-zone=' + name,
         '--rgw-realm=' + realm,
         '--rgw-zonegroup=' + zonegroup,
         '--format=json'

--- a/tests/library/test_radosgw_zone.py
+++ b/tests/library/test_radosgw_zone.py
@@ -129,6 +129,7 @@ class TestRadosgwZoneModule(object):
             fake_binary,
             '--cluster', fake_cluster,
             'zonegroup', 'get',
+            '--rgw-zone=' + fake_zone,
             '--rgw-realm=' + fake_realm,
             '--rgw-zonegroup=' + fake_zonegroup,
             '--format=json'


### PR DESCRIPTION
When trying to run a playbook adding multiple zones+zonegroups to a cluster with ceph built from main branch, I found that it would fail in an unexpected way:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: StopIteration
failed: [XXX -> XXX] (item={'realm': 'my-new-realm', 'zonegroup': 'my-new-zonegroup', 'zone': 'my-new-zone-a' 'is_master': 'true', 'system_access_key': 'XXX', 'system_secret_key': 'XXX'}) => changed=false
  ansible_loop_var: item
  item:
    is_master: 'true'
    realm: my-new-realm
    system_access_key: XXX
    system_secret_key: XXX
    zone: my-new-zone-a
    zonegroup: my-new-zonegroup
  module_stderr: |-
    Traceback (most recent call last):
      File "<stdin>", line 107, in <module>
      File "<stdin>", line 99, in _ansiballz_main
      File "<stdin>", line 48, in invoke_module
      File "/usr/lib64/python3.6/runpy.py", line 205, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/lib64/python3.6/runpy.py", line 96, in _run_module_code
        mod_name, mod_spec, pkg_name, script_name)
      File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_radosgw_zone_payload_guulv0bt/ansible_radosgw_zone_payload.zip/ansible/modules/radosgw_zone.py", line 499, in <module>
      File "/tmp/ansible_radosgw_zone_payload_guulv0bt/ansible_radosgw_zone_payload.zip/ansible/modules/radosgw_zone.py", line 495, in main
      File "/tmp/ansible_radosgw_zone_payload_guulv0bt/ansible_radosgw_zone_payload.zip/ansible/modules/radosgw_zone.py", line 461, in run_module
    StopIteration
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```

Line 461: `'endpoints': next(zone['endpoints'] for zone in zonegroup['zones'] if zone['name'] == name),  # noqa: E501`

This was my zonegroup configuration:

```
$ sudo radosgw-admin zonegroup list                                                
{
    "default_info": "57741494-7a11-49bc-bd61-3419344e5eb6",
    "zonegroups": [
        "my-old-zonegroup",
        "my-new-zonegroup"
    ]
}
```

After tracking through the code, I found that radosgw-admin was returning the default zonegroup when it didn't match:

```
$ sudo radosgw-admin zonegroup get --rgw-zonegroup=my-new-zonegroup
{
    "id": "57741494-7a11-49bc-bd61-3419344e5eb6",
    "name": "my-old-zonegroup",
    "api_name": "my-old-zonegroup",
```

And adding the `--rgw-zone` argument got it to resolve to the zonegroup I was asking for:

```
$ sudo radosgw-admin zonegroup get --rgw-zonegroup=restricted-prod-zonegroup --rgw-zone=restricted-prod-zone-pw
{
    "id": "5404d626-b757-421e-aa2a-1e0eacbb6b73",
    "name": "my-new-zonegroup",
    "api_name": "my-new-zonegroup",
```