### PR TITLE
library: ceph_crush: set containerized param to false to respect docstrings

### DIFF
--- a/library/ceph_crush.py
+++ b/library/ceph_crush.py
@@ -139,16 +139,14 @@ def exec_commands(module, cmd_list):
     return rc, cmd, out, err
 
 
-def run_module():
-    module_args = dict(
-        cluster=dict(type='str', required=False, default='ceph'),
-        location=dict(type='dict', required=True),
-        containerized=dict(type='str', required=True, default=None),
-    )
-
+def main():
     module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=True
+        argument_spec=dict(
+            cluster=dict(type='str', required=False, default='ceph'),
+            location=dict(type='dict', required=True),
+            containerized=dict(type='str', required=False, default=None),
+        ),
+        supports_check_mode=True,
     )
 
     cluster = module.params['cluster']
@@ -192,10 +190,6 @@ def run_module():
         module.fail_json(msg='non-zero return code', **result)
 
     module.exit_json(**result)
-
-
-def main():
-    run_module()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
doc:
```yaml
    containerized:
        description:
            - Weither or not this is a containerized cluster. The value is
            assigned or not depending on how the playbook runs.
        required: false
        default: None
```
fixes:
```python
failed: [mon1.example.com] (item=Set bucket placement for: osd1.example.com) => {"ansible_loop_var": "item", "changed": false, "item": {"host": "osd1.example.com", "rack": "rack1"}, "msg": "missing required arguments: containerized"}
```

Also delete couple of rudiments in `main()`