### PR TITLE
[skip ci]cephadm-adopt: Add --networks parameter support to ceph orch apply rgw

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -455,7 +455,8 @@
     - name: store existing rbd mirror peers in monitor config store
       when:
         - ceph_rbd_mirror_configure | default(True) | bool
-        - ceph_rbd_mirror_remote_user is undefined
+        - ceph_rbd_mirror_remote_user is defined
+        - ceph_rbd_mirror_remote_cluster is defined
       block:
         - name: import ceph-defaults
           import_role:

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -997,11 +997,19 @@
           environment:
             CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 
+    - name: set_fact rgw_subnet
+      set_fact:
+        rgw_subnet: "--networks {{ radosgw_address_block }}"
+      when:
+        - radosgw_address_block is defined
+        - radosgw_address_block != 'subnet'
+
     - name: update the placement of radosgw hosts
       command: >
         {{ cephadm_cmd }} shell -k /etc/ceph/{{ cluster }}.client.admin.keyring --fsid {{ fsid }} --
         ceph orch apply rgw {{ ansible_facts['hostname'] }}
         --placement='count-per-host:{{ radosgw_num_instances }} {{ ansible_facts['nodename'] }}'
+        {{ rgw_subnet if rgw_subnet is defined else '' }}
         --port={{ radosgw_frontend_port }}
         {{ '--ssl' if radosgw_frontend_ssl_certificate else '' }}
       changed_when: false
@@ -1016,6 +1024,7 @@
         ceph orch apply rgw {{ ansible_facts['hostname'] }}.{{ item.rgw_realm }}.{{ item.rgw_zone }}.{{ item.radosgw_frontend_port }}
         --placement={{ ansible_facts['nodename'] }}
         --realm={{ item.rgw_realm }} --zone={{ item.rgw_zone }}
+        {{ rgw_subnet if rgw_subnet is defined else '' }}
         --port={{ item.radosgw_frontend_port }}
         {{ '--ssl' if radosgw_frontend_ssl_certificate else '' }}
       changed_when: false


### PR DESCRIPTION
When radosgw_address_block was defined, it was not taken into account during rgw adoption process

depends on: https://tracker.ceph.com/issues/62185
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2224351