### PR TITLE
do not use update debian cache or try to install packages when package-install is disabled

### DIFF
--- a/roles/ceph-common/tasks/configure_repository.yml
+++ b/roles/ceph-common/tasks/configure_repository.yml
@@ -23,6 +23,7 @@
         cache_valid_time: 3600
       register: result
       until: result is succeeded
+  tags: package-install
 
 - name: include installs/configure_suse_repository_installation.yml
   include_tasks: installs/configure_suse_repository_installation.yml

--- a/roles/ceph-mgr/tasks/pre_requisite.yml
+++ b/roles/ceph-mgr/tasks/pre_requisite.yml
@@ -34,3 +34,4 @@
   register: result
   until: result is succeeded
   when: ansible_facts['os_family'] == 'Debian'
+  tags: package-install


### PR DESCRIPTION
When deploying with --skip-tags=package-install (when there is no access to a repository), the playbook is still trying to update the package cache, or to install ceph-mgr packages, which makes the playbook fail.
This change prevents the playbook to try to update the cache or install ceph-mgr packages when the package-install tag is skipped.