### PR TITLE
cephadm-adopt: Fixes hosts addition to be managed by cephadm

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -363,13 +363,13 @@
       command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv4_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | first }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
-      when: cephadm_mgmt_network is ansible.utils.ipv4
+      when: cephadm_mgmt_network.split(',')[0] is ansible.utils.ipv4
 
     - name: manage nodes with cephadm - ipv6
       command: "{{ ceph_cmd }} orch host add {{ ansible_facts['nodename'] }} {{ ansible_facts['all_ipv6_addresses'] | ips_in_ranges(cephadm_mgmt_network.split(',')) | last | ansible.utils.ipwrap }} {{ group_names | intersect(adopt_label_group_names) | join(' ') }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
-      when: cephadm_mgmt_network is ansible.utils.ipv6
+      when: cephadm_mgmt_network.split(',')[0] is ansible.utils.ipv6
 
     - name: add ceph label for core component
       command: "{{ ceph_cmd }} orch host label add {{ ansible_facts['nodename'] }} ceph"


### PR DESCRIPTION
The tasks "manage nodes with cephadm - ipv4/6" are skipped when cephadm_mgmt_network contains more than one ip network which prevent cephadm from managing the host.