### PR TITLE
site.yaml.sample: do not try to gather facts on "non-ceph" hosts

### DIFF
--- a/site.yml.sample
+++ b/site.yml.sample
@@ -46,7 +46,7 @@
           - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
+      with_items: "{{ ansible_play_hosts | difference(groups.get('clients', [])) }}"
       run_once: true
       when: delegate_facts_host | bool
 


### PR DESCRIPTION
The site.yaml.sample makes ceph-ansible try to gather facts on group "all" which may contains hosts that have nothing to do with ceph-ansible, and/or even unreachable hosts which will make the playbook fail.
This commit will replace the "all" group by "ansible_play_hosts", containing only ceph-ansible related hosts.