### PR TITLE
Do not pass NoneType as argument to ceph_crush_rule

### DIFF
--- a/library/ceph_crush_rule.py
+++ b/library/ceph_crush_rule.py
@@ -46,7 +46,8 @@ description:
 options:
     name:
         description:
-            - name of the Ceph Crush rule.
+            - name of the Ceph Crush rule. If state is 'info' - empty string
+              can be provided as a value to get all crush rules
         required: true
     cluster:
         description:

--- a/roles/ceph-facts/tasks/get_def_crush_rule_name.yml
+++ b/roles/ceph-facts/tasks/get_def_crush_rule_name.yml
@@ -1,7 +1,7 @@
 ---
 - name: get current default crush rule details
   ceph_crush_rule:
-    name: null
+    name: ""
     cluster: "{{ cluster }}"
     state: info
   environment:


### PR DESCRIPTION
With ansible-core 2.15 it is not possible to pass argument of unexpected
type, as otherwise module will fail with:
`'None' is not a string and conversion is not allowed`

With that we want to only get all existing crush rules, so we can simply
supply an empty string as a name argument, which would satisfy
requirements and have same behaviour for previous ansible versions.

Alternative approach would be to stop making `name` as a required
argument to the module and use empty string as default value
when info state is used.