### PR TITLE
Fix rgw_systemd_environment_file.yml

### DIFF
--- a/roles/ceph-config/tasks/rgw_systemd_environment_file.yml
+++ b/roles/ceph-config/tasks/rgw_systemd_environment_file.yml
@@ -7,6 +7,9 @@
     group: "{{ ceph_uid if containerized_deployment | bool else 'ceph' }}"
     mode: "{{ ceph_directories_mode | default('0755') }}"
   with_items: "{{ rgw_instances }}"
+  when:
+    - containerized_deployment | bool
+    - rgw_instances is defined
 
 - name: generate environment file
   copy:


### PR DESCRIPTION
Added "when" statement which allows to have the "when" statement of the 2nd task to even have an effect.

The second task contains this:

```
 when:
    - containerized_deployment | bool
    - rgw_instances is defined
 ```
 
 However, the first task already *uses* this variable and will fail if it is not defined.

To me it looks like this statement should be included for the first task as well. :)