### PR TITLE
doc: project deprecation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,9 @@
-ceph-ansible
-============
+ceph-ansible is deprecated, please migrate to ``cephadm`` instead.
+==================================================================
 
-**NOTE: cephadm is the new official installer, you should consider migrating to cephadm.**
 
-The project is still maintained for the time being but it is encouraged to migrate to ``cephadm``.
+``cephadm`` is the new official Ceph installer.
 
-Ansible playbooks for Ceph, the distributed filesystem.
+See ``cephadm`` documentation [1]
 
-Please refer to our hosted documentation here: https://docs.ceph.com/projects/ceph-ansible/en/latest/
-
-You can view documentation for our ``stable-*`` branches by substituting ``main`` in the link
-above for the name of the branch. For example: https://docs.ceph.com/projects/ceph-ansible/en/stable-6.0/
+[1] https://docs.ceph.com/en/latest/cephadm/


### PR DESCRIPTION
Mark the project as deprecated.

See https://docs.ceph.com/en/latest/cephadm/ for ``cephadm`` documentation.