### PR TITLE
ceph-facts: make set_radosgw_address optional

### DIFF
--- a/roles/ceph-facts/tasks/facts.yml
+++ b/roles/ceph-facts/tasks/facts.yml
@@ -223,7 +223,9 @@
 
 - name: Import_tasks set_radosgw_address.yml
   ansible.builtin.include_tasks: set_radosgw_address.yml
-  when: inventory_hostname in groups.get(rgw_group_name, [])
+  when:
+    - set_radosgw_address | default(true)
+    - inventory_hostname in groups.get(rgw_group_name, [])
 
 - name: Set_fact ceph_run_cmd
   ansible.builtin.set_fact:


### PR DESCRIPTION
This can help to define custom rgw_instances with custom names and ports and addresses.