### PR TITLE
[update] stable-7.0 community-repo available reef

### DIFF
--- a/roles/ceph-validate/tasks/check_repository.yml
+++ b/roles/ceph-validate/tasks/check_repository.yml
@@ -12,8 +12,8 @@
 
 - name: validate ceph_repository_community
   fail:
-    msg: "ceph_stable_release must be 'quincy'"
+    msg: "ceph_stable_release must be 'quincy', 'reef'"
   when:
     - ceph_origin == 'repository'
     - ceph_repository == 'community'
-    - ceph_stable_release not in ['quincy']
+    - ceph_stable_release not in ['quincy', 'reef']


### PR DESCRIPTION
https://download.ceph.com/debian-reef/
exist reef release
and ubuntu 22.04(jammy) only official release

tried installing ref on ubuntu 22.04 version
as if I installed qunicy release on ubuntu 20.04
it works

good to see the `ceph-ansible` again

![image](https://github.com/ceph/ceph-ansible/assets/51896679/4634b4f5-0279-4bf4-b912-1cc5dcc525e0)
