### PR TITLE
site: install mgrs with mons if sharing the same host

### DIFF
--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -121,7 +121,7 @@
         name: ceph-mon
     - import_role:
         name: ceph-mgr
-      when: groups.get(mgr_group_name, []) | length == 0
+      when: groups.get(mgr_group_name, []) | length == 0 or mgr_group_name in group_names
 
 - hosts: mons
   gather_facts: false

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -116,7 +116,7 @@
         name: ceph-mon
     - import_role:
         name: ceph-mgr
-      when: groups.get(mgr_group_name, []) | length == 0
+      when: groups.get(mgr_group_name, []) | length == 0 or mgr_group_name in group_names
 
   post_tasks:
     - name: set ceph monitor install 'Complete'


### PR DESCRIPTION
If mgr is meant to be installed on the mon host it needs to be installed in the same playbook as restart handlers might failed because of non-existance mgr