### PR TITLE
ceph_config: compare current vals in low

### DIFF
--- a/library/ceph_config.py
+++ b/library/ceph_config.py
@@ -165,7 +165,7 @@ def main() -> None:
     current_value = get_current_value(who, option, config_dump)
 
     if action == 'set':
-        if value.lower() == current_value:
+        if current_value and value.lower() == current_value.lower():
             out = 'who={} option={} value={} already set. Skipping.'.format(who, option, value)
         else:
             rc, cmd, out, err = set_option(module, who, option, value, container_image=container_image)


### PR DESCRIPTION
Check the current value and asked both in low case as the asked one might be in capital as it should be.