### PR TITLE
github: update stale github workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/stale@v3
       with:


### PR DESCRIPTION
`ubuntu-18.04` environment is deprecated, let's switch to ubuntu-22.04.