### PR TITLE
ceph-handler: allow 405 as a success restart for rgw

### DIFF
--- a/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
+++ b/roles/ceph-handler/templates/restart_rgw_daemon.sh.j2
@@ -62,7 +62,7 @@ check_rest() {
   local succ=0
   while [ $RETRIES -ne 0 ]; do
     check_for_curl_or_wget ${i}
-    if [ $rgw_test_result -eq 200 ] || [ $rgw_test_result -eq 404 ]; then
+    if [ $rgw_test_result -eq 200 ] || [ $rgw_test_result -eq 404 ] || [ $rgw_test_result -eq 405 ]; then
       succ=$((succ+1))
       break
     fi


### PR DESCRIPTION
If rgw is configured to only operate admin api - this is the status code it will return for GET on no path.