### PR TITLE
ceph_default: stop using ceph/daemon-base

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -471,7 +471,7 @@ dummy:
 ##########
 # DOCKER #
 ##########
-#ceph_docker_image: "ceph/daemon-base"
+#ceph_docker_image: "ceph/ceph"
 #ceph_docker_image_tag: latest-main
 #ceph_docker_registry: quay.io
 #ceph_docker_registry_auth: false

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -463,7 +463,7 @@ ceph_tcmalloc_max_total_thread_cache: 134217728
 ##########
 # DOCKER #
 ##########
-ceph_docker_image: "ceph/daemon-base"
+ceph_docker_image: "ceph/ceph"
 ceph_docker_image_tag: latest-main
 ceph_docker_registry: quay.io
 ceph_docker_registry_auth: false


### PR DESCRIPTION
let's use reef tag quay.io/ceph/ceph instead of ceph/daemon-base