### PR TITLE
ceph-config: move `ceph_config` module call to ceph-config role

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -94,6 +94,22 @@
       ansible.builtin.set_fact:
         num_osds: "{{ num_osds | int + (lvm_list.stdout | default('{}') | from_json | dict2items | map(attribute='value') | flatten | map(attribute='devices') | sum(start=[]) | difference(lvm_volumes | default([]) | map(attribute='data')) | length | int) }}"
 
+- name: Set cluster configs
+  ceph_config:
+    action: set
+    who: "{{ item.0.key }}"
+    option: "{{ item.1.key }}"
+    value: "{{ item.1.value }}"
+  run_once: true
+  delegate_to: "{{ running_mon }}"
+  when:
+    - item.1.value != omit
+    - running_mon is defined
+  loop: "{{ ceph_cluster_conf | dict2dict }}"
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
+
 - name: Set osd related config facts
   when: inventory_hostname in groups.get(osd_group_name, [])
   block:

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -172,27 +172,6 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: mons[0]
-  become: true
-  gather_facts: false
-  any_errors_fatal: true
-  tasks:
-    - name: Import default role
-      ansible.builtin.import_role:
-        name: ceph-defaults
-
-    - name: Set cluster configs
-      ceph_config:
-        action: set
-        who: "{{ item.0.key }}"
-        option: "{{ item.1.key }}"
-        value: "{{ item.1.value }}"
-      when: item.1.value != omit
-      loop: "{{ ceph_cluster_conf | dict2dict }}"
-      environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-        CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-
 - hosts: osds
   become: True
   gather_facts: false

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -164,24 +164,6 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: mons[0]
-  become: true
-  gather_facts: false
-  any_errors_fatal: true
-  tasks:
-    - name: Import default role
-      ansible.builtin.import_role:
-        name: ceph-defaults
-
-    - name: Set cluster configs
-      ceph_config:
-        action: set
-        who: "{{ item.0.key }}"
-        option: "{{ item.1.key }}"
-        value: "{{ item.1.value }}"
-      when: item.1.value != omit
-      loop: "{{ ceph_cluster_conf | dict2dict }}"
-
 - hosts: osds
   gather_facts: false
   become: True


### PR DESCRIPTION
so you don't have to implement a similar play on your own if not using main (sample) playbooks.