### PR TITLE
[skip ci] ceph-mon: move the ceph_config call to ceph-mon role

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -94,22 +94,6 @@
       ansible.builtin.set_fact:
         num_osds: "{{ num_osds | int + (lvm_list.stdout | default('{}') | from_json | dict2items | map(attribute='value') | flatten | map(attribute='devices') | sum(start=[]) | difference(lvm_volumes | default([]) | map(attribute='data')) | length | int) }}"
 
-- name: Set cluster configs
-  ceph_config:
-    action: set
-    who: "{{ item.0.key }}"
-    option: "{{ item.1.key }}"
-    value: "{{ item.1.value }}"
-  run_once: true
-  delegate_to: "{{ running_mon }}"
-  when:
-    - item.1.value != omit
-    - running_mon is defined
-  loop: "{{ ceph_cluster_conf | dict2dict }}"
-  environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
-    CEPH_CONTAINER_BINARY: "{{ container_binary }}"
-
 - name: Set osd related config facts
   when: inventory_hostname in groups.get(osd_group_name, [])
   block:

--- a/roles/ceph-mon/tasks/main.yml
+++ b/roles/ceph-mon/tasks/main.yml
@@ -23,3 +23,17 @@
   when:
     - secure_cluster | bool
     - inventory_hostname == groups[mon_group_name] | first
+
+- name: Set cluster configs
+  ceph_config:
+    action: set
+    who: "{{ item.0.key }}"
+    option: "{{ item.1.key }}"
+    value: "{{ item.1.value }}"
+  run_once: true
+  when:
+    - item.1.value != omit
+  loop: "{{ ceph_cluster_conf | dict2dict }}"
+  environment:
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
+    CEPH_CONTAINER_BINARY: "{{ container_binary }}"


### PR DESCRIPTION
ba7eb62a1bcbd925b053cbd737012f034568a6f7 broke deployments where mgrs are not collocated with mons.