### PR TITLE
ceph_osd: Stop using tmpfs for /var/lib/ceph/osd/ceph-*

### DIFF
--- a/roles/ceph-osd/templates/systemd-run.j2
+++ b/roles/ceph-osd/templates/systemd-run.j2
@@ -22,7 +22,7 @@ else
 fi
 
 # activate
-$CEPH_VOLUME_CMD lvm activate --no-systemd ${OSD_OBJECTSTORE[@]} ${OSD_ID} ${OSD_FSID}
+$CEPH_VOLUME_CMD lvm activate --no-systemd --no-tmpfs ${OSD_OBJECTSTORE[@]} ${OSD_ID} ${OSD_FSID}
 
 # start ceph-osd
 {% if ceph_osd_numactl_opts != "" %}


### PR DESCRIPTION
This is needed to avoid error when running systemd-run script