### PR TITLE
Fix cephadm-adopt test scenario

### DIFF
--- a/tests/functional/all_daemons/container/group_vars/clients
+++ b/tests/functional/all_daemons/container/group_vars/clients
@@ -5,9 +5,11 @@ test:
   name: "test"
   rule_name: "HDD"
   size: 1
+  application: "rbd"
 test2:
   name: "test2"
   size: 1
+  application: "rbd"
 pools:
   - "{{ test }}"
   - "{{ test2 }}"


### PR DESCRIPTION
Fixes cephadm-adopt test scenario by configuring rbd application on test and test2 pools. Otherwise cephadm-adopt failed at task "Check pools have an application enabled"