### PR TITLE
ceph-defaults: use ceph as user and group

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -493,6 +493,8 @@ dummy:
 #    CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
 #    TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES: "{{ ceph_tcmalloc_max_total_thread_cache }}"
 #  args:
+#    - --setuser=ceph
+#    - --setgroup=ceph
 #    - --default-log-to-file=false
 #    - --default-log-to-stderr=true
 #    - --default-log-stderr-prefix="debug "

--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -287,7 +287,7 @@ dummy:
 # must be in octal or symbolic form
 #rbd_client_directory_owner: ceph
 #rbd_client_directory_group: ceph
-#rbd_client_directory_mode: "0770"
+#rbd_client_directory_mode: "0755"
 
 #rbd_client_log_path: /var/log/ceph
 #rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor

--- a/roles/ceph-container-common/tasks/prerequisites.yml
+++ b/roles/ceph-container-common/tasks/prerequisites.yml
@@ -28,7 +28,7 @@
 - name: Ensure tmpfiles.d is present
   ansible.builtin.lineinfile:
     path: /etc/tmpfiles.d/ceph-common.conf
-    line: "d /run/ceph 0770 root root -"
+    line: "d /run/ceph 0755 167 167 -"
     owner: root
     group: root
     mode: "0644"

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -279,7 +279,7 @@ rbd_client_directories: true # this will create rbd_client_log_path and rbd_clie
 # must be in octal or symbolic form
 rbd_client_directory_owner: ceph
 rbd_client_directory_group: ceph
-rbd_client_directory_mode: "0770"
+rbd_client_directory_mode: "0755"
 
 rbd_client_log_path: /var/log/ceph
 rbd_client_log_file: "{{ rbd_client_log_path }}/qemu-guest-$pid.log" # must be writable by QEMU and allowed by SELinux or AppArmor

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -485,6 +485,8 @@ ceph_common_container_params:
     CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
     TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES: "{{ ceph_tcmalloc_max_total_thread_cache }}"
   args:
+    - --setuser=ceph
+    - --setgroup=ceph
     - --default-log-to-file=false
     - --default-log-to-stderr=true
     - --default-log-stderr-prefix="debug "

--- a/tests/functional/collect-logs.yml
+++ b/tests/functional/collect-logs.yml
@@ -49,6 +49,16 @@
       changed_when: false
       ignore_errors: true
 
+    - name: Get mon log
+      ansible.builtin.shell: journalctl -l -u ceph-mon@{{ ansible_facts['hostname'] }} > /var/log/ceph/ceph-mon.{{ ansible_facts['hostname'] }}.log
+      changed_when: false
+      when: inventory_hostname in groups.get(mon_group_name, [])
+
+    - name: Get mds log
+      ansible.builtin.shell: journalctl -l -u ceph-mds@{{ ansible_facts['hostname'] }} > /var/log/ceph/ceph-mon.{{ ansible_facts['hostname'] }}.log
+      changed_when: false
+      when: inventory_hostname in groups.get(mds_group_name, [])
+
     - name: Get mgr log
       ansible.builtin.shell: journalctl -l -u ceph-mgr@{{ ansible_facts['hostname'] }} > /var/log/ceph/ceph-mgr.{{ ansible_facts['hostname'] }}.log
       changed_when: false


### PR DESCRIPTION
To avoid mixup permissions on host and ceph-crash runs as `ceph` which can't send crash reports generated by others with root user.