### PR TITLE
explicitly set bash as the default interpreter

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -794,7 +794,9 @@
   become: true
   handlers:
     - name: Get osd data and lockbox mount points
-      ansible.builtin.shell: "set -o pipefail && (grep /var/lib/ceph/osd /proc/mounts || echo -n) | awk '{ print $2 }'"
+      ansible.builtin.shell: 
+        cmd: "set -o pipefail && (grep /var/lib/ceph/osd /proc/mounts || echo -n) | awk '{ print $2 }'"
+        executable: /bin/bash
       register: mounted_osd
       changed_when: false
       listen: "Remove data"


### PR DESCRIPTION
#7569

This proposed solution would explicitly set the shell interpreter to bash. If the maintainer so desires, I could either add logic to test the existence of bash, or possibly write this statement in a dash/sh compliant method.