### PR TITLE
cephadm-adopt: Fixes binding network for alertmanager

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -1467,8 +1467,18 @@
       when: dashboard_enabled | bool
       block:
         - name: Update the placement of alertmanager hosts
-          ansible.builtin.command: "{{ cephadm_cmd }} shell -k /etc/ceph/{{ cluster }}.client.admin.keyring --fsid {{ fsid }} -- ceph orch apply alertmanager --placement='{{ groups.get(monitoring_group_name, []) | length }} label:{{ monitoring_group_name }}'"
-          changed_when: false
+          ceph_orch_apply:
+            fsid: "{{ fsid }}"
+            spec: |
+              service_type: alertmanager
+              service_id: "{{ ansible_facts['hostname'] }}"
+              placement:
+                label: "{{ monitoring_group_name }}"
+              {% if grafana_server_addr is defined %}
+              networks:
+              - {{ grafana_server_addr }}
+              {% endif %}
+          delegate_to: "{{ groups[mon_group_name][0] }}"
           environment:
             CEPHADM_IMAGE: '{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}'
 


### PR DESCRIPTION
Alertmanager was bind to default * network instead of grafana_server_addr as it was before. Now on if grafana_server_addr is defined, it will be bind to that network.