### PR TITLE
cephadm-adopt: add cephadm ssh config option

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -294,6 +294,13 @@
       run_once: true
       delegate_to: "{{ groups[mon_group_name][0] }}"
 
+    - name: Set cephadm ssh config
+      ansible.builtin.command: "{{ ceph_cmd }} cephadm set-ssh-config -i {{ cephadm_ssh_config_path }}"
+      changed_when: false
+      run_once: true
+      delegate_to: "{{ groups[mon_group_name][0] }}"
+      when: cephadm_ssh_config_path is defined
+
     - name: Run cephadm prepare-host
       ansible.builtin.command: cephadm prepare-host
       changed_when: false


### PR DESCRIPTION
Some clusters have customized ssh config, to adopt these clusters we need to set ssh config for cephadm.