### PR TITLE
cephadm-adopt: Wrong yaml structure in rgw placement

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -943,7 +943,7 @@
             hosts:
               - {{ ansible_facts['nodename'] }}
           {% if rgw_subnet is defined %}
-            networks: "{{ rgw_subnet }}"
+          networks: "{{ rgw_subnet }}"
           {% endif %}
           spec:
             rgw_frontend_port: {{ radosgw_frontend_port }}


### PR DESCRIPTION
networks key was at wrong level