### PR TITLE
cephadm-adopt: fix "Update the placement of radosgw hosts" task

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -943,7 +943,7 @@
             hosts:
               - {{ ansible_facts['nodename'] }}
           {% if rgw_subnet is defined %}
-            networks: "{{ rgw_subnet }}"
+          networks: "{{ rgw_subnet }}"
           {% endif %}
           spec:
             rgw_frontend_port: {{ radosgw_frontend_port }}


### PR DESCRIPTION
networks was at the wrong level in the spec file. Failed with "got an unexpected keyword argument 'networks'"