### PR TITLE
common: configure epel repository (rockylinux)

### DIFF
--- a/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
+++ b/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
@@ -1,6 +1,15 @@
 ---
-- name: include redhat_community_repository.yml
-  include_tasks: redhat_community_repository.yml
+- name: Configure epel repository
+  ansible.builtin.package:
+    name: epel-release
+  register: result
+  until: result is succeeded
+  tags: with_pkg
+  when:
+    - ansible_facts['distribution'] == 'Rocky'
+
+- name: Include redhat_community_repository.yml
+  ansible.builtin.include_tasks: redhat_community_repository.yml
   when: ceph_repository == 'community'
 
 - name: include redhat_rhcs_repository.yml

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = centos-{container,non_container}-{all_daemons,all_daemons_ipv6,collocation,lvm_osds,shrink_mon,shrink_mgr,shrink_mds,shrink_rbdmirror,shrink_rgw,lvm_batch,add_mons,add_mgrs,add_mdss,add_rbdmirrors,add_rgws,rgw_multisite,purge,storage_inventory,lvm_auto_discovery,all_in_one,cephadm_adopt,purge_dashboard}
+envlist = {centos,rocky}-{container,non_container}-{all_daemons,all_daemons_ipv6,collocation,lvm_osds,shrink_mon,shrink_mgr,shrink_mds,shrink_rbdmirror,shrink_rgw,lvm_batch,add_mons,add_mgrs,add_mdss,add_rbdmirrors,add_rgws,rgw_multisite,purge,storage_inventory,lvm_auto_discovery,all_in_one,cephadm_adopt,purge_dashboard}
   centos-non_container-{switch_to_containers}
   infra_lv_create
   migrate_ceph_disk_to_ceph_volume


### PR DESCRIPTION
this is needed in order to make some libraries available when running on RockyLinux

Signed-off-by: Guillaume Abrioux <gabrioux@ibm.com>
(cherry picked from commit 867be7c35c1f10080f842c3c6bdd51062cfd788a)