### PR TITLE
Dashboard: replace hardcoded groupname with groupname variable

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -105,7 +105,7 @@
 # using groups[] here otherwise it can't fallback to the mon if there's no mgr group.
 # adding an additional | default(omit) in case where no monitors are present (external ceph cluster)
 - name: Deploy dashboard
-  hosts: "{{ groups['mgrs'] | default(groups['mons']) | default(omit) }}"
+  hosts: "{{ groups[mgr_group_name] | default(groups[mon_group_name]) | default(omit) }}"
   gather_facts: false
   become: true
   pre_tasks:

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -40,6 +40,7 @@ ceph_release_num:
 cluster: ceph
 
 # Inventory host group variables
+all_group_name: all     # useful if runned against a global inventory that includes non-ceph hosts
 mon_group_name: mons
 osd_group_name: osds
 rgw_group_name: rgws

--- a/roles/ceph-prometheus/templates/alertmanager.yml.j2
+++ b/roles/ceph-prometheus/templates/alertmanager.yml.j2
@@ -10,7 +10,7 @@ route:
 receivers:
 - name: 'ceph-dashboard'
   webhook_configs:
-{% for host in groups['mgrs'] | default(groups['mons']) %}
+{% for host in groups[mgr_group_name] | default(groups[mon_group_name]) %}
   - url: '{{ dashboard_protocol }}://{{ hostvars[host]['ansible_facts']['fqdn'] }}:{{ dashboard_port }}/api/prometheus_receiver'
 {% if dashboard_protocol == 'https' and alertmanager_dashboard_api_no_ssl_verify | bool %}
     http_config:

--- a/roles/ceph-prometheus/templates/prometheus.yml.j2
+++ b/roles/ceph-prometheus/templates/prometheus.yml.j2
@@ -19,7 +19,7 @@ scrape_configs:
 {% endfor %}
   - job_name: 'node'
     static_configs:
-{% for host in (groups['all'] | difference(groups[monitoring_group_name] | union(groups.get(client_group_name, []))) | union(groups.get(osd_group_name, []))) %}
+{% for host in (groups[all_group_name] | difference(groups[monitoring_group_name] | union(groups.get(client_group_name, []))) | union(groups.get(osd_group_name, []))) %}
       - targets: ['{{ host }}:{{ node_exporter_port }}']
         labels:
           instance: "{{ hostvars[host]['ansible_facts']['nodename'] }}"


### PR DESCRIPTION
A little PR for replacing hard-coded group names with the group name variables defined.

Without this modification, we can't deploy dashboard with our global dynamic inventory.