### PR TITLE
playbooks: use group name variables consistently

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -105,7 +105,7 @@
 # using groups[] here otherwise it can't fallback to the mon if there's no mgr group.
 # adding an additional | default(omit) in case where no monitors are present (external ceph cluster)
 - name: Deploy dashboard
-  hosts: "{{ groups['mgrs'] | default(groups['mons']) | default(omit) }}"
+  hosts: "{{ groups[mgr_group_name|default('mgrs')] | default(groups[mon_group_name|default('mons')]) | default(omit) }}"
   gather_facts: false
   become: true
   pre_tasks:

--- a/infrastructure-playbooks/add-mon.yml
+++ b/infrastructure-playbooks/add-mon.yml
@@ -7,7 +7,7 @@
 # group in your inventory so that the ceph configuration file
 # is created correctly for the new OSD(s).
 - name: Pre-requisites operations for adding new monitor(s)
-  hosts: mons
+  hosts: "{{ mon_group_name|default('mons') }}"
   gather_facts: false
   vars:
     delegate_facts_host: true
@@ -72,7 +72,7 @@
       when: containerized_deployment | bool
 
 - name: Deploy Ceph monitors
-  hosts: mons
+  hosts: "{{ mon_group_name|default('mons') }}"
   gather_facts: false
   become: true
   tasks:
@@ -107,7 +107,7 @@
       when: containerized_deployment | bool
 
 - name: Update config file on OSD nodes
-  hosts: osds
+  hosts: "{{ osd_group_name|default('osds') }}"
   gather_facts: true
   become: true
   tasks:

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -32,15 +32,15 @@
 
 - name: Gather facts on all hosts
   hosts:
-    - mons
-    - osds
-    - mdss
-    - rgws
-    - rbdmirrors
-    - nfss
-    - clients
-    - mgrs
-    - monitoring
+    - "{{ mon_group_name | default('mons') }}"
+    - "{{ osd_group_name | default('osds') }}"
+    - "{{ mds_group_name | default('mdss') }}"
+    - "{{ rgw_group_name | default('rgws') }}"
+    - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+    - "{{ nfs_group_name | default('nfss') }}"
+    - "{{ client_group_name | default('clients') }}"
+    - "{{ mgr_group_name | default('mgrs') }}"
+    - "{{ monitoring_group_name | default('monitoring') }}"
   become: true
   tasks:
     - name: Gather facts on all Ceph hosts for following reference
@@ -49,7 +49,7 @@
 
 
 - name: Check there's no ceph kernel threads present
-  hosts: clients
+  hosts: "{{ client_group_name | default('clients') }}"
   become: true
   gather_facts: false
   any_errors_fatal: true
@@ -113,7 +113,7 @@
 
 
 - name: Purge ceph nfs cluster
-  hosts: nfss
+  hosts: "{{ nfs_group_name | default('nfss') }}"
   gather_facts: false # Already gathered previously
   become: true
   tasks:
@@ -140,15 +140,15 @@
 
 - name: Purge node-exporter
   hosts:
-    - mons
-    - osds
-    - mdss
-    - rgws
-    - rbdmirrors
-    - nfss
-    - clients
-    - mgrs
-    - monitoring
+    - "{{ mon_group_name | default('mons') }}"
+    - "{{ osd_group_name | default('osds') }}"
+    - "{{ mds_group_name | default('mdss') }}"
+    - "{{ rgw_group_name | default('rgws') }}"
+    - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+    - "{{ nfs_group_name | default('nfss') }}"
+    - "{{ client_group_name | default('clients') }}"
+    - "{{ mgr_group_name | default('mgrs') }}"
+    - "{{ monitoring_group_name | default('monitoring') }}"
   become: true
   tasks:
     - name: Import ceph-defaults role
@@ -184,7 +184,7 @@
 
 
 - name: Purge ceph monitoring
-  hosts: monitoring
+  hosts: "{{ monitoring_group_name | default('monitoring') }}"
   become: true
   vars:
     grafana_services:
@@ -247,7 +247,7 @@
 
 
 - name: Purge ceph mds cluster
-  hosts: mdss
+  hosts: "{{ mds_group_name | default('mdss') }}"
   gather_facts: false # Already gathered previously
   become: true
   tasks:
@@ -268,7 +268,7 @@
 
 
 - name: Purge ceph mgr cluster
-  hosts: mgrs
+  hosts: "{{ mgr_group_name | default('mgrs') }}"
   gather_facts: false # Already gathered previously
   become: true
   tasks:
@@ -289,7 +289,7 @@
         - '.target'
 
 - name: Purge rgwloadbalancer cluster
-  hosts: rgwloadbalancers
+  hosts: "{{ rgwloadbalancer_group_name | default('rgwloadbalancers') }}"
   gather_facts: false # Already gathered previously
   become: true
   tasks:
@@ -302,7 +302,7 @@
 
 
 - name: Purge ceph rgw cluster
-  hosts: rgws
+  hosts: "{{ rgw_group_name | default('rgws') }}"
   gather_facts: false # Already gathered previously
   become: true
   tasks:
@@ -333,7 +333,7 @@
 
 
 - name: Purge ceph rbd-mirror cluster
-  hosts: rbdmirrors
+  hosts: "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
   gather_facts: false # Already gathered previously
   become: true
   tasks:
@@ -356,7 +356,7 @@
 - name: Purge ceph osd cluster
   vars:
     reboot_osd_node: false
-  hosts: osds
+  hosts: "{{ osd_group_name | default('osds') }}"
   gather_facts: false # Already gathered previously
   become: true
   handlers:
@@ -653,7 +653,7 @@
         - '.target'
 
 - name: Purge ceph mon cluster
-  hosts: mons
+  hosts: "{{ mon_group_name | default('mons') }}"
   gather_facts: false # already gathered previously
   become: true
   tasks:
@@ -689,12 +689,12 @@
 
 - name: Purge ceph-crash daemons
   hosts:
-    - mons
-    - osds
-    - mdss
-    - rgws
-    - rbdmirrors
-    - mgrs
+    - "{{ mon_group_name | default('mons') }}"
+    - "{{ osd_group_name | default('osds') }}"
+    - "{{ mds_group_name | default('mdss') }}"
+    - "{{ rgw_group_name | default('rgws') }}"
+    - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+    - "{{ mgr_group_name | default('mgrs') }}"
   gather_facts: false
   become: true
   tasks:
@@ -728,12 +728,12 @@
 
 - name: Purge ceph-exporter daemons
   hosts:
-    - mons
-    - osds
-    - mdss
-    - rgws
-    - rbdmirrors
-    - mgrs
+    - "{{ mon_group_name | default('mons') }}"
+    - "{{ osd_group_name | default('osds') }}"
+    - "{{ mds_group_name | default('mdss') }}"
+    - "{{ rgw_group_name | default('rgws') }}"
+    - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+    - "{{ mgr_group_name | default('mgrs') }}"
   gather_facts: false
   become: true
   tasks:
@@ -762,13 +762,13 @@
 
 - name: Check container hosts
   hosts:
-    - mons
-    - osds
-    - mdss
-    - rgws
-    - rbdmirrors
-    - nfss
-    - mgrs
+    - "{{ mon_group_name | default('mons') }}"
+    - "{{ osd_group_name | default('osds') }}"
+    - "{{ mds_group_name | default('mdss') }}"
+    - "{{ rgw_group_name | default('rgws') }}"
+    - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+    - "{{ nfs_group_name | default('nfss') }}"
+    - "{{ mgr_group_name | default('mgrs') }}"
   become: true
   tasks:
     - name: Containerized_deployment only
@@ -841,15 +841,15 @@
       - keepalived
       - haproxy
   hosts:
-    - mons
-    - osds
-    - mdss
-    - rgws
-    - rbdmirrors
-    - nfss
-    - clients
-    - mgrs
-    - monitoring
+    - "{{ mon_group_name | default('mons') }}"
+    - "{{ osd_group_name | default('osds') }}"
+    - "{{ mds_group_name | default('mdss') }}"
+    - "{{ rgw_group_name | default('rgws') }}"
+    - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+    - "{{ nfs_group_name | default('nfss') }}"
+    - "{{ client_group_name | default('clients') }}"
+    - "{{ mgr_group_name | default('mgrs') }}"
+    - "{{ monitoring_group_name | default('monitoring') }}"
   gather_facts: false # Already gathered previously
   become: true
   handlers:
@@ -1113,14 +1113,14 @@
 
 - name: Purge ceph directories
   hosts:
-    - mons
-    - osds
-    - mdss
-    - rgws
-    - rbdmirrors
-    - nfss
-    - mgrs
-    - clients
+    - "{{ mon_group_name | default('mons') }}"
+    - "{{ osd_group_name | default('osds') }}"
+    - "{{ mds_group_name | default('mdss') }}"
+    - "{{ rgw_group_name | default('rgws') }}"
+    - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+    - "{{ nfs_group_name | default('nfss') }}"
+    - "{{ mgr_group_name | default('mgrs') }}"
+    - "{{ client_group_name | default('clients') }}"
   gather_facts: false # Already gathered previously
   become: true
   tasks:

--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -80,7 +80,16 @@
           - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: true
-      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
+      with_items:
+        - "{{ groups[mon_group_name | default('mons')] | default([]) }}"
+        - "{{ groups[osd_group_name | default('osds')] | default([]) }}"
+        - "{{ groups[mds_group_name | default('mdss')] | default([]) }}"
+        - "{{ groups[rgw_group_name | default('rgws')] | default([]) }}"
+        - "{{ groups[mgr_group_name | default('mgrs')] | default([]) }}"
+        - "{{ groups[rbd_mirror_group_name | default('rbdmirrors')] | default([]) }}"
+        - "{{ groups[nfs_group_name | default('nfss')] | default([]) }}"
+        - "{{ groups[monitoring_group_name | default('monitoring')] | default([]) }}"
+        - "{{ groups[rgwloadbalancer_group_name | default('rgwloadbalancers')] | default([]) }}"
       run_once: true
       when: delegate_facts_host | bool
 
@@ -537,7 +546,7 @@
     health_osd_check_retries: 600
     health_osd_check_delay: 2
     upgrade_ceph_packages: true
-  hosts: osds
+  hosts: "{{ osd_group_name|default('osds') }}"
   tags: osds
   serial: 1
   become: true

--- a/infrastructure-playbooks/shrink-mds.yml
+++ b/infrastructure-playbooks/shrink-mds.yml
@@ -29,7 +29,7 @@
         tasks_from: container_binary
 
 - name: Perform checks, remove mds and print cluster health
-  hosts: mons[0]
+  hosts: "{{ mon_group_name | default('mons') }}[0]"
   become: true
   vars_prompt:
     - name: ireallymeanit  # noqa: name[casing]

--- a/infrastructure-playbooks/shrink-mgr.yml
+++ b/infrastructure-playbooks/shrink-mgr.yml
@@ -22,7 +22,7 @@
         msg: gather facts on all Ceph hosts for following reference
 
 - name: Confirm if user really meant to remove manager from the ceph cluster
-  hosts: mons[0]
+  hosts: "{{ mon_group_name | default('mons') }}[0]"
   become: true
   vars_prompt:
     - name: ireallymeanit  # noqa: name[casing]

--- a/infrastructure-playbooks/shrink-mon.yml
+++ b/infrastructure-playbooks/shrink-mon.yml
@@ -24,7 +24,7 @@
         msg: "gather facts on all Ceph hosts for following reference"
 
 - name: Confirm whether user really meant to remove monitor from the ceph cluster
-  hosts: mons[0]
+  hosts: "{{ mon_group_name | default('mons') }}[0]"
   become: true
   vars_prompt:
     - name: ireallymeanit  # noqa: name[casing]

--- a/infrastructure-playbooks/shrink-osd.yml
+++ b/infrastructure-playbooks/shrink-osd.yml
@@ -13,8 +13,8 @@
 
 - name: Gather facts and check the init system
   hosts:
-    - mons
-    - osds
+    - "{{ mon_group_name | default('mons') }}"
+    - "{{ osd_group_name | default('osds') }}"
 
   become: true
   tasks:
@@ -23,7 +23,7 @@
         msg: "gather facts on all Ceph hosts for following reference"
 
 - name: Confirm whether user really meant to remove osd(s) from the cluster
-  hosts: mons[0]
+  hosts: "{{ mon_group_name | default('mons') }}[0]"
   become: true
   vars_prompt:
     - name: ireallymeanit  # noqa: name[casing]

--- a/infrastructure-playbooks/shrink-rbdmirror.yml
+++ b/infrastructure-playbooks/shrink-rbdmirror.yml
@@ -13,8 +13,8 @@
 
 - name: Gather facts and check the init system
   hosts:
-    - mons
-    - rbdmirrors
+    - "{{ mon_group_name | default('mons') }}"
+    - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
   become: true
   tasks:
     - name: Gather facts on MONs and RBD mirrors
@@ -23,7 +23,7 @@
 
 - name: Confirm whether user really meant to remove rbd mirror from the ceph
         cluster
-  hosts: mons[0]
+  hosts: "{{ mon_group_name | default('mons') }}[0]"
   become: true
   vars_prompt:
     - name: ireallymeanit  # noqa: name[casing]

--- a/infrastructure-playbooks/shrink-rgw.yml
+++ b/infrastructure-playbooks/shrink-rgw.yml
@@ -54,7 +54,7 @@
           - '!ohai'
 
 - name: Shrink rgw service
-  hosts: mons[0]
+  hosts: "{{ mon_group_name | default('mons') }}[0]"
   become: true
   gather_facts: false
   pre_tasks:

--- a/site-container.yml.sample
+++ b/site-container.yml.sample
@@ -11,15 +11,15 @@
       when: not yes_i_know | default(false) | bool
 
 - hosts:
-  - mons
-  - osds
-  - mdss
-  - rgws
-  - nfss
-  - rbdmirrors
-  - clients
-  - mgrs
-  - monitoring
+  - "{{ mon_group_name | default('mons') }}"
+  - "{{ osd_group_name | default('osds') }}"
+  - "{{ mds_group_name | default('mdss') }}"
+  - "{{ rgw_group_name | default('rgws') }}"
+  - "{{ nfs_group_name | default('nfss') }}"
+  - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+  - "{{ client_group_name | default('clients') }}"
+  - "{{ mgr_group_name | default('mgrs') }}"
+  - "{{ monitoring_group_name | default('monitoring') }}"
 
   gather_facts: false
   become: True
@@ -52,7 +52,16 @@
           - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
+      with_items:
+        - "{{ groups[mon_group_name | default('mons')] | default([]) }}"
+        - "{{ groups[osd_group_name | default('osds')] | default([]) }}"
+        - "{{ groups[mds_group_name | default('mdss')] | default([]) }}"
+        - "{{ groups[rgw_group_name | default('rgws')] | default([]) }}"
+        - "{{ groups[mgr_group_name | default('mgrs')] | default([]) }}"
+        - "{{ groups[rbd_mirror_group_name | default('rbdmirrors')] | default([]) }}"
+        - "{{ groups[nfs_group_name | default('nfss')] | default([]) }}"
+        - "{{ groups[monitoring_group_name | default('monitoring')] | default([]) }}"
+        - "{{ groups[rgwloadbalancer_group_name | default('rgwloadbalancers')] | default([]) }}"
       run_once: true
       when: delegate_facts_host | bool
       tags: always
@@ -88,7 +97,7 @@
       tags: fetch_container_image
       when: (group_names != ['clients'] and group_names != ['clients', '_filtered_clients'] and group_names != ['_filtered_clients', 'clients']) or (inventory_hostname == groups.get('_filtered_clients', [''])|first)
 
-- hosts: mons
+- hosts: "{{ mon_group_name | default('mons') }}"
   gather_facts: false
   any_errors_fatal: true
   tasks:
@@ -100,7 +109,7 @@
             status: "In Progress"
             start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: mons
+- hosts: "{{ mon_group_name | default('mons') }}"
   become: True
   gather_facts: false
   any_errors_fatal: true
@@ -123,7 +132,7 @@
         name: ceph-mgr
       when: groups.get(mgr_group_name, []) | length == 0 or mgr_group_name in group_names
 
-- hosts: mons
+- hosts: "{{ mon_group_name | default('mons') }}"
   gather_facts: false
   any_errors_fatal: true
   tasks:
@@ -135,7 +144,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: mgrs
+- hosts: "{{ mgr_group_name | default('mgrs') }}"
   become: True
   gather_facts: false
   any_errors_fatal: true
@@ -173,7 +182,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: osds
+- hosts: "{{ osd_group_name | default('osds') }}"
   become: True
   gather_facts: false
   any_errors_fatal: true
@@ -211,7 +220,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: mdss
+- hosts: "{{ mds_group_name | default('mdss') }}"
   become: True
   gather_facts: false
   any_errors_fatal: true
@@ -249,7 +258,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: rgws
+- hosts: "{{ rgw_group_name | default('rgws') }}"
   become: True
   gather_facts: false
   any_errors_fatal: true
@@ -287,7 +296,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: clients
+- hosts: "{{ client_group_name | default('clients') }}"
   become: True
   gather_facts: false
   any_errors_fatal: true
@@ -326,7 +335,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: nfss
+- hosts: "{{ nfs_group_name | default('nfss') }}"
   become: True
   gather_facts: false
   any_errors_fatal: true
@@ -364,7 +373,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: rbdmirrors
+- hosts: "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
   become: True
   gather_facts: false
   any_errors_fatal: true
@@ -408,12 +417,12 @@
     - groups.get(monitoring_group_name, []) | length > 0
 
 - hosts:
-  - mons
-  - osds
-  - mdss
-  - rgws
-  - rbdmirrors
-  - mgrs
+  - "{{ mon_group_name | default('mons') }}"
+  - "{{ osd_group_name | default('osds') }}"
+  - "{{ mds_group_name | default('mdss') }}"
+  - "{{ rgw_group_name | default('rgws') }}"
+  - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+  - "{{ mgr_group_name | default('mgrs') }}"
 
   gather_facts: false
   become: True
@@ -448,12 +457,12 @@
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
 - hosts:
-  - mons
-  - osds
-  - mdss
-  - rgws
-  - rbdmirrors
-  - mgrs
+  - "{{ mon_group_name | default('mons') }}"
+  - "{{ osd_group_name | default('osds') }}"
+  - "{{ mds_group_name | default('mdss') }}"
+  - "{{ rgw_group_name | default('rgws') }}"
+  - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+  - "{{ mgr_group_name | default('mgrs') }}"
 
   gather_facts: false
   become: True
@@ -488,14 +497,14 @@
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
 - hosts:
-  - mons
-  - osds
-  - mdss
-  - rgws
-  - rbdmirrors
-  - clients
-  - mgrs
-  - monitoring
+  - "{{ mon_group_name | default('mons') }}"
+  - "{{ osd_group_name | default('osds') }}"
+  - "{{ mds_group_name | default('mdss') }}"
+  - "{{ rgw_group_name | default('rgws') }}"
+  - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+  - "{{ client_group_name | default('clients') }}"
+  - "{{ mgr_group_name | default('mgrs') }}"
+  - "{{ monitoring_group_name | default('monitoring')) }}"
   gather_facts: false
   become: True
   any_errors_fatal: true
@@ -516,7 +525,7 @@
         - not _rgw_handler_called | default(false) | bool
 
 
-- hosts: mons[0]
+- hosts: "{{ groups[mon_group_name | default('mons')][0] }}"
   gather_facts: false
   become: True
   any_errors_fatal: true

--- a/site.yml.sample
+++ b/site.yml.sample
@@ -12,16 +12,16 @@
       when: not yes_i_know | default(false) | bool
 
 - hosts:
-  - mons
-  - osds
-  - mdss
-  - rgws
-  - nfss
-  - rbdmirrors
-  - clients
-  - mgrs
-  - monitoring
-  - rgwloadbalancers
+  - "{{ mon_group_name | default('mons') }}"
+  - "{{ osd_group_name | default('osds') }}"
+  - "{{ mds_group_name | default('mdss') }}"
+  - "{{ rgw_group_name | default('rgws') }}"
+  - "{{ nfs_group_name | default('nfss') }}"
+  - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+  - "{{ client_group_name | default('clients') }}"
+  - "{{ mgr_group_name | default('mgrs') }}"
+  - "{{ monitoring_group_name | default('monitoring') }}"
+  - "{{ rgwloadbalancer_group_name | default('rgwloadbalancers') }}"
 
   gather_facts: false
   any_errors_fatal: true
@@ -57,7 +57,16 @@
           - '!ohai'
       delegate_to: "{{ item }}"
       delegate_facts: True
-      with_items: "{{ groups['all'] | difference(groups.get('clients', [])) }}"
+      with_items:
+        - "{{ groups[mon_group_name | default('mons')] | default([]) }}"
+        - "{{ groups[osd_group_name | default('osds')] | default([]) }}"
+        - "{{ groups[mds_group_name | default('mdss')] | default([]) }}"
+        - "{{ groups[rgw_group_name | default('rgws')] | default([]) }}"
+        - "{{ groups[mgr_group_name | default('mgrs')] | default([]) }}"
+        - "{{ groups[rbd_mirror_group_name | default('rbdmirrors')] | default([]) }}"
+        - "{{ groups[nfs_group_name | default('nfss')] | default([]) }}"
+        - "{{ groups[monitoring_group_name | default('monitoring')] | default([]) }}"
+        - "{{ groups[rgwloadbalancer_group_name | default('rgwloadbalancers')] | default([]) }}"
       run_once: true
       when: delegate_facts_host | bool
 
@@ -86,7 +95,7 @@
     - import_role:
         name: ceph-common
 
-- hosts: mons
+- hosts: "{{ mon_group_name | default('mons') }}"
   gather_facts: false
   become: True
   any_errors_fatal: true
@@ -127,7 +136,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: mgrs
+- hosts: "{{ mgr_group_name | default('mgrs') }}"
   gather_facts: false
   become: True
   any_errors_fatal: true
@@ -165,7 +174,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: osds
+- hosts: "{{ osd_group_name | default('osds') }}"
   gather_facts: false
   become: True
   any_errors_fatal: true
@@ -203,7 +212,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: mdss
+- hosts: "{{ mds_group_name | default('mdss') }}"
   gather_facts: false
   become: True
   any_errors_fatal: true
@@ -241,7 +250,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: rgws
+- hosts: "{{ rgw_group_name | default('rgws') }}"
   gather_facts: false
   become: True
   any_errors_fatal: true
@@ -279,7 +288,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: clients
+- hosts: "{{ client_group_name | default('clients') }}"
   gather_facts: false
   become: True
   any_errors_fatal: true
@@ -318,7 +327,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: nfss
+- hosts: "{{ nfs_group_name | default('nfss') }}"
   gather_facts: false
   become: True
   any_errors_fatal: true
@@ -356,7 +365,7 @@
             status: "Complete"
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
-- hosts: rbdmirrors
+- hosts: "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
   gather_facts: false
   become: True
   any_errors_fatal: true
@@ -395,7 +404,7 @@
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
 - hosts:
-    - rgwloadbalancers
+    - "{{ rgwloadbalancer_group_name | default('rgwloadbalancers') }}"
   gather_facts: false
   become: True
   any_errors_fatal: true
@@ -433,12 +442,12 @@
     - groups.get(monitoring_group_name, []) | length > 0
 
 - hosts:
-  - mons
-  - osds
-  - mdss
-  - rgws
-  - rbdmirrors
-  - mgrs
+  - "{{ mon_group_name | default('mons') }}"
+  - "{{ osd_group_name | default('osds') }}"
+  - "{{ mds_group_name | default('mdss') }}"
+  - "{{ rgw_group_name | default('rgws') }}"
+  - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+  - "{{ mgr_group_name | default('mgrs') }}"
 
   gather_facts: false
   become: True
@@ -473,14 +482,14 @@
             end: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 
 - hosts:
-  - mons
-  - osds
-  - mdss
-  - rgws
-  - rbdmirrors
-  - clients
-  - mgrs
-  - monitoring
+  - "{{ mon_group_name | default('mons') }}"
+  - "{{ osd_group_name | default('osds') }}"
+  - "{{ mds_group_name | default('mdss') }}"
+  - "{{ rgw_group_name | default('rgws') }}"
+  - "{{ rbd_mirror_group_name | default('rbdmirrors') }}"
+  - "{{ client_group_name | default('clients') }}"
+  - "{{ mgr_group_name | default('mgrs') }}"
+  - "{{ monitoring_group_name | default('monitoring')) }}"
   gather_facts: false
   become: True
   any_errors_fatal: true
@@ -500,7 +509,7 @@
         - not _rbdmirror_handler_called | default(false) | bool
         - not _rgw_handler_called | default(false) | bool
 
-- hosts: mons
+- hosts: "{{ mon_group_name | default('mons') }}"
   gather_facts: false
   become: True
   any_errors_fatal: true


### PR DESCRIPTION
In many places, playbooks allow host group names such as 'mons' to be overriden by defining a variable such as 'mon_group_name'. This is very useful when ceph-ansible is sharing the ansible inventory with other playbooks and other hosts which expect different group names. But this was unfinished, with the variables used in some places but hard-coded names used in others places, sometimes within the same playbook.

This commit uses the group name variables everywhere so they can be reliably used to overrride the host group names.

Signed-off-by: Stuart Grace <stuart.grace@bbc.co.uk>
