### PR TITLE
Don't try to set devices fact when osd_auto_discovery was skipped

### DIFF
--- a/roles/ceph-facts/tasks/devices.yml
+++ b/roles/ceph-facts/tasks/devices.yml
@@ -76,5 +76,6 @@
   loop: "{{ devices_check.results }}"
   when:
     - devices_check is defined
+    - devices_check is not skipped
     - not item.skipped | default(false)
     - not item.failed | default(false)


### PR DESCRIPTION
Right now, under certain OS and Ansible versions, ie Rocky Linux and
ansible-core 2.17, `devices_check` variable is getting defined even if
task was skipped.

That results in set_fact to fail, as resulting variable has no `results`
key in it.

Structure of such variable looks like that:
```
"devices_check": {
    "changed": false,
    "false_condition": "osd_auto_discovery | default(False) | bool",
    "skip_reason": "Conditional result was False",
    "skipped": true
}
```

Checking for task not being skipped solves such issues.

Signed-Off-By: Dmitriy Rabotyagov <noonedeadpunk@gmail.com>