### PR TITLE
Handle RGW hosts placement during adoption of older clusters with multiple subnets

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -942,6 +942,7 @@
     - name: Update the placement of radosgw hosts
       ceph_orch_apply:
         fsid: "{{ fsid }}"
+        cluster: "{{ cluster }}"
         spec: |
           service_type: rgw
           service_id: {{ ansible_facts['hostname'] }}
@@ -1480,6 +1481,7 @@
         - name: Update the placement of alertmanager hosts
           ceph_orch_apply:
             fsid: "{{ fsid }}"
+            cluster: "{{ cluster }}"
             spec: |
               service_type: alertmanager
               service_id: "{{ ansible_facts['hostname'] }}"
@@ -1503,6 +1505,7 @@
         - name: Update the placement of prometheus hosts
           ceph_orch_apply:
             fsid: "{{ fsid }}"
+            cluster: "{{ cluster }}"
             spec: |
               service_name: prometheus
               service_id: "{{ ansible_facts['hostname'] }}"

--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -950,7 +950,7 @@
             hosts:
               - {{ ansible_facts['nodename'] }}
           {% if rgw_subnet is defined %}
-          networks: "{{ radosgw_address_block }}"
+          networks: {{ radosgw_address_block.split(',') | list if ',' in radosgw_address_block else radosgw_address_block | string }}
           {% endif %}
           spec:
             rgw_frontend_port: {{ radosgw_frontend_port }}


### PR DESCRIPTION
This PR contains the following commits which patch TASK "Update the placement of radosgw hosts" in the playbook cephadm-adopt.yml.

- Handle adoption when radosgw_address_block is comma delimited list
- Handle radosgw hosts placement with non-default cluster name

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2339149
