### PR TITLE
cephadm-adopt: rgw service fails after being redeployed

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -944,7 +944,7 @@
         fsid: "{{ fsid }}"
         spec: |
           service_type: rgw
-          service_id: {{ ansible_facts['hostname'] }}
+          service_id: rgw
           placement:
             count_per_host: {{ radosgw_num_instances }}
             hosts:


### PR DESCRIPTION
rgw services do not start after adoption due to path to asok file too long:

AdminSocketConfigObs::init: failed: AdminSocket::bind_and_listen: The UNIX domain socket path /var/run/ceph/ceph-client.rgw.hostname.service_id.gmlofh.6.94425541769128.asok is too long! The maximum length on this system is 107

to fix that, service_id in the spec which was the hostname has been replaced by "rgw"