### PR TITLE
cephadm-adopt: fix ssl condition in rgw placement task

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -954,7 +954,7 @@
           {% endif %}
           spec:
             rgw_frontend_port: {{ radosgw_frontend_port }}
-          {% if radosgw_frontend_ssl_certificate is defined %}
+          {% if radosgw_frontend_ssl_certificate | length > 0 %}
             {{ "ssl: true" }}
           {% endif %}
           extra_container_args:


### PR DESCRIPTION
rgw daemons fail to start as they were looking for ssl certificates while none were available.