### PR TITLE
[skip ci] doc: CI readthedocs job fails

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,3 +4,7 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.9"
+
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/source/conf.py


### PR DESCRIPTION
Deprecation of projects using Sphinx without an explicit configuration file

[1] https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/