### PR TITLE
Pass cluster in rolling_update call to ceph_config

### DIFF
--- a/infrastructure-playbooks/rolling_update.yml
+++ b/infrastructure-playbooks/rolling_update.yml
@@ -156,6 +156,7 @@
         who: mon
         option: mon_mds_skip_sanity
         value: true
+        cluster: "{{ cluster }}"
       environment:
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
         CEPH_CONTAINER_BINARY: "{{ container_binary }}" 
@@ -1218,6 +1219,7 @@
         action: rm
         who: mon
         option: mon_mds_skip_sanity
+        cluster: "{{ cluster }}"
       environment:
         CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else None }}"
         CEPH_CONTAINER_BINARY: "{{ container_binary }}" 


### PR DESCRIPTION
This patch is necessary to migrate older clusters which were deployed when custom names were supported.

Follow up to 3cda8e31c4da81efeade9009b2fc9a1e379f2c66