### PR TITLE
Use grafana_server_addr to set prometheus networks list

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -1487,8 +1487,7 @@
                 label: "{{ monitoring_group_name }}"
                 count: "{{ groups.get(monitoring_group_name, []) | length }}"
               {% if grafana_server_addr is defined %}
-              networks:
-              - {{ grafana_server_addr }}
+              networks: {{ grafana_server_addr.split(',') | list if ',' in grafana_server_addr else grafana_server_addr | string }}
               {% endif %}
           delegate_to: "{{ groups[mon_group_name][0] }}"
           environment:
@@ -1509,6 +1508,9 @@
               placement:
                 label: {{ monitoring_group_name }}
                 count: {{ groups.get(monitoring_group_name, []) | length }}
+              {% if grafana_server_addr is defined %}
+              networks: {{ grafana_server_addr.split(',') | list if ',' in grafana_server_addr else grafana_server_addr | string }}
+              {% endif %}
               {% if prometheus_port is defined and prometheus_port != 9095 %}
               spec:
                 port: {{ prometheus_port }}


### PR DESCRIPTION
When dashboard is enabled and module ceph_orch_apply is called, if the grafana_server_addr is defined, then it is used to populate the networks list in the spec of type alertmanager. This is the case without this patch. With this patch the same logic is applied to the spec of type prometheus. Also, if the grafana_server_addr is a comma delimited list, then a jinja2 expression handles passing the IPs as a list.

Without this patch prometheus binds to all networks even if grafana_server_addr is set which can create conflicts with other services.

Fixes: https://bugzilla.redhat.com/2269009