### PR TITLE
Adopt with grafana_network not grafana_server_addr

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -1488,8 +1488,8 @@
               placement:
                 label: "{{ monitoring_group_name }}"
                 count: "{{ groups.get(monitoring_group_name, []) | length }}"
-              {% if grafana_server_addr is defined %}
-              networks: {{ grafana_server_addr.split(',') | list if ',' in grafana_server_addr else grafana_server_addr | string }}
+              {% if grafana_network is defined %}
+              networks: {{ grafana_network.split(',') | list if ',' in grafana_network else [grafana_network] }}
               {% endif %}
           delegate_to: "{{ groups[mon_group_name][0] }}"
           environment:
@@ -1511,8 +1511,8 @@
               placement:
                 label: {{ monitoring_group_name }}
                 count: {{ groups.get(monitoring_group_name, []) | length }}
-              {% if grafana_server_addr is defined %}
-              networks: {{ grafana_server_addr.split(',') | list if ',' in grafana_server_addr else grafana_server_addr | string }}
+              {% if grafana_network is defined %}
+              networks: {{ grafana_network.split(',') | list if ',' in grafana_network else [grafana_network] }}
               {% endif %}
               {% if prometheus_port is defined and prometheus_port != 9095 %}
               spec:


### PR DESCRIPTION
The networks list in a spec is usually a range not a single IP. grafana_server_addr is a fact created from grafana_network so it is a more appropriate parameter to pass.

Follow up to 770a527a9ee6b34091798c6120235026ad1ecfa9