### PR TITLE
common/container: drop CEPH_USE_RANDOM_NONCE env var

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -529,7 +529,6 @@ dummy:
 #ceph_common_container_params:
 #  envs:
 #    NODE_NAME: "{{ ansible_facts['hostname'] }}"
-#    CEPH_USE_RANDOM_NONCE: "1"
 #    CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
 #    TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES: "{{ ceph_tcmalloc_max_total_thread_cache }}"
 #  args:

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -521,7 +521,6 @@ timeout_command: "{{ 'timeout --foreground -s KILL ' ~ docker_pull_timeout if (d
 ceph_common_container_params:
   envs:
     NODE_NAME: "{{ ansible_facts['hostname'] }}"
-    CEPH_USE_RANDOM_NONCE: "1"
     CONTAINER_IMAGE: "{{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}"
     TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES: "{{ ceph_tcmalloc_max_total_thread_cache }}"
   args:


### PR DESCRIPTION
It is not necessary anymore as this behavior became the default one.

Ceph Ref. https://github.com/ceph/ceph/pull/50344