### PR TITLE
Allow to control dashboard standby_behaviour

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -581,6 +581,7 @@ dummy:
 #dashboard_rgw_api_user_id: ceph-dashboard
 #dashboard_rgw_api_admin_resource: ''
 #dashboard_rgw_api_no_ssl_verify: false
+#dashboard_standby_behavior: redirect
 #dashboard_frontend_vip: ''
 #dashboard_disabled_features: []
 #prometheus_frontend_vip: ''

--- a/roles/ceph-dashboard/tasks/configure_dashboard.yml
+++ b/roles/ceph-dashboard/tasks/configure_dashboard.yml
@@ -180,6 +180,12 @@
   run_once: true
   with_items: '{{ groups[mgr_group_name] | default(groups[mon_group_name]) }}'
 
+- name: Config dashboard standby behavior
+  ansible.builtin.command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} mgr/dashboard/standby_behaviour {{ dashboard_standby_behavior }}"
+  delegate_to: "{{ groups[mon_group_name][0] }}"
+  changed_when: false
+  run_once: true
+
 - name: Disable mgr dashboard module (restart)
   ceph_mgr_module:
     name: dashboard

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -573,6 +573,7 @@ dashboard_grafana_api_no_ssl_verify: "{{ true if dashboard_protocol == 'https' a
 dashboard_rgw_api_user_id: ceph-dashboard
 dashboard_rgw_api_admin_resource: ''
 dashboard_rgw_api_no_ssl_verify: false
+dashboard_standby_behavior: redirect
 dashboard_frontend_vip: ''
 dashboard_disabled_features: []
 prometheus_frontend_vip: ''


### PR DESCRIPTION
In case of placing Ceph Dashboard behind of the LoadBalancer
user needs to ensure setting `dashboard_standby_behavior: error`
to notify the LoadBalancer which backend is currently active one
as suggested by the documentation [1]

[1] https://docs.ceph.com/en/reef/mgr/dashboard/#disable-the-redirection