### PR TITLE
fix for issue #11863. Optimize Image Removal

### DIFF
--- a/infrastructure-playbooks/purge-dashboard.yml
+++ b/infrastructure-playbooks/purge-dashboard.yml
@@ -132,12 +132,20 @@
         - /run/prometheus.service-cid
         - /run/grafana-server.service-cid
 
-    - name: Remove ceph dashboard container images
-      ansible.builtin.command: "{{ container_binary }} rmi {{ item }}"
-      loop:
-        - "{{ alertmanager_container_image }}"
-        - "{{ prometheus_container_image }}"
-        - "{{ grafana_container_image }}"
+    #included this task changed the following task as part of fix for issue #11863.
+    #this reduces SSH & Subprocess Overhead of the previous implementation which was spawning multiple SSH sessions for each docker rmi command
+    #with this change we now transfer and execute a single script.
+    #We avoids repetitive command module calls in Ansible. These changes make it more efficient and performant
+
+    - name: Generate remove_images.sh script dynamically
+      ansible.builtin.template:
+        src: remove_images.sh.j2
+        dest: /tmp/remove_images.sh
+        mode: "0755"
+
+    - name: Execute the ceph dashboard container image removal shell script
+      ansible.builtin.command: /tmp/remove_images.sh {{ container_binary }}
+      become: true
       changed_when: false
       failed_when: false
 

--- a/roles/ceph-defaults/templates/remove_images.sh.j2
+++ b/roles/ceph-defaults/templates/remove_images.sh.j2
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Validate input
+if [ -z "$1" ]; then
+    echo "Error: No container binary provided (docker or podman)"
+    exit 1
+fi
+
+CONTAINER_BIN=$1  # First argument to script (docker or podman)
+
+# List of images to remove
+IMAGES=(
+    "{{ alertmanager_container_image }}"
+    "{{ prometheus_container_image }}"
+    "{{ grafana_container_image }}"
+)
+
+# Loop through and remove each image
+for image in "${IMAGES[@]}"; do
+    $CONTAINER_BIN rmi "$image"
+done


### PR DESCRIPTION
**Summary**
This PR optimizes the removal of Ceph dashboard container images by replacing repetitive command module calls with a single shell script execution.

**Changes Made**
Replaced multiple ansible.builtin.command calls in a loop with a dynamically generated script.
The script is templated using Jinja2 (remove_images.sh.j2) to ensure variable substitution for image names.
The script is copied to the target host and executed in one step, reducing SSH overhead and improving efficiency.
Ensures compatibility with both Docker and Podman by passing container_binary dynamically.

**Why This Change?**
Reduces multiple SSH calls by executing a single script instead of looping through docker rmi commands in Ansible.
Enhances performance.