### PR TITLE
Remove six from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # These are Python requirements needed to run ceph-ansible main
 ansible-core>=2.15,<2.17,!=2.9.10
 netaddr
-six


### PR DESCRIPTION
I see no more six usage in this project.

Six is also removed from library/ceph_volume.py [since 2019](https://github.com/ceph/ceph-ansible/pull/4234).