### PR TITLE
radosgw-realm: support default flag for pull

### DIFF
--- a/library/radosgw_realm.py
+++ b/library/radosgw_realm.py
@@ -233,6 +233,7 @@ def pull_realm(module, container_image=None):
     url = module.params.get('url')
     access_key = module.params.get('access_key')
     secret_key = module.params.get('secret_key')
+    default = module.params.get('default', False)
 
     args = [
         'pull',
@@ -241,6 +242,8 @@ def pull_realm(module, container_image=None):
         '--access-key=' + access_key,
         '--secret=' + secret_key
     ]
+    if default:
+        args.append('--default')
 
     cmd = generate_radosgw_cmd(cluster=cluster,
                                args=args,

--- a/tests/library/test_radosgw_realm.py
+++ b/tests/library/test_radosgw_realm.py
@@ -118,7 +118,8 @@ class TestRadosgwRealmModule(object):
             '--rgw-realm=' + fake_realm,
             '--url=' + fake_url,
             '--access-key=' + fake_access_key,
-            '--secret=' + fake_secret_key
+            '--secret=' + fake_secret_key,
+            '--default'
         ]
 
         assert radosgw_realm.pull_realm(fake_module) == expected_cmd


### PR DESCRIPTION
radosgw-admin supports the default flag to set the pulled realm as default if requested.