### PR TITLE
Add copytruncate option In Logrotate for heavily log operations

### DIFF
--- a/roles/ceph-infra/templates/logrotate.conf.j2
+++ b/roles/ceph-infra/templates/logrotate.conf.j2
@@ -2,6 +2,7 @@
     rotate {{ ceph_logrotate_rotate | default(7) }}
     {{ ceph_logrotate_frequency | default('daily') }}
     compress
+    copytruncate
     sharedscripts
     postrotate
         killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw rbd-mirror || pkill -1 -x "ceph-mon|ceph-mgr|ceph-mds|ceph-osd|ceph-fuse|radosgw|rbd-mirror" || true


### PR DESCRIPTION
We had an Issue in Logrotation of the RGW ops logs With This Error:

```
error: Compressing program wrote the following message to stderr when compressing log /var/log/ceph/rgw_ops_rgw.default.si1-cstorage4010.rgw0.log.1:
gzip: stdin: file size changed while zipping
error: Compressing program wrote the following message to stderr when compressing log /var/log/ceph/rgw_ops_rgw.default.si1-cstorage4010.rgw1.log.1:
gzip: stdin: file size changed while zipping
```
Rgws doesn't change inode of log files to write when they get SIGHUP so I Added this option to rotate the logs properly