### PR TITLE
ceph-config: allow to control setting osd memory target

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -113,6 +113,7 @@
         option: "osd_memory_target"
         value: "{{ _osd_memory_target }}"
       when:
+        - ceph_config_osd_memory_target | default(true)
         - _osd_memory_target is defined
         - running_mon is defined
       environment:


### PR DESCRIPTION
Allow to stop setting auto memory target in case like one wants to set it globally for all osds via `ceph_cluster_conf`.