### PR TITLE
ceph-pool: pass pg_num for pg_autoscale_mode warn

### DIFF
--- a/library/ceph_pool.py
+++ b/library/ceph_pool.py
@@ -441,13 +441,15 @@ def create_pool(cluster,
     args = ['create', user_pool_config['pool_name']['value'],
             user_pool_config['type']['value']]
 
-    if user_pool_config['pg_autoscale_mode']['value'] == 'off':
+    pg_autoscale_mode = user_pool_config['pg_autoscale_mode']['value']
+    if pg_autoscale_mode in ['off', 'warn']:
         args.extend(['--pg_num',
                      user_pool_config['pg_num']['value'],
                      '--pgp_num',
                      user_pool_config['pgp_num']['value'] or
                      user_pool_config['pg_num']['value']])
-    elif user_pool_config['target_size_ratio']['value']:
+
+    if pg_autoscale_mode in ['on', 'warn'] and user_pool_config['target_size_ratio']['value']:
         args.extend(['--target_size_ratio',
                      user_pool_config['target_size_ratio']['value']])
 


### PR DESCRIPTION
The pg_autoscale_mode parameter has three possible values 'on', 'off', and 'warn'. In case of 'warn' it should be possible to pass the number of placement groups (pg_num) to the create_pool function. Nothing is lost by allowing this. The health check will still warn if the value needs adjustment.

The evaluation of target_size_ratio works as before.

Add a test iterating through possible value combinations of the parameters target_size_ratio, pg_num and pg_autoscale_mode.