### PR TITLE
Fix name[unique] for ansible-lint

### DIFF
--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -431,7 +431,7 @@
       ansible.builtin.shell: "sync && sleep 1 && echo 3 > /proc/sys/vm/drop_caches"
       changed_when: false
 
-    - name: See if ceph-volume is installed # noqa command-instead-of-shell
+    - name: Check if ceph-volume is installed # noqa command-instead-of-shell
       ansible.builtin.shell: command -v ceph-volume
       changed_when: false
       failed_when: false
@@ -525,7 +525,7 @@
       failed_when: false
       register: ceph_lockbox_partition_to_erase_path
 
-    - name: See if ceph-volume is installed # noqa: command-instead-of-shell
+    - name: Re-check if ceph-volume is installed # noqa: command-instead-of-shell
       ansible.builtin.shell: command -v ceph-volume
       changed_when: false
       failed_when: false

--- a/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
+++ b/infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons.yml
@@ -399,7 +399,7 @@
       ansible.builtin.import_role:
         name: ceph-handler
 
-    - name: Import ceph-container-common role
+    - name: Import ceph-container-engine role
       ansible.builtin.import_role:
         name: ceph-container-engine
 


### PR DESCRIPTION
The name[unique] [1] for ansible-lint which was recently introduced raises due to duplicating names of tasks within same playbooks. We fix task naming to be unique.

[1] https://docs.ansible.com/projects/lint/rules/name/#nameunique

Signed-off-by: Dmitriy Rabotyagov <dmitriy.rabotyagov@cleura.com>