### PR TITLE
Make sure CEPH_CONTAINER_IMAGE is fixed everywhere

### DIFF
--- a/roles/ceph-nfs/tasks/pre_requisite_container.yml
+++ b/roles/ceph-nfs/tasks/pre_requisite_container.yml
@@ -43,7 +43,7 @@
         mode: "0600"
       no_log: "{{ no_log_on_ceph_key_tasks }}"
       environment:
-        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+        CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else '' }}"
         CEPH_CONTAINER_BINARY: "{{ container_binary }}"
       delegate_to: "{{ groups.get(mon_group_name)[0] }}"
       loop: "{{ keyrings_list }}"

--- a/roles/ceph-rgw/tasks/pre_requisite.yml
+++ b/roles/ceph-rgw/tasks/pre_requisite.yml
@@ -27,7 +27,7 @@
   no_log: "{{ no_log_on_ceph_key_tasks }}"
   delegate_to: "{{ groups[mon_group_name][0] if groups.get(mon_group_name, []) | length > 0 else 'localhost' }}"
   environment:
-    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else None }}"
+    CEPH_CONTAINER_IMAGE: "{{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else '' }}"
     CEPH_CONTAINER_BINARY: "{{ container_binary }}"
   with_items: "{{ rgw_instances }}"
   when: cephx | bool


### PR DESCRIPTION
In [1], `CEPH_CONTAINER_IMAGE` was fixed to work properly with ansible-core 2.19, where the way ansible handles environment variables with "None" value has changed.

Unfortunately, `CEPH_CONTAINER_IMAGE` was left unchanged in a few places.
This patch fixes that by making sure that the value of `CEPH_CONTAINER_IMAGE` is correct everywhere.

[1] https://github.com/ceph/ceph-ansible/commit/e70b2e4a1113d323da50b9ec9d16c5a7d7df4bf4