### PR TITLE
Drop yaml callback from ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -20,7 +20,7 @@ fact_caching_connection = $HOME/ansible/facts
 fact_caching_timeout = 7200
 nocows = 1
 callback_allowlist = profile_tasks
-stdout_callback = yaml
+result_format = yaml
 force_valid_group_names = ignore
 inject_facts_as_vars = False
 


### PR DESCRIPTION
community.general.yaml callback has been deprecated and raises a critical error on modern ansible. `result_format` should be used instead[1]

[1] https://docs.ansible.com/projects/ansible/latest/collections/community/general/yaml_callback.html

Signed-off-by: Dmitriy Rabotyagov <noonedeadpunk@gmail.com>