### PR TITLE
Switch to ganesha5

### DIFF
--- a/group_vars/all.yml.sample
+++ b/group_vars/all.yml.sample
@@ -159,11 +159,11 @@ dummy:
 #ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 #nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-#centos_release_nfs: centos-release-nfs-ganesha4
-#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-4/ubuntu
+#centos_release_nfs: centos-release-nfs-ganesha5
+#nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-5/ubuntu
 #nfs_ganesha_apt_keyserver: keyserver.ubuntu.com
 #nfs_ganesha_apt_key_id: EA914D611053D07BD332E18010353E8834DC57CA
-#libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-4/ubuntu
+#libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-5/ubuntu
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/
@@ -524,7 +524,7 @@ dummy:
 #ceph_client_docker_image_tag: "{{ ceph_docker_image_tag }}"
 #ceph_client_docker_registry: "{{ ceph_docker_registry }}"
 #containerized_deployment: false
-#container_binary:
+#container_binary: ""
 #timeout_command: "{{ 'timeout --foreground -s KILL ' ~ docker_pull_timeout if (docker_pull_timeout != '0') and (ceph_docker_dev_image is undefined or not ceph_docker_dev_image) else '' }}"
 #ceph_common_container_params:
 #  envs:
@@ -661,7 +661,7 @@ dummy:
 #               *DO NOT* MODIFY THEM                 #
 ######################################################
 
-#container_exec_cmd:
+#container_exec_cmd: ""
 #docker: false
 #ceph_volume_debug: "{{ enable_ceph_volume_debug | ternary(1, 0) }}"
 

--- a/roles/ceph-defaults/defaults/main.yml
+++ b/roles/ceph-defaults/defaults/main.yml
@@ -151,11 +151,11 @@ ceph_stable_release: squid
 ceph_stable_repo: "{{ ceph_mirror }}/debian-{{ ceph_stable_release }}"
 
 nfs_ganesha_stable: true # use stable repos for nfs-ganesha
-centos_release_nfs: centos-release-nfs-ganesha4
-nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-4/ubuntu
+centos_release_nfs: centos-release-nfs-ganesha5
+nfs_ganesha_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/nfs-ganesha-5/ubuntu
 nfs_ganesha_apt_keyserver: keyserver.ubuntu.com
 nfs_ganesha_apt_key_id: EA914D611053D07BD332E18010353E8834DC57CA
-libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-4/ubuntu
+libntirpc_stable_deb_repo: http://ppa.launchpad.net/nfs-ganesha/libntirpc-5/ubuntu
 
 # Use the option below to specify your applicable package tree, eg. when using non-LTS Ubuntu versions
 # # for a list of available Debian distributions, visit http://download.ceph.com/debian-{{ ceph_stable_release }}/dists/


### PR DESCRIPTION
PPAs for Ubuntu does not contain modern distros for ganesha4.

Ganesha 5 is available both on EL and Ubuntu systems, and should be working just fine with ceph.

Signed-off-by: Dmitriy Rabotyagov <noonedeadpunk@gmail.com>