### PR TITLE
Fix #7681: osd_memory_target is now set correctly for hosts

### DIFF
--- a/roles/ceph-config/tasks/main.yml
+++ b/roles/ceph-config/tasks/main.yml
@@ -109,7 +109,7 @@
     - name: Set osd_memory_target to cluster host config
       ceph_config:
         action: set
-        who: "osd.*/{{ ansible_facts['hostname'] }}:host"
+        who: "osd/host:{{ ansible_facts['hostname'] }}"
         option: "osd_memory_target"
         value: "{{ _osd_memory_target }}"
       when:


### PR DESCRIPTION
Based on [docs](https://docs.ceph.com/en/squid/rados/configuration/ceph-conf/#sections-and-masks) and testing `osd_memory_target` is not being set at all after the memory calculation.

Yes you can see it in `ceph config dump` but its not propagated onto the host because `ansible_facts['hostname']` is taken as CRUSH bucket.

Correct way is other way around:  `host:{{ ansible_facts['hostname'] }}`.

Also while at it the `osd.*` is IMO not required when `osd` does the same job but I'm definitely open to critique :).

This fixes #7681