### PR TITLE
rgw: add support to create/delete accounts and assign user to accounts

### DIFF
--- a/library/radosgw_account.py
+++ b/library/radosgw_account.py
@@ -1,0 +1,274 @@
+# Copyright 2026, Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import datetime
+import os
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: radosgw_account
+
+short_description: Manage RADOS Gateway Account
+
+version_added: "6.0"
+
+description:
+    - Manage RADOS Gateway account(s) creation and deletion.
+options:
+    cluster:
+        description:
+            - The ceph cluster name.
+        required: false
+        default: ceph
+    account_id:
+        description:
+            - The account ID.
+        required: true
+    account_name:
+        description:
+            - The account name.
+        required: false
+        default: None
+    email:
+        description:
+            - The account email.
+        required: false
+        default: None
+    realm:
+        description:
+            - set the realm of the account.
+        required: false
+        default: None
+    zonegroup:
+        description:
+            - set the zonegroup of the account.
+        required: false
+        default: None
+    zone:
+        description:
+            - set the zone of the account.
+        required: false
+        default: None
+    state:
+        description:
+            If 'present' is used, the module creates an account if it doesn't exist.
+            If 'absent' is used, the module will simply delete the account.
+        required: false
+        choices: ['present', 'absent']
+        default: present
+
+author:
+    - Steffen Bohr <steffen.bohr@github.execve.de>
+'''
+
+EXAMPLES = '''
+- name: create a RADOS Gateway account
+  radosgw_account:
+    account_id: RGW00000000000000001
+    account_name: my-account
+
+- name: delete a RADOS Gateway account
+  radosgw_account:
+    account_id: RGW00000000000000001
+    state: absent
+'''
+
+RETURN = '''#  '''
+
+
+def container_exec(binary, container_image):
+    container_binary = os.getenv('CEPH_CONTAINER_BINARY')
+    command_exec = [container_binary,
+                    'run',
+                    '--rm',
+                    '--net=host',
+                    '-v', '/etc/ceph:/etc/ceph:z',
+                    '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
+                    '-v', '/var/log/ceph/:/var/log/ceph/:z',
+                    '--entrypoint=' + binary, container_image]
+    return command_exec
+
+
+def is_containerized():
+    if os.environ.get('CEPH_CONTAINER_IMAGE'):
+        container_image = os.getenv('CEPH_CONTAINER_IMAGE')
+    else:
+        container_image = None
+    return container_image
+
+
+def pre_generate_radosgw_cmd(container_image=None):
+    if container_image:
+        cmd = container_exec('radosgw-admin', container_image)
+    else:
+        cmd = ['radosgw-admin']
+    return cmd
+
+
+def generate_radosgw_cmd(cluster, args, container_image=None):
+    cmd = pre_generate_radosgw_cmd(container_image=container_image)
+    base_cmd = ['--cluster', cluster, 'account']
+    cmd.extend(base_cmd + args)
+    return cmd
+
+
+def exec_commands(module, cmd):
+    rc, out, err = module.run_command(cmd)
+    return rc, cmd, out, err
+
+
+def get_account(module, container_image=None):
+    cluster = module.params.get('cluster')
+    account_id = module.params.get('account_id')
+    realm = module.params.get('realm', None)
+    zonegroup = module.params.get('zonegroup', None)
+    zone = module.params.get('zone', None)
+
+    args = ['get', '--account-id=' + account_id, '--format=json']
+
+    if realm:
+        args.extend(['--rgw-realm=' + realm])
+    if zonegroup:
+        args.extend(['--rgw-zonegroup=' + zonegroup])
+    if zone:
+        args.extend(['--rgw-zone=' + zone])
+
+    return generate_radosgw_cmd(cluster=cluster, args=args, container_image=container_image)
+
+
+def create_account(module, container_image=None):
+    cluster = module.params.get('cluster')
+    account_id = module.params.get('account_id')
+    account_name = module.params.get('account_name', None)
+    email = module.params.get('email', None)
+    realm = module.params.get('realm', None)
+    zonegroup = module.params.get('zonegroup', None)
+    zone = module.params.get('zone', None)
+
+    args = ['create', '--account-id=' + account_id]
+
+    if account_name:
+        args.extend(['--account-name=' + account_name])
+    if email:
+        args.extend(['--email=' + email])
+    if realm:
+        args.extend(['--rgw-realm=' + realm])
+    if zonegroup:
+        args.extend(['--rgw-zonegroup=' + zonegroup])
+    if zone:
+        args.extend(['--rgw-zone=' + zone])
+
+    return generate_radosgw_cmd(cluster=cluster, args=args, container_image=container_image)
+
+
+def remove_account(module, container_image=None):
+    cluster = module.params.get('cluster')
+    account_id = module.params.get('account_id')
+    realm = module.params.get('realm', None)
+    zonegroup = module.params.get('zonegroup', None)
+    zone = module.params.get('zone', None)
+
+    args = ['rm', '--account-id=' + account_id]
+
+    if realm:
+        args.extend(['--rgw-realm=' + realm])
+    if zonegroup:
+        args.extend(['--rgw-zonegroup=' + zonegroup])
+    if zone:
+        args.extend(['--rgw-zone=' + zone])
+
+    return generate_radosgw_cmd(cluster=cluster, args=args, container_image=container_image)
+
+
+def exit_module(module, out, rc, cmd, err, startd, changed=False):
+    endd = datetime.datetime.now()
+    delta = endd - startd
+
+    result = dict(
+        cmd=cmd,
+        start=str(startd),
+        end=str(endd),
+        delta=str(delta),
+        rc=rc,
+        stdout=out.rstrip("\r\n"),
+        stderr=err.rstrip("\r\n"),
+        changed=changed,
+    )
+    module.exit_json(**result)
+
+
+def run_module():
+    module_args = dict(
+        cluster=dict(type='str', required=False, default='ceph'),
+        account_id=dict(type='str', required=True),
+        account_name=dict(type='str', required=False),
+        email=dict(type='str', required=False),
+        realm=dict(type='str', required=False),
+        zonegroup=dict(type='str', required=False),
+        zone=dict(type='str', required=False),
+        state=dict(type='str', required=False, choices=['present', 'absent'], default='present'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    account_id = module.params.get('account_id')
+    state = module.params.get('state')
+
+    startd = datetime.datetime.now()
+    changed = False
+
+    container_image = is_containerized()
+
+    rc, cmd, out, err = exec_commands(module, get_account(module, container_image=container_image))
+
+    if state == 'present':
+        if rc != 0:
+            changed = True
+            if not module.check_mode:
+                rc, cmd, out, err = exec_commands(module, create_account(module, container_image=container_image))
+            else:
+                rc = 0
+
+    elif state == 'absent':
+        if rc == 0:
+            changed = True
+            if not module.check_mode:
+                rc, cmd, out, err = exec_commands(module, remove_account(module, container_image=container_image))
+        else:
+            rc = 0
+            out = "Account {} doesn't exist".format(account_id)
+
+    exit_module(module=module, out=out, rc=rc, cmd=cmd, err=err, startd=startd, changed=changed)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/library/radosgw_user.py
+++ b/library/radosgw_user.py
@@ -102,6 +102,16 @@ options:
             - set the admin flag on the user.
         required: false
         default: false
+    account_id:
+        description:
+            - account-id the user is associated with.
+        required: false
+        default: None
+    account_root:
+        description:
+            - set the account-root flag of the user.
+        required: false
+        default: false
 
 author:
     - Dimitri Savineau <dsavinea@redhat.com>
@@ -242,6 +252,8 @@ def create_user(module, container_image=None):
     system = module.params.get('system', False)
     admin = module.params.get('admin', False)
     caps = module.params.get('caps')
+    account_id = module.params.get('account_id')
+    account_root = module.params.get('account_root')
 
     args = ['create', '--uid=' + name, '--display_name=' + display_name]
 
@@ -268,6 +280,12 @@ def create_user(module, container_image=None):
 
     if admin:
         args.append('--admin')
+
+    if account_id:
+        args.extend(['--account-id=' + account_id])
+
+    if account_root:
+        args.append('--account-root')
 
     if caps:
         caps_args = [f"{cap['type']}={cap['perm']}" for cap in caps]
@@ -360,6 +378,8 @@ def modify_user(module, container_image=None):
     zone = module.params.get('zone', None)
     system = module.params.get('system', False)
     admin = module.params.get('admin', False)
+    account_id = module.params.get('account_id')
+    account_root = module.params.get('account_root')
 
     args = ['modify', '--uid=' + name]
 
@@ -389,6 +409,12 @@ def modify_user(module, container_image=None):
 
     if admin:
         args.append('--admin')
+
+    if account_id:
+        args.extend(['--account-id=' + account_id])
+
+    if account_root:
+        args.append('--account-root')
 
     cmd = generate_radosgw_cmd(cluster=cluster,
                                args=args,
@@ -487,6 +513,8 @@ def run_module():
         system=dict(type='bool', required=False, default=False),
         admin=dict(type='bool', required=False, default=False),
         caps=dict(type='list', required=False),
+        account_id=dict(type='str', required=False),
+        account_root=dict(type='bool', required=False, default=False)
     )
 
     module = AnsibleModule(

--- a/tests/library/test_radosgw_account.py
+++ b/tests/library/test_radosgw_account.py
@@ -1,0 +1,186 @@
+import os
+import sys
+from mock.mock import patch, MagicMock
+import pytest
+sys.path.append('./library')
+import radosgw_account  # noqa: E402
+
+
+fake_binary = 'radosgw-admin'
+fake_cluster = 'ceph'
+fake_container_binary = 'podman'
+fake_container_image = 'docker.io/ceph/daemon:latest'
+fake_container_cmd = [
+    fake_container_binary,
+    'run',
+    '--rm',
+    '--net=host',
+    '-v', '/etc/ceph:/etc/ceph:z',
+    '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
+    '-v', '/var/log/ceph/:/var/log/ceph/:z',
+    '--entrypoint=' + fake_binary,
+    fake_container_image
+]
+fake_account_id = 'RGW00000000000000001'
+fake_account_name = 'my-account'
+fake_email = 'admin@example.com'
+fake_realm = 'myrealm'
+fake_zonegroup = 'myzonegroup'
+fake_zone = 'myzone'
+fake_params = {
+    'cluster': fake_cluster,
+    'account_id': fake_account_id,
+    'account_name': fake_account_name,
+    'email': fake_email,
+    'realm': None,
+    'zonegroup': None,
+    'zone': None,
+}
+
+
+class TestRadosgwAccountModule(object):
+
+    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
+    def test_container_exec(self):
+        cmd = radosgw_account.container_exec(fake_binary, fake_container_image)
+        assert cmd == fake_container_cmd
+
+    def test_not_is_containerized(self):
+        assert radosgw_account.is_containerized() is None
+
+    @patch.dict(os.environ, {'CEPH_CONTAINER_IMAGE': fake_container_image})
+    def test_is_containerized(self):
+        assert radosgw_account.is_containerized() == fake_container_image
+
+    @pytest.mark.parametrize('image', [None, fake_container_image])
+    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
+    def test_pre_generate_radosgw_cmd(self, image):
+        if image:
+            expected_cmd = fake_container_cmd
+        else:
+            expected_cmd = [fake_binary]
+
+        assert radosgw_account.pre_generate_radosgw_cmd(image) == expected_cmd
+
+    @pytest.mark.parametrize('image', [None, fake_container_image])
+    @patch.dict(os.environ, {'CEPH_CONTAINER_BINARY': fake_container_binary})
+    def test_generate_radosgw_cmd(self, image):
+        if image:
+            expected_cmd = fake_container_cmd
+        else:
+            expected_cmd = [fake_binary]
+
+        expected_cmd.extend([
+            '--cluster',
+            fake_cluster,
+            'account'
+        ])
+        assert radosgw_account.generate_radosgw_cmd(fake_cluster, [], image) == expected_cmd
+
+    def test_get_account(self):
+        fake_module = MagicMock()
+        fake_module.params = fake_params
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'account', 'get',
+            '--account-id=' + fake_account_id,
+            '--format=json'
+        ]
+
+        assert radosgw_account.get_account(fake_module) == expected_cmd
+
+    def test_get_account_with_realm_zonegroup_zone(self):
+        fake_module = MagicMock()
+        fake_module.params = dict(fake_params,
+                                  realm=fake_realm,
+                                  zonegroup=fake_zonegroup,
+                                  zone=fake_zone)
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'account', 'get',
+            '--account-id=' + fake_account_id,
+            '--format=json',
+            '--rgw-realm=' + fake_realm,
+            '--rgw-zonegroup=' + fake_zonegroup,
+            '--rgw-zone=' + fake_zone
+        ]
+
+        assert radosgw_account.get_account(fake_module) == expected_cmd
+
+    def test_create_account(self):
+        fake_module = MagicMock()
+        fake_module.params = fake_params
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'account', 'create',
+            '--account-id=' + fake_account_id,
+            '--account-name=' + fake_account_name,
+            '--email=' + fake_email
+        ]
+
+        assert radosgw_account.create_account(fake_module) == expected_cmd
+
+    def test_create_account_minimal(self):
+        fake_module = MagicMock()
+        fake_module.params = dict(fake_params, account_name=None, email=None)
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'account', 'create',
+            '--account-id=' + fake_account_id
+        ]
+
+        assert radosgw_account.create_account(fake_module) == expected_cmd
+
+    def test_create_account_with_realm_zonegroup_zone(self):
+        fake_module = MagicMock()
+        fake_module.params = dict(fake_params,
+                                  realm=fake_realm,
+                                  zonegroup=fake_zonegroup,
+                                  zone=fake_zone)
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'account', 'create',
+            '--account-id=' + fake_account_id,
+            '--account-name=' + fake_account_name,
+            '--email=' + fake_email,
+            '--rgw-realm=' + fake_realm,
+            '--rgw-zonegroup=' + fake_zonegroup,
+            '--rgw-zone=' + fake_zone
+        ]
+
+        assert radosgw_account.create_account(fake_module) == expected_cmd
+
+    def test_remove_account(self):
+        fake_module = MagicMock()
+        fake_module.params = fake_params
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'account', 'rm',
+            '--account-id=' + fake_account_id
+        ]
+
+        assert radosgw_account.remove_account(fake_module) == expected_cmd
+
+    def test_remove_account_with_realm_zonegroup_zone(self):
+        fake_module = MagicMock()
+        fake_module.params = dict(fake_params,
+                                  realm=fake_realm,
+                                  zonegroup=fake_zonegroup,
+                                  zone=fake_zone)
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'account', 'rm',
+            '--account-id=' + fake_account_id,
+            '--rgw-realm=' + fake_realm,
+            '--rgw-zonegroup=' + fake_zonegroup,
+            '--rgw-zone=' + fake_zone
+        ]
+
+        assert radosgw_account.remove_account(fake_module) == expected_cmd

--- a/tests/library/test_radosgw_user.py
+++ b/tests/library/test_radosgw_user.py
@@ -25,6 +25,7 @@ fake_user = 'foo'
 fake_realm = 'canada'
 fake_zonegroup = 'quebec'
 fake_zone = 'montreal'
+fake_account_id = 'RGW93485238593854'
 fake_params = {'cluster': fake_cluster,
                'name': fake_user,
                'display_name': fake_user,
@@ -36,6 +37,9 @@ fake_params = {'cluster': fake_cluster,
                'zone': fake_zone,
                'system': True,
                'admin': True}
+fake_params_with_account = dict(fake_params,
+                                account_id=fake_account_id,
+                                account_root=True)
 
 
 class TestRadosgwUserModule(object):
@@ -98,6 +102,53 @@ class TestRadosgwUserModule(object):
 
         assert radosgw_user.create_user(fake_module) == expected_cmd
 
+    def test_create_user_with_account_id(self):
+        fake_module = MagicMock()
+        fake_module.params = fake_params_with_account
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'user', 'create',
+            '--uid=' + fake_user,
+            '--display_name=' + fake_user,
+            '--email=' + fake_user,
+            '--access-key=PC7NPg87QWhOzXTkXIhX',
+            '--secret-key=jV64v39lVTjEx1ZJN6ocopnhvwMp1mXCD4kzBiPz',
+            '--rgw-realm=' + fake_realm,
+            '--rgw-zonegroup=' + fake_zonegroup,
+            '--rgw-zone=' + fake_zone,
+            '--system',
+            '--admin',
+            '--account-id=' + fake_account_id,
+            '--account-root'
+        ]
+
+        assert radosgw_user.create_user(fake_module) == expected_cmd
+
+    def test_create_user_with_account_id_only(self):
+        fake_module = MagicMock()
+        fake_module.params = dict(fake_params,
+                                  account_id=fake_account_id,
+                                  account_root=False)
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'user', 'create',
+            '--uid=' + fake_user,
+            '--display_name=' + fake_user,
+            '--email=' + fake_user,
+            '--access-key=PC7NPg87QWhOzXTkXIhX',
+            '--secret-key=jV64v39lVTjEx1ZJN6ocopnhvwMp1mXCD4kzBiPz',
+            '--rgw-realm=' + fake_realm,
+            '--rgw-zonegroup=' + fake_zonegroup,
+            '--rgw-zone=' + fake_zone,
+            '--system',
+            '--admin',
+            '--account-id=' + fake_account_id
+        ]
+
+        assert radosgw_user.create_user(fake_module) == expected_cmd
+
     def test_modify_user(self):
         fake_module = MagicMock()
         fake_module.params = fake_params
@@ -115,6 +166,53 @@ class TestRadosgwUserModule(object):
             '--rgw-zone=' + fake_zone,
             '--system',
             '--admin'
+        ]
+
+        assert radosgw_user.modify_user(fake_module) == expected_cmd
+
+    def test_modify_user_with_account_id(self):
+        fake_module = MagicMock()
+        fake_module.params = fake_params_with_account
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'user', 'modify',
+            '--uid=' + fake_user,
+            '--display_name=' + fake_user,
+            '--email=' + fake_user,
+            '--access-key=PC7NPg87QWhOzXTkXIhX',
+            '--secret-key=jV64v39lVTjEx1ZJN6ocopnhvwMp1mXCD4kzBiPz',
+            '--rgw-realm=' + fake_realm,
+            '--rgw-zonegroup=' + fake_zonegroup,
+            '--rgw-zone=' + fake_zone,
+            '--system',
+            '--admin',
+            '--account-id=' + fake_account_id,
+            '--account-root'
+        ]
+
+        assert radosgw_user.modify_user(fake_module) == expected_cmd
+
+    def test_modify_user_with_account_id_only(self):
+        fake_module = MagicMock()
+        fake_module.params = dict(fake_params,
+                                  account_id=fake_account_id,
+                                  account_root=False)
+        expected_cmd = [
+            fake_binary,
+            '--cluster', fake_cluster,
+            'user', 'modify',
+            '--uid=' + fake_user,
+            '--display_name=' + fake_user,
+            '--email=' + fake_user,
+            '--access-key=PC7NPg87QWhOzXTkXIhX',
+            '--secret-key=jV64v39lVTjEx1ZJN6ocopnhvwMp1mXCD4kzBiPz',
+            '--rgw-realm=' + fake_realm,
+            '--rgw-zonegroup=' + fake_zonegroup,
+            '--rgw-zone=' + fake_zone,
+            '--system',
+            '--admin',
+            '--account-id=' + fake_account_id
         ]
 
         assert radosgw_user.modify_user(fake_module) == expected_cmd


### PR DESCRIPTION
ceph-ansible doesn't support the account feature introduced with ceph-squid. 

This pr adds a radosgw_account module focusing on account creation and deletion and modifies radosgw_user.py to assign users to an account. This can be useful when creating users for testing which should be able to interact with the rgw IAM API.