### PR TITLE
Bump version of use config_template

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,7 +2,7 @@
 # These are Ansible requirements needed to run ceph-ansible main
 collections:
   - name: https://opendev.org/openstack/ansible-config_template
-    version: 1.2.1
+    version: 3.0.1
     type: git
   - name: ansible.utils
     version: '>=2.5.0'


### PR DESCRIPTION
There were major compatability and general fixes made to the config_template collection, so let's use latest version of it.

This is duplicate of https://github.com/ceph/ceph-ansible/pull/7704 in order to re-open it.