### PR TITLE
Add AlmaLinux support for EPEL repository configuration

### DIFF
--- a/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
+++ b/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
@@ -6,7 +6,7 @@
   until: result is succeeded
   tags: with_pkg
   when:
-    - ansible_facts['distribution'] == 'Rocky'
+    - ansible_facts['distribution'] in ['Rocky', 'AlmaLinux']
 
 - name: Install python3-packaging
   ansible.builtin.yum:


### PR DESCRIPTION
Extend the EPEL repository configuration task to support AlmaLinux 
in addition to Rocky Linux.