### PR TITLE
Add All-in-One Molecule testing

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,0 +1,44 @@
+---
+name: molecule
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  all-in-one:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+        fail-fast: false
+        matrix:
+          repository:
+            - dev
+            - community
+          distro:
+            - debian-systemd:bookworm
+            - ubuntu-systemd:jammy
+            - centos-systemd:stream10
+          scenario:
+            - molecule-all-in-one
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: "tests/requirements.txt"
+
+      - name: Install Tox
+        run: pip install tox
+
+      - name: Run Tox
+        run: tox -c tox-molecule.ini -e ${{ matrix.scenario }}
+        env:
+          DOCKER_IMAGE_TAG: ${{ matrix.distro }}
+          CEPH_REPOSITORY: ${{ matrix.repository }}

--- a/infrastructure-playbooks/purge-cluster.yml
+++ b/infrastructure-playbooks/purge-cluster.yml
@@ -878,7 +878,7 @@
     - name: Non containerized related tasks
       when: not containerized_deployment | bool
       block:
-        - name: Purge ceph packages with yum
+        - name: Purge ceph packages with yum  # noqa: fqcn[action-core]
           ansible.builtin.yum:
             name: "{{ ceph_packages }}"
             state: absent
@@ -897,7 +897,7 @@
             purge: true
           when: ansible_facts['pkg_mgr'] == 'apt'
 
-        - name: Purge remaining ceph packages with yum
+        - name: Purge remaining ceph packages with yum  # noqa: fqcn[action-core]
           ansible.builtin.yum:
             name: "{{ ceph_remaining_packages }}"
             state: absent
@@ -921,7 +921,7 @@
             - ansible_facts['pkg_mgr'] == 'apt'
             - purge_all_packages | bool
 
-        - name: Purge extra packages with yum
+        - name: Purge extra packages with yum  # noqa: fqcn[action-core]
           ansible.builtin.yum:
             name: "{{ extra_packages }}"
             state: absent
@@ -1064,7 +1064,7 @@
             - name: Yum related tasks on red hat
               when: ansible_facts['pkg_mgr'] == "yum"
               block:
-                - name: Remove packages on redhat
+                - name: Remove packages on redhat  # noqa: fqcn[action-core]
                   ansible.builtin.yum:
                     name: ['epel-release', 'docker', 'python-docker-py']
                     state: absent

--- a/molecule/all_in_one/cleanup.yml
+++ b/molecule/all_in_one/cleanup.yml
@@ -1,0 +1,54 @@
+---
+
+- name: Clean-up loop devices and LVM
+  hosts: osds
+  gather_facts: false
+  tasks:
+    - name: Remove volume groups
+      community.general.lvg:
+        vg: "{{ item }}"
+        state: absent
+        force: true
+      loop:
+        - "{{ inventory_hostname }}_test_group"
+        - "{{ inventory_hostname }}_journals"
+      failed_when: false
+
+    - name: Remove physical volumes
+      ansible.builtin.command: "pvremove -ff -y /dev/{{ item.device }}"
+      loop: "{{ _loop_devices }}"
+      failed_when: false
+      changed_when: false
+
+    - name: Stop loop device systemd services
+      ansible.builtin.systemd_service:
+        name: "{{ item.device }}.service"
+        state: stopped
+        enabled: false
+      loop: "{{ _loop_devices }}"
+      failed_when: false
+
+    - name: Detach loop devices
+      ansible.builtin.command: "losetup -d /dev/{{ item.device }}"
+      loop: "{{ _loop_devices }}"
+      failed_when: false
+      changed_when: false
+
+    - name: Remove loop device service files
+      ansible.builtin.file:
+        path: "/etc/systemd/system/{{ item.device }}.service"
+        state: absent
+      loop: "{{ _loop_devices }}"
+      failed_when: false
+
+    - name: Reload systemd daemon
+      ansible.builtin.systemd_service:
+        daemon_reload: true
+      failed_when: false
+
+    - name: Remove loop device nodes
+      ansible.builtin.file:
+        path: "/dev/{{ item.device }}"
+        state: absent
+      loop: "{{ _loop_devices }}"
+      failed_when: false

--- a/molecule/all_in_one/converge.yml
+++ b/molecule/all_in_one/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Deploy Ceph
+  ansible.builtin.import_playbook: ../../site.yml.sample
+  vars:
+    no_log_on_ceph_key_tasks: false
+    yes_i_know: true

--- a/molecule/all_in_one/molecule.yml
+++ b/molecule/all_in_one/molecule.yml
@@ -1,0 +1,77 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: osd0
+    <<: &host_config
+      groups:
+        - mdss
+        - mgrs
+        - mons
+        - osds
+        - rgws
+      image: "${DOCKER_REGISTRY:-quay.io/gotmax23}/${DOCKER_IMAGE_TAG:-debian-systemd:bookworm}"
+      command: ${DOCKER_COMMAND:-""}
+      privileged: true
+      cgroupns_mode: host
+      pre_build_image: true
+      networks:
+        - name: public
+        - name: cluster
+      docker_networks:
+        - name: public
+          ipam_config:
+            - subnet: "192.168.17.0/24"
+        - name: cluster
+          ipam_config:
+            - subnet: "192.168.18.0/24"
+      security_opts:
+        - apparmor=unconfined
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:rw
+        - /lib/modules:/lib/modules:ro
+        - /run/udev:/run/udev:ro
+  - name: osd1
+    <<: *host_config
+  - name: osd2
+    <<: *host_config
+
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  inventory:
+    links:
+      group_vars: ../../tests/functional/all-in-one/group_vars/
+  config_options:
+    defaults:
+      inject_facts_as_vars: false
+      library: ${MOLECULE_EPHEMERAL_DIRECTORY}/library:${MOLECULE_PROJECT_DIRECTORY}/library
+      module_utils: ${MOLECULE_EPHEMERAL_DIRECTORY}/module_utils:${MOLECULE_PROJECT_DIRECTORY}/module_utils
+      action_plugins: ${MOLECULE_EPHEMERAL_DIRECTORY}/plugins/actions:${MOLECULE_PROJECT_DIRECTORY}/plugins/actions
+      callback_plugins: ${MOLECULE_EPHEMERAL_DIRECTORY}/plugins/callbacks:${MOLECULE_PROJECT_DIRECTORY}/plugins/callback
+      filter_plugins: ${MOLECULE_EPHEMERAL_DIRECTORY}/plugins/filters:${MOLECULE_PROJECT_DIRECTORY}/plugins/filter
+      roles_path: ${MOLECULE_EPHEMERAL_DIRECTORY}/roles:${MOLECULE_PROJECT_DIRECTORY}/roles
+    connection:
+      pipelining: true
+
+scenario:
+  name: all_in_one
+  test_sequence:
+    - dependency
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - side_effect
+    - cleanup
+    - destroy

--- a/molecule/all_in_one/prepare.yml
+++ b/molecule/all_in_one/prepare.yml
@@ -1,0 +1,137 @@
+---
+
+- name: Prepare LVMs on OSDs
+  hosts: osds
+  handlers:
+    - name: Load loop devices
+      ansible.builtin.systemd_service:
+        name: "{{ item.device }}.service"
+        state: restarted
+        daemon_reload: true
+      loop: "{{ _loop_devices }}"
+      loop_control:
+        label: "{{ item.device }}.service"
+  tasks:
+    - name: Install required packages
+      vars:
+        _package_names_mapping:
+          debian:
+            - lvm2
+            - iproute2
+          redhat:
+            - lvm2
+            - iproute
+      ansible.builtin.package:
+        name: "{{ _package_names_mapping[ansible_facts['os_family'] | lower] }}"
+        state: present
+        update_cache: "{{ (ansible_facts['pkg_mgr'] == 'apt') | ternary('yes', omit) }}"
+      register: result
+      until: result is succeeded
+
+    - name: Configure LVM parameters in lvm.conf
+      ansible.builtin.lineinfile:
+        path: /etc/lvm/lvm.conf
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
+        state: present
+      loop:
+        - regexp: '^\s*#?\s*udev_sync\s*='
+          line: '    udev_sync = 0'
+        - regexp: '^\s*#?\s*udev_rules\s*='
+          line: '    udev_rules = 0'
+        - regexp: '^\s*#?\s*obtain_device_list_from_udev\s*='
+          line: '    obtain_device_list_from_udev = 0'
+        - regexp: '^\s*#?\s*filter\s*='
+          line: '    filter = [ "a|/dev/{{ inventory_hostname }}.*|", "a|/dev/mapper/.*|", "r|.*|" ]'
+        - regexp: '^\s*#?\s*global_filter\s*='
+          line: '    global_filter = [ "a|/dev/{{ inventory_hostname }}.*|", "a|/dev/mapper/.*|", "r|.*|" ]'
+
+    - name: Create sparse files
+      ansible.builtin.command: "truncate -s 100G {{ item.path }}"
+      args:
+        creates: "{{ item.path }}"
+      loop: "{{ _loop_devices }}"
+
+    - name: Find next unused loop device ID
+      ansible.builtin.command: losetup -f
+      changed_when: false
+      register: _last_lo_dev
+
+    - name: Create loop devices
+      ansible.builtin.command:
+        argv:
+          - mknod
+          - "/dev/{{ item.device }}"
+          - b
+          - 7
+          - "{{ ansible_play_hosts_all.index(inventory_hostname) * _loop_devices | length + idx + 1 + _last_lo_dev.stdout | regex_search('/dev/loop(\\d+).*', '\\1') | first | int }}"
+      args:
+        creates: "/dev/{{ item.device }}"
+      loop: "{{ _loop_devices }}"
+      loop_control:
+        index_var: idx
+
+    - name: Place service content for loop devices
+      ansible.builtin.copy:
+        dest: "/etc/systemd/system/{{ item.device }}.service"
+        content: |-
+          [Unit]
+          Description = Loop device for /dev/{{ item.device }}
+          After = systemd-udev-settle.service
+          Before = lvm2-activation-early.service
+          Wants = systemd-udev-settle.service
+
+          [Service]
+          Type = oneshot
+          User = root
+          Group = root
+          ExecStart = /bin/bash -c "losetup -P /dev/{{ item.device }} {{ item.path }}"
+          ExecStart = /sbin/pvscan
+          ExecStop = /bin/bash -c "losetup -d /dev/{{ item.device }}"
+          RemainAfterExit = yes
+          TimeoutSec = 120
+          Slice = system.slice
+
+          [Install]
+          WantedBy = multi-user.target
+        mode: "0644"
+        owner: root
+      loop: "{{ _loop_devices }}"
+      loop_control:
+        label: "{{ item.device }}"
+      notify:
+        - Load loop devices
+
+    - name: Restart services if needed
+      ansible.builtin.meta: flush_handlers
+
+    - name: Create volume group
+      community.general.lvg:
+        vg: "{{ inventory_hostname }}_test_group"
+        pvs: "/dev/{{ _loop_devices[0].device }}"
+
+    - name: Create logical volume 1
+      community.general.lvol:
+        vg: "{{ inventory_hostname }}_test_group"
+        lv: data-lv1
+        size: 50%FREE
+        shrink: false
+
+    - name: Create logical volume 2
+      community.general.lvol:
+        vg: "{{ inventory_hostname }}_test_group"
+        lv: data-lv2
+        size: 100%FREE
+        shrink: false
+
+    - name: Create journals vg from "{{ _loop_devices[1].device }}"
+      community.general.lvg:
+        vg: "{{ inventory_hostname }}_journals"
+        pvs: "/dev/{{ _loop_devices[1].device }}"
+
+    - name: Create journal1 lv
+      community.general.lvol:
+        vg: "{{ inventory_hostname }}_journals"
+        lv: journal1
+        size: 100%FREE
+        shrink: false

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+
+platforms: []
+
+scenario:
+  name: default

--- a/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
+++ b/roles/ceph-common/tasks/installs/configure_redhat_repository_installation.yml
@@ -9,7 +9,7 @@
     - ansible_facts['distribution'] in ['Rocky', 'AlmaLinux']
 
 - name: Install python3-packaging
-  ansible.builtin.yum:
+  ansible.builtin.package:
     name: python3-packaging
     enablerepo: powertools
     state: present

--- a/roles/ceph-common/tasks/installs/install_redhat_packages.yml
+++ b/roles/ceph-common/tasks/installs/install_redhat_packages.yml
@@ -8,7 +8,7 @@
   when: ansible_facts['distribution'] == 'RedHat'
 
 - name: Install centos dependencies
-  ansible.builtin.yum:
+  ansible.builtin.package:
     name: "{{ centos_package_dependencies }}"
     state: present
   register: result

--- a/roles/ceph-validate/tasks/check_devices.yml
+++ b/roles/ceph-validate/tasks/check_devices.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set_fact root_device
   ansible.builtin.set_fact:
-    root_device: "{{ ansible_facts['mounts'] | selectattr('mount', 'match', '^/$') | map(attribute='device') | first }}"
+    root_device: "{{ ansible_facts['mounts'] | selectattr('mount', 'match', '^/$') | map(attribute='device') | first | default('overlay') }}"
 
 - name: Lvm_volumes variable's tasks related
   when:

--- a/tests/functional/all-in-one/group_vars/all
+++ b/tests/functional/all-in-one/group_vars/all
@@ -1,8 +1,10 @@
 ---
 containerized_deployment: False
 ceph_origin: repository
-ceph_repository: community
-radosgw_interface: "{{ 'eth1' if ansible_facts['distribution'] == 'CentOS' else 'ens6' }}"
+ceph_repository: "{{ lookup('ansible.builtin.env', 'CEPH_REPOSITORY', default='community') }}"
+ceph_stable_release: "{{ lookup('ansible.builtin.env', 'CEPH_STABLE_RELEASE', default='squid') }}"
+ntp_service_enabled: false
+radosgw_interface: eth1
 ceph_mon_docker_subnet: "{{ public_network }}"
 dashboard_enabled: False
 public_network: "192.168.17.0/24"
@@ -11,6 +13,7 @@ rgw_override_bucket_index_max_shards: 16
 rgw_bucket_default_quota_max_objects: 1638400
 ceph_conf_overrides:
   global:
+    auth_allow_insecure_global_id_reclaim: false
     osd_pool_default_pg_num: 8
     mon_allow_pool_size_one: true
     mon_warn_on_pool_no_redundancy: false
@@ -19,13 +22,36 @@ ceph_conf_overrides:
 handler_health_mon_check_delay: 10
 handler_health_osd_check_delay: 10
 osd_objectstore: "bluestore"
+ceph_mon_docker_memory_limit: 2g
+radosgw_num_instances: 2
+cephfs_pools:
+  - name: cephfs_data
+    pg_num: 8
+    pgp_num: 8
+    rule_name: replicated_rule
+    type: 1
+    erasure_profile: ""
+    expected_num_objects: ""
+    application: cephfs
+    size: 2
+    min_size: 0
+  - name: cephfs_metadata
+    pg_num: 8
+    pgp_num: 8
+    rule_name: replicated_rule
+    type: 1
+    erasure_profile: ""
+    expected_num_objects: ""
+    application: cephfs
+    size: 2
+    min_size: 0
 lvm_volumes:
   - data: data-lv1
-    data_vg: test_group
+    data_vg: "{{ inventory_hostname }}_test_group"
   - data: data-lv2
-    data_vg: test_group
+    data_vg: "{{ inventory_hostname }}_test_group"
     db: journal1
-    db_vg: journals
+    db_vg: "{{ inventory_hostname }}_journals"
 rgw_create_pools:
   foo:
     pg_num: 16
@@ -38,3 +64,9 @@ rgw_create_pools:
     ec_profile: myecprofile
     ec_k: 2
     ec_m: 1
+
+_loop_devices:
+  - path: /opt/{{ inventory_hostname }}.data
+    device: "{{ inventory_hostname }}-data"
+  - path: /opt/{{ inventory_hostname }}.journal
+    device: "{{ inventory_hostname }}-journal"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,10 +1,13 @@
 # These are Python requirements needed to run the functional tests
+docker>=7.0.0
 pytest-testinfra
 pytest-xdist
 pytest
-ansible-core>=2.15,<2.17,!=2.9.10
+ansible-core>=2.16,<2.19
 netaddr
 mock
+molecule==25.12.0
+molecule-plugins[docker]==25.8.12
 jmespath
 pytest-rerunfailures
 pytest-cov

--- a/tox-molecule.ini
+++ b/tox-molecule.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = molecule-all-in-one
+skipsdist = True
+
+[testenv]
+deps= -r{toxinidir}/tests/requirements.txt
+passenv =
+    CEPH_STABLE_RELEASE
+    CEPH_REPOSITORY
+    DOCKER_REGISTRY
+    DOCKER_IMAGE_TAG
+    DOCKER_COMMAND
+
+[testenv:molecule-all-in-one]
+commands =
+    molecule test -s all_in_one


### PR DESCRIPTION
This implements proposal from #7706 to add molecule tests, which are designed to replace the old vagrant tests.

It should also make it possible to run with gitlab actions, rather then rely on 3rd party CI.