### PR TITLE
fix ceph_key generating aes keys instead of aes256k

### DIFF
--- a/library/ceph_key.py
+++ b/library/ceph_key.py
@@ -279,20 +279,26 @@ def create_key(module,
     '''
 
     cmd_list = []
-    if not secret:
+
+    talks_to_cluster = import_key or user != 'client.admin'
+
+    mon_generates = not secret and talks_to_cluster
+
+    if not mon_generates and not secret:
         secret = generate_secret()
 
-    if user == 'client.admin':
+    if secret:
+        cmd_list.append(generate_ceph_authtool_cmd(
+            cluster, name, secret, caps, dest, container_image))
+
+    if user == 'client.admin' and not mon_generates:
         args = ['import', '-i', dest]
     else:
         args = ['get-or-create', name]
         args.extend(generate_caps(None, caps))
         args.extend(['-o', dest])
 
-    cmd_list.append(generate_ceph_authtool_cmd(
-        cluster, name, secret, caps, dest, container_image))
-
-    if import_key or user != 'client.admin':
+    if talks_to_cluster:
         cmd_list.append(generate_cmd(sub_cmd=['auth'],
                                      args=args,
                                      cluster=cluster,

--- a/tests/library/test_ceph_key.py
+++ b/tests/library/test_ceph_key.py
@@ -325,6 +325,144 @@ class TestCephKeyModule(object):
                                      fake_container_image)
         assert result == expected_command_list
 
+    def test_create_key_non_container_no_secret(self):
+        fake_module = "fake"
+        fake_user = 'client.admin'
+        fake_user_key = '/etc/ceph/fake.client.admin.keyring'
+        fake_cluster = "fake"
+        fake_name = "client.fake"
+        fake_secret = None
+        fake_caps = {
+            'mon': 'allow *',
+            'osd': 'allow rwx',
+        }
+        fake_import_key = True
+        fake_dest = "/fake/ceph"
+        fake_keyring_filename = fake_cluster + "." + fake_name + ".keyring"
+        fake_file_destination = os.path.join(fake_dest, fake_keyring_filename)
+        expected_command_list = [
+            ['ceph', '-n', fake_user, '-k', fake_user_key, '--cluster', fake_cluster, 'auth',
+                'get-or-create', fake_name, 'mon', 'allow *', 'osd', 'allow rwx',
+                '-o', fake_file_destination],
+        ]
+        result = ceph_key.create_key(fake_module, fake_cluster, fake_user, fake_user_key,
+                                     fake_name, fake_secret, fake_caps, fake_import_key,
+                                     fake_file_destination)
+        assert result == expected_command_list
+
+    def test_create_key_non_container_empty_secret(self):
+        fake_module = "fake"
+        fake_user = 'client.admin'
+        fake_user_key = '/etc/ceph/fake.client.admin.keyring'
+        fake_cluster = "fake"
+        fake_name = "client.fake"
+        fake_secret = ''
+        fake_caps = {
+            'mon': 'allow *',
+            'osd': 'allow rwx',
+        }
+        fake_import_key = True
+        fake_dest = "/fake/ceph"
+        fake_keyring_filename = fake_cluster + "." + fake_name + ".keyring"
+        fake_file_destination = os.path.join(fake_dest, fake_keyring_filename)
+        # an empty secret must behave like an omitted one
+        expected_command_list = [
+            ['ceph', '-n', fake_user, '-k', fake_user_key, '--cluster', fake_cluster, 'auth',
+                'get-or-create', fake_name, 'mon', 'allow *', 'osd', 'allow rwx',
+                '-o', fake_file_destination],
+        ]
+        result = ceph_key.create_key(fake_module, fake_cluster, fake_user, fake_user_key,
+                                     fake_name, fake_secret, fake_caps, fake_import_key,
+                                     fake_file_destination)
+        assert result == expected_command_list
+
+    def test_create_key_container_no_secret(self):
+        fake_module = "fake"
+        fake_user = 'client.admin'
+        fake_user_key = '/etc/ceph/fake.client.admin.keyring'
+        fake_cluster = "fake"
+        fake_name = "client.fake"
+        fake_secret = None
+        fake_caps = {
+            'mon': 'allow *',
+            'osd': 'allow rwx',
+        }
+        fake_import_key = True
+        fake_dest = "/fake/ceph"
+        fake_keyring_filename = fake_cluster + "." + fake_name + ".keyring"
+        fake_file_destination = os.path.join(fake_dest, fake_keyring_filename)
+        fake_container_image = "quay.io/ceph/daemon:latest-luminous"
+        expected_command_list = [
+            ['docker',
+             'run',
+             '--rm',
+             '--net=host',
+             '-v', '/etc/ceph:/etc/ceph:z',
+             '-v', '/var/lib/ceph/:/var/lib/ceph/:z',
+             '-v', '/var/log/ceph/:/var/log/ceph/:z',
+             '--entrypoint=ceph',
+             'quay.io/ceph/daemon:latest-luminous',
+             '-n', 'client.admin',
+             '-k', '/etc/ceph/fake.client.admin.keyring',
+             '--cluster', fake_cluster,
+             'auth', 'get-or-create', fake_name,
+             'mon', 'allow *', 'osd', 'allow rwx',
+             '-o', fake_file_destination]]
+        result = ceph_key.create_key(fake_module, fake_cluster, fake_user, fake_user_key, fake_name,
+                                     fake_secret, fake_caps, fake_import_key,
+                                     fake_file_destination, fake_container_image)
+        assert result == expected_command_list
+
+    def test_create_key_non_container_no_secret_no_import(self):
+        fake_module = "fake"
+        fake_user = 'client.admin'
+        fake_user_key = '/etc/ceph/fake.client.admin.keyring'
+        fake_cluster = "fake"
+        fake_name = "client.fake"
+        fake_secret = None
+        fake_caps = {
+            'mon': 'allow *',
+            'osd': 'allow rwx',
+        }
+        fake_import_key = False
+        fake_dest = "/fake/ceph"
+        fake_keyring_filename = fake_cluster + "." + fake_name + ".keyring"
+        fake_file_destination = os.path.join(fake_dest, fake_keyring_filename)
+        # the cluster can't be reached, so the key must still be generated
+        # locally with ceph-authtool and no auth command is emitted.
+        result = ceph_key.create_key(fake_module, fake_cluster, fake_user, fake_user_key,
+                                     fake_name, fake_secret, fake_caps, fake_import_key,
+                                     fake_file_destination)
+        assert len(result) == 1
+        assert result[0][0] == 'ceph-authtool'
+        assert result[0][1:6] == ['--create-keyring', fake_file_destination,
+                                  '--name', fake_name, '--add-key']
+
+    def test_create_key_non_container_no_secret_bootstrap_user(self):
+        fake_module = "fake"
+        fake_user = 'client.bootstrap-mds'
+        fake_user_key = '/var/lib/ceph/bootstrap-mds/fake.keyring'
+        fake_cluster = "fake"
+        fake_name = "mds.fake"
+        fake_secret = None
+        fake_caps = {
+            'mon': 'allow profile mds',
+            'osd': 'allow rwx',
+        }
+        fake_import_key = False
+        fake_dest = "/fake/ceph"
+        fake_keyring_filename = fake_cluster + "." + fake_name + ".keyring"
+        fake_file_destination = os.path.join(fake_dest, fake_keyring_filename)
+        expected_command_list = [
+            ['ceph', '-n', fake_user, '-k', fake_user_key, '--cluster', fake_cluster, 'auth',
+                'get-or-create', fake_name, 'mon', 'allow profile mds', 'osd', 'allow rwx',
+                '-o', fake_file_destination],
+        ]
+        result = ceph_key.create_key(fake_module, fake_cluster, fake_user, fake_user_key,
+                                     fake_name, fake_secret, fake_caps, fake_import_key,
+                                     fake_file_destination)
+        assert result == expected_command_list
+
     def test_delete_key_non_container(self):
         fake_user = 'client.admin'
         fake_user_key = '/etc/ceph/fake.client.admin.keyring'


### PR DESCRIPTION
create_key() always generated the entity's secret locally via
generate_secret(), which hardcodes cephx key type 1 (aes). Keys
created this way (e.g. ceph-mgr) could never be aes256k, causing
mgr auth failures on 20.2.4+ clusters that no longer accept aes:

handle_auth_bad_method failed to auth with my available
methods: (13) Permission denied

Signed-off-by: Dmitriy Chubinidze <dcu995@gmail.com>