### PR TITLE
Fix for 'ceph_dashboard_call_item' is undefined

### DIFF
--- a/infrastructure-playbooks/cephadm-adopt.yml
+++ b/infrastructure-playbooks/cephadm-adopt.yml
@@ -1506,7 +1506,7 @@
             fsid: "{{ fsid }}"
             cluster: "{{ cluster }}"
             spec: |
-              service_name: prometheus
+              service_type: prometheus
               service_id: "{{ ansible_facts['hostname'] }}"
               placement:
                 label: {{ monitoring_group_name }}


### PR DESCRIPTION
[WARNING]: Encountered 1 template error.
error 1 - 'ceph_dashboard_call_item' is undefined
Origin: /etc/ansible/roles/ceph-ansible/roles/ceph-facts/tasks/set_radosgw_address.yml:5:13

3   when: ceph_dashboard_call_item is defined
4   block:
5     - name: Set current radosgw_address_block, radosgw_address, radosgw_interface  from node "{{ ceph_dashboard_cal...
              ^ column 13