### PR TITLE
chore/cleanup: ceph-ec-profile: ISA-L is default EC plugin

### DIFF
--- a/library/ceph_ec_profile.py
+++ b/library/ceph_ec_profile.py
@@ -173,7 +173,7 @@ def run_module():
         state=dict(type='str', required=False,
                    choices=['present', 'absent'], default='present'),
         stripe_unit=dict(type='str', required=False),
-        plugin=dict(type='str', required=False, default='jerasure'),
+        plugin=dict(type='str', required=False, default='isa'),
         k=dict(type='str', required=False),
         m=dict(type='str', required=False),
         d=dict(type='str', required=False),

--- a/tests/library/test_ceph_ec_profile.py
+++ b/tests/library/test_ceph_ec_profile.py
@@ -94,7 +94,7 @@ class TestCephEcProfile(object):
         m_fail_json.side_effect = ca_test_common.fail_json
         m_exec_command.return_value = (0,
                                        ['ceph', 'osd', 'erasure-code-profile', 'get', 'foo', '--format', 'json'],
-                                       '{"crush-device-class":"","crush-failure-domain":"host","crush-root":"default","jerasure-per-chunk-alignment":"false","k":"2","m":"4","plugin":"jerasure","stripe_unit":"32","technique":"reed_sol_van","w":"8"}',  # noqa: E501
+                                       '{"crush-device-class":"","crush-failure-domain":"host","crush-root":"default","jerasure-per-chunk-alignment":"false","k":"2","m":"4","plugin":"isa","stripe_unit":"32","technique":"reed_sol_van","w":"8"}',  # noqa: E501
                                        '')
 
         with pytest.raises(ca_test_common.AnsibleExitJson) as r:
@@ -103,7 +103,7 @@ class TestCephEcProfile(object):
         result = r.value.args[0]
         assert result['changed']
         assert result['cmd'] == ['ceph', 'osd', 'erasure-code-profile', 'get', 'foo', '--format', 'json']
-        assert result['stdout'] == '{"crush-device-class":"","crush-failure-domain":"host","crush-root":"default","jerasure-per-chunk-alignment":"false","k":"2","m":"4","plugin":"jerasure","stripe_unit":"32","technique":"reed_sol_van","w":"8"}'  # noqa: E501
+        assert result['stdout'] == '{"crush-device-class":"","crush-failure-domain":"host","crush-root":"default","jerasure-per-chunk-alignment":"false","k":"2","m":"4","plugin":"isa","stripe_unit":"32","technique":"reed_sol_van","w":"8"}'  # noqa: E501
         assert not result['stderr']
         assert result['rc'] == 0
 
@@ -122,7 +122,7 @@ class TestCephEcProfile(object):
         m_exec_command.side_effect = [
                                        (0,
                                         ['ceph', 'osd', 'erasure-code-profile', 'get', 'foo', '--format', 'json'],
-                                        '{"crush-device-class":"","crush-failure-domain":"host","crush-root":"default","jerasure-per-chunk-alignment":"false","k":"2","m":"4","plugin":"jerasure","stripe_unit":"32","technique":"reed_sol_van","w":"8"}',  # noqa: E501
+                                        '{"crush-device-class":"","crush-failure-domain":"host","crush-root":"default","jerasure-per-chunk-alignment":"false","k":"2","m":"4","plugin":"isa","stripe_unit":"32","technique":"reed_sol_van","w":"8"}',  # noqa: E501
                                         ''),
                                        (0,
                                         ['ceph', 'osd', 'erasure-code-profile', 'set', 'foo', 'k=2', 'm=6', 'stripe_unit=32', '--force'],


### PR DESCRIPTION
 Since Tentalce release the default was changed. We should switch there default plugin, because Jerasure is unmaintained

From T release notes [1]:

```
The default plugin for erasure coded pools has been changed from Jerasure to ISA-L. Clusters created on Tentacle or later releases will use ISA-L as the default plugin when creating a new pool. Clusters that upgrade to the T release will continue to use their existing default values. The default values can be overridden by creating a new erasure code profile and selecting it when creating a new pool. ISA-L is recommended for new pools because the Jerasure library is no longer maintained.
```

[1] https://ceph.io/en/news/blog/2025/v20-2-0-tentacle-released/